### PR TITLE
Automated link tests on push

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+general:
+  build_dir: tool/
+dependencies:
+  pre:
+    - pyenv global 3.4.0
+  override:
+    - pip3 install jinja2 requests beautifulsoup4
+test:
+  override:
+    - ./parse_pages.py
+    - ./check_links.py

--- a/tool/check_links.py
+++ b/tool/check_links.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from bs4 import BeautifulSoup
+import requests
+import os
+
+externalCache = []
+atRoot = True
+
+for dirpath, dirnames, filenames in os.walk("../"):
+  if atRoot:
+    dirnames.remove('tool')
+    atRoot = False
+  for fname in filenames:
+    fullPath = os.path.join(dirpath, fname);
+    if fullPath.endswith(".html"):
+      f = open(fullPath, 'r')
+      soup = BeautifulSoup(f.read())
+      links = soup.find_all('a')
+      for link in links:
+        endpoint = link['href']
+        if "://" in endpoint:
+          if endpoint not in externalCache:
+            print("Testing remote URL %s"%(endpoint))
+            code = requests.head(endpoint).status_code
+            if code < 200 or code >= 400:
+              print("Broken remote link in %s to %s"%(fullPath, endpoint))
+            else:
+              externalCache.append(endpoint)
+        elif endpoint[0] == '#':
+          continue
+        elif endpoint[0] == '/':
+          continue
+        else:
+          if not os.path.exists(os.path.join(dirpath, endpoint)):
+            print("Broken local link in %s to %s"%(fullPath, endpoint))


### PR DESCRIPTION
This adds two small things to the dev portal docs:
- check_links.py, which can be used to verify that all output .html files have valid external and local links
- Running check_links.py on push through circleci.

To enable circleci, you'll want to visit https://circleci.com/add-projects and add ripple/ripple-dev-portal.
