### PR TITLE
Document can_delete method to rippled.

### DIFF
--- a/content/rippled.md
+++ b/content/rippled.md
@@ -465,6 +465,7 @@ The `wallet_accounts` command is deprecated and may be removed without further n
 
 Additionally, this page contains an explanation of the following important admin-only command:
 
+* [`can_delete` - Allow online deletion of ledgers up to a specific ledger.](#can-delete)
 * [`wallet_propose` - Generate keys for a new account](#wallet-propose)
 
 For information about other Admin Commands, consult [the old wiki documentation](https://ripple.com/wiki/JSON_Messages).
@@ -1698,6 +1699,70 @@ this is the part where we plug our ears and don't acknowledge that you can provi
 * `noGenDecrypt`
 -->
 
+## can_delete ##
+[[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/CanDelete.cpp "Source")
+
+With `online_delete` and `advisory_delete` configuration options enabled,
+the `can_delete` method informs the rippled server of the latest ledger
+which may be deleted.
+
+#### Request Format ####
+
+An example of the request format:
+
+<div class='multicode'>
+*WebSocket*
+```
+{
+  "id": 2,
+  "command": "can_delete",
+  "can_delete": 11320417
+}
+```
+
+*JSON-RPC*
+```
+{
+    "method": "can_delete",
+    "params": [
+        {
+            "can_delete": 11320417
+        }
+    ]
+}
+```
+
+*Commandline*
+```
+#Syntax can_delete [<ledger_index>|<ledger_hash>|now|always|never]
+rippled -- can_delete 11320417
+```
+</div>
+
+The request includes the following optional parameter:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| can_delete | String or Integer | The maximum ledger to allow to be deleted. For `ledger_index` or `ledger_hash`, see [Specifying a Ledger](#specifying-a-ledger-instance). `never` sets the value to 0, and effectively disables online deletion until another `can_delete` is appropriately called.  `always` sets the value to the maximum possible ledger (4294967295), and online deletion will occur as of each configured `online_delete` interval. `now` triggers online deletion at the next validated ledger that meets or exceeds the configured `online_delete` interval, but no further. |
+
+If no parameter is specified, no change is made.
+
+The response follows the [standard format](#response-formatting), with
+a successful result containing the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| can_delete | Integer | The maximum ledger index that may be removed by the online deletion routine. |
+
+Use this command with no parameter to query the existing `can_delete` setting.
+
+#### Possible Errors ####
+
+* Any of the [universal error types](#universal-errors).
+* `notEnabled` - Not enabled in configuration.
+* `notReady` - Not ready to handle this request.
+* `lgrNotFound` - Ledger not found.
+* `invalidParams` - Invalid parameters.
 
 ## wallet_propose ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp "Source")


### PR DESCRIPTION
I proof-read this in a mark-down editor. It didn't pick up all of the formatting, but the content is correct. I'm assuming that this file gets generated into https://ripple.com/build/rippled-apis/
Is that correct?
