### PR TITLE
fixes for terms+conditions and rippled APIs

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -54,6 +54,10 @@ body .content-root {
     margin-top: -50px;
 }
 
+.content pre code {
+    white-space: pre;
+}
+
 .menubar {
 	padding-top: 10px;
 }

--- a/js/expandcode.js
+++ b/js/expandcode.js
@@ -1,6 +1,8 @@
-$(document).on('flatdoc:ready', function() {
+function make_code_expandable() {
     $('code').dblclick(function(eo) {
         $(eo.target).toggleClass('expanded');
     });
     $('code').attr('title', 'Double-click to expand/collapse');
-});
+}
+
+$(document).on('flatdoc:ready', make_code_expandable);

--- a/rippled-apis.html
+++ b/rippled-apis.html
@@ -77,8 +77,10 @@ mixpanel.init("132d42885e094171f34467fc54da6fab");
   <script>
     $(document).ready(function() {
         $(".multicode").minitabs()
+        make_code_expandable();
     });
   </script>
+  <!--end alt code for compiled page -->
   <link type="text/css" rel="stylesheet" href="css/mod.css">
   <script src="js/expandcode.js"></script>
   <script src="js/fixsidebarscroll.js"></script>

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -1,91 +1,92 @@
-<!doctype html>
-<!--
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ripple Dev Portal Resources</title>
 
-  Instructions:
-
-  - Save this file.
-  - Replace "ripple" with your GitHub ripplename.
-  - Replace "ripple-client" with your GitHub ripple-client name.
-  - Replace "Ripple Web Client" with Ripple Web Client name.
-  - Upload this file (or commit to GitHub Pages).
-
-  Customize as you see fit!
-
--->
-<html>
-<head>
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
-
-    <title>Ripple Web Client</title>
-
-    <!-- Flatdoc -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <!-- Bootstrap -->
+	<link href="css/bootstrap.min.css" rel="stylesheet">
+    
+    <!--  Google Font -->
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
    
-    <!-- Custom Js -->
-
-    <script src="js/main.js"></script>
-    <script src="js/bootstrap-modal.js"></script>
-
-
-    <script src='vendor/flatdoc/v/0.8.0/legacy.js'></script>
-    <script src='vendor/flatdoc/v/0.8.0/flatdoc.js'></script>
-
-    <!-- Flatdoc theme -->
-    <link  href='vendor/flatdoc/v/0.8.0/theme-white/style.css' rel='stylesheet'>
-    <script src='vendor/flatdoc/v/0.8.0/theme-white/script.js'></script>
-
-    <!-- Meta -->
-    <meta content="Ripple Web Client" property="og:title">
-    <meta content="Ripple Web Client description goes here." name="description">
-
-    <!-- Custom Stylesheet -->
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:600italic,400,700,300' rel='stylesheet' type='text/css'>
-    <link  href='css/main.css' rel='stylesheet'>
+  	<!-- Font Awesome -->
+	<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+	
+	<!-- Custom stuff -->
+    <link href="css/custom.css" rel="stylesheet">
     
     <link rel="shortcut icon" href="favicon.ico?v=2" type="image/x-icon">
 	<link rel="icon" href="favicon.ico?v=2" type="image/x-icon">
 
-  <!-- start Mixpanel -->
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+    
+      <!-- start Mixpanel -->
   <script type="text/javascript">(function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src=("https:"===e.location.protocol?"https:":"http:")+'//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f);b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==
 typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");for(g=0;g<i.length;g++)f(c,i[g]);
 b._i.push([a,e,d])};b.__SV=1.2}})(document,window.mixpanel||[]);
 mixpanel.init("132d42885e094171f34467fc54da6fab");
   </script>
     
-  <script>if (window.location.host == "dev.ripple.com") { mixpanel.track("terms"); }</script>    
+  <script>if (window.location.host == "dev.ripple.com") { mixpanel.track("View"); }</script>    
   <!-- end Mixpanel -->
-</head>
-<body role='flatdoc'>
+    
+    <!-- start google analytics -->
+	  <script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    <div class='header'>
-        <div class='left'>
-          <h1>{<i class="icon-ripple-logo"></i>}</h1>
-          <ul>
-        <li><a href='index.html'>Documentation</a></li>
-        <li><a href='https://ripple.com/dev/blog'>Developer blog</a></li>
-        <li><a href='https://ripple.com/forum/viewforum.php?f=2&sid=c016bc6b934120b7117c0e136e74de98' target='_blank'>Developer Forum</a></li>
-        <li><a href='guidelines.html'>Brand Guidelines</a></li>
-        <li><a href='https://www.bountysource.com/teams/ripple/bounties'target='_blank'>Bounties</a></li>       
+	  ga('create', 'UA-49188512-1', 'ripple.com');
+	  ga('send', 'pageview');
+
+	  </script>
+  <!-- end google analytics -->  
+  
+  </head>
+  <body>
+  <div class="wrapper">
+	<!--   navigation -->
+  	<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="https://dev.ripple.com/"><img class="small_logo" src="assets/img/ripple_logo_small.png"></a>
+        </div>
+        <div class="navbar-collapse collapse">
+          <ul class="nav navbar-nav">
+			<li class="active"><a href="/">Resources</a></li>
+            <li><a href="https://www.bountysource.com/teams/ripple/bounties">Bounties</a></li>
+            <li><a href="https://ripplelabs.atlassian.net/">Bug Tracking</a></li>
+            <li><a href="https://ripple.com/dev/blog/">Dev Blog</a></li>
+            <li><a href="https://ripple.com/forum/viewforum.php?f=2&sid=c016bc6b934120b7117c0e136e74de98">Forums</a></li>
           </ul>
