### PR TITLE
[FIX] REST tool handle DEV-44 in all cases

### DIFF
--- a/js/apitool-rest.js
+++ b/js/apitool-rest.js
@@ -255,7 +255,6 @@ function select_request(request) {
     rest_method.change();
     
     if (command.method == POST || command.method == PUT) {
-        //first show the request, then set its contents
         cm_request.setValue(JSON.stringify(command.body, null, 2));
     } else {
         //No body, so wipe out the current contents.

--- a/js/apitool-rest.js
+++ b/js/apitool-rest.js
@@ -271,15 +271,22 @@ function select_request(request) {
     //rest_url.val(command.path);
     rest_url.text(command.path);
 
-    rest_method.val(command.method);
-    rest_method.change();
+    
     
     if (command.method == POST || command.method == PUT) {
+        //first show the request, then set its contents
+        rest_method.val(command.method);
+        rest_method.change();
         cm_request.setValue(JSON.stringify(command.body, null, 2));
     } else {
         //No body, so wipe out the current contents.
         //This prevents confusion if the user toggles the HTTP method dropdown
         cm_request.setValue("");
+        
+        //cm_request.setValue() doesn't work if the element is hidden, 
+        // so wait until now to hide cm_request
+        rest_method.val(command.method);
+        rest_method.change();
     }
     
     reset_response_area();

--- a/js/apitool-rest.js
+++ b/js/apitool-rest.js
@@ -227,6 +227,7 @@ function update_method() {
         request_body.hide();
     } else {
         request_body.show();
+        cm_request.refresh();
     }
 }
 
@@ -250,21 +251,16 @@ function select_request(request) {
     rest_url.text(command.path);
 
     
+    rest_method.val(command.method);
+    rest_method.change();
     
     if (command.method == POST || command.method == PUT) {
         //first show the request, then set its contents
-        rest_method.val(command.method);
-        rest_method.change();
         cm_request.setValue(JSON.stringify(command.body, null, 2));
     } else {
         //No body, so wipe out the current contents.
         //This prevents confusion if the user toggles the HTTP method dropdown
         cm_request.setValue("");
-        
-        //cm_request.setValue() doesn't work if the element is hidden, 
-        // so wait until now to hide cm_request
-        rest_method.val(command.method);
-        rest_method.change();
     }
     
     reset_response_area();


### PR DESCRIPTION
First "fix" for this issue (part of b2fa86a) did not work because .setValue() doesn't work when the CodeMirror element is hidden.

Second "fix" for this issue (060c5ad) didn't work in one particular case:
1. Choose a command that uses the POST method
2. Change method to GET
3. Change command to one that uses GET method
4. Change method to POST
---> POST body from previous command remains (despite being set to "", it didn't stick.)

This change (calling refresh on the cm_request object) should fix that.
