### PR TITLE
Rippled updates 201601

### DIFF
--- a/content/data_types/account_sequence.md
+++ b/content/data_types/account_sequence.md
@@ -1,0 +1,5 @@
+A Sequence number is a 32-bit unsigned integer used to identify a transaction or Offer relative to a specific account.
+
+Every [account object in the Ripple Consensus Ledger](ripple-ledger.html#accountroot) has a Sequence number, which starts at 1. For a transaction to be relayed to the network and possibly included in a validated ledger, it must have a `Sequence` field that matches the sending account's current `Sequence` number. An account's Sequence field is incremented whenever a transaction from that account is included in a validated ledger (regardless of whether the transaction succeeded or failed). This preserves the order of transactions submitted by an account, and differentiates transactions that would otherwise be identical.
+
+Every [Offer node in the Ripple Consensus Ledger](ripple-ledger.html#offer) is marked with the sending `Account` [Address][] and the `Sequence` value of the [OfferCreate transaction](transactions.html#offercreate) that created it. These two fields, together, uniquely identify the Offer.

--- a/content/data_types/address.md
+++ b/content/data_types/address.md
@@ -1,0 +1,22 @@
+Ripple Accounts are identified by a base-58 Ripple Address, which is derived from the account's master public key. An address is represented as a String in JSON, with the following characteristics:
+
+* Between 25 and 35 characters in length
+* Starts with the character `r`
+* Case-sensitive
+* [Base-58](https://wiki.ripple.com/Encodings) encoded using only the following characters: `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz` That's alphanumeric characters, excluding zero (`0`), capital O (`O`), capital I (`I`), and lowercase L (`l`).
+* Contains error-checking that makes it unlikely that a randomly-generated string is a valid address.
+
+#### Special Addresses ####
+[ACCOUNT_ONE]: #special-addresses
+[ACCOUNT_ZERO]: #special-addresses
+
+Some addresses have special meaning, or historical uses, in the Ripple Consensus Ledger. In many cases, these are "black hole" addresses, meaning the address is not derived from a known secret key. Since it is almost impossible to guess a secret key from just an address, any XRP possessed by those addresses is lost forever.
+
+| Address                     | Name | Meaning | Black Hole? |
+|-----------------------------|------|---------|-------------|
+| rrrrrrrrrrrrrrrrrrrrrhoLvTp | ACCOUNT\_ZERO | An address that is the base-58 encoding of the value `0`. In peer-to-peer communications, `rippled` uses this address as the issuer for XRP. | Yes |
+| rrrrrrrrrrrrrrrrrrrrBZbvji  | ACCOUNT\_ONE | An address that is the base-58 encoding of the value `1`. In the ledger, [RippleState entries](ripple-ledger.html#ripplestate) use this address as a placeholder for the issuer of a trust line balance. | Yes |
+| rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh | The genesis account | When `rippled` starts a new genesis ledger from scratch (for example, in stand-alone mode), this account holds all the XRP. This address is generated from the seed value "masterpassphrase" which is [hard-coded](https://github.com/ripple/rippled/blob/94ed5b3a53077d815ad0dd65d490c8d37a147361/src/ripple/app/ledger/Ledger.cpp#L184). | No |
+| rrrrrrrrrrrrrrrrrNAMEtxvNvQ | Ripple Name reservation black-hole | In the past, Ripple asked users to send XRP to this account to reserve Ripple Names.| Yes |
+| rrrrrrrrrrrrrrrrrrrn5RM1rHd | NaN Address | Previous versions of [ripple-lib](https://github.com/ripple/ripple-lib) generated this address when base-58 encoding the value [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN). | Yes |
+

--- a/content/data_types/currency_code.md
+++ b/content/data_types/currency_code.md
@@ -1,0 +1,5 @@
+There are two kinds of currency code in the Ripple Consensus Ledger:
+
+* Three-character currency code. We recommend using all-uppercase [ISO 4217 Currency Codes](http://www.xe.com/iso4217.php). However, any combination of the following characters is permitted: all uppercase and lowercase letters, digits, as well as the symbols `?`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `<`, `>`, `(`, `)`, `{`, `}`, `[`, `]`, and <code>&#124;</code>. The currency code `XRP` (all-uppercase) is reserved for XRP and cannot be used by issued currencies.
+* 160-bit hexadecimal values, such as `0158415500000000C1F76FF6ECB0BAC600000000`, according to Ripple's internal [Currency Format](https://wiki.ripple.com/Currency_format). This representation is uncommon.
+

--- a/content/data_types/hash.md
+++ b/content/data_types/hash.md
@@ -1,0 +1,10 @@
+Many objects in Ripple, particularly transactions and ledgers, are uniquely identified by a 256-bit hash value. This value is typically calculated as a "SHA-512Half", which calculates a [SHA-512](http://dx.doi.org/10.6028/NIST.FIPS.180-4) hash from some contents, then takes the first 64 characters of the hexadecimal representation. Since the hash of an object is derived from the contents in a way that is extremely unlikely to produce collisions, two objects with the same hash can be considered identical.
+
+A Ripple hash value has the following characteristics:
+
+* Exactly 64 characters in length
+* [Hexadecimal](https://en.wikipedia.org/wiki/Hexadecimal) character set: 0-9 and A-F.
+* Typically written in upper case.
+
+**Note:** SHA-512Half has similar security to the officially-defined _SHA-512/256_ hash function. However, Ripple's usage predates SHA-512/256 and is also easier to implement on top of an existing SHA-512 function. (As of this writing, SHA-512 support in cryptographic libraries is much more common than for SHA-512/256.)
+

--- a/content/data_types/ledger_index.md
+++ b/content/data_types/ledger_index.md
@@ -1,0 +1,6 @@
+A ledger index is a 32-bit unsigned integer used to identify a ledger. The ledger index is also known as the ledger's sequence number. The very first ledger was ledger index 1, and each subsequent ledger has a ledger index 1 higher than that of the ledger immediately before it.
+
+The ledger index indicates the order of the ledgers; the [Hash][] value identifies the exact contents of the ledger. Two ledgers with the same hash are always identical. For closed ledgers, hash values and sequence numbers are equally valid and correlate 1:1. However, this is not true for in-progress ledgers:
+
+* Two different `rippled` servers may have different contents for a current ledger with the same ledger index, due to latency in propagating transactions throughout the network.
+* A current ledger's contents change over time, which would cause its hash to change, even though its ledger index number stays the same. Therefore, the hash of a ledger is not calculated until the ledger is closed.

--- a/content/data_v2.md
+++ b/content/data_v2.md
@@ -2996,26 +2996,13 @@ In other words, XRP has the same precision as a 64-bit unsigned integer where ea
 ### Addresses ###
 [Address]: #addresses
 
-Ripple Accounts are identified by a base-58 Ripple Address, which is derived from the account's master public key. An address is represented as a String in JSON, with the following characteristics:
+{% include 'data_types/address.md' %}
 
-* Between 25 and 35 characters in length
-* Starts with the character `r`
-* Case-sensitive
-* Base-58 encoded using only the following characters: `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz` That's alphanumeric characters, excluding zero (`0`), capital O (`O`), capital I (`I`), and lowercase L (`l`).
-* Contains error-checking that makes it unlikely that a randomly-generated string is a valid address.
 
 ### Hashes ###
 [Hash]: #hashes
 
-Many objects in Ripple, particularly transactions and ledgers, are uniquely identified by a 256-bit hash value. This value is typically calculated as a "SHA-512Half", which calculates a SHA-512 hash from some contents, then takes the first 64 characters of the hexadecimal representation. Since the hash of an object is derived from the contents in a way that is extremely unlikely to produce collisions, two objects with the same hash can be considered identical.
-
-A Ripple hash value has the following characteristics:
-
-* Exactly 64 characters in length
-* [Hexadecimal](https://en.wikipedia.org/wiki/Hexadecimal) character set: 0-9 and A-F.
-* Typically written in upper case.
-
-**Note:** SHA-512Half has similar security to the officially-defined _SHA-512/256_ hash function. However, Ripple's usage predates SHA-512/256 and is also easier to implement on top of an existing SHA-512 function (since support for SHA-512/256 is not common in cryptographic libraries as of this writing).
+{% include 'data_types/hash.md' %}
 
 
 ### Timestamps ###
@@ -3038,26 +3025,17 @@ All dates and times are written in ISO 8601 Timestamp Format, using UTC. This fo
 ### Ledger Index ###
 [Ledger Index]: #ledger-index
 
-A ledger index is a 32-bit unsigned integer used to identify a ledger. The ledger index is also known as the ledger's sequence number. The very first ledger was ledger index 1, and each subsequent ledger has a ledger index 1 higher than that of the ledger immediately before it.
-
-Two ledgers with the same ledger index are guaranteed to have identical contents _if they are validated by consensus_. Ledgers that are not validated by consensus may have different contents even with the same ledger index. (The [Hash][] values of two ledgers can tell you whether those ledgers have the exact same contents.)
+{% include 'data_types/ledger_index.md' %}
 
 ### Account Sequence ###
 [Sequence Number]: #account-sequence
 
-A Sequence number is a 32-bit unsigned integer used to identify a transaction or Offer relative to a specific account.
-
-Every [account object in the Ripple Consensus Ledger](ripple-ledger.html#accountroot) has a Sequence number, which starts at 1. For a transaction to be relayed to the network and possibly included in a validated ledger, it must have a `Sequence` field that matches the sending account's current `Sequence` number. An account's Sequence field is incremented whenever a transaction from that account is included in a validated ledger (regardless of whether the transaction succeeded or failed). This preserves the order of transactions submitted by an account, and differentiates transactions that would otherwise be identical.
-
-Every [Offer node in the Ripple Consensus Ledger](ripple-ledger.html#offer) is marked with the sending `Account` [Address][] and the `Sequence` value of the [OfferCreate transaction](transactions.html#offercreate) that created it. These two fields, together, uniquely identify the Offer.
+{% include 'data_types/account_sequence.md' %}
 
 ### Currency Code ###
 [Currency Code]: #currency-code
 
-Currencies in Ripple can be represented in two ways:
-
-* As three-letter [ISO 4217 Currency Codes](http://www.xe.com/iso4217.php). These currency codes must be written in uppercase ("USD" is valid, "usd" is not). Ripple permits currency codes that are not officially approved, including currency codes with digits in them.
-* As 160-bit hexadecimal values, such as `0158415500000000C1F76FF6ECB0BAC600000000`, according to Ripple's internal [Currency Format](https://wiki.ripple.com/Currency_format). This representation is uncommon.
+{% include 'data_types/currency_code.md' %}
 
 ## Pagination ##
 

--- a/content/rippled.md
+++ b/content/rippled.md
@@ -73,7 +73,7 @@ If you plan on making multiple requests, use [Keep-Alives](http://tools.ietf.org
 Send request body as a [JSON](http://www.w3schools.com/json/) object with the following attributes:
 
 * Put the command in the top-level `"method"` field
-* Include a top-level `"params"` field. The contents of this field should be **a one-item array** where the one items is a nested JSON object with all the parameters for the command.
+* Include a top-level `"params"` field. The contents of this field should be **a one-item array** containing only a nested JSON object with all the parameters for the command.
 
 The response is also a JSON object.
 
@@ -998,7 +998,7 @@ Each trust-line object has some combination of the following fields:
 | no\_ripple | Boolean | (May be omitted) `true` if this account has enabled the [NoRipple flag](https://ripple.com/knowledge_center/understanding-the-noripple-flag/) for this line. If omitted, that is the same as `false`. |
 | no\_ripple\_peer | Boolean | (May be omitted) `true` if the peer account has enabled the [NoRipple flag](https://ripple.com/knowledge_center/understanding-the-noripple-flag/). If omitted, that is the same as `false`. |
 | freeze | Boolean | (May be omitted) `true` if this account has [frozen](freeze.html) this trust line. If omitted, that is the same as `false`. |
-| freeze\_peer | (May be omitted) `true` if the peer account has [frozen](freeze.html) this trust line. If omitted, that is the same as `false`. |
+| freeze\_peer | Boolean | (May be omitted) `true` if the peer account has [frozen](freeze.html) this trust line. If omitted, that is the same as `false`. |
 
 #### Possible Errors ####
 

--- a/content/tx_format.md
+++ b/content/tx_format.md
@@ -467,8 +467,8 @@ The available AccountSet flags are:
 | asfDisallowXRP | 3 | XRP should not be sent to this account. (Enforced by client applications, not by `rippled`) | lsfDisallowXRP |
 | asfDisableMaster | 4 | Disallow use of the master key. Can only be enabled if the account has a [RegularKey](#setregularkey) configured. | lsfDisableMaster |
 | asfAccountTxnID | 5 | Track the ID of this account's most recent transaction. Required for [AccountTxnID](#accounttxnid) | (None) |
-| asfNoFreeze | 6 | Permanently give up the ability to freeze individual trust lines. This flag can never be disabled after being enabled. | lsfNoFreeze |
-| asfGlobalFreeze | 7 | Freeze all assets issued by this account. | lsfGlobalFreeze |
+| asfNoFreeze | 6 | Permanently give up the ability to [freeze individual trust lines or disable Global Freeze](freeze.html). This flag can never be disabled after being enabled. | lsfNoFreeze |
+| asfGlobalFreeze | 7 | [Freeze](freeze.html) all assets issued by this account. | lsfGlobalFreeze |
 | asfDefaultRipple | 8 | Enable [rippling](https://ripple.com/knowledge_center/understanding-the-noripple-flag/) on this account's trust lines by default. _(New in [rippled 0.27.3](https://github.com/ripple/rippled/releases/tag/0.27.3))_ | lsfDefaultRipple |
 
 _New in [rippled 0.28.0][]:_ You cannot send a transaction that enables `asfDisableMaster` or `asfNoFreeze` using a [regular key](#setregularkey). You must use the master key to sign the transaction.
@@ -572,7 +572,7 @@ It is possible for an offer to become temporarily or permanently *unfunded*:
 
 * If the creator no longer has any of the `TakerGets` currency.
   * The offer becomes funded again when the creator obtains more of that currency.
-* If the currency required to fund the offer is held in a [frozen trust line](https://wiki.ripple.com/Freeze).
+* If the currency required to fund the offer is held in a [frozen trust line](freeze.html).
   * The offer becomes funded again when the trust line is no longer frozen.
 * If the creator does not have enough XRP for the reserve amount of a new trust line required by the offer. (See [Offers and Trust](#offers-and-trust).)
   * The offer becomes funded again when the creator obtains more XRP, or the reserve requirements decrease.
@@ -726,8 +726,8 @@ Transactions of the TrustSet type support additional values in the [`Flags` fiel
 | tfSetfAuth | 0x00010000 | 65536 | Authorize the other party to hold issuances from this account. (No effect unless using the [*asfRequireAuth* AccountSet flag](#accountset-flags).) Cannot be unset. |
 | tfSetNoRipple | 0x00020000 | 131072 | Blocks rippling between two trustlines of the same currency, if this flag is set on both. (See [No Ripple](https://ripple.com/knowledge_center/understanding-the-noripple-flag/) for details.) |
 | tfClearNoRipple | 0x00040000 | 262144 | Clears the No-Rippling flag. (See [No Ripple](https://ripple.com/knowledge_center/understanding-the-noripple-flag/) for details.) |
-| tfSetFreeze | 0x00100000 | 1048576 | [Freeze](https://wiki.ripple.com/Freeze) the trustline.
-| tfClearFreeze | 0x00200000 | 2097152 | Unfreeze the trustline. |
+| tfSetFreeze | 0x00100000 | 1048576 | [Freeze](freeze.html) the trustline.
+| tfClearFreeze | 0x00200000 | 2097152 | [Unfreeze](freeze.html) the trustline. |
 
 
 # Pseudo-Transactions #
@@ -1016,7 +1016,7 @@ These codes indicate that the transaction failed, but it was applied to a ledger
 | tecNO\_AUTH | 134 | The transaction failed because it needs to add a balance on a trust line to an account with the `lsfRequireAuth` flag enabled, and that trust line has not been authorized. If the trust line does not exist at all, tecNO\_LINE occurs instead. |
 | tecNO\_LINE | 135 | The `TakerPays` field of the [OfferCreate transaction](#offercreate) specifies an asset whose issuer has `lsfRequireAuth` enabled, and the account making the offer does not have a trust line for that asset. (Normally, making an offer implicitly creates a trust line if necessary, but in this case it does not bother because you cannot hold the asset without authorization.) If the trust line exists, but is not authorized, tecNO\_AUTH occurs instead. |
 | tecINSUFF\_FEE | 136 | The account sending the transaction does not possess enough XRP to pay the specified `Fee`. This error only occurs if the transaction has already been propagated through the network to achieve consensus, |
-| tecFROZEN | 137 | The [OfferCreate transaction](#offercreate) failed because one or both of the assets involved are subject to a [global freeze](https://ripple.com/files/GB-2014-02.pdf). |
+| tecFROZEN | 137 | The [OfferCreate transaction](#offercreate) failed because one or both of the assets involved are subject to a [global freeze](freeze.html). |
 | tecNO\_TARGET | 138 | **FORTHCOMING** Part of multi-signature transactions. |
 | tecNO\_PERMISSION | 139 | **FORTHCOMING** Part of multi-signature transactions. |
 | tecNO\_ENTRY | 140 | **FORTHCOMING** Part of multi-signature transactions. |

--- a/data_api_v2.html
+++ b/data_api_v2.html
@@ -4460,18 +4460,62 @@ Content-Type: image/svg+xml
 <li>Between 25 and 35 characters in length</li>
 <li>Starts with the character <code>r</code></li>
 <li>Case-sensitive</li>
-<li>Base-58 encoded using only the following characters: <code>rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz</code> That's alphanumeric characters, excluding zero (<code>0</code>), capital O (<code>O</code>), capital I (<code>I</code>), and lowercase L (<code>l</code>).</li>
+<li><a href="https://wiki.ripple.com/Encodings">Base-58</a> encoded using only the following characters: <code>rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz</code> That's alphanumeric characters, excluding zero (<code>0</code>), capital O (<code>O</code>), capital I (<code>I</code>), and lowercase L (<code>l</code>).</li>
 <li>Contains error-checking that makes it unlikely that a randomly-generated string is a valid address.</li>
 </ul>
+<h4 id="special-addresses">Special Addresses</h4>
+<p>Some addresses have special meaning, or historical uses, in the Ripple Consensus Ledger. In many cases, these are "black hole" addresses, meaning the address is not derived from a known secret key. Since it is almost impossible to guess a secret key from just an address, any XRP possessed by those addresses is lost forever.</p>
+<table>
+<thead>
+<tr>
+<th>Address</th>
+<th>Name</th>
+<th>Meaning</th>
+<th>Black Hole?</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>rrrrrrrrrrrrrrrrrrrrrhoLvTp</td>
+<td>ACCOUNT_ZERO</td>
+<td>An address that is the base-58 encoding of the value <code>0</code>. In peer-to-peer communications, <code>rippled</code> uses this address as the issuer for XRP.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>rrrrrrrrrrrrrrrrrrrrBZbvji</td>
+<td>ACCOUNT_ONE</td>
+<td>An address that is the base-58 encoding of the value <code>1</code>. In the ledger, <a href="ripple-ledger.html#ripplestate">RippleState entries</a> use this address as a placeholder for the issuer of a trust line balance.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh</td>
+<td>The genesis account</td>
+<td>When <code>rippled</code> starts a new genesis ledger from scratch (for example, in stand-alone mode), this account holds all the XRP. This address is generated from the seed value "masterpassphrase" which is <a href="https://github.com/ripple/rippled/blob/94ed5b3a53077d815ad0dd65d490c8d37a147361/src/ripple/app/ledger/Ledger.cpp#L184">hard-coded</a>.</td>
+<td>No</td>
+</tr>
+<tr>
+<td>rrrrrrrrrrrrrrrrrNAMEtxvNvQ</td>
+<td>Ripple Name reservation black-hole</td>
+<td>In the past, Ripple asked users to send XRP to this account to reserve Ripple Names.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>rrrrrrrrrrrrrrrrrrrn5RM1rHd</td>
+<td>NaN Address</td>
+<td>Previous versions of <a href="https://github.com/ripple/ripple-lib">ripple-lib</a> generated this address when base-58 encoding the value <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a>.</td>
+<td>Yes</td>
+</tr>
+</tbody>
+</table>
 <h3 id="hashes">Hashes</h3>
-<p>Many objects in Ripple, particularly transactions and ledgers, are uniquely identified by a 256-bit hash value. This value is typically calculated as a "SHA-512Half", which calculates a SHA-512 hash from some contents, then takes the first 64 characters of the hexadecimal representation. Since the hash of an object is derived from the contents in a way that is extremely unlikely to produce collisions, two objects with the same hash can be considered identical.</p>
+<p>Many objects in Ripple, particularly transactions and ledgers, are uniquely identified by a 256-bit hash value. This value is typically calculated as a "SHA-512Half", which calculates a <a href="http://dx.doi.org/10.6028/NIST.FIPS.180-4">SHA-512</a> hash from some contents, then takes the first 64 characters of the hexadecimal representation. Since the hash of an object is derived from the contents in a way that is extremely unlikely to produce collisions, two objects with the same hash can be considered identical.</p>
 <p>A Ripple hash value has the following characteristics:</p>
 <ul>
 <li>Exactly 64 characters in length</li>
 <li><a href="https://en.wikipedia.org/wiki/Hexadecimal">Hexadecimal</a> character set: 0-9 and A-F.</li>
 <li>Typically written in upper case.</li>
 </ul>
-<p><strong>Note:</strong> SHA-512Half has similar security to the officially-defined <em>SHA-512/256</em> hash function. However, Ripple's usage predates SHA-512/256 and is also easier to implement on top of an existing SHA-512 function (since support for SHA-512/256 is not common in cryptographic libraries as of this writing).</p>
+<p><strong>Note:</strong> SHA-512Half has similar security to the officially-defined <em>SHA-512/256</em> hash function. However, Ripple's usage predates SHA-512/256 and is also easier to implement on top of an existing SHA-512 function. (As of this writing, SHA-512 support in cryptographic libraries is much more common than for SHA-512/256.)</p>
 <h3 id="timestamps">Timestamps</h3>
 <p>All dates and times are written in ISO 8601 Timestamp Format, using UTC. This format is summarized as:</p>
 <p><code>YYYY-MM-DDThh:mm:ssZ</code></p>
@@ -4487,16 +4531,20 @@ Content-Type: image/svg+xml
 <p>(As of <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.4">v2.0.4</a>, the offset <code>+00:00</code> is no longer used.)</p>
 <h3 id="ledger-index">Ledger Index</h3>
 <p>A ledger index is a 32-bit unsigned integer used to identify a ledger. The ledger index is also known as the ledger's sequence number. The very first ledger was ledger index 1, and each subsequent ledger has a ledger index 1 higher than that of the ledger immediately before it.</p>
-<p>Two ledgers with the same ledger index are guaranteed to have identical contents <em>if they are validated by consensus</em>. Ledgers that are not validated by consensus may have different contents even with the same ledger index. (The <a href="#hashes">Hash</a> values of two ledgers can tell you whether those ledgers have the exact same contents.)</p>
+<p>The ledger index indicates the order of the ledgers; the <a href="#hashes">Hash</a> value identifies the exact contents of the ledger. Two ledgers with the same hash are always identical. For closed ledgers, hash values and sequence numbers are equally valid and correlate 1:1. However, this is not true for in-progress ledgers:</p>
+<ul>
+<li>Two different <code>rippled</code> servers may have different contents for a current ledger with the same ledger index, due to latency in propagating transactions throughout the network.</li>
+<li>A current ledger's contents change over time, which would cause its hash to change, even though its ledger index number stays the same. Therefore, the hash of a ledger is not calculated until the ledger is closed.</li>
+</ul>
 <h3 id="account-sequence">Account Sequence</h3>
 <p>A Sequence number is a 32-bit unsigned integer used to identify a transaction or Offer relative to a specific account.</p>
 <p>Every <a href="ripple-ledger.html#accountroot">account object in the Ripple Consensus Ledger</a> has a Sequence number, which starts at 1. For a transaction to be relayed to the network and possibly included in a validated ledger, it must have a <code>Sequence</code> field that matches the sending account's current <code>Sequence</code> number. An account's Sequence field is incremented whenever a transaction from that account is included in a validated ledger (regardless of whether the transaction succeeded or failed). This preserves the order of transactions submitted by an account, and differentiates transactions that would otherwise be identical.</p>
 <p>Every <a href="ripple-ledger.html#offer">Offer node in the Ripple Consensus Ledger</a> is marked with the sending <code>Account</code> <a href="#addresses">Address</a> and the <code>Sequence</code> value of the <a href="transactions.html#offercreate">OfferCreate transaction</a> that created it. These two fields, together, uniquely identify the Offer.</p>
 <h3 id="currency-code">Currency Code</h3>
-<p>Currencies in Ripple can be represented in two ways:</p>
+<p>There are two kinds of currency code in the Ripple Consensus Ledger:</p>
 <ul>
-<li>As three-letter <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Codes</a>. These currency codes must be written in uppercase ("USD" is valid, "usd" is not). Ripple permits currency codes that are not officially approved, including currency codes with digits in them.</li>
-<li>As 160-bit hexadecimal values, such as <code>0158415500000000C1F76FF6ECB0BAC600000000</code>, according to Ripple's internal <a href="https://wiki.ripple.com/Currency_format">Currency Format</a>. This representation is uncommon.</li>
+<li>Three-character currency code. We recommend using all-uppercase <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Codes</a>. However, any combination of the following characters is permitted: all uppercase and lowercase letters, digits, as well as the symbols <code>?</code>, <code>!</code>, <code>@</code>, <code>#</code>, <code>$</code>, <code>%</code>, <code>^</code>, <code>&amp;</code>, <code>*</code>, <code>&lt;</code>, <code>&gt;</code>, <code>(</code>, <code>)</code>, <code>{</code>, <code>}</code>, <code>[</code>, <code>]</code>, and <code>|</code>. The currency code <code>XRP</code> (all-uppercase) is reserved for XRP and cannot be used by issued currencies.</li>
+<li>160-bit hexadecimal values, such as <code>0158415500000000C1F76FF6ECB0BAC600000000</code>, according to Ripple's internal <a href="https://wiki.ripple.com/Currency_format">Currency Format</a>. This representation is uncommon.</li>
 </ul>
 <h2 id="pagination">Pagination</h2>
 <p>Many queries may return more data than is reasonable to return in a single HTTP response. The Data API uses a "limit and marker" system to control how much is returned in a single response ("page") and to query for additional content.</p>

--- a/rippled-apis.html
+++ b/rippled-apis.html
@@ -148,7 +148,7 @@
 <li>The JSON-RPC API relies on simple request-response communication via HTTP or HTTPS. (The <code>rippled</code> server can be configured to accept HTTP, HTTPS, or both.) For commands that prompt multiple responses, you can provide a callback URL.</li>
 <li>The <code>rippled</code> program can also be used as a quick commandline client to make JSON-RPC requests to a running <code>rippled</code> server. This is only intended for administrative purposes, and is not a supported API.</li>
 </ul>
-<p>In general, we recommend using WebSocket, because WebSocket's push paradigm has less latency and less network overhead. JSON-RPC must open and close an HTTP connection for each individual message. WebSocket is also more reliable; you can worry less about missing messages and establishing multiple connections. However, all three have valid use cases and will continue to be supported for the foreseeable future.</p>
+<p>In general, we recommend using WebSocket, because WebSocket's push paradigm has less latency and less network overhead. WebSocket is also more reliable; you can worry less about missing messages and establishing multiple connections. On the other hand, there is widespread support for JSON-RPC because you can use a standard HTTP library to connect to <code>rippled</code>'s JSON-RPC API.</p>
 <h2 id="changes-to-the-apis">Changes to the APIs</h2>
 <p>The WebSocket and JSON-RPC APIs are still in development, and are subject to change. If you want to be notified of upcoming changes and future versions of <code>rippled</code>, subscribe to the Ripple Server mailing list:</p>
 <p><a href="https://groups.google.com/forum/#!forum/ripple-server">https://groups.google.com/forum/#!forum/ripple-server</a></p>
@@ -158,36 +158,70 @@
 <p>The <a href="https://github.com/ripple/rippled/blob/d7def5509d8338b1e46c0adf309b5912e5168af0/doc/rippled-example.cfg#L831-L854">example config file</a> listens for connections on the local loopback network (127.0.0.1), with JSON-RPC (HTTP) on port 5005 and WebSocket (WS) on port 6006, and treats all connected clients as admin.</p>
 <h3 id="websocket-api">WebSocket API</h3>
 <p>If you are just looking to try out some methods on the Ripple network, you can skip writing your own WebSocket code and go straight to using the API at the <a href="ripple-api-tool.html">Ripple WebSocket API Tool</a>. Later on, when you want to connect to your own <code>rippled</code> server, you can build your own client in Javascript to run in a browser (See <a href="http://www.websocket.org/echo.html">this example</a> ) or possibly <a href="https://github.com/einaros/ws">Node.js</a>.</p>
+<h4 id="request-formatting">Request Formatting</h4>
+<p>After you open a WebSocket to the <code>rippled</code> server, you can send commands as a <a href="http://www.w3schools.com/json/">JSON</a> object, with the following attributes:</p>
+<ul>
+<li>Put command name in top-level <code>"command"</code> field</li>
+<li>All the relevant parameters for the command are also in the top level</li>
+<li>Optionally include an <code>"id"</code> field with an arbitrary value. The response to this request uses the same <code>"id"</code> field. This way, even if responses arrive out of order, you know which request prompted which response.</li>
+</ul>
+<p>The response comes as a JSON object.</p>
+<h4 id="public-servers">Public Servers</h4>
 <p>Currently Ripple Labs maintains a set of public WebSocket servers at:</p>
 <table>
 <thead>
 <tr>
 <th>Domain</th>
 <th>Port</th>
+<th>Notes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>s1.ripple.com</td>
 <td>443</td>
+<td><code>wss://</code> only; general purpose server</td>
+</tr>
+<tr>
+<td>s2.ripple.com</td>
+<td>443</td>
+<td><code>wss://</code> only; full-history server</td>
 </tr>
 </tbody>
 </table>
 <p>These public servers are not for sustained or business use, and they may become unavailable at any time. For regular use, you should run your own <code>rippled</code> server or contract someone you trust to do so.</p>
 <h3 id="json-rpc">JSON-RPC</h3>
-<p>You can use any HTTP client (like <a href="https://addons.mozilla.org/en-US/firefox/addon/poster/">Poster for Firefox</a> or <a href="https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm?hl=en">Postman for Chrome</a>) to make JSON-RPC calls a <code>rippled</code> server. </p>
+<p>You can use any HTTP client (like <a href="https://addons.mozilla.org/en-US/firefox/addon/poster/">Poster for Firefox</a> or <a href="https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm?hl=en">Postman for Chrome</a>) to make JSON-RPC calls a <code>rippled</code> server. Most programming languages have a library for making HTTP requests built in.</p>
+<h4 id="request-formatting-1">Request Formatting</h4>
+<p>To make a JSON-RPC request, send an HTTP <strong>POST</strong> request to the root path (<code>/</code>) on the port and IP where the <code>rippled</code> server is listening for JSON-RPC connections. You can use HTTP/1.0 or HTTP/1.1. If you use HTTPS, you should use TLS v1.2. For security reasons, <code>rippled</code> <em>does not support</em> SSL v3 or earlier.</p>
+<p>Always include a <code>Content-Type</code> header with the value <code>application/json</code>.</p>
+<p>If you plan on making multiple requests, use <a href="http://tools.ietf.org/html/rfc7230#section-6.3">Keep-Alives</a> so that you do not have to close and re-open the connection in between requests.</p>
+<p>Send request body as a <a href="http://www.w3schools.com/json/">JSON</a> object with the following attributes:</p>
+<ul>
+<li>Put the command in the top-level <code>"method"</code> field</li>
+<li>Include a top-level <code>"params"</code> field. The contents of this field should be <strong>a one-item array</strong> where the one items is a nested JSON object with all the parameters for the command.</li>
+</ul>
+<p>The response is also a JSON object.</p>
+<h4 id="public-servers-1">Public Servers</h4>
 <p>Currently, Ripple Labs maintains a set of public JSON-RPC servers at:</p>
 <table>
 <thead>
 <tr>
 <th>Domain</th>
 <th>Port</th>
+<th>Notes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>s1.ripple.com</td>
 <td>51234</td>
+<td>General purpose server</td>
+</tr>
+<tr>
+<td>s2.ripple.com</td>
+<td>51234</td>
+<td>Full-history server</td>
 </tr>
 </tbody>
 </table>
@@ -196,14 +230,9 @@
 <p>The commandline interface connects to the same service as the JSON-RPC one, so the public servers and server configuration are the same. As a commandline client, <code>rippled</code> connects to the local instance. For example:</p>
 <pre><code>rippled --conf=/etc/rippled.cfg server_info
 </code></pre>
-<h2 id="request-formatting">Request Formatting</h2>
-<p>Both the WebSocket API and the JSON-RPC API use <a href="http://www.w3schools.com/json/">JSON</a> for requests and responses. The methods and parameters available on both APIs are generally the same, but the exact formatting is slightly different between the two. The commandline interface supports the same commands, with the parameters in the commandline as well.</p>
-<ul>
-<li>A WebSocket request puts the command name in the <code>"command"</code> field alongside the command's parameters at the top level of the JSON object, with an optional <code>"id"</code> field that will be returned with the response, so you can identify responses that come back out of order. </li>
-<li>A JSON-RPC request puts the command in the <code>"method"</code> field, with parameters in a separate object, as the first member of a <code>"params"</code> array. There is no <code>"id"</code> field, since all responses are direct replies to the requests.</li>
-<li>The commandline puts the command after any normal (dash-prefaced) commandline options, followed by a limited set of parameters, separated by spaces. </li>
-</ul>
-<h4 id="example-request">Example Request</h4>
+<h4 id="request-formatting-2">Request Formatting</h4>
+<p>The commandline puts the command after any normal (dash-prefaced) commandline options, followed by a limited set of parameters, separated by spaces. For any parameter values that might contain spaces or other unusual characters, use single-quotes to encapsulate them.</p>
+<h2 id="example-request">Example Request</h2>
 <div class="multicode">
 <p><em>WebSocket</em></p>
 <pre><code>{
@@ -448,7 +477,7 @@ Null method
 <tr>
 <td>result.request</td>
 <td>Object</td>
-<td>A copy of the request that prompted this error, in JSON format. <strong><em>Caution:</em></strong> If the request contained any account secrets, they are copied here! <strong><em>Note:</em></strong> The request is re-formatted in WebSocket format, regardless of the request made. This may be changed in the future: See <a href="https://ripplelabs.atlassian.net/browse/RIPD-279">RIPD-279</a>.</td>
+<td>A copy of the request that prompted this error, in JSON format. <strong>Caution:</strong> If the request contained any account secrets, they are copied here! <strong>Note:</strong> The request is re-formatted in WebSocket format, regardless of the request made.</td>
 </tr>
 </tbody>
 </table>
@@ -546,7 +575,7 @@ Null method
 <h4 id="specifying-currencies-without-amounts">Specifying Currencies Without Amounts</h4>
 <p>If you are specifying a non-XRP currency without an amount (typically for defining an order book of currency exchange offers) you should specify it as above, but omit the <code>value</code> field.</p>
 <p>If you are specifying XRP without an amount (typically for defining an order book) you should specify it as a JSON object with <em>only</em> a <code>currency</code> field. Never include an <code>issuer</code> field for XRP.</p>
-<p>Finally, if you are specifying a non-currency for a payment or path definition, and the recipient account of the payment trusts multiple gateways that issue the same currency, you can indicate that the payment should be made in any combination of issuers that the recipient accepts. To do this, specify the recipient account's address as the <code>issuer</code> value in the JSON object.</p>
+<p>Finally, if the recipient account of the payment trusts multiple gateways for a currency, you can indicate that the payment should be made in any combination of issuers that the recipient accepts. To do this, specify the recipient account's address as the <code>issuer</code> value in the JSON object.</p>
 <h3 id="specifying-time">Specifying Time</h3>
 <p>The <code>rippled</code> server and its APIs represent time as an unsigned integer. This number measures the number of seconds since the "Ripple Epoch" of January 1, 2000 (00:00 UTC). This is similar to the way the <a href="http://en.wikipedia.org/wiki/Unix_time">Unix epoch</a> works, except the Ripple Epoch is 946684800 seconds after the Unix Epoch.</p>
 <p>Don't convert Ripple Epoch times to UNIX Epoch times in 32-bit variables: this could lead to integer overflows.</p>
@@ -673,8 +702,7 @@ Null method
     "command": "account_currencies",
     "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
     "strict": true,
-    "ledger_index": "validated",
-    "account_index": 0
+    "ledger_index": "validated"
 }
 </code></pre>
 <p><em>JSON-RPC</em></p>
@@ -830,7 +858,7 @@ Null method
 </tr>
 </tbody>
 </table>
-<p><em>Note:</em> The currencies that an account can send or receive are defined based on a simple check of its trust lines. If an account has a trust line for a currency and enough room to increase its balance, it can receive that currency. If the trust line's balance can go down, the account can send that currency. This method <em>does not</em> check whether the trust line is frozen or authorized.</p>
+<p><em>Note:</em> The currencies that an account can send or receive are defined based on a simple check of its trust lines. If an account has a trust line for a currency and enough room to increase its balance, it can receive that currency. If the trust line's balance can go down, the account can send that currency. This method <em>doesn't</em> check whether the trust line is <a href="freeze.html">frozen</a> or authorized.</p>
 <h4 id="possible-errors">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
@@ -997,7 +1025,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>validated</td>
 <td>Boolean</td>
-<td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-275">New in version 0.26</a>)</td>
+<td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. (<a href="https://wiki.ripple.com/Rippled-0.26.0">New in version 0.26</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -1068,12 +1096,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-343">New in 0.26.4</a>)</td>
+<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. (<a href="https://wiki.ripple.com/Rippled-0.26.4">New in 0.26.4</a>)</td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>(Optional) Server-provided value to specify where to resume retrieving data from. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-343">New in 0.26.4</a>)</td>
+<td>(Optional) Server-provided value to specify where to resume retrieving data from. (<a href="https://wiki.ripple.com/Rippled-0.26.4">New in 0.26.4</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -1390,22 +1418,22 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>ledger_current_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-682">New in 0.26.4-sp1</a>)</td>
+<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. (<a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">New in 0.26.4-sp1</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-682">New in 0.26.4-sp1</a>)</td>
+<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">New in 0.26.4-sp1</a>)</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-682">New in 0.26.4-sp1</a>)</td>
+<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">New in 0.26.4-sp1</a>)</td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-defined value. Pass this to the next call in order to resume where this call left off. Omitted when there are no additional pages after this one. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-343">New in 0.26.4</a>)</td>
+<td>Server-defined value. Pass this to the next call in order to resume where this call left off. Omitted when there are no additional pages after this one. (<a href="https://wiki.ripple.com/Rippled-0.26.4">New in 0.26.4</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -1482,7 +1510,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
 <li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
-<li><code>actMalformed</code> - If the <code>marker</code> field provided is not acceptable. (See <a href="https://ripplelabs.atlassian.net/browse/RIPD-684">RIPD-684</a>)</li>
+<li><code>actMalformed</code> - If the <code>marker</code> field provided is not acceptable.</li>
 </ul>
 <h2 id="account-offers">account_offers</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountOffers.cpp" title="Source">[Source]<br/></a></p>
@@ -1494,8 +1522,8 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <pre><code>{
   "id": 2,
   "command": "account_offers",
-  "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-  "ledger_index": "current"
+  "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+  "ledger": "current"
 }
 </code></pre>
 <p><em>JSON-RPC</em></p>
@@ -1503,7 +1531,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
     "method": "account_offers",
     "params": [
         {
-            "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
             "ledger_index": "current"
         }
     ]
@@ -1548,12 +1576,12 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-344">New in 0.26.4</a>)</td>
+<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. (<a href="https://wiki.ripple.com/Rippled-0.26.4">New in 0.26.4</a>)</td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-provided value to specify where to resume retrieving data from. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-344">New in 0.26.4</a>)</td>
+<td>Server-provided value to specify where to resume retrieving data from. (<a href="https://wiki.ripple.com/Rippled-0.26.4">New in 0.26.4</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -1563,23 +1591,40 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <div class="multicode">
 <p><em>WebSocket</em></p>
 <pre><code>{
-  "id": 2,
+  "id": 9,
   "status": "success",
   "type": "response",
   "result": {
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+    "ledger_current_index": 18539550,
     "offers": [
       {
         "flags": 0,
-        "seq": 1399,
-        "taker_gets": "16666666",
+        "quality": "0.00000000574666765650638",
+        "seq": 6577664,
+        "taker_gets": "33687728098",
+        "taker_pays": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "193.5921774819578"
+        }
+      },
+      {
+        "flags": 0,
+        "quality": "7989247009094510e-27",
+        "seq": 6572128,
+        "taker_gets": "2361918758",
         "taker_pays": {
           "currency": "XAU",
-          "issuer": "rs9M85karFkCRjvc6KMWn8Coigm9cbcgcx",
-          "value": "0.0001"
+          "issuer": "rrh7rf1gV2pXAoqA8oYbpHd8TKv5ZQeo67",
+          "value": "0.01886995237307572"
         }
-      }
-    ]
+      },
+
+      ...
+
+    ],
+    "validated": false
   }
 }
 </code></pre>
@@ -1587,9 +1632,45 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <pre><code>200 OK
 {
     "result": {
-        "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-        "offers": [],
-        "status": "success"
+        "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+        "ledger_current_index": 18539596,
+        "offers": [{
+            "flags": 0,
+            "quality": "0.000000007599140009999998",
+            "seq": 6578020,
+            "taker_gets": "29740867287",
+            "taker_pays": {
+                "currency": "USD",
+                "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                "value": "226.0050145327418"
+            }
+        }, {
+            "flags": 0,
+            "quality": "7989247009094510e-27",
+            "seq": 6572128,
+            "taker_gets": "2361918758",
+            "taker_pays": {
+                "currency": "XAU",
+                "issuer": "rrh7rf1gV2pXAoqA8oYbpHd8TKv5ZQeo67",
+                "value": "0.01886995237307572"
+            }
+        }, {
+            "flags": 0,
+            "quality": "0.00000004059594001318974",
+            "seq": 6576905,
+            "taker_gets": "3892952574",
+            "taker_pays": {
+                "currency": "CNY",
+                "issuer": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y",
+                "value": "158.0380691682966"
+            }
+        },
+
+        ...
+
+        ],
+        "status": "success",
+        "validated": false
     }
 }
 </code></pre>
@@ -1617,22 +1698,22 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>ledger_current_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-682">New in 0.26.4-sp1</a>)</td>
+<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. (<a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">New in 0.26.4-sp1</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-682">New in 0.26.4-sp1</a>)</td>
+<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">New in 0.26.4-sp1</a>)</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-682">New in 0.26.4-sp1</a>)</td>
+<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. (<a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">New in 0.26.4-sp1</a>)</td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-defined value. Pass this to the next call in order to resume where this call left off. Omitted when there are no pages of information after this one. (<a href="https://ripplelabs.atlassian.net/browse/RIPD-344">New in 0.26.4</a>)</td>
+<td>Server-defined value. Pass this to the next call in order to resume where this call left off. Omitted when there are no pages of information after this one. (<a href="https://wiki.ripple.com/Rippled-0.26.4">New in 0.26.4</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -1666,6 +1747,11 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <td>String or Object</td>
 <td>The amount the account accepting the offer provides, as a String representing an amount in XRP, or a currency specification object. (See <a href="#specifying-currency-amounts">Specifying Currency Amounts</a>)</td>
 </tr>
+<tr>
+<td>quality</td>
+<td>Number</td>
+<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. _(<a href="https://wiki.ripple.com/Rippled-0.29.0">New in version 0.29.0</a>)</td>
+</tr>
 </tbody>
 </table>
 <h4 id="possible-errors-3">Possible Errors</h4>
@@ -1674,7 +1760,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
 <li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
-<li><code>actMalformed</code> - If the <code>marker</code> field provided is not acceptable. (See <a href="https://ripplelabs.atlassian.net/browse/RIPD-684">RIPD-684</a>)</li>
+<li><code>actMalformed</code> - If the <code>marker</code> field provided is not acceptable.</li>
 </ul>
 <h2 id="account-objects">account_objects</h2>
 <p><a href="https://github.com/ripple/rippled/blob/399c43cae6e90a428e9ce6a988123972b0f03c99/src/ripple/rpc/handlers/AccountObjects.cpp" title="Source">[Source]<br/></a></p>
@@ -3469,7 +3555,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <h2 id="wallet-propose">wallet_propose</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp" title="Source">[Source]<br/></a></p>
 <p>Use the <code>wallet_propose</code> method to generate the keys needed for a new account. The account created this way will only become officially included in the Ripple network when it receives a transaction that provides enough XRP to meet the account reserve. (The <code>wallet_propose</code> command does not affect the global network. Technically, it is not strictly necessary for creating a new account: you could generate keys some other way, but that is not recommended.)</p>
-<p><em>The <code>wallet_propose</code> request is an admin command that cannot be run by unpriviledged users!</em> (Since admin commands are not transmitted over the outside network this command is protected against people sniffing the network for account secrets.)</p>
+<p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em> (Since admin commands are not transmitted over the outside network this command is protected against people sniffing the network for account secrets.)</p>
 <h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -4449,7 +4535,7 @@ rippled ledger_current
 <h2 id="ledger-request">ledger_request</h2>
 <p><a href="https://github.com/ripple/rippled/blob/e980e69eca9ea843d200773eb1f43abe3848f1a0/src/ripple/rpc/handlers/LedgerRequest.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_request</code> command tells server to fetch a specific ledger version from its connected peers. This only works if one of the server's immediately-connected peers has that ledger. You may need to run the command several times to completely fetch a ledger.</p>
-<p><em>The <code>ledger_request</code> request is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>ledger_request</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-14">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -4594,7 +4680,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="ledger-accept">ledger_accept</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_accept</code> method forces the server to close the current-working ledger and move to the next ledger number. This method is intended for testing purposes only, and is only available when the <code>rippled</code> server is running stand-alone mode.</p>
-<p><em>The <code>ledger_accept</code> method is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>ledger_accept</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-15">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -6010,7 +6096,7 @@ rippled tx_history 0
 </ul>
 <h2 id="path-find">path_find</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp" title="Source">[Source]<br/></a></p>
-<p><em>WebSocket API only!</em> The <code>path_find</code> method searches for a path along which a transaction can possibly be made, and periodically sends updates when the path changes over time. For a simpler version that is supported by JSON-RPC, see <a href="#ripple-path-find"><code>ripple_path_find</code></a>. For payments occurring strictly in XRP, it is not necessary to find a path, because XRP can be sent directly to any account. </p>
+<p><em>WebSocket API only!</em> The <code>path_find</code> method searches for a <a href="paths.html">path</a> along which a transaction can possibly be made, and periodically sends updates when the path changes over time. For a simpler version that is supported by JSON-RPC, see <a href="#ripple-path-find"><code>ripple_path_find</code></a>. For payments occurring strictly in XRP, it is not necessary to find a path, because XRP can be sent directly to any account. </p>
 <p>There are three different modes, or sub-commands, of the path_find command. Specify which one you want with the <code>subcommand</code> parameter:</p>
 <ul>
 <li><code>create</code> - Start sending pathfinding information </li>
@@ -6661,7 +6747,7 @@ rippled tx_history 0
 </ul>
 <h2 id="ripple-path-find">ripple_path_find</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/RipplePathFind.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>ripple_path_find</code> method is a simplified version of <a href="#path-find"><code>path_find</code></a> that provides a single response to be used to make a payment transaction immediately. It is available in both the WebSocket and JSON-RPC APIs. However, the results tend to become outdated as time passes. Instead of making many subsequent calls, you should use <a href="#path-find"><code>path_find</code></a> instead where possible.</p>
+<p>The <code>ripple_path_find</code> method is a simplified version of <a href="#path-find"><code>path_find</code></a> that provides a single response with a <a href="paths.html">payment path</a> you can use right away. It is available in both the WebSocket and JSON-RPC APIs. However, the results tend to become outdated as time passes. Instead of making many subsequent calls, you should use <a href="#path-find"><code>path_find</code></a> instead where possible.</p>
 <p>Although the <code>rippled</code> server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (<strong><em>Note:</em></strong> A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)</p>
 <h4 id="request-format-22">Request Format</h4>
 <p>An example of the request format:</p>
@@ -7121,7 +7207,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <tr>
 <td>build_path</td>
 <td>Boolean</td>
-<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. <strong><em>Caution:</em></strong> The server looks for the presence or absence of this field, not its value. This behavior may change. (See <a href="https://ripplelabs.atlassian.net/browse/RIPD-173">RIPD-173</a> for status.)</td>
+<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. <strong><em>Caution:</em></strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
 </tr>
 <tr>
 <td>fee_mult_max</td>
@@ -7321,7 +7407,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td>build_path</td>
 <td>Boolean</td>
-<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. <strong><em>Caution:</em></strong> The server looks for the presence or absence of this field, not its value. This behavior may change. (See <a href="https://ripplelabs.atlassian.net/browse/RIPD-173">RIPD-173</a> for status.)</td>
+<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. <strong><em>Caution:</em></strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
 </tr>
 <tr>
 <td>fee_mult_max</td>
@@ -7580,7 +7666,6 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 </tbody>
 </table>
-<p><strong><em>Note:</em></strong> The other parameters of this command (<code>marker</code>, <code>proof</code>, and <code>autobridge</code>) cannot be fully implemented with the current design. (See <a href="https://ripplelabs.atlassian.net/browse/RIPD-295">RIPD-295</a> for more information).</p>
 <p>Normally, offers that are not funded are omitted; however, offers made by the specified <code>taker</code> account are always displayed. This allows you to look up your own unfunded offers in order to cancel them with an OfferCancel transaction.</p>
 <h4 id="response-format-25">Response Format</h4>
 <p>An example of a successful response:</p>
@@ -8242,7 +8327,6 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
 <li><code>noPermission</code> - The request included the <code>url</code> field, but you are not connected as an admin.</li>
-<li><em>Unknown Stream</em> - One or more the members of the <code>streams</code> field in the request was not recognized as a valid stream name. (The response does not use an exact code; this is a bug. See <a href="https://ripplelabs.atlassian.net/browse/RIPD-702">RIPD-702</a> for details and status.)</li>
 <li><code>malformedStream</code> - The <code>streams</code> field of the request was not formatted properly.</li>
 <li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address. (<strong><em>Note</em></strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)</li>
 <li><code>srcCurMalformed</code> - One or more <code>taker_pays</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
@@ -8314,32 +8398,129 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <p><em>JSON-RPC</em></p>
 <pre><code>200 OK
 {
-    "result": {
-        "info": {
-            "build_version": "0.26.3",
-            "complete_ledgers": "32570-8696244",
-            "hostid": "AIR",
-            "io_latency_ms": 1,
-            "last_close": {
-                "converge_time_s": 3.123,
-                "proposers": 5
+   "result" : {
+      "info" : {
+         "build_version" : "0.30.1-b15",
+         "complete_ledgers" : "32570-18217433",
+         "hostid" : "sjc13",
+         "io_latency_ms" : 1,
+         "last_close" : {
+            "converge_time_s" : 2.001,
+            "proposers" : 4
+         },
+         "load" : {
+            "job_types" : [
+               {
+                  "job_type" : "untrustedValidation",
+                  "peak_time" : 2,
+                  "per_second" : 2
+               },
+               {
+                  "avg_time" : 1,
+                  "job_type" : "ledgerRequest",
+                  "peak_time" : 82,
+                  "per_second" : 6
+               },
+               {
+                  "job_type" : "untrustedProposal",
+                  "per_second" : 3
+               },
+               {
+                  "avg_time" : 1,
+                  "in_progress" : 2,
+                  "job_type" : "clientCommand",
+                  "peak_time" : 39,
+                  "per_second" : 1
+               },
+               {
+                  "in_progress" : 1,
+                  "job_type" : "updatePaths"
+               },
+               {
+                  "job_type" : "transaction",
+                  "peak_time" : 1
+               },
+               {
+                  "avg_time" : 29,
+                  "job_type" : "writeObjects",
+                  "peak_time" : 209
+               },
+               {
+                  "avg_time" : 28,
+                  "job_type" : "acceptLedger",
+                  "peak_time" : 88
+               },
+               {
+                  "job_type" : "trustedProposal",
+                  "peak_time" : 2,
+                  "per_second" : 2
+               },
+               {
+                  "job_type" : "peerCommand",
+                  "per_second" : 529
+               },
+               {
+                  "avg_time" : 29,
+                  "job_type" : "diskAccess",
+                  "peak_time" : 209
+               },
+               {
+                  "avg_time" : 316,
+                  "job_type" : "pathFind",
+                  "peak_time" : 2663
+               },
+               {
+                  "job_type" : "SyncReadNode",
+                  "per_second" : 135
+               },
+               {
+                  "job_type" : "WriteNode",
+                  "peak_time" : 2,
+                  "per_second" : 77
+               }
+            ],
+            "threads" : 6
+         },
+         "load_factor" : 1000,
+         "load_factor_net" : 1000,
+         "peers" : 66,
+         "pubkey_node" : "n9JveA1hHDGjZECaYC7KM4JP8NXXzNXAxixbzcLTGnrsFZsA9AD1",
+         "pubkey_validator" : "none",
+         "server_state" : "full",
+         "state_accounting" : {
+            "connected" : {
+               "duration_us" : "102137155",
+               "transitions" : 1
             },
-            "load_factor": 1,
-            "peers": 62,
-            "pubkey_node": "n9LVtEwRBRfLhrs5cZcKYiYMw6wT9MgmAZEMQEXmX4Bwkq4D6hc1",
-            "server_state": "full",
-            "validated_ledger": {
-                "age": 3,
-                "base_fee_xrp": 1e-05,
-                "hash": "43660857C8FD74D8D5B9D6D9E3D4BE11FAD92985F6B8C9A406DC1F87FF6CB77F",
-                "reserve_base_xrp": 20,
-                "reserve_inc_xrp": 5,
-                "seq": 8696244
+            "disconnected" : {
+               "duration_us" : "1126989",
+               "transitions" : 1
             },
-            "validation_quorum": 3
-        },
-        "status": "success"
-    }
+            "full" : {
+               "duration_us" : "233465512872",
+               "transitions" : 514
+            },
+            "syncing" : {
+               "duration_us" : "1480415394",
+               "transitions" : 514
+            },
+            "tracking" : {
+               "duration_us" : "25881256",
+               "transitions" : 514
+            }
+         },
+         "uptime" : 235075,
+         "validated_ledger" : {
+            "base_fee_xrp" : 1e-05,
+            "hash" : "EB4EB596D85381AAE54196648FC3FAD28A49091CF03ACF7812EF1D311252656C",
+            "reserve_base_xrp" : 20,
+            "reserve_inc_xrp" : 5,
+            "seq" : 18217433
+         },
+         "validation_quorum" : 3
+      },
+      "status" : "success"
+   }
 }
 </code></pre>
 </div>
@@ -9426,7 +9607,7 @@ Connecting to 127.0.0.1:5005
 <h4 id="possible-errors-34">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
-<li><code>internal</code> if one the parameters was specified in a way that the server couldn't interpret. (This is a bug, and it should return <code>invalidParams</code> instead. See <a href="https://ripplelabs.atlassian.net/browse/RIPD-916">RPD-916</a> for status.)</li>
+<li><code>internal</code> if one the parameters was specified in a way that the server couldn't interpret. (This is a bug, and it should return <code>invalidParams</code> instead.)</li>
 </ul>
 <h2 id="log-level">log_level</h2>
 <p><a href="https://github.com/ripple/rippled/blob/155fcdbcd0b4927152892c8c8be01d9cf62bed68/src/ripple/rpc/handlers/LogLevel.cpp" title="Source">[Source]<br/></a></p>
@@ -9739,7 +9920,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="validation-seed">validation_seed</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ValidationSeed.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>validation_seed</code> command temporarily sets the secret value that rippled uses to sign validations. This value resets based on the config file when you restart the server.</p>
-<p><em>The <code>validation_seed</code> request is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>validation_seed</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-39">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9834,7 +10015,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="peers">peers</h2>
 <p><a href="https://github.com/ripple/rippled/blob/52f298f150fc1530d201d3140c80d3eaf781cb5f/src/ripple/rpc/handlers/Peers.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>peers</code> command returns a list of all other <code>rippled</code> servers currently connected to this one, including information on their connection and sync status.</p>
-<p><em>The <code>peers</code> request is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>peers</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-40">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -10133,7 +10314,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="print">print</h2>
 <p><a href="https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/Print.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>print</code> command returns the current status of various internal subsystems, including peers, the ledger cleaner, and the resource manager.</p>
-<p><em>The <code>print</code> request is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>print</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-41">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -10493,7 +10674,7 @@ rippled -q json ledger_closed '{}'
 <h2 id="connect">connect</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/Connect.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>connect</code> command forces the rippled server to connect to a specific peer rippled server.</p>
-<p><em>The <code>connect</code> request is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>connect</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-45">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -10591,7 +10772,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="stop">stop</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Stop.cpp" title="Source">[Source]<br/></a></p>
 <p>Gracefully shuts down the server.</p>
-<p><em>The <code>stop</code> request is an admin command that cannot be run by unpriviledged users!</em></p>
+<p><em>The <code>stop</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em></p>
 <h4 id="request-format-46">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">

--- a/rippled-apis.html
+++ b/rippled-apis.html
@@ -153,7 +153,7 @@
 <p>The WebSocket and JSON-RPC APIs are still in development, and are subject to change. If you want to be notified of upcoming changes and future versions of <code>rippled</code>, subscribe to the Ripple Server mailing list:</p>
 <p><a href="https://groups.google.com/forum/#!forum/ripple-server">https://groups.google.com/forum/#!forum/ripple-server</a></p>
 <h2 id="connecting-to-rippled">Connecting to rippled</h2>
-<p>Before you can run any commands against a <code>rippled</code> server, you must know which server you are connecting to. Most servers are configured not to accept requests directly from the outside network. </p>
+<p>Before you can run any commands against a <code>rippled</code> server, you must know which server you are connecting to. Most servers are configured not to accept requests directly from the outside network.</p>
 <p>Alternatively, you can <a href="rippled-setup.html">run your own local copy of <code>rippled</code></a>. This is required if you want to access any of the <a href="#list-of-admin-commands">Admin Commands</a>. In this case, you should use whatever IP and port you configured the server to bind. (For example, <code>127.0.0.1:54321</code>) Additionally, in order to access admin functionality, you must connect from a port/IP address marked as admin in the config file.</p>
 <p>The <a href="https://github.com/ripple/rippled/blob/d7def5509d8338b1e46c0adf309b5912e5168af0/doc/rippled-example.cfg#L831-L854">example config file</a> listens for connections on the local loopback network (127.0.0.1), with JSON-RPC (HTTP) on port 5005 and WebSocket (WS) on port 6006, and treats all connected clients as admin.</p>
 <h3 id="websocket-api">WebSocket API</h3>
@@ -504,16 +504,89 @@ Null method
 <h2 id="formatting-conventions">Formatting Conventions</h2>
 <p>The WebSocket and JSON-RPC APIs generally take the same arguments, although they're provided in a different way (See <a href="#request-formatting">Request Formatting</a> for details). Many similar parameters appear throughout the APIs, and there are conventions for how to specify these parameters.</p>
 <p>All field names are case-sensitive. In responses, fields that are taken directly from Ledger Node or Transaction objects start with upper-case letters. Other fields, including ones that are dynamically generated for a response, are lower case.</p>
-<h3 id="unique-identifiers">Unique Identifiers</h3>
+<h2 id="basic-data-types">Basic Data Types</h2>
 <p>Different types of objects are uniquely identified in different ways:</p>
-<p><em>Accounts</em> are identified by their <em>address</em>, a <a href="https://wiki.ripple.com/Encodings">base-58-encoded</a> string, for example <code>"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"</code>. Addresses always start with "r". You can also provide an un-encoded hex representation instead.</p>
-<p><em>Transactions</em> are identified by their <em>hash</em>, which is a <a href="http://en.wikipedia.org/wiki/Sha512">SHA-512</a> hash of the transaction's binary format. Transaction hashes are represented as hex strings.</p>
-<p>Each instance of the Ripple <em>Ledger</em> has a sequence number and a hash value. See <a href="#specifying-a-ledger-instance">Specifying a Ledger Instance</a> for details.</p>
-<h3 id="specifying-a-ledger-instance">Specifying a Ledger Instance</h3>
+<p><em>Accounts</em> are identified by their <a href="#addresses">Address</a>, for example <code>"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"</code>. Addresses always start with "r". Many <code>rippled</code> methods also accept an un-encoded hex representation.</p>
+<p><em>Transactions</em> are identified by a <a href="#hashes">Hash</a> of the transaction's binary format. You can also identify a transaction by its sending account and <a href="#account-sequence">Sequence Number</a>.</p>
+<p>Each closed <em>Ledger</em> has a <a href="#ledger-index">Ledger Index</a> and a <a href="#hashes">Hash</a> value. When <a href="#specifying-ledgers">Specifying a Ledger Instance</a> you can use either one.</p>
+<h3 id="addresses">Addresses</h3>
+<p>Ripple Accounts are identified by a base-58 Ripple Address, which is derived from the account's master public key. An address is represented as a String in JSON, with the following characteristics:</p>
+<ul>
+<li>Between 25 and 35 characters in length</li>
+<li>Starts with the character <code>r</code></li>
+<li>Case-sensitive</li>
+<li><a href="https://wiki.ripple.com/Encodings">Base-58</a> encoded using only the following characters: <code>rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz</code> That's alphanumeric characters, excluding zero (<code>0</code>), capital O (<code>O</code>), capital I (<code>I</code>), and lowercase L (<code>l</code>).</li>
+<li>Contains error-checking that makes it unlikely that a randomly-generated string is a valid address.</li>
+</ul>
+<h4 id="special-addresses">Special Addresses</h4>
+<p>Some addresses have special meaning, or historical uses, in the Ripple Consensus Ledger. In many cases, these are "black hole" addresses, meaning the address is not derived from a known secret key. Since it is almost impossible to guess a secret key from just an address, any XRP possessed by those addresses is lost forever.</p>
+<table>
+<thead>
+<tr>
+<th>Address</th>
+<th>Name</th>
+<th>Meaning</th>
+<th>Black Hole?</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>rrrrrrrrrrrrrrrrrrrrrhoLvTp</td>
+<td>ACCOUNT_ZERO</td>
+<td>An address that is the base-58 encoding of the value <code>0</code>. In peer-to-peer communications, <code>rippled</code> uses this address as the issuer for XRP.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>rrrrrrrrrrrrrrrrrrrrBZbvji</td>
+<td>ACCOUNT_ONE</td>
+<td>An address that is the base-58 encoding of the value <code>1</code>. In the ledger, <a href="ripple-ledger.html#ripplestate">RippleState entries</a> use this address as a placeholder for the issuer of a trust line balance.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh</td>
+<td>The genesis account</td>
+<td>When <code>rippled</code> starts a new genesis ledger from scratch (for example, in stand-alone mode), this account holds all the XRP. This address is generated from the seed value "masterpassphrase" which is <a href="https://github.com/ripple/rippled/blob/94ed5b3a53077d815ad0dd65d490c8d37a147361/src/ripple/app/ledger/Ledger.cpp#L184">hard-coded</a>.</td>
+<td>No</td>
+</tr>
+<tr>
+<td>rrrrrrrrrrrrrrrrrNAMEtxvNvQ</td>
+<td>Ripple Name reservation black-hole</td>
+<td>In the past, Ripple asked users to send XRP to this account to reserve Ripple Names.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>rrrrrrrrrrrrrrrrrrrn5RM1rHd</td>
+<td>NaN Address</td>
+<td>Previous versions of <a href="https://github.com/ripple/ripple-lib">ripple-lib</a> generated this address when base-58 encoding the value <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a>.</td>
+<td>Yes</td>
+</tr>
+</tbody>
+</table>
+<h3 id="hashes">Hashes</h3>
+<p>Many objects in Ripple, particularly transactions and ledgers, are uniquely identified by a 256-bit hash value. This value is typically calculated as a "SHA-512Half", which calculates a <a href="http://dx.doi.org/10.6028/NIST.FIPS.180-4">SHA-512</a> hash from some contents, then takes the first 64 characters of the hexadecimal representation. Since the hash of an object is derived from the contents in a way that is extremely unlikely to produce collisions, two objects with the same hash can be considered identical.</p>
+<p>A Ripple hash value has the following characteristics:</p>
+<ul>
+<li>Exactly 64 characters in length</li>
+<li><a href="https://en.wikipedia.org/wiki/Hexadecimal">Hexadecimal</a> character set: 0-9 and A-F.</li>
+<li>Typically written in upper case.</li>
+</ul>
+<p><strong>Note:</strong> SHA-512Half has similar security to the officially-defined <em>SHA-512/256</em> hash function. However, Ripple's usage predates SHA-512/256 and is also easier to implement on top of an existing SHA-512 function. (As of this writing, SHA-512 support in cryptographic libraries is much more common than for SHA-512/256.)</p>
+<h3 id="account-sequence">Account Sequence</h3>
+<p>A Sequence number is a 32-bit unsigned integer used to identify a transaction or Offer relative to a specific account.</p>
+<p>Every <a href="ripple-ledger.html#accountroot">account object in the Ripple Consensus Ledger</a> has a Sequence number, which starts at 1. For a transaction to be relayed to the network and possibly included in a validated ledger, it must have a <code>Sequence</code> field that matches the sending account's current <code>Sequence</code> number. An account's Sequence field is incremented whenever a transaction from that account is included in a validated ledger (regardless of whether the transaction succeeded or failed). This preserves the order of transactions submitted by an account, and differentiates transactions that would otherwise be identical.</p>
+<p>Every <a href="ripple-ledger.html#offer">Offer node in the Ripple Consensus Ledger</a> is marked with the sending <code>Account</code> <a href="#addresses">Address</a> and the <code>Sequence</code> value of the <a href="transactions.html#offercreate">OfferCreate transaction</a> that created it. These two fields, together, uniquely identify the Offer.</p>
+<h3 id="ledger-index">Ledger Index</h3>
+<p>A ledger index is a 32-bit unsigned integer used to identify a ledger. The ledger index is also known as the ledger's sequence number. The very first ledger was ledger index 1, and each subsequent ledger has a ledger index 1 higher than that of the ledger immediately before it.</p>
+<p>The ledger index indicates the order of the ledgers; the <a href="#hashes">Hash</a> value identifies the exact contents of the ledger. Two ledgers with the same hash are always identical. For closed ledgers, hash values and sequence numbers are equally valid and correlate 1:1. However, this is not true for in-progress ledgers:</p>
+<ul>
+<li>Two different <code>rippled</code> servers may have different contents for a current ledger with the same ledger index, due to latency in propagating transactions throughout the network.</li>
+<li>A current ledger's contents change over time, which would cause its hash to change, even though its ledger index number stays the same. Therefore, the hash of a ledger is not calculated until the ledger is closed.</li>
+</ul>
+<h3 id="specifying-ledgers">Specifying Ledgers</h3>
 <p>Many API methods require you to specify an instance of the ledger, with the data retrieved being considered accurate and up-to-date as of that particular version of the shared ledger. The commands that accept a ledger version all work the same way. There are three ways you can specify which ledger you want to use:</p>
 <ol>
-<li>Specify a ledger by its Sequence Number in the <code>ledger_index</code> parameter. Each closed ledger has an identifying sequence number that is 1 higher than the previously-validated ledger. (The Genesis Ledger has sequence number 0)</li>
-<li>Specify a ledger by its hash value in the <code>ledger_hash</code> parameter. </li>
+<li>Specify a ledger by its <a href="#ledger-index">Ledger Index</a> in the <code>ledger_index</code> parameter. Each closed ledger has an identifying sequence number that is 1 higher than the previously-validated ledger. (The Genesis Ledger has sequence number 0)</li>
+<li>Specify a ledger by its <a href="#hashes">Hash</a> value in the <code>ledger_hash</code> parameter. </li>
 <li>Specify a ledger by one of the following shortcuts, in the <code>ledger_index</code> parameter:<ul>
 <li><code>validated</code> for the most recent ledger that has been validated by the whole network</li>
 <li><code>closed</code> for the most recent ledger that has been closed for modifications and proposed for validation by the node</li>
@@ -523,15 +596,46 @@ Null method
 </ol>
 <p>There is also a deprecated <code>ledger</code> parameter which accepts any of the above three formats. <em>Do not</em> use this parameter; it may be removed without further notice.</p>
 <p>If you do not specify a ledger, the <code>current</code> (in-progress) ledger will be chosen by default. If you provide more than one field specifying ledgers, the deprecated <code>ledger</code> field will be used first if it exists, falling back to <code>ledger_hash</code>. The <code>ledger_index</code> field is ignored unless neither of the other two are present. <strong><em>Note:</em></strong> Do not rely on this default behavior; it is subject to change. Instead, you should always specify a ledger version in each call.</p>
-<p>The sequence number indicates the order of the ledgers; the hash value identifies the exact contents of the ledger. Two ledgers with the same hash are always identical. For closed ledgers, hash values and sequence numbers are equally valid and correlate 1:1. However, this is not true for in-progress ledgers:</p>
-<ul>
-<li>Two different rippled servers may have different contents for a current ledger with the same sequence number, due to transactions not being fully propagated throughout the network.</li>
-<li>A current ledger's contents change over time, which would cause its hash to change, even though its sequence number stays the same. Therefore, the hash of a ledger is not calculated until it is closed.</li>
-</ul>
+<h2 id="currencies">Currencies</h2>
+<p>There are two kinds of currencies in the Ripple Consensus Ledger: XRP, and everything else. There are many differences between the two:</p>
+<table>
+<thead>
+<tr>
+<th>XRP</th>
+<th>Issued Currencies</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Has no issuer.</td>
+<td>Always issued by a Ripple account</td>
+</tr>
+<tr>
+<td>Specified as a string</td>
+<td>Specified as an object</td>
+</tr>
+<tr>
+<td>Tracked in <a href="ripple-ledger.html#accountroot">accounts</a></td>
+<td>Tracked in <a href="ripple-ledger.html#ripplestate">trust lines</a></td>
+</tr>
+<tr>
+<td>Can never be created; can only be destroyed</td>
+<td>Can be issued or redeemed freely</td>
+</tr>
+<tr>
+<td>Maximum value <code>100000000000</code> (<code>1e11</code>)</td>
+<td>Maximum value <code>9999999999999999e80</code></td>
+</tr>
+<tr>
+<td>Precise to the nearest <a href="#xrp">"drop"</a> (0.000001 XRP)</td>
+<td>15 decimal digits of precision, with a minimum nonzero absolute value of <code>1000000000000000e-96</code></td>
+</tr>
+</tbody>
+</table>
 <h3 id="specifying-currency-amounts">Specifying Currency Amounts</h3>
 <p>Some API methods require you to specify an amount of currency. Depending on whether you are dealing in the network's native XRP currency or other currency units (sometimes referred to as IOUs), the style for specifying it is very different.</p>
 <h4 id="xrp">XRP</h4>
-<p>Amounts of XRP are represented as strings. (JSON integers are limited to 32 bits, so integer overflows are possible.) XRP is formally specified in "drops", which are equivalent to 0.000001 (one 1-millionth) of an XRP each. Thus, to represent 1.0 XRP in a JSON document, you would write:</p>
+<p>Amounts of XRP are represented as strings. (XRP has precision equivalent to a 64-bit integer, but JSON integers are limited to 32 bits, so XRP can overflow if represented in a JSON integer.) XRP is formally specified in "drops", which are equivalent to 0.000001 (one 1-millionth) of an XRP each. Thus, to represent 1.0 XRP in a JSON document, you would write:</p>
 <pre><code>"1000000"
 </code></pre>
 <p><strong>Do not specify XRP as an object.</strong></p>
@@ -549,8 +653,8 @@ Null method
 <tbody>
 <tr>
 <td>currency</td>
-<td>String</td>
-<td>3-character currency code. We recommend using uppercase <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Codes</a> only. The string <code>"XRP"</code> is disallowed. The following characters are permitted: all uppercase and lowercase letters, digits, as well as the symbols <code>?</code>, <code>!</code>, <code>@</code>, <code>#</code>, <code>$</code>, <code>%</code>, <code>^</code>, <code>&amp;</code>, <code>*</code>, <code>&lt;</code>, <code>&gt;</code>, <code>(</code>, <code>)</code>, <code>{</code>, <code>}</code>, <code>[</code>, <code>]</code>, and <code>|</code>. Instead of a 3-character code, this field could also be a 40-character hex value according to the internal <a href="https://wiki.ripple.com/Currency_format">Currency format</a>.</td>
+<td>String - <a href="#currency-codes">Currency Code</a></td>
+<td>Arbitrary code for currency to issue. Cannot be <code>XRP</code>.</td>
 </tr>
 <tr>
 <td>value</td>
@@ -576,10 +680,16 @@ Null method
 <p>If you are specifying a non-XRP currency without an amount (typically for defining an order book of currency exchange offers) you should specify it as above, but omit the <code>value</code> field.</p>
 <p>If you are specifying XRP without an amount (typically for defining an order book) you should specify it as a JSON object with <em>only</em> a <code>currency</code> field. Never include an <code>issuer</code> field for XRP.</p>
 <p>Finally, if the recipient account of the payment trusts multiple gateways for a currency, you can indicate that the payment should be made in any combination of issuers that the recipient accepts. To do this, specify the recipient account's address as the <code>issuer</code> value in the JSON object.</p>
-<h3 id="specifying-time">Specifying Time</h3>
+<h3 id="currency-codes">Currency Codes</h3>
+<p>There are two kinds of currency code in the Ripple Consensus Ledger:</p>
+<ul>
+<li>Three-character currency code. We recommend using all-uppercase <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Codes</a>. However, any combination of the following characters is permitted: all uppercase and lowercase letters, digits, as well as the symbols <code>?</code>, <code>!</code>, <code>@</code>, <code>#</code>, <code>$</code>, <code>%</code>, <code>^</code>, <code>&amp;</code>, <code>*</code>, <code>&lt;</code>, <code>&gt;</code>, <code>(</code>, <code>)</code>, <code>{</code>, <code>}</code>, <code>[</code>, <code>]</code>, and <code>|</code>. The currency code <code>XRP</code> (all-uppercase) is reserved for XRP and cannot be used by issued currencies.</li>
+<li>160-bit hexadecimal values, such as <code>0158415500000000C1F76FF6ECB0BAC600000000</code>, according to Ripple's internal <a href="https://wiki.ripple.com/Currency_format">Currency Format</a>. This representation is uncommon.</li>
+</ul>
+<h2 id="specifying-time">Specifying Time</h2>
 <p>The <code>rippled</code> server and its APIs represent time as an unsigned integer. This number measures the number of seconds since the "Ripple Epoch" of January 1, 2000 (00:00 UTC). This is similar to the way the <a href="http://en.wikipedia.org/wiki/Unix_time">Unix epoch</a> works, except the Ripple Epoch is 946684800 seconds after the Unix Epoch.</p>
 <p>Don't convert Ripple Epoch times to UNIX Epoch times in 32-bit variables: this could lead to integer overflows.</p>
-<h3 id="possible-server-states">Possible Server States</h3>
+<h2 id="possible-server-states">Possible Server States</h2>
 <p>Depending on how the <code>rippled</code> server is configured, how long it has been running, and other factors, a server may be participating in the global Ripple Network to different degrees. This is represented as the <code>server_state</code> field in the responses to the <a href="#server-info"><code>server_info</code></a> and <a href="#server-state"><code>server_state</code></a> commands. The possible responses follow a range of ascending interaction, with each subsequent value superseding the previous one. Their definitions are as follows (in order of increasing priority):</p>
 <table>
 <thead>
@@ -620,7 +730,7 @@ Null method
 </tbody>
 </table>
 <p><strong><em>Note:</em></strong> The distinction between <code>full</code>, <code>validating</code>, and <code>proposing</code> is based on synchronization with the rest of the global network, and it is normal for a server to fluctuate between these states as a course of general operation.</p>
-<h3 id="markers-and-pagination">Markers and Pagination</h3>
+<h2 id="markers-and-pagination">Markers and Pagination</h2>
 <p>Some methods return more data than can efficiently fit into one response. When there are more results than contained, the response includes a <code>marker</code> field. You can use this to retrieve more pages of data across multiple calls. In each subsequent request, pass the <code>marker</code> value from the previous response in order to resume from the point where you left off. If the <code>marker</code> is omitted from a response, then you have reached the end of the data set.</p>
 <p>The format of the <code>marker</code> field is intentionally undefined. Each server can define a <code>marker</code> field as desired, so it may take the form of a string, a nested object, or another type. Different servers, and different methods provided by the same server, can have different <code>marker</code> definitions. Each <code>marker</code> is ephemeral, and may not work as expected after 10 minutes.</p>
 <h2 id="modifying-the-ledger">Modifying the Ledger</h2>
@@ -733,7 +843,7 @@ Null method
 <tr>
 <td>account</td>
 <td>String</td>
-<td>A unique identifier for the account, most commonly the account's address.</td>
+<td>A unique identifier for the account, most commonly the account's <a href="#addresses">Address</a>.</td>
 </tr>
 <tr>
 <td>strict</td>
@@ -743,12 +853,12 @@ Null method
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -833,23 +943,23 @@ Null method
 <tbody>
 <tr>
 <td>ledger_hash</td>
-<td>String</td>
+<td>String - <a href="#hashes">Hash</a></td>
 <td>(May be omitted) The identifying hash of the ledger version used to retrieve this data, as hex.</td>
 </tr>
 <tr>
 <td>ledger_index</td>
-<td>Integer</td>
+<td>Integer - <a href="#ledger-index">Ledger Index</a></td>
 <td>The sequence number of the ledger version used to retrieve this data.</td>
 </tr>
 <tr>
 <td>receive_currencies</td>
 <td>Array of Strings</td>
-<td>Array of currency codes for currencies that this account can receive. Each currency is either a 3-letter <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Code</a> or a 160-bit hex value according to the <a href="https://wiki.ripple.com/Currency_format">currency format</a>.</td>
+<td>Array of <a href="#currency-codes">Currency Code</a>s for currencies that this account can receive.</td>
 </tr>
 <tr>
 <td>send_currencies</td>
 <td>Array of Strings</td>
-<td>Array of currency codes for currencies that this account can send. Each currency is either a 3-letter <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Code</a> or a 160-bit hex value according to the <a href="https://wiki.ripple.com/Currency_format">currency format</a>.</td>
+<td>Array of <a href="#currency-codes">Currency Code</a>s for currencies that this account can send.</td>
 </tr>
 <tr>
 <td>validated</td>
@@ -912,7 +1022,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>account</td>
 <td>String</td>
-<td>A unique identifier for the account, most commonly the account's address.</td>
+<td>A unique identifier for the account, most commonly the account's <a href="#addresses">Address</a>.</td>
 </tr>
 <tr>
 <td>strict</td>
@@ -922,12 +1032,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -970,47 +1080,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>account_data</td>
 <td>Object</td>
-<td>Information about the requested account</td>
-</tr>
-<tr>
-<td>account_data.Account</td>
-<td>String</td>
-<td>Address of the requested account</td>
-</tr>
-<tr>
-<td>account_data.Balance</td>
-<td>String</td>
-<td>XRP balance in "drops" represented as a string</td>
-</tr>
-<tr>
-<td>account_data.Flags</td>
-<td>32-bit unsigned integer</td>
-<td>Integer with different bits representing the status of several <a href="ripple-ledger.html#accountroot-flags">account flags</a></td>
-</tr>
-<tr>
-<td>account_data.LedgerEntryType</td>
-<td>String</td>
-<td>"AccountRoot" is the type of ledger entry that holds an account's data</td>
-</tr>
-<tr>
-<td>account_data.OwnerCount</td>
-<td>Integer</td>
-<td>Number of other ledger entries (specifically, trust lines and offers) attributed to this account. This is used to calculate the total reserve required to use the account.</td>
-</tr>
-<tr>
-<td>account_data.PreviousTxnID</td>
-<td>String</td>
-<td>Hash value representing the most recent transaction that affected this account node directly. <strong>Note:</strong> This does not include all changes to the account's trust lines and offers. Use <a href="#account-tx">account_tx</a> to get a more inclusive list.</td>
-</tr>
-<tr>
-<td>account_data.Sequence</td>
-<td>Integer</td>
-<td>The sequence number of the next valid transaction for this account. (Each account starts with Sequence = 1 and increases each time a transaction is made.)</td>
-</tr>
-<tr>
-<td>account_data.index</td>
-<td>String</td>
-<td>A unique index for the AccountRoot node that represents this account in the ledger.</td>
+<td>The <a href="ripple-ledger.html#accountroot">AccountRoot ledger node</a> with this account's information, as stored in the ledger.</td>
 </tr>
 <tr>
 <td>ledger_current_index</td>
@@ -1076,22 +1146,22 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>account</td>
 <td>String</td>
-<td>A unique identifier for the account, most commonly the account's address as a base-58 string.</td>
+<td>A unique identifier for the account, most commonly the account's <a href="#addresses">Address</a>.</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>peer</td>
 <td>String</td>
-<td>(Optional) A unique ID for a second account. If provided, show only lines of trust connecting the two accounts.</td>
+<td>(Optional) The <a href="#addresses">Address</a> of a second account. If provided, show only lines of trust connecting the two accounts.</td>
 </tr>
 <tr>
 <td>limit</td>
@@ -1178,214 +1248,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
                 "quality_out": 0
             },
             {
-                "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-                "balance": "5",
-                "currency": "USD",
-                "limit": "5",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rHpXfibHgSb64n8kK9QWDpdbfqSpYbM9a4",
-                "balance": "481.992867407479",
-                "currency": "MXN",
-                "limit": "1000",
-                "limit_peer": "0",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
-                "balance": "0.793598266778297",
-                "currency": "EUR",
-                "limit": "1",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rnuF96W4SZoCJmbHYBFoJZpR8eCaxNvekK",
-                "balance": "0",
-                "currency": "CNY",
-                "limit": "3",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rGwUWgN5BEg3QGNY3RX2HfYowjUTZdid3E",
-                "balance": "1.326889190631542",
-                "currency": "DYM",
-                "limit": "3",
-                "limit_peer": "0",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-                "balance": "0.3488146605801446",
-                "currency": "CHF",
-                "limit": "0",
-                "limit_peer": "0",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-                "balance": "0",
-                "currency": "BTC",
-                "limit": "3",
-                "limit_peer": "0",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-                "balance": "10.06051402019741",
-                "currency": "USD",
-                "limit": "5000",
-                "limit_peer": "0",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rpgKWEmNqSDAGFhy5WDnsyPqfQxbWxKeVd",
-                "balance": "-0.00111",
-                "currency": "BTC",
-                "limit": "0",
-                "limit_peer": "10",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rBJ3YjwXi2MGbg7GVLuTXUWQ8DjL7tDXh4",
-                "balance": "-0.0008744482690504699",
-                "currency": "BTC",
-                "limit": "0",
-                "limit_peer": "10",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
-                "balance": "0.982191732527743",
-                "currency": "USD",
-                "limit": "1",
-                "limit_peer": "0",
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA",
-                "balance": "9.07619790068559",
-                "currency": "CNY",
-                "limit": "100",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-                "balance": "7.292695098901099",
-                "currency": "JPY",
-                "limit": "0",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z",
-                "balance": "0",
-                "currency": "AUX",
-                "limit": "0",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "no_ripple_peer": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
-                "balance": "0",
-                "currency": "USD",
-                "limit": "1",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-                "balance": "12.41688780720394",
-                "currency": "EUR",
-                "limit": "100",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rfF3PNkwkq1DygW2wum2HK3RGfgkJjdPVD",
-                "balance": "35",
-                "currency": "USD",
-                "limit": "500",
-                "limit_peer": "0",
-                "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rwUVoVMSURqNyvocPCcvLu3ygJzZyw8qwp",
-                "balance": "-5",
-                "currency": "JOE",
-                "limit": "0",
-                "limit_peer": "50",
-                "no_ripple_peer": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rE6R3DWF9fBD7CyiQciePF9SqK58Ubp8o2",
-                "balance": "0",
-                "currency": "USD",
-                "limit": "0",
-                "limit_peer": "100",
-                "no_ripple_peer": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rE6R3DWF9fBD7CyiQciePF9SqK58Ubp8o2",
-                "balance": "0",
-                "currency": "JOE",
-                "limit": "0",
-                "limit_peer": "100",
-                "no_ripple_peer": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
                 "account": "rs9M85karFkCRjvc6KMWn8Coigm9cbcgcx",
                 "balance": "0",
                 "currency": "015841551A748AD2C1F76FF6ECB0CCCD00000000",
                 "limit": "10.01037626125837",
                 "limit_peer": "0",
                 "no_ripple": true,
-                "quality_in": 0,
-                "quality_out": 0
-            },
-            {
-                "account": "rEhDDUUNxpXgEHVJtC2cjXAgyx5VCFxdMF",
-                "balance": "0",
-                "currency": "USD",
-                "limit": "0",
-                "limit_peer": "1",
                 "quality_in": 0,
                 "quality_out": 0
             }
@@ -1408,7 +1276,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>account</td>
 <td>String</td>
-<td>Unique address of the account this request corresponds to</td>
+<td>Unique <a href="#addresses">Address</a> of the account this request corresponds to. This is the "perspective account" for purpose of the trust lines.</td>
 </tr>
 <tr>
 <td>lines</td>
@@ -1450,17 +1318,17 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>account</td>
 <td>String</td>
-<td>The unique address of the account this line applies to.</td>
+<td>The unique <a href="#addresses">Address</a> of the counterparty to this trust line.</td>
 </tr>
 <tr>
 <td>balance</td>
 <td>String</td>
-<td>Representation of the numeric balance currently held against this line. A positive balance means that the account holds value; a negative balance means that the account owes value.</td>
+<td>Representation of the numeric balance currently held against this line. A positive balance means that the perspective account holds value; a negative balance means that the perspective account owes value.</td>
 </tr>
 <tr>
 <td>currency</td>
 <td>String</td>
-<td>The currency this line applies to</td>
+<td>A <a href="#currency-codes">Currency Code</a> identifying what currency this trust line can hold.</td>
 </tr>
 <tr>
 <td>limit</td>
@@ -1470,7 +1338,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>limit_peer</td>
 <td>String</td>
-<td>The maximum amount of currency that the peer account is willing to owe this account</td>
+<td>The maximum amount of currency that the counterparty account is willing to owe the perspective account</td>
 </tr>
 <tr>
 <td>quality_in</td>
@@ -1508,7 +1376,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
+<li><code>actNotFound</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 <li><code>actMalformed</code> - If the <code>marker</code> field provided is not acceptable.</li>
 </ul>
@@ -1556,7 +1424,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>account</td>
 <td>String</td>
-<td>A unique identifier for the account, most commonly the account's address as a base-58 string.</td>
+<td>A unique identifier for the account, most commonly the account's <a href="#addresses">Address</a>.</td>
 </tr>
 <tr>
 <td>ledger</td>
@@ -1570,8 +1438,8 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 </tr>
 <tr>
 <td>ledger_index</td>
-<td>(Optional) Unsigned integer, or String</td>
-<td>(Optional, defaults to <code>current</code>) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See Ledger Indexes.)</td>
+<td>(Optional) <a href="#ledger-index">Ledger Index</a></td>
+<td>(Optional, defaults to <code>current</code>) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See <a href="#specifying-ledgers">Specifying Ledgers</a>)</td>
 </tr>
 <tr>
 <td>limit</td>
@@ -1688,7 +1556,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>account</td>
 <td>String</td>
-<td>Unique address identifying the account that made the offers</td>
+<td>Unique <a href="#addresses">Address</a> identifying the account that made the offers</td>
 </tr>
 <tr>
 <td>offers</td>
@@ -1758,7 +1626,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
+<li><code>actNotFound</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 <li><code>actMalformed</code> - If the <code>marker</code> field provided is not acceptable.</li>
 </ul>
@@ -1819,12 +1687,12 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>limit</td>
@@ -2368,7 +2236,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <tr>
 <td>account</td>
 <td>String</td>
-<td>Unique address of the account this request corresponds to</td>
+<td>Unique <a href="#addresses">Address</a> of the account this request corresponds to</td>
 </tr>
 <tr>
 <td>account_objects</td>
@@ -2411,7 +2279,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
+<li><code>actNotFound</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 </ul>
 <h2 id="account-tx">account_tx</h2>
@@ -2485,12 +2353,12 @@ rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>binary</td>
@@ -3003,7 +2871,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td>account</td>
 <td>String</td>
-<td>Unique address identifying the related account</td>
+<td>Unique <a href="#addresses">Address</a> identifying the related account</td>
 </tr>
 <tr>
 <td>ledger_index_min</td>
@@ -3084,9 +2952,9 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>actMalformed</code> - If the address specified in the <code>account</code> field of the request is not formatted properly.</li>
-<li><code>actBitcoin</code> - If the address specified in the <code>account</code> field is formatted like a Bitcoin address instead of a Ripple address.</li>
-<li><code>lgrIdxsInvalid</code> - If the ledger specified by the <code>ledger_index_min</code> or <code>ledger_index_max</code> does not exist, or if it does exist but the server does not have it.</li>
+<li><code>actMalformed</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field of the request is not formatted properly.</li>
+<li><code>actBitcoin</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field is formatted like a Bitcoin address instead of a Ripple address.</li>
+<li><code>lgrIdxsInvalid</code> - The ledger specified by the <code>ledger_index_min</code> or <code>ledger_index_max</code> does not exist, or if it does exist but the server does not have it.</li>
 </ul>
 <h2 id="noripple-check">noripple_check</h2>
 <p><a href="https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/NoRippleCheck.cpp" title="Source">[Source]<br/></a></p>
@@ -3154,12 +3022,12 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -3295,7 +3163,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
+<li><code>actNotFound</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 </ul>
 <h2 id="gateway-balances">gateway_balances</h2>
@@ -3344,7 +3212,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td>account</td>
 <td>String</td>
-<td>The address of the account to use</td>
+<td>The <a href="#addresses">Address</a> of the account to use</td>
 </tr>
 <tr>
 <td>strict</td>
@@ -3354,17 +3222,17 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td>hotwallet</td>
 <td>String or Array</td>
-<td>The address of a hot wallet account to exclude from the balances issued, or an array of such addresses.</td>
+<td>The <a href="#addresses">Address</a> of a hot wallet account to exclude from the balances issued, or an array of such addresses.</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger version to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger version to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -3548,8 +3416,8 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>invalidHotWallet</code> - One or more of the addresses specified in the <code>hotwallet</code> field is not the address of an account holding currency issued by the account from the request.</li>
-<li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
+<li><code>invalidHotWallet</code> - One or more of the addresses specified in the <code>hotwallet</code> field is not the <a href="#addresses">Address</a> of an account holding currency issued by the account from the request.</li>
+<li><code>actNotFound</code> - The <a href="#addresses">Address</a> specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 </ul>
 <h2 id="wallet-propose">wallet_propose</h2>
@@ -3627,7 +3495,7 @@ rippled wallet_propose test
 <tr>
 <td>master_seed</td>
 <td>String</td>
-<td>The <a href="https://ripple.com/wiki/Master_Key">master seed</a> from which all other information about this account is derived, in Ripple's base-58 encoded string format.</td>
+<td>The master seed from which all other information about this account is derived, in Ripple's base-58 encoded string format.</td>
 </tr>
 <tr>
 <td>master_seed_hex</td>
@@ -3642,7 +3510,7 @@ rippled wallet_propose test
 <tr>
 <td>account_id</td>
 <td>String</td>
-<td>The public address of the account.</td>
+<td>The <a href="#addresses">Address</a> of the account.</td>
 </tr>
 <tr>
 <td>public_key</td>
@@ -3733,12 +3601,12 @@ rippled ledger current false
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>binary</td>
@@ -4058,12 +3926,12 @@ rippled ledger_current
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>binary</td>
@@ -4322,7 +4190,7 @@ rippled ledger_current
 </ul>
 <h2 id="ledger-entry">ledger_entry</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerEntry.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>ledger_entry</code> method returns a single ledger node from the Ripple Consensus Ledger. See <a href="ripple-ledger.html">ledger format</a> for information on the different types of objects you can retrieve.</p>
+<p>The <code>ledger_entry</code> method returns a single ledger node from the Ripple Consensus Ledger in its raw format. See <a href="ripple-ledger.html">ledger format</a> for information on the different types of objects you can retrieve.</p>
 <p><strong><em>Note:</em></strong> There is no commandline version of this method. You can use the <a href="#json"><code>json</code> command</a> to access this method from the commandline instead.</p>
 <h4 id="request-format-13">Request Format</h4>
 <p>An example of the request format:</p>
@@ -4352,11 +4220,11 @@ rippled ledger_current
 <p><a class="button" href="ripple-api-tool.html#ledger_entry">Try it! &gt;</a></p>
 <p>This method can retrieve several different types of data. You can select which type of item to retrieve by passing the appropriate parameters. Specifically, you should provide exactly one of the following fields:</p>
 <ol>
-<li><code>index</code> - Retrieve an individual ledger node by its unique index</li>
-<li><code>account_root</code> - Retrieve an account node, similar to the <a href="#account-info">account_info</a> command</li>
-<li><code>directory</code> - Retrieve a directory node, which contains a list of IDs linking things</li>
-<li><code>offer</code> - Retrieve an offer node, which defines an offer to exchange currency</li>
-<li><code>ripple_state</code> - Retrieve a RippleState node, which is a trust line where non-XRP balances are held</li>
+<li><code>index</code> - Retrieve any type of ledger node by its unique index</li>
+<li><code>account_root</code> - Retrieve an <a href="ripple-ledger.html#accountroot">AccountRoot node</a>, similar to the <a href="#account-info">account_info</a> command</li>
+<li><code>directory</code> - Retrieve a <a href="ripple-ledger.html#directorynode">DirectoryNode</a>, which contains a list of other nodes</li>
+<li><code>offer</code> - Retrieve an <a href="ripple-ledger.html#offer">Offer node</a>, which defines an offer to exchange currency</li>
+<li><code>ripple_state</code> - Retrieve a <a href="ripple-ledger.html#ripplestate">RippleState node</a>, which tracks a (non-XRP) currency balance between two accounts.</li>
 </ol>
 <p>If you specify more than one of the above items, the server will retrieve only of them; it is undefined which one will be chosen.</p>
 <p>The full list of parameters recognized by this method is as follows:</p>
@@ -4376,18 +4244,18 @@ rippled ledger_current
 </tr>
 <tr>
 <td>account_root</td>
-<td>String</td>
-<td>(Optional) Specify the unique address of an account object to retrieve.</td>
+<td>String - <a href="#addresses">Address</a></td>
+<td>(Optional) Specify an <a href="ripple-ledger.html#accountroot">AccountRoot node</a> to retrieve.</td>
 </tr>
 <tr>
 <td>directory</td>
 <td>Object or String</td>
-<td>(Optional) Specify a directory node to retrieve from the tree. (Directory nodes each contain a list of IDs for things contained in them.) If a string, interpret as the unique key to the directory, in hex. If an object, requires either <code>dir_root</code> or <code>owner</code> as a sub-field, plus optionally a <code>sub_index</code> sub-field.</td>
+<td>(Optional) Specify a <a href="ripple-ledger.html#directorynode">DirectoryNode</a>. (Directory nodes each contain a list of IDs for things contained in them.) If a string, interpret as the <a href="ripple-ledger.html#tree-format">unique index</a> to the directory, in hex. If an object, requires either <code>dir_root</code> or <code>owner</code> as a sub-field, plus optionally a <code>sub_index</code> sub-field.</td>
 </tr>
 <tr>
 <td>directory.sub_index</td>
 <td>Unsigned Integer</td>
-<td>(Optional) If provided, jumps to a further sub-node in the directory linked-list.</td>
+<td>(Optional) If provided, jumps to a further sub-node in the <a href="ripple-ledger.html#directorynode">DirectoryNode</a>.</td>
 </tr>
 <tr>
 <td>directory.dir_root</td>
@@ -4402,47 +4270,47 @@ rippled ledger_current
 <tr>
 <td>offer</td>
 <td>Object or String</td>
-<td>(Optional) Specify an offer to retrieve. If a string, interpret as a 256-key hex hash. If an object, requires the sub-fields <code>account</code> and <code>seq</code> to uniquely identify the offer.</td>
+<td>(Optional) Specify an <a href="ripple-ledger.html#offer">Offer node</a> to retrieve. If a string, interpret as the <a href="ripple-ledger.html#tree-format">unique index</a> to the Offer. If an object, requires the sub-fields <code>account</code> and <code>seq</code> to uniquely identify the offer.</td>
 </tr>
 <tr>
 <td>offer.account</td>
-<td>String</td>
-<td>(Required if <code>offer</code> specified) The unique address of the account making the offer to retrieve.</td>
+<td>String - <a href="#addresses">Address</a></td>
+<td>(Required if <code>offer</code> specified) The account that placed the offer.</td>
 </tr>
 <tr>
 <td>offer.seq</td>
 <td>Unsigned Integer</td>
-<td>(Required if <code>offer</code> specified) The sequence number of the transaction making the offer to retrieve.</td>
+<td>(Required if <code>offer</code> specified) The sequence number of the transaction that created the Offer node.</td>
 </tr>
 <tr>
 <td>ripple_state</td>
 <td>Object</td>
-<td>(Optional) Object specifying the RippleState entry to retrieve. The <code>accounts</code> and <code>currency</code> sub-fields are required to uniquely specify the RippleState entry to retrieve.</td>
+<td>(Optional) Object specifying the RippleState (trust line) node to retrieve. The <code>accounts</code> and <code>currency</code> sub-fields are required to uniquely specify the RippleState entry to retrieve.</td>
 </tr>
 <tr>
 <td>ripple_state.accounts</td>
 <td>Array</td>
-<td>(Required if <code>ripple_state</code> specified) 2-length array of account address strings, defining the two accounts linked by this RippleState entry</td>
+<td>(Required if <code>ripple_state</code> specified) 2-length array of account <a href="#addresses">Address</a>es, defining the two accounts linked by this <a href="ripple-ledger.html#ripplestate">RippleState node</a></td>
 </tr>
 <tr>
 <td>ripple_state.currency</td>
 <td>String</td>
-<td>(Required if <code>ripple_state</code> specified) String representation of a currency that this RippleState entry relates to, as either a 3-letter currency code or a 40-character hex code</td>
+<td>(Required if <code>ripple_state</code> specified) <a href="#currency-codes">Currency Code</a> of the <a href="ripple-ledger.html#ripplestate">RippleState node</a> to retrieve.</td>
 </tr>
 <tr>
 <td>binary</td>
 <td>Boolean</td>
-<td>(Optional, defaults to false) If true, return hashed data as hex strings. Otherwise, return data in JSON format.</td>
+<td>(Optional, defaults to false) If true, return the requested ledger node's contents as a hex string. Otherwise, return data in JSON format.</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -4517,12 +4385,12 @@ rippled ledger_current
 <tr>
 <td>node</td>
 <td>Object</td>
-<td>(<code>"binary":false</code> only) Object containing the data of this ledger node, according to the <a href="ripple-ledger.html">ledger format</a>.</td>
+<td>(Omitted if <code>"binary": true</code> specified.) Object containing the data of this ledger node, according to the <a href="ripple-ledger.html">ledger format</a>.</td>
 </tr>
 <tr>
 <td>node_binary</td>
 <td>String</td>
-<td>(<code>"binary":true</code> only) Binary data of the ledger node retrieved, as hex.</td>
+<td>(Omitted unless <code>"binary":true</code> specified) Binary data of the ledger node, as hex.</td>
 </tr>
 </tbody>
 </table>
@@ -4563,12 +4431,12 @@ rippled ledger_current
 <tr>
 <td>ledger_index</td>
 <td>Number</td>
-<td>(Optional) Retrieve the specified ledger by its sequence number.</td>
+<td>(Optional) Retrieve the specified ledger by its <a href="#ledger-index">Ledger Index</a>.</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) Retrieve the specified ledger by its identifying hash.</td>
+<td>(Optional) Retrieve the specified ledger by its identifying <a href="#hashes">Hash</a>.</td>
 </tr>
 </tbody>
 </table>
@@ -4637,7 +4505,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>hash</td>
 <td>String</td>
-<td>The hash of the requested ledger, if the server knows it.</td>
+<td>The <a href="#hashes">Hash</a> of the requested ledger, if the server knows it.</td>
 </tr>
 <tr>
 <td>have_header</td>
@@ -5007,12 +4875,12 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>tx_hash</td>
@@ -6841,12 +6709,12 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -7637,12 +7505,12 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String or Unsigned Integer</td>
-<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>)</td>
+<td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td>limit</td>
@@ -7652,7 +7520,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>taker</td>
 <td>String</td>
-<td>(Optional, defaults to <a href="https://ripple.com/wiki/Accounts#ACCOUNT_ONE">ACCOUNT_ONE</a>) Unique base-58 address of an account to use as point-of-view. (This affects which unfunded offers are returned.)</td>
+<td>(Optional, defaults to [ACCOUNT_ONE][]) The <a href="#addresses">Address</a> of an account to use as a perspective. (This affects which unfunded offers are returned.)</td>
 </tr>
 <tr>
 <td>taker_gets</td>
@@ -8895,7 +8763,7 @@ rippled can_delete 11320417
 <tr>
 <td>can_delete</td>
 <td>String or Integer</td>
-<td>The maximum ledger to allow to be deleted. For <code>ledger_index</code> or <code>ledger_hash</code>, see <a href="#specifying-a-ledger-instance">Specifying a Ledger</a>. <code>never</code> sets the value to 0, and effectively disables online deletion until another <code>can_delete</code> is appropriately called.  <code>always</code> sets the value to the maximum possible ledger (4294967295), and online deletion will occur as of each configured <code>online_delete</code> interval. <code>now</code> triggers online deletion at the next validated ledger that meets or exceeds the configured <code>online_delete</code> interval, but no further.</td>
+<td>The maximum ledger to allow to be deleted. For <code>ledger_index</code> or <code>ledger_hash</code>, see <a href="#specifying-ledgers">Specifying a Ledger</a>. <code>never</code> sets the value to 0, and effectively disables online deletion until another <code>can_delete</code> is appropriately called.  <code>always</code> sets the value to the maximum possible ledger (4294967295), and online deletion will occur as of each configured <code>online_delete</code> interval. <code>now</code> triggers online deletion at the next validated ledger that meets or exceeds the configured <code>online_delete</code> interval, but no further.</td>
 </tr>
 </tbody>
 </table>

--- a/rippled-apis.html
+++ b/rippled-apis.html
@@ -199,7 +199,7 @@
 <p>Send request body as a <a href="http://www.w3schools.com/json/">JSON</a> object with the following attributes:</p>
 <ul>
 <li>Put the command in the top-level <code>"method"</code> field</li>
-<li>Include a top-level <code>"params"</code> field. The contents of this field should be <strong>a one-item array</strong> where the one items is a nested JSON object with all the parameters for the command.</li>
+<li>Include a top-level <code>"params"</code> field. The contents of this field should be <strong>a one-item array</strong> containing only a nested JSON object with all the parameters for the command.</li>
 </ul>
 <p>The response is also a JSON object.</p>
 <h4 id="public-servers-1">Public Servers</h4>
@@ -1367,8 +1367,8 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tr>
 <tr>
 <td>freeze_peer</td>
+<td>Boolean</td>
 <td>(May be omitted) <code>true</code> if the peer account has <a href="freeze.html">frozen</a> this trust line. If omitted, that is the same as <code>false</code>.</td>
-<td></td>
 </tr>
 </tbody>
 </table>

--- a/rippled-apis.html
+++ b/rippled-apis.html
@@ -6033,7 +6033,7 @@ rippled tx_history 0
 <tr>
 <td>paths</td>
 <td>Array</td>
-<td>(Optional) Array of arrays of objects, representing paths to confirm. You can use this to keep updated on changes to particular paths you already know about, or to check the overall cost to make a payment along a certain path.</td>
+<td>(Optional) Array of arrays of objects, representing <a href="paths.html">payment paths</a> to check. You can use this to keep updated on changes to particular paths you already know about, or to check the overall cost to make a payment along a certain path.</td>
 </tr>
 </tbody>
 </table>
@@ -6420,7 +6420,7 @@ rippled tx_history 0
 <tr>
 <td>alternatives</td>
 <td>Array</td>
-<td>Array of objects with suggested paths to take, as described below. If empty, then no paths were found connecting the source and destination accounts.</td>
+<td>Array of objects with suggested <a href="paths.html">paths</a> to take, as described below. If empty, then no paths were found connecting the source and destination accounts.</td>
 </tr>
 <tr>
 <td>destination_account</td>
@@ -6478,7 +6478,7 @@ rippled tx_history 0
 <li><code>noEvents</code> - You are using a protocol that does not support asynchronous callbacks, for example JSON-RPC. (See <a href="#ripple-path-find">ripple_path_find</a> for a pathfinding method that <em>is</em> compatible with JSON-RPC.)</li>
 </ul>
 <h4 id="asynchronous-follow-ups">Asynchronous Follow-ups</h4>
-<p>In addition to the initial response, the server sends more messages in a similar format to update on the status of the paths over time. These messages include the <code>id</code> of the original WebSocket request so you can tell which request prompted them, and the field <code>"type": "path_find"</code> at the top level to indicate that they are additional responses. The other fields are defined in the same way as the initial response.</p>
+<p>In addition to the initial response, the server sends more messages in a similar format to update on the status of <a href="paths.html">payment paths</a> over time. These messages include the <code>id</code> of the original WebSocket request so you can tell which request prompted them, and the field <code>"type": "path_find"</code> at the top level to indicate that they are additional responses. The other fields are defined in the same way as the initial response.</p>
 <p>If the follow-up includes <code>"full_reply": true</code>, then this is the best path that rippled can find as of the current ledger.</p>
 <p>Here is an example of an asychronous follow-up from a path_find create request:</p>
 <div class="multicode">
@@ -7767,6 +7767,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li><code>ledger</code> - Sends a message whenever the consensus process declares a new validated ledger</li>
 <li><code>transactions</code> - Sends a message whenever a transaction is included in a closed ledger</li>
 <li><code>transactions_proposed</code> - Sends a message whenever a transaction is included in a closed ledger, as well as some transactions that have not yet been included in a validated ledger and may never be. Not all proposed transactions appear before validation, however. (<strong><em>Note:</em></strong> <a href="transactions.html#result-categories">Even some transactions that don't succeed are included</a> in validated ledgers, because they take the anti-spam transaction fee.)</li>
+<li><code>validations</code> - Sends a message whenever the server receives a validation message from a server it trusts. (An individual <code>rippled</code> declares a ledger validated when the server receives validation messages from at least a quorum of trusted validators.)</li>
 </ul>
 <p>Each member of the <code>books</code> array, if provided, is an object with the following fields:</p>
 <table>
@@ -7805,7 +7806,6 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 </tbody>
 </table>
-<p>The field <code>proof</code> is reserved for future use.</p>
 <h4 id="response-format-26">Response Format</h4>
 <p>An example of a successful response:</p>
 <div class="multicode">
@@ -7822,7 +7822,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <ul>
 <li><code>accounts</code> and <code>accounts_proposed</code> - No fields returned</li>
 <li><em>Stream: server</em> - Information about the server status, such as <code>load_base</code> (the current load level of the server), <code>random</code> (a randomly-generated value), and others, subject to change. </li>
-<li><em>Stream: transactions</em> and <em>Stream: transactions_proposed</em> - No fields returned</li>
+<li><em>Stream: transactions</em>, <em>Stream: transactions_proposed</em>, and <em>Stream: validations</em> - No fields returned</li>
 <li><em>Stream: ledger</em> - Information about the ledgers on hand and current fee schedule, such as <code>fee_base</code> (current base fee for transactions in XRP), <code>fee_ref</code> (current base fee for transactions in fee units), <code>ledger_hash</code> (hash of the latest validated ledger), <code>reserve_base</code> (minimum reserve for accounts), and more.</li>
 <li><code>books</code> - No fields returned by default. If <code>"snapshot": true</code> is set in the request, returns <code>offers</code> (an array of offer definition objects defining the order book)</li>
 </ul>
@@ -7915,7 +7915,48 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>validated_ledgers</td>
 <td>String</td>
-<td>Range of ledgers that the server has available. This may be discontiguous.</td>
+<td>(May be omitted) Range of ledgers that the server has available. This may be discontiguous. This field is not returned if the server is not connected to the network, or if it is connected but has not yet obtained a ledger from the network.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="stream-validations-message">Stream: validations Message</h4>
+<p>The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:</p>
+<pre><code>{
+  "type": "validationReceived",
+  "ledger_hash": "7B0B865DC3B648E35B1EB21FAD9501A765E6523B382CB182AC63DBE7D3DA5CC2",
+  "signature": "3045022100FA33615FCE1DDF56D0EEE0B750414D9C41FBE31B59A17B6A139F65A500ACA11702205B1129FFE78E2A4BC6BE98213C8172E2416780AB6F757D9067A2DBE224865495",
+  "validation_public_key": "n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj"
+}
+</code></pre>
+<p>The fields from a validations stream message are as follows:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>type</td>
+<td>String</td>
+<td><code>validationReceived</code> indicates this is from the validations stream</td>
+</tr>
+<tr>
+<td>ledger_hash</td>
+<td>String</td>
+<td>The identifying hash of the proposed ledger that this server declares validated by consensus.</td>
+</tr>
+<tr>
+<td>signature</td>
+<td>String</td>
+<td>The signature that the validator used to sign its vote for this ledger.</td>
+</tr>
+<tr>
+<td>validation_public_key</td>
+<td>String</td>
+<td>The base-58 encoded public key from the key-pair that the validator used to sign the message. This identifies the validator sending the message and can also be used to verify the <code>signature</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -8213,7 +8254,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <div class="multicode">
 <p><em>WebSocket</em></p>
 <pre><code>{
-  "id": 11,
+  "id": 1,
   "command": "server_info"
 }
 </code></pre>
@@ -8225,6 +8266,10 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
     ]
 }
 </code></pre>
+<p><em>Commandline</em></p>
+<pre><code>#Syntax: server_info
+rippled server_info
+</code></pre>
 </div>
 <p><a class="button" href="ripple-api-tool.html#server_info">Try it! &gt;</a></p>
 <p>The request does not takes any parameters.</p>
@@ -8233,32 +8278,102 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <div class="multicode">
 <p><em>WebSocket</em></p>
 <pre><code>{
-  "id": 11,
+  "id": 1,
   "status": "success",
   "type": "response",
   "result": {
     "info": {
-      "build_version": "0.25.2",
-      "complete_ledgers": "32570-7695432",
-      "hostid": "AIR",
+      "build_version": "0.30.1-rc3",
+      "complete_ledgers": "18611104-18614732",
+      "hostid": "trace",
       "io_latency_ms": 1,
       "last_close": {
-        "converge_time_s": 2.037,
+        "converge_time_s": 4.003,
         "proposers": 5
       },
-      "load_factor": 1,
-      "peers": 56,
-      "pubkey_node": "n9LVtEwRBRfLhrs5cZcKYiYMw6wT9MgmAZEMQEXmX4Bwkq4D6hc1",
-      "server_state": "full",
+      "load": {
+        "job_types": [
+          {
+            "job_type": "untrustedProposal",
+            "per_second": 2
+          },
+          {
+            "in_progress": 1,
+            "job_type": "clientCommand"
+          },
+          {
+            "job_type": "transaction",
+            "per_second": 4
+          },
+          {
+            "job_type": "batch",
+            "per_second": 3
+          },
+          {
+            "job_type": "writeObjects",
+            "per_second": 2
+          },
+          {
+            "job_type": "trustedProposal",
+            "per_second": 1
+          },
+          {
+            "job_type": "peerCommand",
+            "per_second": 108
+          },
+          {
+            "job_type": "diskAccess",
+            "per_second": 1
+          },
+          {
+            "job_type": "processTransaction",
+            "per_second": 4
+          },
+          {
+            "job_type": "WriteNode",
+            "per_second": 63
+          }
+        ],
+        "threads": 6
+      },
+      "load_factor": 1000,
+      "load_factor_net": 1000,
+      "peers": 10,
+      "pubkey_node": "n94UE1ukbq6pfZY9j54sv2A1UrEeHZXLbns3xK5CzU9NbNREytaa",
+      "pubkey_validator": "n9KM73uq5BM3Fc6cxG3k5TruvbLc8Ffq17JZBmWC4uP4csL4rFST",
+      "server_state": "proposing",
+      "state_accounting": {
+        "connected": {
+          "duration_us": "150510079",
+          "transitions": 1
+        },
+        "disconnected": {
+          "duration_us": "1827731",
+          "transitions": 1
+        },
+        "full": {
+          "duration_us": "166972201508",
+          "transitions": 1853
+        },
+        "syncing": {
+          "duration_us": "6249156726",
+          "transitions": 1854
+        },
+        "tracking": {
+          "duration_us": "13035222",
+          "transitions": 1854
+        }
+      },
+      "uptime": 173379,
       "validated_ledger": {
         "age": 3,
         "base_fee_xrp": 0.00001,
-        "hash": "274C27799A91DF08603AF9B5CB03372ECF844B6D643CAF69F25205C9509E212F",
+        "hash": "04F7CF4EACC57140C8088F6BFDC8A824BB3ED5717C3DAA6642101F9FB446226C",
         "reserve_base_xrp": 20,
         "reserve_inc_xrp": 5,
-        "seq": 7695432
+        "seq": 18614732
       },
-      "validation_quorum": 3
+      "validation_quorum": 4
     }
   }
 }
@@ -8268,124 +8383,81 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 {
    "result" : {
       "info" : {
-         "build_version" : "0.30.1-b15",
-         "complete_ledgers" : "32570-18217433",
-         "hostid" : "sjc13",
+         "build_version" : "0.30.1-rc3",
+         "complete_ledgers" : "18611104-18614536",
+         "hostid" : "trace",
          "io_latency_ms" : 1,
          "last_close" : {
-            "converge_time_s" : 2.001,
-            "proposers" : 4
+            "converge_time_s" : 3.002,
+            "proposers" : 5
          },
          "load" : {
             "job_types" : [
-               {
-                  "job_type" : "untrustedValidation",
-                  "peak_time" : 2,
-                  "per_second" : 2
-               },
-               {
-                  "avg_time" : 1,
-                  "job_type" : "ledgerRequest",
-                  "peak_time" : 82,
-                  "per_second" : 6
-               },
                {
                   "job_type" : "untrustedProposal",
                   "per_second" : 3
                },
                {
-                  "avg_time" : 1,
-                  "in_progress" : 2,
-                  "job_type" : "clientCommand",
-                  "peak_time" : 39,
+                  "in_progress" : 1,
+                  "job_type" : "clientCommand"
+               },
+               {
+                  "job_type" : "writeObjects",
                   "per_second" : 1
                },
                {
-                  "in_progress" : 1,
-                  "job_type" : "updatePaths"
-               },
-               {
-                  "job_type" : "transaction",
-                  "peak_time" : 1
-               },
-               {
-                  "avg_time" : 29,
-                  "job_type" : "writeObjects",
-                  "peak_time" : 209
-               },
-               {
-                  "avg_time" : 28,
-                  "job_type" : "acceptLedger",
-                  "peak_time" : 88
-               },
-               {
                   "job_type" : "trustedProposal",
-                  "peak_time" : 2,
-                  "per_second" : 2
+                  "per_second" : 1
                },
                {
                   "job_type" : "peerCommand",
-                  "per_second" : 529
-               },
-               {
-                  "avg_time" : 29,
-                  "job_type" : "diskAccess",
-                  "peak_time" : 209
-               },
-               {
-                  "avg_time" : 316,
-                  "job_type" : "pathFind",
-                  "peak_time" : 2663
-               },
-               {
-                  "job_type" : "SyncReadNode",
-                  "per_second" : 135
+                  "per_second" : 61
                },
                {
                   "job_type" : "WriteNode",
-                  "peak_time" : 2,
-                  "per_second" : 77
+                  "per_second" : 41
                }
             ],
             "threads" : 6
          },
          "load_factor" : 1000,
          "load_factor_net" : 1000,
-         "peers" : 66,
-         "pubkey_node" : "n9JveA1hHDGjZECaYC7KM4JP8NXXzNXAxixbzcLTGnrsFZsA9AD1",
-         "pubkey_validator" : "none",
-         "server_state" : "full",
+         "peers" : 10,
+         "pubkey_node" : "n94UE1ukbq6pfZY9j54sv2A1UrEeHZXLbns3xK5CzU9NbNREytaa",
+         "pubkey_validator" : "n9KM73uq5BM3Fc6cxG3k5TruvbLc8Ffq17JZBmWC4uP4csL4rFST",
+         "server_state" : "proposing",
          "state_accounting" : {
             "connected" : {
-               "duration_us" : "102137155",
+               "duration_us" : "150510079",
                "transitions" : 1
             },
             "disconnected" : {
-               "duration_us" : "1126989",
+               "duration_us" : "1827731",
                "transitions" : 1
             },
             "full" : {
-               "duration_us" : "233465512872",
-               "transitions" : 514
+               "duration_us" : "166170134942",
+               "transitions" : 1838
             },
             "syncing" : {
-               "duration_us" : "1480415394",
-               "transitions" : 514
+               "duration_us" : "6196072160",
+               "transitions" : 1839
             },
             "tracking" : {
-               "duration_us" : "25881256",
-               "transitions" : 514
+               "duration_us" : "9023236",
+               "transitions" : 1839
             }
          },
-         "uptime" : 235075,
+         "uptime" : 172520,
          "validated_ledger" : {
+            "age" : 4,
             "base_fee_xrp" : 1e-05,
-            "hash" : "EB4EB596D85381AAE54196648FC3FAD28A49091CF03ACF7812EF1D311252656C",
+            "hash" : "B69EDD86AB57C6F80F5AA6D4246AC2C9EC0BE0E49649FBC46EEE12DE56500DCA",
             "reserve_base_xrp" : 20,
             "reserve_inc_xrp" : 5,
-            "seq" : 18217433
+            "seq" : 18614536
          },
-         "validation_quorum" : 3
+         "validation_quorum" : 4
       },
       "status" : "success"
    }
@@ -8461,7 +8533,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>pubkey_validator</td>
 <td>String</td>
-<td><em>Admin only</em> Public key used by this node to sign ledger validations; .</td>
+<td><em>Admin only</em> Public key used by this node to sign ledger validations.</td>
 </tr>
 <tr>
 <td>server_state</td>
@@ -8469,13 +8541,33 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <td>A string indicating to what extent the server is participating in the network. See <a href="#possible-server-states">Possible Server States</a> for more details.</td>
 </tr>
 <tr>
+<td>state_accounting</td>
+<td>Object</td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
+<td>state_accounting.*.duration_us</td>
+<td>String</td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
+<td>state_accounting.*.transitions</td>
+<td>Number</td>
+<td>The number of times the server has transitioned into this state. (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
+<td>uptime</td>
+<td>Number</td>
+<td>Number of consecutive seconds that the server has been operational. (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
 <td>validated_ledger</td>
 <td>Object</td>
-<td>Information about the fully-validated ledger with the highest sequence number (the most recent)</td>
+<td>Information about the fully-validated ledger with the highest <a href="#ledger-index">Ledger Index</a> (the most recent)</td>
 </tr>
 <tr>
 <td>validated_ledger.age</td>
-<td>Unsigned Integer</td>
+<td>Number</td>
 <td>The time since the ledger was closed, in seconds</td>
 </tr>
 <tr>
@@ -8500,8 +8592,8 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 <tr>
 <td>validated_ledger.seq</td>
-<td>Unsigned Integer</td>
-<td>Identifying sequence number of this ledger version</td>
+<td>Number - <a href="#ledger-index">Ledger Index</a></td>
+<td>The ledger index of the latest validate ledger</td>
 </tr>
 <tr>
 <td>validation_quorum</td>
@@ -8522,7 +8614,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <div class="multicode">
 <p><em>WebSocket</em></p>
 <pre><code>{
-  "id": 12,
+  "id": 2,
   "command": "server_state"
 }
 </code></pre>
@@ -8533,6 +8625,10 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
         {}
     ]
 }
+</code></pre>
+<p><em>Commandline</em></p>
+<pre><code>#Syntax: server_state
+rippled server_state
 </code></pre>
 </div>
 <p><a class="button" href="ripple-api-tool.html#server_state">Try it! &gt;</a></p>
@@ -8547,27 +8643,88 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
   "type": "response",
   "result": {
     "state": {
-      "build_version": "0.25.2",
-      "complete_ledgers": "32570-7696746",
+      "build_version": "0.30.1-rc3",
+      "complete_ledgers": "18611104-18615049",
       "io_latency_ms": 1,
       "last_close": {
-        "converge_time": 2097,
-        "proposers": 4
+        "converge_time": 3003,
+        "proposers": 5
+      },
+      "load": {
+        "job_types": [
+          {
+            "job_type": "untrustedProposal",
+            "peak_time": 1,
+            "per_second": 3
+          },
+          {
+            "in_progress": 1,
+            "job_type": "clientCommand"
+          },
+          {
+            "avg_time": 12,
+            "job_type": "writeObjects",
+            "peak_time": 345,
+            "per_second": 2
+          },
+          {
+            "job_type": "trustedProposal",
+            "per_second": 1
+          },
+          {
+            "job_type": "peerCommand",
+            "per_second": 64
+          },
+          {
+            "avg_time": 33,
+            "job_type": "diskAccess",
+            "peak_time": 526
+          },
+          {
+            "job_type": "WriteNode",
+            "per_second": 55
+          }
+        ],
+        "threads": 6
       },
       "load_base": 256,
-      "load_factor": 256,
-      "peers": 61,
-      "pubkey_node": "n9L4DuE6NsZiVWyYdHcYbKoELTXr4fs32VY8bdic5c4uVrfrADmX",
-      "server_state": "full",
+      "load_factor": 256000,
+      "peers": 10,
+      "pubkey_node": "n94UE1ukbq6pfZY9j54sv2A1UrEeHZXLbns3xK5CzU9NbNREytaa",
+      "pubkey_validator": "n9KM73uq5BM3Fc6cxG3k5TruvbLc8Ffq17JZBmWC4uP4csL4rFST",
+      "server_state": "proposing",
+      "state_accounting": {
+        "connected": {
+          "duration_us": "150510079",
+          "transitions": 1
+        },
+        "disconnected": {
+          "duration_us": "1827731",
+          "transitions": 1
+        },
+        "full": {
+          "duration_us": "168295542987",
+          "transitions": 1865
+        },
+        "syncing": {
+          "duration_us": "6294237352",
+          "transitions": 1866
+        },
+        "tracking": {
+          "duration_us": "13035524",
+          "transitions": 1866
+        }
+      },
+      "uptime": 174748,
       "validated_ledger": {
         "base_fee": 10,
-        "close_time": 458432860,
-        "hash": "95A05F232C8C4B4DC313CB91A4C823A221120DD8692395150A3012876C8CD772",
+        "close_time": 507693650,
+        "hash": "FEB17B15FB64E3AF8D371E6AAFCFD8B92775BB80AB953803BD73EA8EC75ECA34",
         "reserve_base": 20000000,
         "reserve_inc": 5000000,
-        "seq": 7696746
+        "seq": 18615049
       },
-      "validation_quorum": 3
+      "validation_quorum": 4
     }
   }
 }
@@ -8575,33 +8732,96 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <p><em>JSON-RPC</em></p>
 <pre><code>200 OK
 {
-    "result": {
-        "state": {
-            "build_version": "0.26.3",
-            "complete_ledgers": "32570-8696244",
-            "io_latency_ms": 1,
-            "last_close": {
-                "converge_time": 2120,
-                "proposers": 5
+   "result" : {
+      "state" : {
+         "build_version" : "0.30.1-rc3",
+         "complete_ledgers" : "18611104-18615037",
+         "io_latency_ms" : 1,
+         "last_close" : {
+            "converge_time" : 2001,
+            "proposers" : 5
+         },
+         "load" : {
+            "job_types" : [
+               {
+                  "job_type" : "untrustedProposal",
+                  "per_second" : 2
+               },
+               {
+                  "in_progress" : 1,
+                  "job_type" : "clientCommand"
+               },
+               {
+                  "job_type" : "writeObjects",
+                  "per_second" : 2
+               },
+               {
+                  "avg_time" : 2,
+                  "job_type" : "acceptLedger",
+                  "peak_time" : 6
+               },
+               {
+                  "job_type" : "trustedProposal",
+                  "per_second" : 1
+               },
+               {
+                  "job_type" : "peerCommand",
+                  "per_second" : 80
+               },
+               {
+                  "job_type" : "diskAccess",
+                  "per_second" : 1
+               },
+               {
+                  "job_type" : "WriteNode",
+                  "per_second" : 91
+               }
+            ],
+            "threads" : 6
+         },
+         "load_base" : 256,
+         "load_factor" : 256000,
+         "peers" : 10,
+         "pubkey_node" : "n94UE1ukbq6pfZY9j54sv2A1UrEeHZXLbns3xK5CzU9NbNREytaa",
+         "pubkey_validator" : "n9KM73uq5BM3Fc6cxG3k5TruvbLc8Ffq17JZBmWC4uP4csL4rFST",
+         "server_state" : "proposing",
+         "state_accounting" : {
+            "connected" : {
+               "duration_us" : "150510079",
+               "transitions" : 1
             },
-            "load_base": 256,
-            "load_factor": 256,
-            "peers": 58,
-            "pubkey_node": "n9LJ5eCNjeUXQpNXHCcLv9PQ8LMFYy4W8R1BdVNcpjc1oDwe6XZF",
-            "server_state": "full",
-            "validated_ledger": {
-                "base_fee": 10,
-                "close_time": 463192610,
-                "hash": "43660857C8FD74D8D5B9D6D9E3D4BE11FAD92985F6B8C9A406DC1F87FF6CB77F",
-                "reserve_base": 20000000,
-                "reserve_inc": 5000000,
-                "seq": 8696244
+            "disconnected" : {
+               "duration_us" : "1827731",
+               "transitions" : 1
             },
-            "validation_quorum": 3
-        },
-        "status": "success"
-    }
+            "full" : {
+               "duration_us" : "168241260112",
+               "transitions" : 1865
+            },
+            "syncing" : {
+               "duration_us" : "6294237352",
+               "transitions" : 1866
+            },
+            "tracking" : {
+               "duration_us" : "13035524",
+               "transitions" : 1866
+            }
+         },
+         "uptime" : 174693,
+         "validated_ledger" : {
+            "base_fee" : 10,
+            "close_time" : 507693592,
+            "hash" : "1C26209AE593C7EB5123363B3152D86514845FBD42CC6B05111D57F62D02B113",
+            "reserve_base" : 20000000,
+            "reserve_inc" : 5000000,
+            "seq" : 18615037
+         },
+         "validation_quorum" : 4
+      },
+      "status" : "success"
+   }
 }
+
 </code></pre>
 </div>
 <p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing a <code>state</code> object as its only field.</p>
@@ -8663,17 +8883,37 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>pubkey_node</td>
 <td>String</td>
-<td>Public key used by this server (along with the corresponding private key) for secure communications between nodes. This key pair is automatically created and stored in rippled's local database the first time it starts up; if lost or deleted, a new key pair can be generated with no ill effects.</td>
+<td>Public key used by this server (along with the corresponding private key) for secure communications between nodes. This key pair is automatically created and stored in <code>rippled</code>'s local database the first time it starts up; if lost or deleted, a new key pair can be generated with no ill effects.</td>
 </tr>
 <tr>
 <td>pubkey_validator</td>
 <td>String</td>
-<td><em>Admin only</em> Public key used by this server (along with the corresponding private key) to sign proposed ledgers for validation.</td>
+<td><em>Admin only</em> Public key of the keypair used by this server to sign proposed ledgers for validation.</td>
 </tr>
 <tr>
 <td>server_state</td>
 <td>String</td>
 <td>A string indicating to what extent the server is participating in the network. See <a href="#possible-server-states">Possible Server States</a> for more details.</td>
+</tr>
+<tr>
+<td>state_accounting</td>
+<td>Object</td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
+<td>state_accounting.*.duration_us</td>
+<td>String</td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
+<td>state_accounting.*.transitions</td>
+<td>Number</td>
+<td>The number of times the server has transitioned into this state. (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
+</tr>
+<tr>
+<td>uptime</td>
+<td>Number</td>
+<td>Number of consecutive seconds that the server has been operational. (New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -8724,7 +8964,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <h2 id="can-delete">can_delete</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/CanDelete.cpp" title="Source">[Source]<br/></a></p>
 <p>With <code>online_delete</code> and <code>advisory_delete</code> configuration options enabled, the <code>can_delete</code> method informs the rippled server of the latest ledger which may be deleted. </p>
-<p><em>The <code>can_delete</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>can_delete</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-31">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -8798,7 +9038,7 @@ a successful result containing the following fields:</p>
 <h2 id="consensus-info">consensus_info</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ConsensusInfo.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>consensus_info</code> command provides information about the consensus process for debugging purposes.</p>
-<p><em>The <code>consensus_info</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>consensus_info</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-32">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9041,7 +9281,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="fetch-info">fetch_info</h2>
 <p><a href="https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/FetchInfo.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>fetch_info</code> command returns information about objects that this server is currently fetching from the network, and how many peers have that information. It can also be used to reset current fetches. </p>
-<p><em>The <code>fetch_info</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>fetch_info</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-33">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9227,7 +9467,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="get-counts">get_counts</h2>
 <p><a href="https://github.com/ripple/rippled/blob/c7118a183a660648aa88a3546a6b2c5bce858440/src/ripple/rpc/handlers/GetCounts.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>get_counts</code> command provides various stats about the health of the server, mostly the number of objects of different types that it currently holds in memory. </p>
-<p><em>The <code>get_counts</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>get_counts</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-34">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9381,7 +9621,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="ledger-cleaner">ledger_cleaner</h2>
 <p><a href="https://github.com/ripple/rippled/blob/df54b47cd0957a31837493cd69e4d9aade0b5055/src/ripple/rpc/handlers/LedgerCleaner.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_cleaner</code> command controls the <a href="https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner">Ledger Cleaner</a>, an asynchronous maintenance process that can find and repair corruption in rippled's database of ledgers. </p>
-<p><em>The <code>ledger_cleaner</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>ledger_cleaner</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-35">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9480,7 +9720,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="log-level">log_level</h2>
 <p><a href="https://github.com/ripple/rippled/blob/155fcdbcd0b4927152892c8c8be01d9cf62bed68/src/ripple/rpc/handlers/LogLevel.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>log_level</code> command changes the <code>rippled</code> server's logging verbosity, or returns the current logging level for each category (called a <em>partition</em>) of log messages.</p>
-<p><em>The <code>log_level</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>log_level</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-36">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9619,7 +9859,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="logrotate">logrotate</h2>
 <p><a href="https://github.com/ripple/rippled/blob/743bd6c9175c472814448ea889413be79dfd1c07/src/ripple/rpc/handlers/LogRotate.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>logrotate</code> command closes and reopens the log file. This is intended to facilitate log rotation on Linux file systems.</p>
-<p><em>The <code>logrotate</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>logrotate</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-37">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -9683,7 +9923,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="validation-create">validation_create</h2>
 <p><a href="https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/ValidationCreate.cpp" title="Source">[Source]<br/></a></p>
 <p>Use the <code>validation_create</code> command to generate the keys for a rippled <a href="rippled-setup.html#validator-setup">validating node</a>. Similar to the <a href="#wallet-propose">wallet_propose</a> command, this command makes no real changes, but only generates a set of keys in the proper format.</p>
-<p><em>The <code>validation_create</code> method is an admin command that cannot be run by unpriviledged users.</em></p>
+<p><em>The <code>validation_create</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-38">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">

--- a/transactions.html
+++ b/transactions.html
@@ -746,13 +746,13 @@
 <tr>
 <td>asfNoFreeze</td>
 <td>6</td>
-<td>Permanently give up the ability to freeze individual trust lines. This flag can never be disabled after being enabled.</td>
+<td>Permanently give up the ability to <a href="freeze.html">freeze individual trust lines or disable Global Freeze</a>. This flag can never be disabled after being enabled.</td>
 <td>lsfNoFreeze</td>
 </tr>
 <tr>
 <td>asfGlobalFreeze</td>
 <td>7</td>
-<td>Freeze all assets issued by this account.</td>
+<td><a href="freeze.html">Freeze</a> all assets issued by this account.</td>
 <td>lsfGlobalFreeze</td>
 </tr>
 <tr>
@@ -914,7 +914,7 @@
 <ul>
 <li>If the creator no longer has any of the <code>TakerGets</code> currency.</li>
 <li>The offer becomes funded again when the creator obtains more of that currency.</li>
-<li>If the currency required to fund the offer is held in a <a href="https://wiki.ripple.com/Freeze">frozen trust line</a>.</li>
+<li>If the currency required to fund the offer is held in a <a href="freeze.html">frozen trust line</a>.</li>
 <li>The offer becomes funded again when the trust line is no longer frozen.</li>
 <li>If the creator does not have enough XRP for the reserve amount of a new trust line required by the offer. (See <a href="#offers-and-trust">Offers and Trust</a>.)</li>
 <li>The offer becomes funded again when the creator obtains more XRP, or the reserve requirements decrease.</li>
@@ -1129,13 +1129,13 @@
 <td>tfSetFreeze</td>
 <td>0x00100000</td>
 <td>1048576</td>
-<td><a href="https://wiki.ripple.com/Freeze">Freeze</a> the trustline.</td>
+<td><a href="freeze.html">Freeze</a> the trustline.</td>
 </tr>
 <tr>
 <td>tfClearFreeze</td>
 <td>0x00200000</td>
 <td>2097152</td>
-<td>Unfreeze the trustline.</td>
+<td><a href="freeze.html">Unfreeze</a> the trustline.</td>
 </tr>
 </tbody>
 </table>
@@ -1849,7 +1849,7 @@
 <tr>
 <td>tecFROZEN</td>
 <td>137</td>
-<td>The <a href="#offercreate">OfferCreate transaction</a> failed because one or both of the assets involved are subject to a <a href="https://ripple.com/files/GB-2014-02.pdf">global freeze</a>.</td>
+<td>The <a href="#offercreate">OfferCreate transaction</a> failed because one or both of the assets involved are subject to a <a href="freeze.html">global freeze</a>.</td>
 </tr>
 <tr>
 <td>tecNO_TARGET</td>


### PR DESCRIPTION
This changeset fixes a large number of shortcomings in the `rippled` docs:
Task    DEV-178     Better linking to topic articles from rippled reference
Bug     DEV-177     Corrections to JSON-RPC section
Task    DEV-175     Update rippled server_info docs
Task    DEV-172     Clarify when validated_ledgers is missing from ledger subscription message
Task    DEV-148     Update rippled docs with data types descriptions from Data v2
Task    DEV-142     Update response format for rippled account_offers API
Task    DEV-141     Document new rippled subscription stream 
