### PR TITLE
Better code expansion

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -90,9 +90,17 @@ body .content-root {
 }
 
 /* code samples scrolling */
-code { max-height: 14em; overflow: auto;}
+.code_sample code { max-height: 14em; overflow: auto;}
+.code_sample code.expanded,
+.code_sample .hljs.expanded {
+    max-height: none;
+    width: 100%;
+}
+
+.code_sample { position: relative; }
+.code_sample .code_toggler { position: absolute; bottom: 0; right: 0; }
+
 .content code { color: #111; }
-.expanded { max-height: none; overflow: none;}
 
 /* code tabs css */
 .multicode {

--- a/css/custom.css
+++ b/css/custom.css
@@ -94,11 +94,19 @@ body .content-root {
 .code_sample code.expanded,
 .code_sample .hljs.expanded {
     max-height: none;
-    width: 100%;
+    position: absolute;
 }
 
 .code_sample { position: relative; }
 .code_sample .code_toggler { position: absolute; bottom: 0; right: 0; }
+
+.code-placeholder {
+    margin: 11px;
+}
+
+.content-root pre {
+    overflow: visible;
+}
 
 .content code { color: #111; }
 

--- a/js/expandcode.js
+++ b/js/expandcode.js
@@ -1,8 +1,26 @@
+var toggle_cs = function(eo) {
+    //eo = $("#"+id);
+    var wrapper = $(eo.target).parent();
+    wrapper.find("code").toggleClass('expanded');
+    current_button_text = wrapper.find(".code_toggler").val();
+    $(eo.target).val(current_button_text == 'Expand' ? "Collapse" : "Expand");
+}
+
 function make_code_expandable() {
-    $('code').dblclick(function(eo) {
+    var newid = 0;
+    $(".content > pre > code").parent().wrap(function() {
+        newid = newid+1;
+        return "<div class='code_sample' id='code_autoid_"+newid+"'>";
+    });
+
+    var cs = $('.code_sample');
+    cs.find("code").dblclick(function(eo) {
         $(eo.target).toggleClass('expanded');
     });
-    $('code').attr('title', 'Double-click to expand/collapse');
+    cs.find("code").attr('title', 'Double-click to expand/collapse');
+    var newbtn = $("<input type='button' class='code_toggler' value='Expand' />");
+    newbtn.appendTo(cs);
+    $(".code_toggler").click(toggle_cs);
 }
 
 $(document).on('flatdoc:ready', make_code_expandable);

--- a/js/expandcode.js
+++ b/js/expandcode.js
@@ -1,7 +1,20 @@
 var toggle_cs = function(eo) {
     //eo = $("#"+id);
     var wrapper = $(eo.target).parent();
-    wrapper.find("code").toggleClass('expanded');
+    var code_el = wrapper.find("code");
+    code_el.toggleClass('expanded');
+    var placeholders = wrapper.find(".code-placeholder");
+    if (placeholders.length) {
+        console.log("bye bye placeholders");
+        placeholders.remove();
+    } else {
+        console.log("makin' a placeholder");
+        code_el.after("<div class='code-placeholder' style='width:"
+                            + code_el.width()
+                            + "px; height:"
+                            + code_el.height()
+                            + "px;'>&nbsp;</div>");
+    }
     current_button_text = wrapper.find(".code_toggler").val();
     $(eo.target).val(current_button_text == 'Expand' ? "Collapse" : "Expand");
 }
@@ -14,9 +27,7 @@ function make_code_expandable() {
     });
 
     var cs = $('.code_sample');
-    cs.find("code").dblclick(function(eo) {
-        $(eo.target).toggleClass('expanded');
-    });
+    cs.find("code").dblclick(toggle_cs);
     cs.find("code").attr('title', 'Double-click to expand/collapse');
     var newbtn = $("<input type='button' class='code_toggler' value='Expand' />");
     newbtn.appendTo(cs);

--- a/js/multicodetab.js
+++ b/js/multicodetab.js
@@ -16,7 +16,7 @@ jQuery.fn.multicode_tabs = function() {
         // for each code, give it a unique ID and wrap it in a pre
         cb_area.children('code').each(function(index2,el2) {
             var linkid = 'code-'+index+'-'+index2;
-            $(el2).wrap("<div id='"+linkid+"'><pre>");
+            $(el2).wrap("<div id='"+linkid+"' class='code_sample'><pre>");
             //also put in a link to this in the tab header ul
             $('ul', cb_area).append("<li><a href='#"+linkid+"'></a></li>");
         });

--- a/js/multicodetab.js
+++ b/js/multicodetab.js
@@ -49,7 +49,7 @@ jQuery.fn.multicode_tabs_pandoc = function() {
         
         cb_area.children('pre').each(function(index2,el2) {
             var linkid = 'code-'+index+'-'+index2;
-            $(el2).wrap("<div id='"+linkid+"'>");
+            $(el2).wrap("<div id='"+linkid+"' class='code_sample'>");
             //also put in a link to this in the tab header ul
             $('ul', cb_area).append("<li><a href='#"+linkid+"'></a></li>");
         });


### PR DESCRIPTION
There are some cases where double-clicking to expand code samples doesn't work. (For example, if the code sample is followed by a header that invisibly overlaps the bottom of the code sample, the header can invisibly steal focus from the code sample.) Reportedly, double-clicking to expand doesn't work on iOS, either. This change improves expanding code in a couple ways:
1. Adds an "expand/collapse" button to the bottom-right of code samples, which is much more visible and also works when the focus would be otherwise stolen, or when double-clicking is impossible.
2. Code expands horizontally as well as vertically.
