### PR TITLE
data v2.1.0 changes

### DIFF
--- a/assets/js/apitool-methods-data_v2.js
+++ b/assets/js/apitool-methods-data_v2.js
@@ -165,6 +165,26 @@ Request('Get Issued Value', {
     }
 });
 
+Request('Get Top Currencies', {
+    method: GET,
+    path: "/v2/network/top_currencies/{:date}",
+    description: "Get most used currencies for a given date.",
+    link: "#get-top-currencies",
+    params: {
+        "{:date}": "2016-04-14"
+    }
+});
+
+Request('Get Top Markets', {
+    method: GET,
+    path: "/v2/network/top_markets/{:date}",
+    description: "Get most active markets for a given date.",
+    link: "#get-top-currencies",
+    params: {
+        "{:date}": "2016-04-15"
+    }
+});
+
 Request('Get All Gateways', {
     method: GET,
     path: "/v2/gateways",
@@ -323,5 +343,27 @@ Request('Get Account Reports Range', {
         "{:query_params}": "accounts=true&payments=true&descending=true"
     }
 });
+
+Request('Get Account Transaction Stats', {
+    method: GET,
+    path: "/v2/accounts/{:address}/stats/transactions?{:query_params}",
+    description: "Retrieve daily summaries of transaction activity for an account.",
+    link: "#get-account-transaction-stats",
+    params: {
+        "{:address}": DEFAULT_ADDRESS_1,
+        "{:query_params}": "limit=2&descending=true"
+    }
+})
+
+Request('Get Account Value Stats', {
+    method: GET,
+    path: "/v2/accounts/{:address}/stats/value?{:query_params}",
+    description: "Retrieve daily summaries of the currency held by an account.",
+    link: "#get-account-value-stats",
+    params: {
+        "{:address}": DEFAULT_ADDRESS_1,
+        "{:query_params}": "limit=2&descending=true"
+    }
+})
 
 //---------- End req. List ---------------------------//

--- a/content/reference-data-api.md
+++ b/content/reference-data-api.md
@@ -1422,7 +1422,7 @@ Each object in the `components` array of the Volume Objects represent the volume
 | amount | Number | The amount of volume in the market, in units of the base currency. |
 | base   | Object | The `currency` and `issuer` that identify the base currency of this market. There is no `issuer` for XRP. |
 | counter | Object | The `currency` and `issuer` that identify the counter currency of this market. There is no `issuer` for XRP. |
-| converted\_amount | Number | The total amount of volume in the market, converted to the display currency. |
+| converted\_amount | Number | The total amount of volume in the market, converted to the display currency. _(Before [v2.1.0][], this was `convertedAmount`.)_ |
 
 #### Example ####
 
@@ -1570,7 +1570,7 @@ Each object in the `components` array of the Volume Objects represent the volume
 | amount | Number | Total payment volume for this currency during the interval, in units of the currency itself. |
 | count  | Number | The total number of payments in this currency |
 | rate   | Number | The exchange rate between this currency and the display currency. |
-| converted\_amount | Number | Total payment volume for this currency, converted to the display currency. |
+| converted\_amount | Number | Total payment volume for this currency, converted to the display currency. _(Before [v2.1.0][], this was `convertedAmount`.)_ |
 
 #### Example ####
 

--- a/content/reference-data-api.md
+++ b/content/reference-data-api.md
@@ -9,7 +9,7 @@ Ripple provides a live instance of the Data API with as complete a transaction r
 
 
 ## More Information ##
-The Ripple Data API v2 replaces the Historical Database v1 and the [Charts API](https://github.com/ripple/ripple-data-api/). 
+The Ripple Data API v2 replaces the Historical Database v1 and the [Charts API](https://github.com/ripple/ripple-data-api/).
 
 * [API Methods](#api-method-reference)
 * [API Conventions](#api-conventions)
@@ -22,6 +22,7 @@ The Ripple Data API v2 replaces the Historical Database v1 and the [Charts API](
 [v2.0.6]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.6
 [v2.0.7]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.7
 [v2.0.8]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.8
+[v2.1.0]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0
 
 
 # API Method Reference #
@@ -44,6 +45,8 @@ General Methods:
 * [Get Exchange Volume - `GET /v2/network/exchange_volume`](#get-exchange-volume)
 * [Get Payment Volume - `GET /v2/network/payment_volume`](#get-payment-volume)
 * [Get Issued Value - `GET /v2/network/issued_value`](#get-issued-value)
+* [Get Top Currencies - `GET /v2/network/top_currencies`](#get-top-currencies)
+* [Get Top Markets - `GET /v2/network/top_markets`](#get-top-markets)
 * [Get All Gateways - `GET /v2/gateways`](#get-all-gateways)
 * [Get Gateway - `GET /v2/gateways/{:gateway}`](#get-gateway)
 * [Get Currency Image - `GET /v2/currencies/{:currencyimage}`](#get-currency-image)
@@ -60,6 +63,8 @@ Account Methods:
 * [Get Account Exchanges - `GET /v2/accounts/{:address}/exchanges`](#get-account-exchanges)
 * [Get Account Balance Changes - `GET /v2/accounts/{:address}/balance_changes`](#get-account-balance-changes)
 * [Get Account Reports - `GET /v2/accounts/{:address}/reports`](#get-account-reports)
+* [Get Account Transaction Stats - `GET /v2/accounts/{:address}/stats/transactions`](#get-account-transaction-stats)
+* [Get Account Value Stats - `GET /v2/accounts/{:address}/stats/value`](#get-account-value-stats)
 
 Health Checks:
 
@@ -234,7 +239,7 @@ Response (trimmed for size):
                         }
                     }
                 },
-                
+
                 ...
             ],
             "TransactionResult": "tesSUCCESS"
@@ -476,7 +481,7 @@ If the request specifies a `currency` and an `interval`, the result includes obj
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/payments/BTC+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?limit=2
@@ -736,7 +741,7 @@ The rate is derived from the volume weighted average over the calendar day speci
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/exchange_rates/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q/XRP?date=2015-11-13T00:00:00Z
@@ -800,7 +805,7 @@ All exchange rates are calculating by converting both currencies to XRP.
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/normalize?amount=100&currency=XRP&exchange_currency=USD&exchange_issuer=rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
@@ -902,9 +907,9 @@ Response (trimmed for size):
                     "amount": "40",
                     "type": "received"
                 },
-                
+
                 ...(additional results trimmed)...
-                
+
                 {
                     "tx_hash": "76041BD6546389B5EC2CDBAA543200CF7B8D300F34F908BA5CA8523B0CA158C8",
                     "amount": "1400",
@@ -916,18 +921,18 @@ Response (trimmed for size):
             "receiving_counterparties": [
                 "rDMFJrKg2jyoNG6WDWJknXDEKZ6ywNFGwD",
                 "r4XXHxraHLuCiLmLMw96FTPXXywZSnWSyR",
-                
+
                 ...(additional results trimmed)...
-                
-                
+
+
                 "rp1C4Ld6uGjurFpempUJ8q5hPSWhak5EQf"
             ],
             "sending_counterparties": [
                 "rwxcJVWZSEgN2DmLZYYjyagHjMx5jQ7BAa",
-                
+
                 ...(additional results trimmed)...
-                
-                
+
+
                 "rBK1rLjbWsSU9EuST1cAz9RsiYdJPVGXXA"
             ],
             "total_value": "210940",
@@ -945,10 +950,10 @@ Response (trimmed for size):
                     "amount": "900",
                     "type": "sent"
                 },
-                
+
                 ...(additional results trimmed)...
-                
-                
+
+
                 {
                     "tx_hash": "EC25427964419394BB5D06343BC74235C33655C1F70523C688F9A201957D65BA",
                     "amount": "100",
@@ -959,19 +964,19 @@ Response (trimmed for size):
             "payments_sent": 62,
             "receiving_counterparties": [
                 "rB4cyZxrBrTmJcWZSBc8YoW2t3bafiKRp",
-                
+
                 ...(additional results trimmed)...
-                
-                
+
+
                 "rKybkw3Pu74VfJfrWr7QJbVPJNarnKP2EJ"
             ],
             "sending_counterparties": [
                 "rNRCXw8PQRjvTwMDDLZVvuLHSKqqXUXQHv",
                 "r7CLMVEuNvK2yXTPLPnkWMqzkkXuopWeL",
-                
+
                 ...(additional results trimmed)...
-                
-                
+
+
                 "ranyeoYRhvwiFABzDvxSVyqQKp1bMkFsaX"
             ],
             "total_value": "117600",
@@ -1023,7 +1028,7 @@ The `family` and `metrics` query parameters provide a way to filter results to a
 
 | Family | Included Metrics | Meaning |
 |--------|------------------|---------|
-| type | All Ripple [transaction types](reference-transaction-format.html), including `Payment`, `AccountSet`, `SetRegularKey`, `OfferCreate`, `OfferCancel`, `TrustSet`. | Number of transactions of the given type that occurred during the interval. |
+| type | All Ripple [transaction types](reference-transaction-format.html), including `Payment`, `AccountSet`, `OfferCreate`, and others. | Number of transactions of the given type that occurred during the interval. |
 | result | All [transaction result codes](reference-transaction-format.html#transaction-results) (string codes, not the numeric codes), including `tesSUCCESS`, `tecPATH_DRY`, and many others. | Number of transactions that resulted in the given code during the interval. |
 | metric | Data-API defined Special Transaction Metrics. | (Varies) |
 
@@ -1054,7 +1059,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/stats/?start=2015-08-30&end=2015-08-31&interval=day&family=metric&metrics=accounts_created,exchanges_count,ledger_count,payments_count
@@ -1151,7 +1156,7 @@ Each **issuer capitalization object** has the following fields:
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/capitalization/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?start=2015-01-01T00:00:00Z&end=2015-10-31&interval=month
@@ -1324,9 +1329,9 @@ Response:
             "counter_volume": 52.4909286454546,
             "count": 1
         },
-        
+
         ... (additional results trimmed)...
-        
+
         {
             "buy": {
                 "base_volume": 1.996007,
@@ -1417,7 +1422,7 @@ Each object in the `components` array of the Volume Objects represent the volume
 | amount | Number | The amount of volume in the market, in units of the base currency. |
 | base   | Object | The `currency` and `issuer` that identify the base currency of this market. There is no `issuer` for XRP. |
 | counter | Object | The `currency` and `issuer` that identify the counter currency of this market. There is no `issuer` for XRP. |
-| convertedAmount | Number | The total amount of volume in the market, converted to the display currency. |
+| converted\_amount | Number | The total amount of volume in the market, converted to the display currency. |
 
 #### Example ####
 
@@ -1448,7 +1453,7 @@ Response:
                     "counter": {
                         "currency": "XRP"
                     },
-                    "convertedAmount": 117720.99268355068
+                    "converted_amount": 117720.99268355068
                 },
                 {
                     "count": 1977,
@@ -1461,11 +1466,11 @@ Response:
                     "counter": {
                         "currency": "XRP"
                     },
-                    "convertedAmount": 74003.51871932109
+                    "converted_amount": 74003.51871932109
                 },
-                
+
                 ... (additional results trimmed) ...
-                
+
                 {
                     "count": 3,
                     "rate": 0.022999083584408355,
@@ -1478,7 +1483,7 @@ Response:
                         "currency": "USD",
                         "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
                     },
-                    "convertedAmount": 12.72863756671683
+                    "converted_amount": 12.72863756671683
                 },
                 {
                     "count": 3,
@@ -1492,7 +1497,7 @@ Response:
                         "currency": "BTC",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
                     },
-                    "convertedAmount": 4.4137945368632545
+                    "converted_amount": 4.4137945368632545
                 }
             ],
             "count": 11105,
@@ -1565,7 +1570,7 @@ Each object in the `components` array of the Volume Objects represent the volume
 | amount | Number | Total payment volume for this currency during the interval, in units of the currency itself. |
 | count  | Number | The total number of payments in this currency |
 | rate   | Number | The exchange rate between this currency and the display currency. |
-| convertedAmount | Number | Total payment volume for this currency, converted to the display currency. |
+| converted\_amount | Number | Total payment volume for this currency, converted to the display currency. |
 
 #### Example ####
 
@@ -1590,7 +1595,7 @@ Response:
                     "amount": 87279.59029136538,
                     "count": 331,
                     "rate": 0.004412045860957953,
-                    "convertedAmount": 19782113.1153009
+                    "converted_amount": 19782113.1153009
                 },
                 {
                     "currency": "USD",
@@ -1598,7 +1603,7 @@ Response:
                     "amount": 0,
                     "count": 0,
                     "rate": 0.00451165816091143,
-                    "convertedAmount": 0
+                    "converted_amount": 0
                 },
                 {
                     "currency": "BTC",
@@ -1606,25 +1611,25 @@ Response:
                     "amount": 279.03077460240354,
                     "count": 107,
                     "rate": 0.000013312520335244644,
-                    "convertedAmount": 20960026.169024874
+                    "converted_amount": 20960026.169024874
                 },
-                
+
                 ... (additional results trimmed) ...
-                
+
                 {
                     "currency": "MXN",
                     "issuer": "rG6FZ31hDHN1K5Dkbma3PSB5uVCuVVRzfn",
                     "amount": 49263.13280138676,
                     "count": 19,
                     "rate": 0.07640584677247926,
-                    "convertedAmount": 644756.0609868265
+                    "converted_amount": 644756.0609868265
                 },
                 {
                     "currency": "XRP",
                     "amount": 296246369.30089426,
                     "count": 8691,
                     "rate": 1,
-                    "convertedAmount": 296246369.30089426
+                    "converted_amount": 296246369.30089426
                 }
             ],
             "count": 9388,
@@ -1691,13 +1696,13 @@ Each Issued Value Object represents the total value issued at one point in time,
 |--------|-------|-------------|
 | components | Array of Objects | The data on individual issuers that was used to assemble this total. |
 | exchange | Object | Indicates the display currency used, as with fields `currency` and (except for XRP) `issuer`. All amounts are normalized by first converting to XRP, and then to the display currency specified in the request. |
-| exchangeRate | Number | The exchange rate to the displayed currency from XRP. 
+| exchangeRate | Number | The exchange rate to the displayed currency from XRP.
 | time | String - [Timestamp][] | The time at which this data was measured. |
 | total | Number | Total value of all issued assets at this time, in units of the display currency. |
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/network/issued_value?start=2015-10-01T00:00:00&end=2015-10-01T00:00:00&exchange_currency=USD&exchange_issuer=rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
@@ -1726,9 +1731,9 @@ Response:
           "rate": "0.000028888001",
           "converted_amount": "1639021.4313562333"
         },
-        
+
         ... (additional results trimmed for size) ...
-        
+
         {
           "currency": "MXN",
           "issuer": "rG6FZ31hDHN1K5Dkbma3PSB5uVCuVVRzfn",
@@ -1749,6 +1754,207 @@ Response:
 }
 ```
 
+
+
+
+## Get Top Currencies ##
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topCurrencies.js "Source")
+
+Returns the top currencies on the Ripple Consensus Ledger over a rolling 30 day window. The currencies are ordered from highest ranked to lowest, where the rank is determined by the volume and count of transactions and the number of unique counterparties. By default, returns the top currencies for the most recent date available. You can query historical data by date. _(New in [v2.1.0][])_
+
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*Most Recent*
+
+```
+GET /v2/network/top_currencies
+```
+
+*By Date*
+
+```
+GET /v2/network/top_currencies/2016-01-01
+```
+
+<!--</div>-->
+
+[Try it! >](data-api-v2-tool.html#get-top-currencies)
+
+
+#### Response Format ####
+
+A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| result | `success` | Indicates that the body represents a successful response. |
+| date   | String - [Timestamp][] | The time at which this data was measured. |
+| count  | Integer | Number of results returned. |
+| currencies | Array of Top Currency Objects | A currency + issuer, and the metrics measured for inclusion and ranking |
+
+Each Top Currency Object has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| currency | String - [Currency Code][] | The currency this object describes |
+| issuer | String - [Address][] | The Ripple address that issues this currency |
+| avg_exchange_count | [String - Number][] | Daily average number of exchanges |
+| avg_exchange_volume | [String - Number][] | Daily average volume of exchanges, normalized to XRP |
+| avg_payment_count | [String - Number][] | Daily average number of payments |
+| avg_payment_volume | [String - Number][] | Daily average volume of payments, normalized to XRP |
+| issued_value | [String - Number][] | Total amount of this currency issued by this issuer, normalized to XRP |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/network/top_currencies/2015-12-31
+```
+
+Response:
+
+```
+{
+  result: "success",
+  date: "2015-12-31T00:00:00Z",
+  count: 41,
+  currencies: [
+    {
+      avg_exchange_count: "4652.1612903225805",
+      avg_exchange_volume: "5.872515158748898E7",
+      avg_payment_count: "406.5625",
+      avg_payment_volume: "592537.1043782063",
+      issued_value: "3.3304427137620807E8",
+      currency: "USD",
+      issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+    },
+    {
+      avg_exchange_count: "6083.193548387097",
+      avg_exchange_volume: "3.558897661266646E7",
+      avg_payment_count: "520.71875",
+      avg_payment_volume: "3507232.307236187",
+      issued_value: "1.1695602455168623E8",
+      currency: "CNY",
+      issuer: "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y"
+    },
+    {
+      avg_exchange_count: "3715.0967741935483",
+      avg_exchange_volume: "3.7346262589967564E7",
+      avg_payment_count: "163.1875",
+      avg_payment_volume: "775.0342076125125",
+      issued_value: "1.906530130641547E8",
+      currency: "BTC",
+      issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+    },
+    ...
+  ]
+}
+```
+
+
+
+## Get Top Markets ##
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topMarkets.js "Source")
+
+Returns the top exchange markets on the Ripple Consensus Ledger over a rolling 30 day window.  The markets are ordered from highest ranked to lowest, where the rank is determined by the number and volume of exchanges and the number of counterparties participating.  By default, returns top markets for the latest date available.  You can query historical data by date. _(New in [v2.1.0][])_
+
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*Most Recent*
+
+```
+GET /v2/network/top_markets
+```
+
+*By Date*
+
+```
+GET /v2/network/top_markets/2016-01-01
+```
+
+<!--</div>-->
+
+[Try it! >](data-api-v2-tool.html#get-top-markets)
+
+
+#### Response Format ####
+
+A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| result | `success` | Indicates that the body represents a successful response. |
+| date   | String - [Timestamp][] | The time at which this data was measured. |
+| count  | Integer | Number of results returned. |
+| markets | Array of Top Market Objects | A currency pair and the metrics measured for inclusion and ranking |
+
+Each Top Market object has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| base_currency | String - [Currency Code][] | The base currency for this market |
+| base_issuer | String - [Address][] | (Omitted if `base_currency` is XRP) The Ripple address that issues the base currency |
+| counter_currency | String - [Currency Code][] | The counter currency for this market |
+| counter_issuer | String - [Address][] | (Omitted if `counter_currency` is XRP) The Ripple address that issues the counter currency |
+| avg_base_volume | String | Daily average volume in terms of the base currency |
+| avg_counter_volume | String | Daily average volume in terms of the counter currency |
+| avg_exchange_count | String | Daily average number of exchanges |
+| avg_volume | String | Daily average volume, normalized to XRP |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/network/top_markets/2015-12-31
+```
+
+Response:
+
+```
+{
+  result: "success",
+  date: "2015-12-31T00:00:00Z",
+  count: 56,
+  markets: [
+    {
+      avg_base_volume: "116180.98607935428",
+      avg_counter_volume: "1.6657039295476614E7",
+      avg_exchange_count: "1521.4603174603174",
+      avg_volume: "1.6657039295476614E7",
+      base_currency: "USD",
+      base_issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+      counter_currency: "XRP"
+    },
+    {
+      avg_base_volume: "410510.0286920887",
+      avg_counter_volume: "9117398.719214212",
+      avg_exchange_count: "1902.1587301587301",
+      avg_volume: "9117398.719214212",
+      base_currency: "CNY",
+      base_issuer: "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y",
+      counter_currency: "XRP"
+    },
+    {
+      avg_base_volume: "178.06809101586364",
+      avg_counter_volume: "1.1343000055456754E7",
+      avg_exchange_count: "1224.2857142857142",
+      avg_volume: "1.1343000055456754E7",
+      base_currency: "BTC",
+      base_issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+      counter_currency: "XRP"
+    },
+    ...
+  ]
+}
+```
 
 
 
@@ -1784,7 +1990,7 @@ Each field in the top level JSON object is a [Currency Code][]. The content of e
 |----------|---------|-------------|
 | name     | String  | A human-readable proper name for the gateway. |
 | account  | String - [Address][] | The issuing account (cold wallet) that issues the currency. |
-| featured | Boolean | Whether this gateway is considered a "featured" issuer of the currency. Ripple, Inc. decides which gateways to feature based on responsible business practices, volume, and other measures. |
+| featured | Boolean | Whether this gateway is considered a "featured" issuer of the currency. Ripple decides which gateways to feature based on responsible business practices, volume, and other measures. |
 | label    | String  | (May be omitted) Only provided when the [Currency Code][] is a 40-character hexadecimal value. This is an alternate human-readable name for the currency issued by this gateway.
 | assets   | Array of Strings | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by Ripple Charts.) |
 
@@ -1894,7 +2100,7 @@ Each object in the `accounts` field array has the following fields:
 | Field      | Value  | Description |
 |------------|--------|-------------|
 | address    | String | The [Address][] of an [issuing address](concept-issuing-and-operational-addresses.html) (cold wallet) used by this gateway. |
-| currencies | Object | Each field in this object is a [Currency Code][] corresponding to a currency issued from this address. Each value is an object with a `featured` boolean indicating whether that currency is featured. Ripple, Inc. decides which currencies and gateways to feature based on responsible business practices, volume, and other measures. |
+| currencies | Object | Each field in this object is a [Currency Code][] corresponding to a currency issued from this address. Each value is an object with a `featured` boolean indicating whether that currency is featured. Ripple decides which currencies and gateways to feature based on responsible business practices, volume, and other measures. |
 
 #### Example ####
 
@@ -2306,7 +2512,7 @@ Each order object has the following fields:
 
 #### Example ####
 
-Request: 
+Request:
 
 ```
 GET /v2/accounts/rK5j9n8baXfL4gzUoZsfxBvvsv97P5swaV/orders?limit=2&date=2015-11-11T00:00:00Z
@@ -3006,6 +3212,190 @@ Response:
 
 
 
+## Get Account Transaction Stats ##
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountStats.js "Source")
+
+Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.0][].)_
+
+<!--<div class='multicode'>-->
+
+*REST*
+
+```
+GET /v2/accounts/{:address}/stats/transactions
+```
+
+<!--</div>-->
+
+[Try it! >](data-api-v2-tool.html#get-account-transaction-stats)
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String | Ripple address to query |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String  | UTC start time of query range. Defaults to start of current date. |
+| end        | String  | UTC end time of query range. Defaults to current date. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| descending | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response. |
+| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+
+
+#### Response Format ####
+A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| result | `success` | Indicates that the body represents a successful response. |
+| count | Integer | Number of reports returned. |
+| rows | Array of Transaction Stats Objects | Daily summaries of account transaction activity for the given account. |
+
+Each Transaction Stats Object has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| date   | String - [Timestamp][] | The date this transaction stats object describes. |
+| transaction\_count | Integer | The total number of transactions sent by the account on this date. |
+| result | Object | Map of [transaction result codes](reference-transaction-format.html#transaction-results), indicating how many of each result code occurred in the transactions sent by this account on this date. |
+| type | Object | Map of [transaction types](reference-transaction-format.html), indicating how many of each transaction type the account sent on this date. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX/stats/transactions?start=2015-01-01&limit=2
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 2,
+  "marker": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX|20150116000000",
+  "rows": [
+    {
+      "date": "2015-01-14T00:00:00Z",
+      "transaction_count": 44,
+      "result": {
+        "tecUNFUNDED_PAYMENT": 1,
+        "tesSUCCESS": 43
+      },
+      "type": {
+        "Payment": 42,
+        "TrustSet": 2
+      }
+    },
+    {
+      "date": "2015-01-15T00:00:00Z",
+      "transaction_count": 116,
+      "result": {
+        "tesSUCCESS": 116
+      },
+      "type": {
+        "Payment": 116
+      }
+    }
+  ]
+}
+```
+
+
+
+## Get Account Value Stats ##
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountStats.js "Source")
+
+Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.0][].)_
+
+<!--<div class='multicode'>-->
+
+*REST*
+
+```
+GET /v2/accounts/{:address}/stats/value
+```
+
+<!--</div>-->
+
+[Try it! >](data-api-v2-tool.html#get-account-value-stats)
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String | Ripple address to query |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String - [Timestamp][] | Start time of query range. Defaults to the start of the most recent interval. |
+| end        | String - [Timestamp][] | End time of query range. Defaults to the end of the most recent interval. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response. |
+| descending | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+
+
+#### Response Format ####
+A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| result | `success` | Indicates that the body represents a successful response. |
+| count | Integer | Number of reports returned. |
+| rows | Array of Value Stats Objects | Daily summaries of account value for the given account. |
+
+Each Value Stats Object has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| date   | String - [Timestamp][] | This date this object describes. |
+| value  | [String - Number][] | The total of all currency held by this account, normalized to XRP. |
+| balance_change_count | Number | The number of times the account's balance changed on this date. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX/stats/value?limit=2&descending=true
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 2,
+  "marker": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX|20160412000000",
+  "rows": [
+    {
+      "date": "2016-04-14T00:00:00Z",
+      "account_value": "7.666658705139822E7",
+      "balance_change_count": 58
+    },
+    {
+      "date": "2016-04-13T00:00:00Z",
+      "account_value": "1.0022208004947332E8",
+      "balance_change_count": 184
+    }
+  ]
+}
+```
+
+
+
+
 ## Health Check - API ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/checkHealth.js "Source")
 
@@ -3030,7 +3420,7 @@ Optionally, you can also include the following query parameters:
 
 #### Response Format ####
 
-A successful response uses the HTTP code **200 OK**. By default, the response body is an **integer health value only**. 
+A successful response uses the HTTP code **200 OK**. By default, the response body is an **integer health value only**.
 
 The health value `0` always indicates a healthy status. Other health values are defined as follows:
 
@@ -3060,9 +3450,9 @@ Response:
 
 ```
 {
-  score: 0,
-  response_time: "0.389s",
-  response_time_threshold: "5s"
+	"score": 0,
+	"response_time": "0.014s",
+	"response_time_threshold": "5s"
 }
 ```
 
@@ -3092,7 +3482,7 @@ Optionally, you can also include the following query parameters:
 
 #### Response Format ####
 
-A successful response uses the HTTP code **200 OK**. By default, the response body is an **integer health value only**. 
+A successful response uses the HTTP code **200 OK**. By default, the response body is an **integer health value only**.
 
 The health value `0` always indicates a healthy status. Other health values are defined as follows:
 
@@ -3126,12 +3516,12 @@ Response:
 
 ```
 {
-	"score": 0,
-	"response_time": "0.081s",
-	"ledger_gap": "1.891s",
-	"ledger_gap_threshold": "5.00m",
-	"validation_gap": "29.894s",
-	"validation_gap_threshold": "15.00m"
+    "score": 0,
+    "response_time": "0.081s",
+    "ledger_gap": "1.891s",
+    "ledger_gap_threshold": "5.00m",
+    "validation_gap": "29.894s",
+    "validation_gap_threshold": "15.00m"
 }
 ```
 
@@ -3341,7 +3731,7 @@ Reports objects show the activity of a given account over a specific interval of
 ## Payment Summary Objects ##
 [Payment Summary Objects]: #payment-summary-objects
 
-A Payment Summary Object contains a reduced amount of information about a single payment from the perspective of either the sender or receiver of that payment. 
+A Payment Summary Object contains a reduced amount of information about a single payment from the perspective of either the sender or receiver of that payment.
 
 | Field | Value | Description |
 |-------|-------|-------------|
@@ -3436,7 +3826,7 @@ Volume objects represent the total volumes of money moved, in either payments or
 | count | Number | The total number of exchanges in this period. |
 | endTime | String - [Timestamp][] | The end time of this interval. |
 | exchange | Object | Indicates the display currency used, as with fields `currency` and (except for XRP) `issuer`. All amounts are normalized by first converting to XRP, and then to the display currency specified in the request. |
-| exchangeRate | Number | The exchange rate to the displayed currency from XRP. 
+| exchangeRate | Number | The exchange rate to the displayed currency from XRP.
 | startTime | String - [Timestamp][] | The start of this time period. |
 | total | Number | Total volume of all recorded exchanges in the time period. |
 
@@ -3463,7 +3853,7 @@ Version 2 of the Historical Database requires HBase instead of [PostgreSQL](http
 
 ### Installation Process ###
 
-Starting in 
+Starting in
 
   1. Install HBase. For production use, configure it in distributed mode.
   2. Clone the rippled Historical Database Git Repository:
@@ -3478,6 +3868,17 @@ Starting in
 Reports, stats, and aggregated exchange data needs additional processing before the API can make it available. This processing uses Apache Storm as well as some custom scripts. See [Storm Setup](https://github.com/ripple/rippled-historical-database/blob/develop/storm/README.md) for more information.
 
 At this point, the rippled Historical Database is installed. See [Services](#services) for the different components that you can run.
+
+### Tests ###
+
+Dependencies:
+* [Docker Compose](https://docs.docker.com/compose/install/)
+
+```
+$ docker-compose build
+$ docker-compose up -d hbase
+$ docker-compose run webapp npm test
+```
 
 ### Services ###
 
@@ -3524,7 +3925,7 @@ The `--startIndex` parameter defines the most-recent ledger to retrieve. The Bac
 
 The `--stopIndex` parameter defines the oldest ledger to retrieve. The Backfiller stops after it retrieves this ledger. If omitted, the Backfiller continues as far back as possible. Because backfilling goes from most recent to least recent, the stop index should be a smaller than the start index.
 
-**Warning:** The Backfiller is best for filling in relatively short histories of transactions. Importing a complete history of all Ripple transactions using the Backfiller could take weeks. If you want a full history, we recommend acquiring a database dump with early transctions, and importing it directly. Ripple, Inc. used the internal SQLite database from an offline `rippled` to populate its historical databases with the early transactions, then used the Backfiller to catch up to date after the import finished.
+**Warning:** The Backfiller is best for filling in relatively short histories of transactions. Importing a complete history of all Ripple transactions using the Backfiller could take weeks. If you want a full history, we recommend acquiring a database dump with early transctions, and importing it directly. For the public server, Ripple (the company) used the internal SQLite database from an offline `rippled` to populate its historical databases with the early transactions, then used the Backfiller to catch up to date after the import finished.
 
 Example usage:
 
@@ -3532,4 +3933,3 @@ Example usage:
 // get ledgers #1,000,000 to #2,000,000 (inclusive) and store in HBase
 node import/hbase/backfill --startIndex 2000000 --stopIndex 1000000
 ```
-

--- a/content/reference-data-api.md
+++ b/content/reference-data-api.md
@@ -111,7 +111,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | ledger | [Ledger object](#ledger-objects) | The requested ledger |
 
 #### Example ####
@@ -181,7 +181,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | transaction | [Transaction object](#transaction-objects) | The requested transaction |
 
 #### Example ####
@@ -281,7 +281,7 @@ Optionally, you can include the following query parameters:
 | type       | String | Filter transactions to a specific [transaction type](reference-transaction-format.html). |
 | result     | String | Filter transactions for a specific [transaction result](reference-transaction-format.html#transaction-results). |
 | binary     | Boolean | If true, return transactions in binary form. Defaults to false. |
-| limit      | Integer | Max results per page (defaults to 20). Cannot be more than 100. |
+| limit      | Integer | Maximum results per page. Defaults to 20. Cannot be more than 100. |
 | marker     | String | [Pagination](#pagination) marker from a previous response. |
 
 #### Response Format ####
@@ -289,7 +289,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of Transactions returned. |
 | marker | String | (May be omitted) Pagination marker |
 | transactions | Array of [Transaction object](#transaction-objects) | The requested transactions |
@@ -449,7 +449,7 @@ Optionally, you can also include the following query parameters:
 | end        | String - [Timestamp][]  | Filter results to this time and earlier. |
 | interval   | String  | If provided and `currency` is also specified, return results aggregated into intervals of the specified length instead of individual payments. Valid intervals are `day`, `week`, or `month`. |
 | descending | Boolean | Reverse chronological order. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response. |
 | format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
@@ -460,7 +460,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of Transactions returned |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | payments | Array of [Payment Objects][], or array of aggregate objects | The requested payments |
@@ -606,7 +606,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of Transactions returned. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | exchanges | Array of [Exchange Objects][] | The requested exchanges |
@@ -732,7 +732,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | rate | Number | The requested exchange rate, or `0` if the exchange rate could not be determined. |
 
 All exchange rates are calcuated by converting the base currency and counter currency to XRP.
@@ -796,7 +796,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | amount | Number | Pre-conversion amount specified in the request |
 | converted | Number | Post-conversion amount of the `exchange_currency`, or `0` if the exchange rate could not be determined. |
 | rate | Number | Exchange rate used to calculate the conversion, or `0` if the exchange rate could not be determined. |
@@ -857,7 +857,7 @@ Optionally, you can also include the following query parameters:
 | accounts | Boolean | If true, include lists of counterparty accounts. Defaults to false. |
 | payments | Boolean | If true, include lists of individual payments. Defaults to false. |
 | format   | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response |
 
 #### Response Format ####
@@ -866,7 +866,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | date   | String - [Timestamp][] | The date for which this report applies. |
 | count | Integer | Number of reports returned. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker. |
@@ -1017,7 +1017,7 @@ Optionally, you can also include the following query parameters:
 | start        | String - [Timestamp][] | Filter results to this time and later. |
 | end        | String - [Timestamp][] | Filter results to this time and earlier |
 | interval   | String  | Aggregation interval (`hour`,`day`,`week`, defaults to `day`) |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response. |
 | descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
 | format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
@@ -1052,7 +1052,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of reports returned. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | stats | Array of stats objects | The requested stats. Omits metrics with a value of 0, and intervals that have no nonzero metrics. |
@@ -1126,7 +1126,7 @@ Optionally, you can also include the following query parameters:
 | start      | String - [Timestamp][] | Start time of query range. Defaults to `2013-01-01T00:00:00Z`. |
 | end        | String - [Timestamp][] | End time of query range. Defaults to the current time. |
 | interval   | String  | Aggregation interval - `day`, `week`, or `month`. Defaults to `day`. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response |
 | descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
 | adjusted   | Boolean | If true, do not count known issuer-owned wallets towards market capitalization. Defaults to true. |
@@ -1140,7 +1140,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of reports returned. |
 | currency | String | Currency requested |
 | issuer | String | Issuer requested |
@@ -1259,7 +1259,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of accounts returned. |
 | exchanges\_count | Integer | Total number of exchanges in the period. |
 | accounts | Array of active Account Trading Objects | Active trading accounts for the period |
@@ -1400,7 +1400,7 @@ Optionally, you can include the following query parameters:
 | interval | String  | Aggregation interval - valid intervals are `day`, `week`, or `month`. Defaults to `day`. |
 | exchange\_currency | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
 | exchange\_issuer | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
-| limit    | Integer | Max results per page. Defaults to 200. Cannot be more than 1000. |
+| limit    | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker   | String  | [Pagination](#pagination) key from previously returned response |
 | format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
@@ -1409,7 +1409,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of results returned. |
 | rows | Array of exchange [Volume Objects][] | Exchange volumes for each interval in the requested time period. (By default, this method only returns the most recent interval.) |
 
@@ -1548,7 +1548,7 @@ Optionally, you can include the following query parameters:
 | interval | String  | Aggregation interval - valid intervals are `day`, `week`, or `month`. Defaults to `day`. |
 | exchange\_currency | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
 | exchange\_issuer | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
-| limit    | Integer | Max results per page. Defaults to 200. Cannot be more than 1000. |
+| limit    | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker   | String  | [Pagination](#pagination) key from previously returned response |
 | format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
@@ -1557,7 +1557,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of results returned. |
 | rows | Array of payment [Volume Objects][] | Payment volumes for each interval in the requested time period. (By default, this method only returns the most recent interval.) |
 
@@ -1676,7 +1676,7 @@ Optionally, you can include the following query parameters:
 | end        | String - [Timestamp][]  | End time of query range. Defaults to the end of the most recent interval. |
 | exchange\_currency | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
 | exchange\_issuer | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
-| limit    | Integer | Max results per page. Defaults to 200. Cannot be more than 1000. |
+| limit    | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker   | String  | [Pagination](#pagination) key from previously returned response |
 | format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
@@ -1686,7 +1686,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of results returned. |
 | rows | Array of Issued Value Objects | Aggregated capitalization at the requested point(s) in time. |
 
@@ -1760,7 +1760,7 @@ Response:
 ## Get Top Currencies ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topCurrencies.js "Source")
 
-Returns the top currencies on the Ripple Consensus Ledger over a rolling 30 day window. The currencies are ordered from highest ranked to lowest, where the rank is determined by the volume and count of transactions and the number of unique counterparties. By default, returns the top currencies for the most recent date available. You can query historical data by date. _(New in [v2.1.0][])_
+Returns the top currencies on the Ripple Consensus Ledger, ordered from highest rank to lowest. The ranking is determined by the volume and count of transactions and the number of unique counterparties. By default, returns results for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. _(New in [v2.1.0][])_
 
 
 #### Request Format ####
@@ -1783,6 +1783,7 @@ GET /v2/network/top_currencies/2016-01-01
 
 [Try it! >](data-api-v2-tool.html#get-top-currencies)
 
+This method does not accept any query parameters.
 
 #### Response Format ####
 
@@ -1790,10 +1791,10 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | date   | String - [Timestamp][] | The time at which this data was measured. |
-| count  | Integer | Number of results returned. |
-| currencies | Array of Top Currency Objects | A currency + issuer, and the metrics measured for inclusion and ranking |
+| count  | Integer | Number of objects in the `currencies` field. |
+| currencies | Array of Top Currency Objects | The top currencies for this data sample. Each member represents one currency, by currency code and issuer. |
 
 Each Top Currency Object has the following fields:
 
@@ -1801,9 +1802,9 @@ Each Top Currency Object has the following fields:
 |--------|-------|-------------|
 | currency | String - [Currency Code][] | The currency this object describes |
 | issuer | String - [Address][] | The Ripple address that issues this currency |
-| avg_exchange_count | [String - Number][] | Daily average number of exchanges |
+| avg_exchange_count | [String - Number][] | Daily average number of [exchanges](#exchange-objects) |
 | avg_exchange_volume | [String - Number][] | Daily average volume of exchanges, normalized to XRP |
-| avg_payment_count | [String - Number][] | Daily average number of payments |
+| avg_payment_count | [String - Number][] | Daily average number of [payments](#payment-objects) |
 | avg_payment_volume | [String - Number][] | Daily average volume of payments, normalized to XRP |
 | issued_value | [String - Number][] | Total amount of this currency issued by this issuer, normalized to XRP |
 
@@ -1860,8 +1861,7 @@ Response:
 ## Get Top Markets ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topMarkets.js "Source")
 
-Returns the top exchange markets on the Ripple Consensus Ledger over a rolling 30 day window.  The markets are ordered from highest ranked to lowest, where the rank is determined by the number and volume of exchanges and the number of counterparties participating.  By default, returns top markets for the latest date available.  You can query historical data by date. _(New in [v2.1.0][])_
-
+Returns the top exchange markets on the Ripple Consensus Ledger, ordered from highest rank to lowest. The rank is determined by the number and volume of exchanges and the number of counterparties participating. By default, returns top markets for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. _(New in [v2.1.0][])_
 
 #### Request Format ####
 
@@ -1881,6 +1881,8 @@ GET /v2/network/top_markets/2016-01-01
 
 <!--</div>-->
 
+This method does not accept any query parameters.
+
 [Try it! >](data-api-v2-tool.html#get-top-markets)
 
 
@@ -1890,10 +1892,10 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| date   | String - [Timestamp][] | The time at which this data was measured. |
-| count  | Integer | Number of results returned. |
-| markets | Array of Top Market Objects | A currency pair and the metrics measured for inclusion and ranking |
+| result | String | The value `success` indicates that this is a successful response. |
+| date   | String - [Timestamp][] | The end of the rolling window over which this data was calculated. |
+| count  | Integer | Number of results in the `markets` field. |
+| markets | Array of Top Market Objects | The top markets for this data sample. Each member represents a currency pair. |
 
 Each Top Market object has the following fields:
 
@@ -1905,7 +1907,7 @@ Each Top Market object has the following fields:
 | counter_issuer | String - [Address][] | (Omitted if `counter_currency` is XRP) The Ripple address that issues the counter currency |
 | avg_base_volume | String | Daily average volume in terms of the base currency |
 | avg_counter_volume | String | Daily average volume in terms of the counter currency |
-| avg_exchange_count | String | Daily average number of exchanges |
+| avg_exchange_count | String | Daily average number of [exchanges](#exchange-objects) |
 | avg_volume | String | Daily average volume, normalized to XRP |
 
 #### Example ####
@@ -2233,7 +2235,7 @@ Optionally, you can include the following query parameters:
 | start      | String - [Timestamp][]  | Start time of query range |
 | end        | String - [Timestamp][]  | End time of query range |
 | interval   | String  | Aggregation interval (`hour`,`day`,`week`). If omitted, return individual accounts. Not compatible with the `parent` parameter. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1,000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1,000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response |
 | descending | Boolean | Reverse chronological order |
 | parent     | String  | Filter results to children of the specified parent account. Not compatible with the `interval` parameter. |
@@ -2245,8 +2247,8 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| count  | Integer | Number of reports returned. |
+| result | String | The value `success` indicates that this is a successful response. |
+| count  | Integer | Number of accounts returned. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | accounts | Array | If the request used the `interval` query parameter, each member of the array is an interval object. Otherwise, this field is an array of [account creation objects](#account-creation-objects). |
 
@@ -2336,7 +2338,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | account | Object - [Account Creation](#account-creation-objects) | The requested account |
 
 #### Example ####
@@ -2392,25 +2394,25 @@ Optionally, you can also include the following query parameters:
 
 | Field        | Value   | Description |
 |--------------|---------|-------------|
-| ledger_index | Integer | Index of ledger for historical balances |
-| ledger_hash  | String  | Ledger hash for historical balances |
+| ledger_index | Integer | Index of ledger for historical balances. |
+| ledger_hash  | String  | Ledger hash for historical balances. |
 | date         | String  | UTC date for historical balances. |
-| currency     | String  | Restrict results to specified currency |
-| counterparty | String  | Restrict results to specified counterparty/issuer |
-| limit        | Integer | Max results per page (defaults to 200). Cannot be greater than 400, but you can use the value `all` to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. Large gateways can have several tens of thousands of results.) |
-| format       | String  | Format of returned results: `csv`,`json` defaults to `json` |
+| currency     | String  | Restrict results to specified currency. |
+| counterparty | String  | Restrict results to specified counterparty/issuer. |
+| limit        | Integer | Maximum results per page. Defaults to 200. Cannot be greater than 400, but you can use the value `all` to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. Large gateways can have several tens of thousands of results.) |
+| format       | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| ledger_index | Integer | ledger index for balances query |
-| close_time | String | close time of the ledger |
-| limit | String | number of results returned, if limit was exceeded |
-| marker | String | (May be omitted) [Pagination](#pagination) marker |
-| balances | Array of [Balance Object][]s | The requested balances |
+| result | String | The value `success` indicates that this is a successful response. |
+| ledger_index | Integer | ledger index for balances query. |
+| close_time | String | close time of the ledger. |
+| limit | String | number of results returned, if limit was exceeded. |
+| marker | String | (May be omitted) [Pagination](#pagination) marker. |
+| balances | Array of [Balance Object][]s | The requested balances. |
 
 #### Example ####
 
@@ -2481,7 +2483,7 @@ Optionally, you can also include the following query parameters:
 | ledger\_index | Integer | Get orders as of this ledger. Not compatible with `ledger_hash` or `date`. |
 | ledger\_hash  | String  | Get orders as of this ledger. Not compatible with `ledger_index` or `date`. |
 | date          | String - [Timestamp][] | Get orders at this time. Not compatible with `ledger_index` or `ledger_hash`. |
-| limit         | Integer | Max results per page (defaults to 200). Cannot be greater than 400. |
+| limit         | Integer | Maximum results per page. Defaults to 200. Cannot be greater than 400. |
 | format        | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 If none of `ledger_index`, `ledger_hash`, or `date` are specified, the API uses the most current data available.
@@ -2491,18 +2493,18 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | ledger\_index | Integer | `ledger_index` of the ledger version used. |
 | close\_time | String | Close time of the ledger version used. |
 | limit | String | The `limit` from the request. |
-| orders | Array of order objects | The requested orders |
+| orders | Array of order objects | The requested orders. |
 
 Each order object has the following fields:
 
 | Field                        | Value  | Description |
 |------------------------------|--------|-------------|
 | specification                | Object | Details of this order's current state. |
-| specification.direction      | String | Either `buy` or `sell` |
+| specification.direction      | String | Either `buy` or `sell`. |
 | specification.quantity       | [Balance Object][] | The maximum amount of the base currency this order would buy or sell (depending on the direction). This value decreases as the order gets partially filled. |
 | specification.totalPrice     | [Balance Object][] | The maximum amount of the counter currency that will be spent or gained in order to buy or sell the base currency. This value decreases as the order gets partially filled. |
 | properties                   | Object | Details of how the order was placed. |
@@ -2604,17 +2606,17 @@ Optionally, you can also include the following query parameters:
 
 | Field        | Value   | Description |
 |--------------|---------|-------------|
-| start        | String  | UTC start time of query range |
-| end          | String  | UTC end time of query range |
+| start        | String - [Timestamp][] | Start time of query range. Defaults to the earliest date available. |
+| end          | String - [Timestamp][]  | End time of query range. Defaults to the current date. |
 | min_sequence | String  | Minimum sequence number to query |
 | max_sequence | String  | Max sequence number to query |
 | type         | String  | Restrict results to a specified [transaction type](reference-transaction-format.html) |
 | result       | String  | Restrict results to specified transaction result |
 | binary       | Boolean | Return results in binary format |
 | descending   | Boolean | Reverse chronological order |
-| limit        | Integer | Max results per page (defaults to 20). Cannot be more than 1,000. |
+| limit        | Integer | Maximum results per page. Defaults to 20. Cannot be more than 1,000. |
 | marker       | String  | [Pagination](#pagination) key from previously returned response |
-| format       | String  | Format of returned results: `csv`,`json` defaults to `json` |
+| format       | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 
 #### Response Format ####
@@ -2623,7 +2625,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count  | Integer | The number of objects contained in the `transactions` field. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | transactions | Array of [transaction objects](#transaction-objects) | All transactions matching the request. |
@@ -2744,7 +2746,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | transaction | [transaction object](#transaction-objects) | requested transaction |
 
 #### Example ####
@@ -2795,7 +2797,7 @@ This method requires the following URL parameters:
 
 | Field    | Value  | Description |
 |----------|--------|-------------|
-| :address | String | Ripple address to query |
+| :address | String | Ripple address to query. |
 
 
 Optionally, you can also include the following query parameters:
@@ -2810,9 +2812,9 @@ Optionally, you can also include the following query parameters:
 | source\_tag | Integer | Filter results to specified source tag |
 | destination\_tag | Integer | Filter results to specified destination tag |
 | descending | Boolean | Reverse chronological order |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1,000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1,000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response |
-| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 
 #### Response Format ####
@@ -2821,7 +2823,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count  | Integer | The number of objects contained in the `payments` field. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | payments | Array of [payment objects][] | All payments matching the request. |
@@ -2908,7 +2910,7 @@ This method requires the following URL parameters:
 
 | Field    | Value  | Description |
 |----------|--------|-------------|
-| :address | String | Ripple address to query |
+| :address | String | Ripple address to query. |
 | :base    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 | :counter | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 
@@ -2920,9 +2922,9 @@ Optionally, you can also include the following query parameters:
 | start      | String - [Timestamp][]  | Start time of query range |
 | end        | String - [Timestamp][]  | End time of query range |
 | descending | Boolean | Reverse chronological order |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response |
-| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 
 #### Response Format ####
@@ -2930,7 +2932,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of exchanges returned. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker |
 | exchanges | Array of [Exchange Objects][] | The requested exchanges |
@@ -3019,7 +3021,7 @@ This method requires the following URL parameters:
 
 | Field    | Value  | Description |
 |----------|--------|-------------|
-| :address | String | Ripple address to query |
+| :address | String | Ripple address to query. |
 
 
 Optionally, you can also include the following query parameters:
@@ -3031,7 +3033,7 @@ Optionally, you can also include the following query parameters:
 | start      | String - [Timestamp][]  | Start time of query range. |
 | end        | String - [Timestamp][]  | End time of query range. |
 | descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response. |
 | format     | String  | Format of returned results: `csv` or`json`. Defaults to `json`. |
 
@@ -3041,7 +3043,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
+| result | String | The value `success` indicates that this is a successful response. |
 | count | Integer | Number of balance changes returned. |
 | marker | String | (May be omitted) [Pagination](#pagination) marker. |
 | exchanges | Array of [balance change descriptors][] | The requested balance changes. |
@@ -3127,7 +3129,7 @@ This method requires the following URL parameters:
 
 | Field    | Value  | Description |
 |----------|--------|-------------|
-| :address | String | Ripple address to query |
+| :address | String | Ripple address to query. |
 | :date    | String | (Optional) UTC date for single report. If omitted, use the `start` and `end` query parameters. |
 
 
@@ -3135,12 +3137,12 @@ Optionally, you can also include the following query parameters:
 
 | Field      | Value   | Description |
 |------------|---------|-------------|
-| start      | String  | UTC start time of query range. Defaults to start of current date. Ignored if `date` specified. |
-| end        | String  | UTC end time of query range. Defaults to current date. Ignored if `date` specified. |
+| start      | String - [Timestamp][] | Start time of query range. Defaults to start of current date. Ignored if `date` specified. |
+| end        | String - [Timestamp][] | End time of query range. Defaults to current date. Ignored if `date` specified. |
 | accounts   | Boolean | If true, provide lists with addresses of all `sending_counterparties` and `receiving_counterparties` in results. Otherwise, return only the number of sending and receiving counterparties. |
 | payments   | Boolean | Include [Payment Summary Objects][] in the `payments` field for each interval, with the payments that occurred during that interval. |
 | descending | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
-| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 
 #### Response Format ####
@@ -3148,8 +3150,8 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| count | Integer | Number of reports returned. |
+| result | String | The value `success` indicates that this is a successful response. |
+| count | Integer | Number of reports in the `reports` field. |
 | reports | Array of [Reports Objects][] | Daily summaries of account activity for the given account and date range. |
 
 #### Example ####
@@ -3233,19 +3235,19 @@ This method requires the following URL parameters:
 
 | Field    | Value  | Description |
 |----------|--------|-------------|
-| :address | String | Ripple address to query |
+| :address | String | Ripple address to query. |
 
 
 Optionally, you can also include the following query parameters:
 
 | Field      | Value   | Description |
 |------------|---------|-------------|
-| start      | String  | UTC start time of query range. Defaults to start of current date. |
-| end        | String  | UTC end time of query range. Defaults to current date. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| start      | String - [Timestamp][] | Start time of query range. Defaults to the earliest date available. |
+| end        | String - [Timestamp][] | End time of query range. Defaults to the current date. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | descending | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response. |
-| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 
 #### Response Format ####
@@ -3253,15 +3255,15 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| count | Integer | Number of reports returned. |
+| result | String | The value `success` indicates that this is a successful response. |
+| count | Integer | Number of transaction stats objects in the `rows` field. |
 | rows | Array of Transaction Stats Objects | Daily summaries of account transaction activity for the given account. |
 
 Each Transaction Stats Object has the following fields:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| date   | String - [Timestamp][] | The date this transaction stats object describes. |
+| date   | String - [Timestamp][] | This object describes activity on this date. |
 | transaction\_count | Integer | The total number of transactions sent by the account on this date. |
 | result | Object | Map of [transaction result codes](reference-transaction-format.html#transaction-results), indicating how many of each result code occurred in the transactions sent by this account on this date. |
 | type | Object | Map of [transaction types](reference-transaction-format.html), indicating how many of each transaction type the account sent on this date. |
@@ -3331,7 +3333,7 @@ This method requires the following URL parameters:
 
 | Field    | Value  | Description |
 |----------|--------|-------------|
-| :address | String | Ripple address to query |
+| :address | String | Ripple address to query. |
 
 
 Optionally, you can also include the following query parameters:
@@ -3340,7 +3342,7 @@ Optionally, you can also include the following query parameters:
 |------------|---------|-------------|
 | start      | String - [Timestamp][] | Start time of query range. Defaults to the start of the most recent interval. |
 | end        | String - [Timestamp][] | End time of query range. Defaults to the end of the most recent interval. |
-| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| limit      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
 | marker     | String  | [Pagination](#pagination) key from previously returned response. |
 | descending | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
 | format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
@@ -3351,15 +3353,15 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| count | Integer | Number of reports returned. |
+| result | String | The value `success` indicates that this is a successful response. |
+| count | Integer | Number of value stats objects in the `rows` field. |
 | rows | Array of Value Stats Objects | Daily summaries of account value for the given account. |
 
 Each Value Stats Object has the following fields:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
-| date   | String - [Timestamp][] | This date this object describes. |
+| date   | String - [Timestamp][] | This object describes activity on this date. |
 | value  | [String - Number][] | The total of all currency held by this account, normalized to XRP. |
 | balance_change_count | Number | The number of times the account's balance changed on this date. |
 

--- a/reference-data-api.html
+++ b/reference-data-api.html
@@ -2217,7 +2217,7 @@
 <tr>
 <td>converted_amount</td>
 <td>Number</td>
-<td>The total amount of volume in the market, converted to the display currency.</td>
+<td>The total amount of volume in the market, converted to the display currency. <em>(Before <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>, this was <code>convertedAmount</code>.)</em></td>
 </tr>
 </tbody>
 </table>
@@ -2432,7 +2432,7 @@
 <tr>
 <td>converted_amount</td>
 <td>Number</td>
-<td>Total payment volume for this currency, converted to the display currency.</td>
+<td>Total payment volume for this currency, converted to the display currency. <em>(Before <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>, this was <code>convertedAmount</code>.)</em></td>
 </tr>
 </tbody>
 </table>

--- a/reference-data-api.html
+++ b/reference-data-api.html
@@ -147,7 +147,7 @@
 <p>Ripple provides a live instance of the Data API with as complete a transaction record as possible at the following address:</p>
 <p><a href="https://data.ripple.com"><strong>https://data.ripple.com</strong></a></p>
 <h2 id="more-information">More Information</h2>
-<p>The Ripple Data API v2 replaces the Historical Database v1 and the <a href="https://github.com/ripple/ripple-data-api/">Charts API</a>. </p>
+<p>The Ripple Data API v2 replaces the Historical Database v1 and the <a href="https://github.com/ripple/ripple-data-api/">Charts API</a>.</p>
 <ul>
 <li><a href="#api-method-reference">API Methods</a></li>
 <li><a href="#api-conventions">API Conventions</a></li>
@@ -173,6 +173,8 @@
 <li><a href="#get-exchange-volume">Get Exchange Volume - <code>GET /v2/network/exchange_volume</code></a></li>
 <li><a href="#get-payment-volume">Get Payment Volume - <code>GET /v2/network/payment_volume</code></a></li>
 <li><a href="#get-issued-value">Get Issued Value - <code>GET /v2/network/issued_value</code></a></li>
+<li><a href="#get-top-currencies">Get Top Currencies - <code>GET /v2/network/top_currencies</code></a></li>
+<li><a href="#get-top-markets">Get Top Markets - <code>GET /v2/network/top_markets</code></a></li>
 <li><a href="#get-all-gateways">Get All Gateways - <code>GET /v2/gateways</code></a></li>
 <li><a href="#get-gateway">Get Gateway - <code>GET /v2/gateways/{:gateway}</code></a></li>
 <li><a href="#get-currency-image">Get Currency Image - <code>GET /v2/currencies/{:currencyimage}</code></a></li>
@@ -189,6 +191,8 @@
 <li><a href="#get-account-exchanges">Get Account Exchanges - <code>GET /v2/accounts/{:address}/exchanges</code></a></li>
 <li><a href="#get-account-balance-changes">Get Account Balance Changes - <code>GET /v2/accounts/{:address}/balance_changes</code></a></li>
 <li><a href="#get-account-reports">Get Account Reports - <code>GET /v2/accounts/{:address}/reports</code></a></li>
+<li><a href="#get-account-transaction-stats">Get Account Transaction Stats - <code>GET /v2/accounts/{:address}/stats/transactions</code></a></li>
+<li><a href="#get-account-value-stats">Get Account Value Stats - <code>GET /v2/accounts/{:address}/stats/value</code></a></li>
 </ul>
 <p>Health Checks:</p>
 <ul>
@@ -772,7 +776,7 @@
 </tbody>
 </table>
 <h4 id="example-3">Example</h4>
-<p>Request: </p>
+<p>Request:</p>
 <pre><code>GET /v2/payments/BTC+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?limit=2
 </code></pre>
 <p>Response:</p>
@@ -1116,7 +1120,7 @@
 <p>All exchange rates are calcuated by converting the base currency and counter currency to XRP.</p>
 <p>The rate is derived from the volume weighted average over the calendar day specified, averaged with the volume weighted average of the last 50 trades within the last 14 days.</p>
 <h4 id="example-5">Example</h4>
-<p>Request: </p>
+<p>Request:</p>
 <pre><code>GET /v2/exchange_rates/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q/XRP?date=2015-11-13T00:00:00Z
 </code></pre>
 <p>Response:</p>
@@ -1217,7 +1221,7 @@
 </table>
 <p>All exchange rates are calculating by converting both currencies to XRP.</p>
 <h4 id="example-6">Example</h4>
-<p>Request: </p>
+<p>Request:</p>
 <pre><code>GET /v2/normalize?amount=100&amp;currency=XRP&amp;exchange_currency=USD&amp;exchange_issuer=rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
 </code></pre>
 <p>Response:</p>
@@ -1517,7 +1521,7 @@
 <tbody>
 <tr>
 <td>type</td>
-<td>All Ripple <a href="reference-transaction-format.html">transaction types</a>, including <code>Payment</code>, <code>AccountSet</code>, <code>SetRegularKey</code>, <code>OfferCreate</code>, <code>OfferCancel</code>, <code>TrustSet</code>.</td>
+<td>All Ripple <a href="reference-transaction-format.html">transaction types</a>, including <code>Payment</code>, <code>AccountSet</code>, <code>OfferCreate</code>, and others.</td>
 <td>Number of transactions of the given type that occurred during the interval.</td>
 </tr>
 <tr>
@@ -1610,7 +1614,7 @@
 </tbody>
 </table>
 <h4 id="example-8">Example</h4>
-<p>Request: </p>
+<p>Request:</p>
 <pre><code>GET /v2/stats/?start=2015-08-30&amp;end=2015-08-31&amp;interval=day&amp;family=metric&amp;metrics=accounts_created,exchanges_count,ledger_count,payments_count
 </code></pre>
 <p>Response:</p>
@@ -1781,7 +1785,7 @@
 </tbody>
 </table>
 <h4 id="example-9">Example</h4>
-<p>Request: </p>
+<p>Request:</p>
 <pre><code>GET /v2/capitalization/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?start=2015-01-01T00:00:00Z&amp;end=2015-10-31&amp;interval=month
 </code></pre>
 <p>Response:</p>
@@ -2211,7 +2215,7 @@
 <td>The <code>currency</code> and <code>issuer</code> that identify the counter currency of this market. There is no <code>issuer</code> for XRP.</td>
 </tr>
 <tr>
-<td>convertedAmount</td>
+<td>converted_amount</td>
 <td>Number</td>
 <td>The total amount of volume in the market, converted to the display currency.</td>
 </tr>
@@ -2239,7 +2243,7 @@
                     "counter": {
                         "currency": "XRP"
                     },
-                    "convertedAmount": 117720.99268355068
+                    "converted_amount": 117720.99268355068
                 },
                 {
                     "count": 1977,
@@ -2252,7 +2256,7 @@
                     "counter": {
                         "currency": "XRP"
                     },
-                    "convertedAmount": 74003.51871932109
+                    "converted_amount": 74003.51871932109
                 },
 
                 ... (additional results trimmed) ...
@@ -2269,7 +2273,7 @@
                         "currency": "USD",
                         "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
                     },
-                    "convertedAmount": 12.72863756671683
+                    "converted_amount": 12.72863756671683
                 },
                 {
                     "count": 3,
@@ -2283,7 +2287,7 @@
                         "currency": "BTC",
                         "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
                     },
-                    "convertedAmount": 4.4137945368632545
+                    "converted_amount": 4.4137945368632545
                 }
             ],
             "count": 11105,
@@ -2426,7 +2430,7 @@
 <td>The exchange rate between this currency and the display currency.</td>
 </tr>
 <tr>
-<td>convertedAmount</td>
+<td>converted_amount</td>
 <td>Number</td>
 <td>Total payment volume for this currency, converted to the display currency.</td>
 </tr>
@@ -2449,7 +2453,7 @@
                     "amount": 87279.59029136538,
                     "count": 331,
                     "rate": 0.004412045860957953,
-                    "convertedAmount": 19782113.1153009
+                    "converted_amount": 19782113.1153009
                 },
                 {
                     "currency": "USD",
@@ -2457,7 +2461,7 @@
                     "amount": 0,
                     "count": 0,
                     "rate": 0.00451165816091143,
-                    "convertedAmount": 0
+                    "converted_amount": 0
                 },
                 {
                     "currency": "BTC",
@@ -2465,7 +2469,7 @@
                     "amount": 279.03077460240354,
                     "count": 107,
                     "rate": 0.000013312520335244644,
-                    "convertedAmount": 20960026.169024874
+                    "converted_amount": 20960026.169024874
                 },
 
                 ... (additional results trimmed) ...
@@ -2476,14 +2480,14 @@
                     "amount": 49263.13280138676,
                     "count": 19,
                     "rate": 0.07640584677247926,
-                    "convertedAmount": 644756.0609868265
+                    "converted_amount": 644756.0609868265
                 },
                 {
                     "currency": "XRP",
                     "amount": 296246369.30089426,
                     "count": 8691,
                     "rate": 1,
-                    "convertedAmount": 296246369.30089426
+                    "converted_amount": 296246369.30089426
                 }
             ],
             "count": 9388,
@@ -2622,7 +2626,7 @@
 </tbody>
 </table>
 <h4 id="example-13">Example</h4>
-<p>Request: </p>
+<p>Request:</p>
 <pre><code>GET /v2/network/issued_value?start=2015-10-01T00:00:00&amp;end=2015-10-01T00:00:00&amp;exchange_currency=USD&amp;exchange_issuer=rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
 </code></pre>
 <p>Response:</p>
@@ -2668,10 +2672,283 @@
   ]
 }
 </code></pre>
+<h2 id="get-top-currencies">Get Top Currencies</h2>
+<p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topCurrencies.js" title="Source">[Source]<br/></a></p>
+<p>Returns the top currencies on the Ripple Consensus Ledger over a rolling 30 day window. The currencies are ordered from highest ranked to lowest, where the rank is determined by the volume and count of transactions and the number of unique counterparties. By default, returns the top currencies for the most recent date available. You can query historical data by date. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>)</em></p>
+<h4 id="request-format-14">Request Format</h4>
+<div class="multicode">
+<p><em>Most Recent</em></p>
+<pre><code>GET /v2/network/top_currencies
+</code></pre>
+<p><em>By Date</em></p>
+<pre><code>GET /v2/network/top_currencies/2016-01-01
+</code></pre>
+</div>
+<p><a class="button" href="data-api-v2-tool.html#get-top-currencies">Try it! &gt;</a></p>
+<h4 id="response-format-14">Response Format</h4>
+<p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>result</td>
+<td><code>success</code></td>
+<td>Indicates that the body represents a successful response.</td>
+</tr>
+<tr>
+<td>date</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>The time at which this data was measured.</td>
+</tr>
+<tr>
+<td>count</td>
+<td>Integer</td>
+<td>Number of results returned.</td>
+</tr>
+<tr>
+<td>currencies</td>
+<td>Array of Top Currency Objects</td>
+<td>A currency + issuer, and the metrics measured for inclusion and ranking</td>
+</tr>
+</tbody>
+</table>
+<p>Each Top Currency Object has the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>currency</td>
+<td>String - <a href="#currency-code">Currency Code</a></td>
+<td>The currency this object describes</td>
+</tr>
+<tr>
+<td>issuer</td>
+<td>String - <a href="#addresses">Address</a></td>
+<td>The Ripple address that issues this currency</td>
+</tr>
+<tr>
+<td>avg_exchange_count</td>
+<td><a href="#numbers-and-precision">String - Number</a></td>
+<td>Daily average number of exchanges</td>
+</tr>
+<tr>
+<td>avg_exchange_volume</td>
+<td><a href="#numbers-and-precision">String - Number</a></td>
+<td>Daily average volume of exchanges, normalized to XRP</td>
+</tr>
+<tr>
+<td>avg_payment_count</td>
+<td><a href="#numbers-and-precision">String - Number</a></td>
+<td>Daily average number of payments</td>
+</tr>
+<tr>
+<td>avg_payment_volume</td>
+<td><a href="#numbers-and-precision">String - Number</a></td>
+<td>Daily average volume of payments, normalized to XRP</td>
+</tr>
+<tr>
+<td>issued_value</td>
+<td><a href="#numbers-and-precision">String - Number</a></td>
+<td>Total amount of this currency issued by this issuer, normalized to XRP</td>
+</tr>
+</tbody>
+</table>
+<h4 id="example-14">Example</h4>
+<p>Request:</p>
+<pre><code>GET /v2/network/top_currencies/2015-12-31
+</code></pre>
+<p>Response:</p>
+<pre><code>{
+  result: "success",
+  date: "2015-12-31T00:00:00Z",
+  count: 41,
+  currencies: [
+    {
+      avg_exchange_count: "4652.1612903225805",
+      avg_exchange_volume: "5.872515158748898E7",
+      avg_payment_count: "406.5625",
+      avg_payment_volume: "592537.1043782063",
+      issued_value: "3.3304427137620807E8",
+      currency: "USD",
+      issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+    },
+    {
+      avg_exchange_count: "6083.193548387097",
+      avg_exchange_volume: "3.558897661266646E7",
+      avg_payment_count: "520.71875",
+      avg_payment_volume: "3507232.307236187",
+      issued_value: "1.1695602455168623E8",
+      currency: "CNY",
+      issuer: "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y"
+    },
+    {
+      avg_exchange_count: "3715.0967741935483",
+      avg_exchange_volume: "3.7346262589967564E7",
+      avg_payment_count: "163.1875",
+      avg_payment_volume: "775.0342076125125",
+      issued_value: "1.906530130641547E8",
+      currency: "BTC",
+      issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+    },
+    ...
+  ]
+}
+</code></pre>
+<h2 id="get-top-markets">Get Top Markets</h2>
+<p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topMarkets.js" title="Source">[Source]<br/></a></p>
+<p>Returns the top exchange markets on the Ripple Consensus Ledger over a rolling 30 day window.  The markets are ordered from highest ranked to lowest, where the rank is determined by the number and volume of exchanges and the number of counterparties participating.  By default, returns top markets for the latest date available.  You can query historical data by date. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>)</em></p>
+<h4 id="request-format-15">Request Format</h4>
+<div class="multicode">
+<p><em>Most Recent</em></p>
+<pre><code>GET /v2/network/top_markets
+</code></pre>
+<p><em>By Date</em></p>
+<pre><code>GET /v2/network/top_markets/2016-01-01
+</code></pre>
+</div>
+<p><a class="button" href="data-api-v2-tool.html#get-top-markets">Try it! &gt;</a></p>
+<h4 id="response-format-15">Response Format</h4>
+<p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>result</td>
+<td><code>success</code></td>
+<td>Indicates that the body represents a successful response.</td>
+</tr>
+<tr>
+<td>date</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>The time at which this data was measured.</td>
+</tr>
+<tr>
+<td>count</td>
+<td>Integer</td>
+<td>Number of results returned.</td>
+</tr>
+<tr>
+<td>markets</td>
+<td>Array of Top Market Objects</td>
+<td>A currency pair and the metrics measured for inclusion and ranking</td>
+</tr>
+</tbody>
+</table>
+<p>Each Top Market object has the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>base_currency</td>
+<td>String - <a href="#currency-code">Currency Code</a></td>
+<td>The base currency for this market</td>
+</tr>
+<tr>
+<td>base_issuer</td>
+<td>String - <a href="#addresses">Address</a></td>
+<td>(Omitted if <code>base_currency</code> is XRP) The Ripple address that issues the base currency</td>
+</tr>
+<tr>
+<td>counter_currency</td>
+<td>String - <a href="#currency-code">Currency Code</a></td>
+<td>The counter currency for this market</td>
+</tr>
+<tr>
+<td>counter_issuer</td>
+<td>String - <a href="#addresses">Address</a></td>
+<td>(Omitted if <code>counter_currency</code> is XRP) The Ripple address that issues the counter currency</td>
+</tr>
+<tr>
+<td>avg_base_volume</td>
+<td>String</td>
+<td>Daily average volume in terms of the base currency</td>
+</tr>
+<tr>
+<td>avg_counter_volume</td>
+<td>String</td>
+<td>Daily average volume in terms of the counter currency</td>
+</tr>
+<tr>
+<td>avg_exchange_count</td>
+<td>String</td>
+<td>Daily average number of exchanges</td>
+</tr>
+<tr>
+<td>avg_volume</td>
+<td>String</td>
+<td>Daily average volume, normalized to XRP</td>
+</tr>
+</tbody>
+</table>
+<h4 id="example-15">Example</h4>
+<p>Request:</p>
+<pre><code>GET /v2/network/top_markets/2015-12-31
+</code></pre>
+<p>Response:</p>
+<pre><code>{
+  result: "success",
+  date: "2015-12-31T00:00:00Z",
+  count: 56,
+  markets: [
+    {
+      avg_base_volume: "116180.98607935428",
+      avg_counter_volume: "1.6657039295476614E7",
+      avg_exchange_count: "1521.4603174603174",
+      avg_volume: "1.6657039295476614E7",
+      base_currency: "USD",
+      base_issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+      counter_currency: "XRP"
+    },
+    {
+      avg_base_volume: "410510.0286920887",
+      avg_counter_volume: "9117398.719214212",
+      avg_exchange_count: "1902.1587301587301",
+      avg_volume: "9117398.719214212",
+      base_currency: "CNY",
+      base_issuer: "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y",
+      counter_currency: "XRP"
+    },
+    {
+      avg_base_volume: "178.06809101586364",
+      avg_counter_volume: "1.1343000055456754E7",
+      avg_exchange_count: "1224.2857142857142",
+      avg_volume: "1.1343000055456754E7",
+      base_currency: "BTC",
+      base_issuer: "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+      counter_currency: "XRP"
+    },
+    ...
+  ]
+}
+</code></pre>
 <h2 id="get-all-gateways">Get All Gateways</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/gateways.js" title="Source">[Source]<br/></a></p>
 <p>Get information about <a href="https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json">known gateways</a>. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.4">v2.0.4</a>)</em></p>
-<h4 id="request-format-14">Request Format</h4>
+<h4 id="request-format-16">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/gateways/
@@ -2679,7 +2956,7 @@
 </div>
 <p><a class="button" href="data-api-v2-tool.html#get-all-gateways">Try it! &gt;</a></p>
 <p>This method takes no query parameters.</p>
-<h4 id="response-format-14">Response Format</h4>
+<h4 id="response-format-16">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body.</p>
 <p>Each field in the top level JSON object is a <a href="#currency-code">Currency Code</a>. The content of each field is an array of objects, representing gateways that issue that currency. Each object has the following fields:</p>
 <table>
@@ -2704,7 +2981,7 @@
 <tr>
 <td>featured</td>
 <td>Boolean</td>
-<td>Whether this gateway is considered a "featured" issuer of the currency. Ripple, Inc. decides which gateways to feature based on responsible business practices, volume, and other measures.</td>
+<td>Whether this gateway is considered a "featured" issuer of the currency. Ripple decides which gateways to feature based on responsible business practices, volume, and other measures.</td>
 </tr>
 <tr>
 <td>label</td>
@@ -2718,7 +2995,7 @@
 </tr>
 </tbody>
 </table>
-<h4 id="example-14">Example</h4>
+<h4 id="example-16">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/gateways/
 </code></pre>
@@ -2772,7 +3049,7 @@
 <h2 id="get-gateway">Get Gateway</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/gateways.js" title="Source">[Source]<br/></a></p>
 <p>Get information about a specific gateway from <a href="https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json">the Data API's list of known gateways</a>. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.4">v2.0.4</a>)</em></p>
-<h4 id="request-format-15">Request Format</h4>
+<h4 id="request-format-17">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/gateways/{:gateway}
@@ -2797,7 +3074,7 @@
 </tbody>
 </table>
 <p>This method takes no query parameters.</p>
-<h4 id="response-format-15">Response Format</h4>
+<h4 id="response-format-17">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -2863,11 +3140,11 @@
 <tr>
 <td>currencies</td>
 <td>Object</td>
-<td>Each field in this object is a <a href="#currency-code">Currency Code</a> corresponding to a currency issued from this address. Each value is an object with a <code>featured</code> boolean indicating whether that currency is featured. Ripple, Inc. decides which currencies and gateways to feature based on responsible business practices, volume, and other measures.</td>
+<td>Each field in this object is a <a href="#currency-code">Currency Code</a> corresponding to a currency issued from this address. Each value is an object with a <code>featured</code> boolean indicating whether that currency is featured. Ripple decides which currencies and gateways to feature based on responsible business practices, volume, and other measures.</td>
 </tr>
 </tbody>
 </table>
-<h4 id="example-15">Example</h4>
+<h4 id="example-17">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/gateways/Gatehub
 </code></pre>
@@ -2903,7 +3180,7 @@
 <h2 id="get-currency-image">Get Currency Image</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/v0.0.4-rc2/api/routesV2/gateways.js#L196" title="Source">[Source]<br/></a></p>
 <p>Retrieve vector icons for various currencies. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.4">v2.0.4</a>)</em></p>
-<h4 id="request-format-16">Request Format</h4>
+<h4 id="request-format-18">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/currencies/{:currencyimage}
@@ -2926,9 +3203,9 @@
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-16">Response Format</h4>
+<h4 id="response-format-18">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a <strong>Content-Type</strong> header of <code>image/svg+xml</code> to indicate that the contents are XML representing a file in <a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">SVG format</a>.</p>
-<h4 id="example-16">Example</h4>
+<h4 id="example-18">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/currencies/mxn.svg
 </code></pre>
@@ -2957,7 +3234,7 @@ Content-Type: image/svg+xml
 <h2 id="get-accounts">Get Accounts</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accounts.js" title="Source">[Source]<br/></a></p>
 <p>Retrieve information about the creation of new accounts in the Ripple Consensus Ledger.</p>
-<h4 id="request-format-17">Request Format</h4>
+<h4 id="request-format-19">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/accounts
@@ -3021,7 +3298,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-17">Response Format</h4>
+<h4 id="response-format-19">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3077,7 +3354,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-17">Example</h4>
+<h4 id="example-19">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v1/accounts?parent=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn
 </code></pre>
@@ -3116,7 +3393,7 @@ Content-Type: image/svg+xml
 <h2 id="get-account">Get Account</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getAccount.js" title="Source">[Source]<br/></a></p>
 <p>Get creation info for a specific ripple account</p>
-<h4 id="request-format-18">Request Format</h4>
+<h4 id="request-format-20">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/accounts/{:address}
@@ -3140,7 +3417,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-18">Response Format</h4>
+<h4 id="response-format-20">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3163,7 +3440,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-18">Example</h4>
+<h4 id="example-20">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn
 </code></pre>
@@ -3253,7 +3530,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-19">Response Format</h4>
+<h4 id="response-format-21">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3296,7 +3573,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-19">Example</h4>
+<h4 id="example-21">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/balances?currency=USD&amp;date=2015-01-01T00:00:00Z&amp;limit=3
 </code></pre>
@@ -3328,7 +3605,7 @@ Content-Type: image/svg+xml
 <h2 id="get-account-orders">Get Account Orders</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountOrders.js" title="Source">[Source]<br/></a></p>
 <p>Get orders in the order books, placed by a specific account. This does not return orders that have already been filled.</p>
-<h4 id="request-format-19">Request Format</h4>
+<h4 id="request-format-21">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/account/{:address}/orders
@@ -3390,7 +3667,7 @@ Content-Type: image/svg+xml
 </tbody>
 </table>
 <p>If none of <code>ledger_index</code>, <code>ledger_hash</code>, or <code>date</code> are specified, the API uses the most current data available.</p>
-<h4 id="response-format-20">Response Format</h4>
+<h4 id="response-format-22">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3480,8 +3757,8 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-20">Example</h4>
-<p>Request: </p>
+<h4 id="example-22">Example</h4>
+<p>Request:</p>
 <pre><code>GET /v2/accounts/rK5j9n8baXfL4gzUoZsfxBvvsv97P5swaV/orders?limit=2&amp;date=2015-11-11T00:00:00Z
 </code></pre>
 <p>Response:</p>
@@ -3537,7 +3814,7 @@ Content-Type: image/svg+xml
 <h2 id="get-account-transaction-history">Get Account Transaction History</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountTransactions.js" title="Source">[Source]<br/></a></p>
 <p>Retrieve a history of transactions that affected a specific account. This includes all transactions the account sent, payments the account received, and payments that rippled through the account.</p>
-<h4 id="request-format-20">Request Format</h4>
+<h4 id="request-format-22">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/accounts/{:address}/transactions
@@ -3628,7 +3905,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-21">Response Format</h4>
+<h4 id="response-format-23">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3661,7 +3938,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-21">Example</h4>
+<h4 id="example-23">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/transactions?type=Payment&amp;result=tesSUCCESS&amp;limit=1
 </code></pre>
@@ -3730,7 +4007,7 @@ Content-Type: image/svg+xml
 <h2 id="get-transaction-by-account-and-sequence">Get Transaction By Account And Sequence</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountTxSeq.js" title="Source">[Source]<br/></a></p>
 <p>Retrieve a specifc transaction originating from a specified account</p>
-<h4 id="request-format-21">Request Format</h4>
+<h4 id="request-format-23">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/accounts/{:address}/transactions/{:sequence}
@@ -3776,7 +4053,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-22">Response Format</h4>
+<h4 id="response-format-24">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3799,7 +4076,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-22">Example</h4>
+<h4 id="example-24">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/transactions/10?binary=true
 </code></pre>
@@ -3818,7 +4095,7 @@ Content-Type: image/svg+xml
 <h2 id="get-account-payments">Get Account Payments</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountPayments.js" title="Source">[Source]<br/></a></p>
 <p>Retrieve a payments for a specified account</p>
-<h4 id="request-format-22">Request Format</h4>
+<h4 id="request-format-24">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/accounts/{:address}/payments
@@ -3909,7 +4186,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-23">Response Format</h4>
+<h4 id="response-format-25">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -3942,7 +4219,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-23">Example</h4>
+<h4 id="example-25">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/payments?currency=USD&amp;limit=1
 </code></pre>
@@ -3986,7 +4263,7 @@ Content-Type: image/svg+xml
 <h2 id="get-account-exchanges">Get Account Exchanges</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountExchanges.js" title="Source">[Source]<br/></a></p>
 <p>Retrieve Exchanges for a given account over time.</p>
-<h4 id="request-format-23">Request Format</h4>
+<h4 id="request-format-25">Request Format</h4>
 <p>There are two variations on this method:</p>
 <div class="multicode">
 <p><em>REST - All Exchanges</em></p>
@@ -4066,7 +4343,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-24">Response Format</h4>
+<h4 id="response-format-26">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -4099,7 +4376,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-24">Example</h4>
+<h4 id="example-26">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw/exchanges/KRW+rUkMKjQitpgAM5WTGk79xpjT38DEJY283d/XRP?start=2015-08-08T00:00:00Z&amp;end=2015-08-31T00:00:00Z&amp;limit=2
 
@@ -4153,7 +4430,7 @@ Content-Type: image/svg+xml
 <h2 id="get-account-balance-changes">Get Account Balance Changes</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountBalanceChanges.js" title="Source">[Source]<br/></a></p>
 <p>Retrieve Balance changes for a given account over time.</p>
-<h4 id="request-format-24">Request Format</h4>
+<h4 id="request-format-26">Request Format</h4>
 <div class="multicode">
 <p><em>REST</em></p>
 <pre><code>GET /v2/accounts/{:address}/balance_changes/
@@ -4229,7 +4506,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-25">Response Format</h4>
+<h4 id="response-format-27">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -4262,7 +4539,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-25">Example</h4>
+<h4 id="example-27">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/balance_changes?descending=true&amp;limit=3
 </code></pre>
@@ -4382,7 +4659,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-26">Response Format</h4>
+<h4 id="response-format-28">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
 <thead>
@@ -4410,7 +4687,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-26">Example</h4>
+<h4 id="example-28">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/accounts/rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q/reports?start=2015-08-28T00:00:00&amp;end=2015-08-28T00:00:00&amp;accounts=true&amp;payments=true&amp;descending=true
 </code></pre>
@@ -4461,6 +4738,315 @@ Content-Type: image/svg+xml
   ]
 }
 </code></pre>
+<h2 id="get-account-transaction-stats">Get Account Transaction Stats</h2>
+<p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountStats.js" title="Source">[Source]<br/></a></p>
+<p>Retrieve daily summaries of transaction activity for an account. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>.)</em></p>
+<div class="multicode">
+<p><em>REST</em></p>
+<pre><code>GET /v2/accounts/{:address}/stats/transactions
+</code></pre>
+</div>
+<p><a class="button" href="data-api-v2-tool.html#get-account-transaction-stats">Try it! &gt;</a></p>
+<p>This method requires the following URL parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>:address</td>
+<td>String</td>
+<td>Ripple address to query</td>
+</tr>
+</tbody>
+</table>
+<p>Optionally, you can also include the following query parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>start</td>
+<td>String</td>
+<td>UTC start time of query range. Defaults to start of current date.</td>
+</tr>
+<tr>
+<td>end</td>
+<td>String</td>
+<td>UTC end time of query range. Defaults to current date.</td>
+</tr>
+<tr>
+<td>limit</td>
+<td>Integer</td>
+<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+</tr>
+<tr>
+<td>descending</td>
+<td>Boolean</td>
+<td>If true, sort results with most recent first. By default, sort results with oldest first.</td>
+</tr>
+<tr>
+<td>marker</td>
+<td>String</td>
+<td><a href="#pagination">Pagination</a> key from previously returned response.</td>
+</tr>
+<tr>
+<td>format</td>
+<td>String</td>
+<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+</tr>
+</tbody>
+</table>
+<h4 id="response-format-29">Response Format</h4>
+<p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>result</td>
+<td><code>success</code></td>
+<td>Indicates that the body represents a successful response.</td>
+</tr>
+<tr>
+<td>count</td>
+<td>Integer</td>
+<td>Number of reports returned.</td>
+</tr>
+<tr>
+<td>rows</td>
+<td>Array of Transaction Stats Objects</td>
+<td>Daily summaries of account transaction activity for the given account.</td>
+</tr>
+</tbody>
+</table>
+<p>Each Transaction Stats Object has the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>date</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>The date this transaction stats object describes.</td>
+</tr>
+<tr>
+<td>transaction_count</td>
+<td>Integer</td>
+<td>The total number of transactions sent by the account on this date.</td>
+</tr>
+<tr>
+<td>result</td>
+<td>Object</td>
+<td>Map of <a href="reference-transaction-format.html#transaction-results">transaction result codes</a>, indicating how many of each result code occurred in the transactions sent by this account on this date.</td>
+</tr>
+<tr>
+<td>type</td>
+<td>Object</td>
+<td>Map of <a href="reference-transaction-format.html">transaction types</a>, indicating how many of each transaction type the account sent on this date.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="example-29">Example</h4>
+<p>Request:</p>
+<pre><code>GET /v2/accounts/rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX/stats/transactions?start=2015-01-01&amp;limit=2
+</code></pre>
+<p>Response:</p>
+<pre><code>{
+  "result": "success",
+  "count": 2,
+  "marker": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX|20150116000000",
+  "rows": [
+    {
+      "date": "2015-01-14T00:00:00Z",
+      "transaction_count": 44,
+      "result": {
+        "tecUNFUNDED_PAYMENT": 1,
+        "tesSUCCESS": 43
+      },
+      "type": {
+        "Payment": 42,
+        "TrustSet": 2
+      }
+    },
+    {
+      "date": "2015-01-15T00:00:00Z",
+      "transaction_count": 116,
+      "result": {
+        "tesSUCCESS": 116
+      },
+      "type": {
+        "Payment": 116
+      }
+    }
+  ]
+}
+</code></pre>
+<h2 id="get-account-value-stats">Get Account Value Stats</h2>
+<p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountStats.js" title="Source">[Source]<br/></a></p>
+<p>Retrieve daily summaries of transaction activity for an account. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>.)</em></p>
+<div class="multicode">
+<p><em>REST</em></p>
+<pre><code>GET /v2/accounts/{:address}/stats/value
+</code></pre>
+</div>
+<p><a class="button" href="data-api-v2-tool.html#get-account-value-stats">Try it! &gt;</a></p>
+<p>This method requires the following URL parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>:address</td>
+<td>String</td>
+<td>Ripple address to query</td>
+</tr>
+</tbody>
+</table>
+<p>Optionally, you can also include the following query parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>start</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>Start time of query range. Defaults to the start of the most recent interval.</td>
+</tr>
+<tr>
+<td>end</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>End time of query range. Defaults to the end of the most recent interval.</td>
+</tr>
+<tr>
+<td>limit</td>
+<td>Integer</td>
+<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+</tr>
+<tr>
+<td>marker</td>
+<td>String</td>
+<td><a href="#pagination">Pagination</a> key from previously returned response.</td>
+</tr>
+<tr>
+<td>descending</td>
+<td>Boolean</td>
+<td>If true, sort results with most recent first. By default, sort results with oldest first.</td>
+</tr>
+<tr>
+<td>format</td>
+<td>String</td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="response-format-30">Response Format</h4>
+<p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>result</td>
+<td><code>success</code></td>
+<td>Indicates that the body represents a successful response.</td>
+</tr>
+<tr>
+<td>count</td>
+<td>Integer</td>
+<td>Number of reports returned.</td>
+</tr>
+<tr>
+<td>rows</td>
+<td>Array of Value Stats Objects</td>
+<td>Daily summaries of account value for the given account.</td>
+</tr>
+</tbody>
+</table>
+<p>Each Value Stats Object has the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>date</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>This date this object describes.</td>
+</tr>
+<tr>
+<td>value</td>
+<td><a href="#numbers-and-precision">String - Number</a></td>
+<td>The total of all currency held by this account, normalized to XRP.</td>
+</tr>
+<tr>
+<td>balance_change_count</td>
+<td>Number</td>
+<td>The number of times the account's balance changed on this date.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="example-30">Example</h4>
+<p>Request:</p>
+<pre><code>GET /v2/accounts/rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX/stats/value?limit=2&amp;descending=true
+</code></pre>
+<p>Response:</p>
+<pre><code>{
+  "result": "success",
+  "count": 2,
+  "marker": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX|20160412000000",
+  "rows": [
+    {
+      "date": "2016-04-14T00:00:00Z",
+      "account_value": "7.666658705139822E7",
+      "balance_change_count": 58
+    },
+    {
+      "date": "2016-04-13T00:00:00Z",
+      "account_value": "1.0022208004947332E8",
+      "balance_change_count": 184
+    }
+  ]
+}
+</code></pre>
 <h2 id="health-check-api">Health Check - API</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/checkHealth.js" title="Source">[Source]<br/></a></p>
 <p>Check the health of the API service.</p>
@@ -4491,8 +5077,8 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-27">Response Format</h4>
-<p>A successful response uses the HTTP code <strong>200 OK</strong>. By default, the response body is an <strong>integer health value only</strong>. </p>
+<h4 id="response-format-31">Response Format</h4>
+<p>A successful response uses the HTTP code <strong>200 OK</strong>. By default, the response body is an <strong>integer health value only</strong>.</p>
 <p>The health value <code>0</code> always indicates a healthy status. Other health values are defined as follows:</p>
 <table>
 <thead>
@@ -4543,15 +5129,15 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-27">Example</h4>
+<h4 id="example-31">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/health/api?verbose=true
 </code></pre>
 <p>Response:</p>
 <pre><code>{
-  score: 0,
-  response_time: "0.389s",
-  response_time_threshold: "5s"
+    "score": 0,
+    "response_time": "0.014s",
+    "response_time_threshold": "5s"
 }
 </code></pre>
 <h2 id="health-check-ledger-importer">Health Check - Ledger Importer</h2>
@@ -4589,8 +5175,8 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-28">Response Format</h4>
-<p>A successful response uses the HTTP code <strong>200 OK</strong>. By default, the response body is an <strong>integer health value only</strong>. </p>
+<h4 id="response-format-32">Response Format</h4>
+<p>A successful response uses the HTTP code <strong>200 OK</strong>. By default, the response body is an <strong>integer health value only</strong>.</p>
 <p>The health value <code>0</code> always indicates a healthy status. Other health values are defined as follows:</p>
 <table>
 <thead>
@@ -4660,7 +5246,7 @@ Content-Type: image/svg+xml
 </tr>
 </tbody>
 </table>
-<h4 id="example-28">Example</h4>
+<h4 id="example-32">Example</h4>
 <p>Request:</p>
 <pre><code>GET /v2/health/importer?verbose=true
 </code></pre>
@@ -5172,7 +5758,7 @@ Content-Type: image/svg+xml
 </tbody>
 </table>
 <h2 id="payment-summary-objects">Payment Summary Objects</h2>
-<p>A Payment Summary Object contains a reduced amount of information about a single payment from the perspective of either the sender or receiver of that payment. </p>
+<p>A Payment Summary Object contains a reduced amount of information about a single payment from the perspective of either the sender or receiver of that payment.</p>
 <table>
 <thead>
 <tr>
@@ -5476,7 +6062,7 @@ Content-Type: image/svg+xml
 </ul>
 <p>Version 2 of the Historical Database requires HBase instead of <a href="http://www.postgresql.org/">PostgreSQL</a>. Postgres support is deprecated.</p>
 <h3 id="installation-process">Installation Process</h3>
-<p>Starting in </p>
+<p>Starting in</p>
 <ol>
 <li>Install HBase. For production use, configure it in distributed mode.</li>
 <li>Clone the rippled Historical Database Git Repository:
@@ -5490,6 +6076,13 @@ Content-Type: image/svg+xml
 </ol>
 <p>Reports, stats, and aggregated exchange data needs additional processing before the API can make it available. This processing uses Apache Storm as well as some custom scripts. See <a href="https://github.com/ripple/rippled-historical-database/blob/develop/storm/README.md">Storm Setup</a> for more information.</p>
 <p>At this point, the rippled Historical Database is installed. See <a href="#services">Services</a> for the different components that you can run.</p>
+<h3 id="tests">Tests</h3>
+<p>Dependencies:
+* <a href="https://docs.docker.com/compose/install/">Docker Compose</a></p>
+<pre><code>$ docker-compose build
+$ docker-compose up -d hbase
+$ docker-compose run webapp npm test
+</code></pre>
 <h3 id="services">Services</h3>
 <p>The <code>rippled</code> Historical Database consists of several processes that can be run separately.</p>
 <ul>
@@ -5523,7 +6116,7 @@ $ node import/live
 <p>The Backfiller retrieves old ledgers from a <code>rippled</code> instance by moving backwards in time. You can optionally provide start and stop indexes to retrieve a specific range of ledgers, by their sequence number.</p>
 <p>The <code>--startIndex</code> parameter defines the most-recent ledger to retrieve. The Backfiller retrieves this ledger first and then continues retrieving progressively older ledgers. If this parameter is omitted, the Backfiller begins with the newest validated ledger.</p>
 <p>The <code>--stopIndex</code> parameter defines the oldest ledger to retrieve. The Backfiller stops after it retrieves this ledger. If omitted, the Backfiller continues as far back as possible. Because backfilling goes from most recent to least recent, the stop index should be a smaller than the start index.</p>
-<p><strong>Warning:</strong> The Backfiller is best for filling in relatively short histories of transactions. Importing a complete history of all Ripple transactions using the Backfiller could take weeks. If you want a full history, we recommend acquiring a database dump with early transctions, and importing it directly. Ripple, Inc. used the internal SQLite database from an offline <code>rippled</code> to populate its historical databases with the early transactions, then used the Backfiller to catch up to date after the import finished.</p>
+<p><strong>Warning:</strong> The Backfiller is best for filling in relatively short histories of transactions. Importing a complete history of all Ripple transactions using the Backfiller could take weeks. If you want a full history, we recommend acquiring a database dump with early transctions, and importing it directly. For the public server, Ripple (the company) used the internal SQLite database from an offline <code>rippled</code> to populate its historical databases with the early transactions, then used the Backfiller to catch up to date after the import finished.</p>
 <p>Example usage:</p>
 <pre><code>// get ledgers #1,000,000 to #2,000,000 (inclusive) and store in HBase
 node import/hbase/backfill --startIndex 2000000 --stopIndex 1000000

--- a/reference-data-api.html
+++ b/reference-data-api.html
@@ -266,8 +266,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>ledger</td>
@@ -354,8 +354,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>transaction</td>
@@ -474,7 +474,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 20). Cannot be more than 100.</td>
+<td>Maximum results per page. Defaults to 20. Cannot be more than 100.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -496,8 +496,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -685,7 +685,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -712,8 +712,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -948,8 +948,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -1107,8 +1107,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>rate</td>
@@ -1199,8 +1199,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>amount</td>
@@ -1287,7 +1287,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -1309,8 +1309,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>date</td>
@@ -1489,7 +1489,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -1593,8 +1593,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -1694,7 +1694,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -1732,8 +1732,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -1916,8 +1916,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -2137,7 +2137,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page. Defaults to 200. Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -2164,8 +2164,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -2352,7 +2352,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page. Defaults to 200. Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -2379,8 +2379,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -2546,7 +2546,7 @@
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page. Defaults to 200. Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -2573,8 +2573,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -2674,7 +2674,7 @@
 </code></pre>
 <h2 id="get-top-currencies">Get Top Currencies</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topCurrencies.js" title="Source">[Source]<br/></a></p>
-<p>Returns the top currencies on the Ripple Consensus Ledger over a rolling 30 day window. The currencies are ordered from highest ranked to lowest, where the rank is determined by the volume and count of transactions and the number of unique counterparties. By default, returns the top currencies for the most recent date available. You can query historical data by date. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>)</em></p>
+<p>Returns the top currencies on the Ripple Consensus Ledger, ordered from highest rank to lowest. The ranking is determined by the volume and count of transactions and the number of unique counterparties. By default, returns results for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>)</em></p>
 <h4 id="request-format-14">Request Format</h4>
 <div class="multicode">
 <p><em>Most Recent</em></p>
@@ -2685,6 +2685,7 @@
 </code></pre>
 </div>
 <p><a class="button" href="data-api-v2-tool.html#get-top-currencies">Try it! &gt;</a></p>
+<p>This method does not accept any query parameters.</p>
 <h4 id="response-format-14">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
@@ -2698,8 +2699,8 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>date</td>
@@ -2709,12 +2710,12 @@
 <tr>
 <td>count</td>
 <td>Integer</td>
-<td>Number of results returned.</td>
+<td>Number of objects in the <code>currencies</code> field.</td>
 </tr>
 <tr>
 <td>currencies</td>
 <td>Array of Top Currency Objects</td>
-<td>A currency + issuer, and the metrics measured for inclusion and ranking</td>
+<td>The top currencies for this data sample. Each member represents one currency, by currency code and issuer.</td>
 </tr>
 </tbody>
 </table>
@@ -2741,7 +2742,7 @@
 <tr>
 <td>avg_exchange_count</td>
 <td><a href="#numbers-and-precision">String - Number</a></td>
-<td>Daily average number of exchanges</td>
+<td>Daily average number of <a href="#exchange-objects">exchanges</a></td>
 </tr>
 <tr>
 <td>avg_exchange_volume</td>
@@ -2751,7 +2752,7 @@
 <tr>
 <td>avg_payment_count</td>
 <td><a href="#numbers-and-precision">String - Number</a></td>
-<td>Daily average number of payments</td>
+<td>Daily average number of <a href="#payment-objects">payments</a></td>
 </tr>
 <tr>
 <td>avg_payment_volume</td>
@@ -2808,7 +2809,7 @@
 </code></pre>
 <h2 id="get-top-markets">Get Top Markets</h2>
 <p><a href="https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/topMarkets.js" title="Source">[Source]<br/></a></p>
-<p>Returns the top exchange markets on the Ripple Consensus Ledger over a rolling 30 day window.  The markets are ordered from highest ranked to lowest, where the rank is determined by the number and volume of exchanges and the number of counterparties participating.  By default, returns top markets for the latest date available.  You can query historical data by date. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>)</em></p>
+<p>Returns the top exchange markets on the Ripple Consensus Ledger, ordered from highest rank to lowest. The rank is determined by the number and volume of exchanges and the number of counterparties participating. By default, returns top markets for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. <em>(New in <a href="https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0">v2.1.0</a>)</em></p>
 <h4 id="request-format-15">Request Format</h4>
 <div class="multicode">
 <p><em>Most Recent</em></p>
@@ -2818,6 +2819,7 @@
 <pre><code>GET /v2/network/top_markets/2016-01-01
 </code></pre>
 </div>
+<p>This method does not accept any query parameters.</p>
 <p><a class="button" href="data-api-v2-tool.html#get-top-markets">Try it! &gt;</a></p>
 <h4 id="response-format-15">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
@@ -2832,23 +2834,23 @@
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>date</td>
 <td>String - <a href="#timestamps">Timestamp</a></td>
-<td>The time at which this data was measured.</td>
+<td>The end of the rolling window over which this data was calculated.</td>
 </tr>
 <tr>
 <td>count</td>
 <td>Integer</td>
-<td>Number of results returned.</td>
+<td>Number of results in the <code>markets</code> field.</td>
 </tr>
 <tr>
 <td>markets</td>
 <td>Array of Top Market Objects</td>
-<td>A currency pair and the metrics measured for inclusion and ranking</td>
+<td>The top markets for this data sample. Each member represents a currency pair.</td>
 </tr>
 </tbody>
 </table>
@@ -2895,7 +2897,7 @@
 <tr>
 <td>avg_exchange_count</td>
 <td>String</td>
-<td>Daily average number of exchanges</td>
+<td>Daily average number of <a href="#exchange-objects">exchanges</a></td>
 </tr>
 <tr>
 <td>avg_volume</td>
@@ -3269,7 +3271,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1,000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1,000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -3311,13 +3313,13 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
 <td>Integer</td>
-<td>Number of reports returned.</td>
+<td>Number of accounts returned.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -3430,8 +3432,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>account</td>
@@ -3496,12 +3498,12 @@ Content-Type: image/svg+xml
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>Index of ledger for historical balances</td>
+<td>Index of ledger for historical balances.</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>Ledger hash for historical balances</td>
+<td>Ledger hash for historical balances.</td>
 </tr>
 <tr>
 <td>date</td>
@@ -3511,22 +3513,22 @@ Content-Type: image/svg+xml
 <tr>
 <td>currency</td>
 <td>String</td>
-<td>Restrict results to specified currency</td>
+<td>Restrict results to specified currency.</td>
 </tr>
 <tr>
 <td>counterparty</td>
 <td>String</td>
-<td>Restrict results to specified counterparty/issuer</td>
+<td>Restrict results to specified counterparty/issuer.</td>
 </tr>
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be greater than 400, but you can use the value <code>all</code> to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. Large gateways can have several tens of thousands of results.)</td>
+<td>Maximum results per page. Defaults to 200. Cannot be greater than 400, but you can use the value <code>all</code> to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. Large gateways can have several tens of thousands of results.)</td>
 </tr>
 <tr>
 <td>format</td>
 <td>String</td>
-<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -3543,33 +3545,33 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>ledger index for balances query</td>
+<td>ledger index for balances query.</td>
 </tr>
 <tr>
 <td>close_time</td>
 <td>String</td>
-<td>close time of the ledger</td>
+<td>close time of the ledger.</td>
 </tr>
 <tr>
 <td>limit</td>
 <td>String</td>
-<td>number of results returned, if limit was exceeded</td>
+<td>number of results returned, if limit was exceeded.</td>
 </tr>
 <tr>
 <td>marker</td>
 <td>String</td>
-<td>(May be omitted) <a href="#pagination">Pagination</a> marker</td>
+<td>(May be omitted) <a href="#pagination">Pagination</a> marker.</td>
 </tr>
 <tr>
 <td>balances</td>
 <td>Array of <a href="#balance-objects-and-balance-change-objects">Balance Object</a>s</td>
-<td>The requested balances</td>
+<td>The requested balances.</td>
 </tr>
 </tbody>
 </table>
@@ -3657,7 +3659,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be greater than 400.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be greater than 400.</td>
 </tr>
 <tr>
 <td>format</td>
@@ -3680,8 +3682,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>ledger_index</td>
@@ -3701,7 +3703,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>orders</td>
 <td>Array of order objects</td>
-<td>The requested orders</td>
+<td>The requested orders.</td>
 </tr>
 </tbody>
 </table>
@@ -3723,7 +3725,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>specification.direction</td>
 <td>String</td>
-<td>Either <code>buy</code> or <code>sell</code></td>
+<td>Either <code>buy</code> or <code>sell</code>.</td>
 </tr>
 <tr>
 <td>specification.quantity</td>
@@ -3850,13 +3852,13 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>start</td>
-<td>String</td>
-<td>UTC start time of query range</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>Start time of query range. Defaults to the earliest date available.</td>
 </tr>
 <tr>
 <td>end</td>
-<td>String</td>
-<td>UTC end time of query range</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>End time of query range. Defaults to the current date.</td>
 </tr>
 <tr>
 <td>min_sequence</td>
@@ -3891,7 +3893,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 20). Cannot be more than 1,000.</td>
+<td>Maximum results per page. Defaults to 20. Cannot be more than 1,000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -3901,7 +3903,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>format</td>
 <td>String</td>
-<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -3918,8 +3920,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -4066,8 +4068,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>transaction</td>
@@ -4115,7 +4117,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>:address</td>
 <td>String</td>
-<td>Ripple address to query</td>
+<td>Ripple address to query.</td>
 </tr>
 </tbody>
 </table>
@@ -4172,7 +4174,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1,000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1,000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -4182,7 +4184,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>format</td>
 <td>String</td>
-<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -4199,8 +4201,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -4287,7 +4289,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>:address</td>
 <td>String</td>
-<td>Ripple address to query</td>
+<td>Ripple address to query.</td>
 </tr>
 <tr>
 <td>:base</td>
@@ -4329,7 +4331,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -4339,7 +4341,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>format</td>
 <td>String</td>
-<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -4356,8 +4358,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -4450,7 +4452,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>:address</td>
 <td>String</td>
-<td>Ripple address to query</td>
+<td>Ripple address to query.</td>
 </tr>
 </tbody>
 </table>
@@ -4492,7 +4494,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -4519,8 +4521,8 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
@@ -4608,7 +4610,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>:address</td>
 <td>String</td>
-<td>Ripple address to query</td>
+<td>Ripple address to query.</td>
 </tr>
 <tr>
 <td>:date</td>
@@ -4629,13 +4631,13 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>start</td>
-<td>String</td>
-<td>UTC start time of query range. Defaults to start of current date. Ignored if <code>date</code> specified.</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>Start time of query range. Defaults to start of current date. Ignored if <code>date</code> specified.</td>
 </tr>
 <tr>
 <td>end</td>
-<td>String</td>
-<td>UTC end time of query range. Defaults to current date. Ignored if <code>date</code> specified.</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>End time of query range. Defaults to current date. Ignored if <code>date</code> specified.</td>
 </tr>
 <tr>
 <td>accounts</td>
@@ -4655,7 +4657,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>format</td>
 <td>String</td>
-<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -4672,13 +4674,13 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
 <td>Integer</td>
-<td>Number of reports returned.</td>
+<td>Number of reports in the <code>reports</code> field.</td>
 </tr>
 <tr>
 <td>reports</td>
@@ -4760,7 +4762,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>:address</td>
 <td>String</td>
-<td>Ripple address to query</td>
+<td>Ripple address to query.</td>
 </tr>
 </tbody>
 </table>
@@ -4776,18 +4778,18 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>start</td>
-<td>String</td>
-<td>UTC start time of query range. Defaults to start of current date.</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>Start time of query range. Defaults to the earliest date available.</td>
 </tr>
 <tr>
 <td>end</td>
-<td>String</td>
-<td>UTC end time of query range. Defaults to current date.</td>
+<td>String - <a href="#timestamps">Timestamp</a></td>
+<td>End time of query range. Defaults to the current date.</td>
 </tr>
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>descending</td>
@@ -4802,7 +4804,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>format</td>
 <td>String</td>
-<td>Format of returned results: <code>csv</code>,<code>json</code> defaults to <code>json</code></td>
+<td>Format of returned results: <code>csv</code> or <code>json</code>. Defaults to <code>json</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -4819,13 +4821,13 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
 <td>Integer</td>
-<td>Number of reports returned.</td>
+<td>Number of transaction stats objects in the <code>rows</code> field.</td>
 </tr>
 <tr>
 <td>rows</td>
@@ -4847,7 +4849,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>date</td>
 <td>String - <a href="#timestamps">Timestamp</a></td>
-<td>The date this transaction stats object describes.</td>
+<td>This object describes activity on this date.</td>
 </tr>
 <tr>
 <td>transaction_count</td>
@@ -4923,7 +4925,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>:address</td>
 <td>String</td>
-<td>Ripple address to query</td>
+<td>Ripple address to query.</td>
 </tr>
 </tbody>
 </table>
@@ -4950,7 +4952,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>Max results per page (defaults to 200). Cannot be more than 1000.</td>
+<td>Maximum results per page. Defaults to 200. Cannot be more than 1000.</td>
 </tr>
 <tr>
 <td>marker</td>
@@ -4982,13 +4984,13 @@ Content-Type: image/svg+xml
 <tbody>
 <tr>
 <td>result</td>
-<td><code>success</code></td>
-<td>Indicates that the body represents a successful response.</td>
+<td>String</td>
+<td>The value <code>success</code> indicates that this is a successful response.</td>
 </tr>
 <tr>
 <td>count</td>
 <td>Integer</td>
-<td>Number of reports returned.</td>
+<td>Number of value stats objects in the <code>rows</code> field.</td>
 </tr>
 <tr>
 <td>rows</td>
@@ -5010,7 +5012,7 @@ Content-Type: image/svg+xml
 <tr>
 <td>date</td>
 <td>String - <a href="#timestamps">Timestamp</a></td>
-<td>This date this object describes.</td>
+<td>This object describes activity on this date.</td>
 </tr>
 <tr>
 <td>value</td>


### PR DESCRIPTION
Four new methods (documentation mostly done by the Data team; I've just polished it up slightly):
- Get Top Currencies
- Get Top Markets
- Get Account Transaction Stats
- Get Account Value Stats

Various whitespace changes (this happened automatically because I switched text editors)

`convertedAmount` -> `converted_amount`

Found a few cases of "Ripple, Inc" and replaced them accordingly

Fixed one or two cases of invalid JSON