-
-          <a href="" class="header-menu-button">
-             &nbsp;
-          </a>
-
-        </div>
-        <div class='right'>
-              <!-- GitHub buttons: see http://ghbtns.com 
-            <iframe src="http://ghbtns.com/github-btn.html?ripple=ripple&amp;ripple-client=ripple-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20">
-    </iframe> -->
-        </div>
+          	<div class='right'>
+		 	 <!-- GitHub buttons -->
+		 		 <iframe src="https://dev.ripple.com/vendor/ghbtn.html?user=ripple&repo=ripple-dev-portal&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+			</div>
+        </div><!--/.nav-collapse -->
+      </div>
     </div>
 
-    <div class='content-root  guidelines-content'>
-      
-        <div role='flatdoc-content' class='content'>
-            
+    <!-- main container -->
+	<div class="container">
+      <div class="content-root">
+		 <div class="row">
             <div class="brand-guidelines-row terms-conditions-content">
               <h2 class="brand-guidelines-title">            
                 Terms and Conditions 
@@ -144,7 +145,77 @@ mixpanel.init("132d42885e094171f34467fc54da6fab");
             </div>
         </div>
     </div>
+    </div>
 
+	<div class="footer">
+      <div class="container">
+        <p class="text-muted">
+        	<div class="row">
+				<div class="col-md-2">
+					
+						<ul class="footer_links applications">
+							<li><a href="https://www.rippletrade.com">Ripple Trade</a>
+							<li><a href="https://www.ripplecharts.com">Ripple Charts</a>
+							<li><a href="https://ripple.com/graph">Ripple Graph</a>
+							<li><a href="http://codius.org/">Codius</a>
+						</ul>
+				</div>
+				<div class="col-md-2">
+					
+						<ul class="footer_links middleware">
+							<li><a href="gatewayd.html">Gatewayd</a>
+							<li><a href="ripple-rest.html">Ripple REST</a>
+							<li><a href="https://github.com/ripple/ripple-lib">Ripple Lib</a>
+						</ul>
+				
+				</div>
+				<div class="col-md-2">
+					
+						<ul class="footer_links core_network">
+							<li><a href="rippled-apis.html">rippled</a>
+						</ul>
+				
+				</div>
+				<div class="col-md-2">
+						<ul class="footer_links bounties">
+							<li><a href="https://www.bountysource.com/teams/ripple/bounties">Bounties</a>
+							<li><a href="https://ripplelabs.atlassian.net/">Bug tracking</a>
+							<li><a href="guidelines.html">Brand guidelines</a>
+							<li><a href="https://ripple.com/dev/blog/">Dev blog</a>
+							<li><a href="https://ripple.com/forum/viewforum.php?f=2&sid=c016bc6b934120b7117c0e136e74de98">Forums</a>
+							<li><a href="https://ripple.com/wiki/Main_Page">Wiki</a>
+						</ul>
+				
+				</div>
+				<div class="col-md-4">
+				<p>Join the mailing list!</p>
+				<label for="mce-EMAIL">Email address</label>
+					<!-- Begin MailChimp Signup Form -->
+						<link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
+						<style type="text/css">
+							#mc_embed_signup{clear:left; font:14px; }
+	
+						</style>
+						<div id="mc_embed_signup">
+						<form action="//ripple.us4.list-manage.com/subscribe/post?u=245dbc1c47849f034390dc5bf&amp;id=4dfbe160d0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+	
+							<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="" required>
+							<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+							<div style="position: absolute; left: -5000px; top: -50px;"><input type="text" name="b_245dbc1c47849f034390dc5bf_4dfbe160d0" tabindex="-1" value=""></div>
+							<input type="submit" value="Submit" name="subscribe" id="mc-embedded-subscribe" class="button btn btn-primary">
+						</form>
+						</div>
 
-</body>
+					<!--End mc_embed_signup-->
+				</div>
+      		</div>
+      </div>
+    </div>
+
+</div>
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="js/bootstrap.min.js"></script>
+  </body>
 </html>

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -36,7 +36,7 @@ b._i.push([a,e,d])};b.__SV=1.2}})(document,window.mixpanel||[]);
 mixpanel.init("132d42885e094171f34467fc54da6fab");
   </script>
     
-  <script>if (window.location.host == "dev.ripple.com") { mixpanel.track("View"); }</script>    
+  <script>if (window.location.host == "dev.ripple.com") { mixpanel.track("terms"); }</script>    
   <!-- end Mixpanel -->
     
     <!-- start google analytics -->


### PR DESCRIPTION
- make terms+conditions page use same header/footer/style as other page (quick & dirty fix)
- make double-click-to-expand code tabs still work in compiled rippled-apis page
- stop word-wrapping code examples
