### PR TITLE
Rippled 0.31.0 additional edits

### DIFF
--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -7511,8 +7511,8 @@ The fields from a validations stream message are as follows:
 | Field | Type | Description |
 |-------|------|-------------|
 | type | String | `validationReceived` indicates this is from the validations stream |
-| ledger\_hash | String | The identifying hash of the proposed ledger is being validated. _(New in [version 0.30.1][])_ |
-| ledger\_index | String - Integer | The [Ledger Index][] of the proposed ledger. |
+| ledger\_hash | String | The identifying hash of the proposed ledger is being validated. |
+| ledger\_index | String - Integer | The [Ledger Index][] of the proposed ledger. _(New in [version 0.31.0][])_ |
 | signature | String | The signature that the validator used to sign its vote for this ledger. |
 | validation\_public\_key | String | The base-58 encoded public key from the key-pair that the validator used to sign the message. This identifies the validator sending the message and can also be used to verify the `signature`. |
 

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -2818,7 +2818,7 @@ The response follows the [standard format](#response-formatting), with a success
 ## wallet_propose ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp "Source")
 
-Use the `wallet_propose` method to generate a key pair and Ripple [address]. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded account in the Ripple Consensus Ledger, an address must [receive a Payment transaction](reference-transaction-format.html#creating-accounts) that provides enough XRP to meet the [reserve requirement](concept-reserves.html).
+Use the `wallet_propose` method to generate a key pair and Ripple [address]. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded address stored in the ledger, the address must [receive a Payment transaction](reference-transaction-format.html#creating-accounts) that provides enough XRP to meet the [reserve requirement](concept-reserves.html).
 
 *The `wallet_propose` request is an [admin command](#connecting-to-rippled) that cannot be run by unpriviledged users!* (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)
 
@@ -5894,7 +5894,9 @@ If there was no outstanding pathfinding request, an error is returned instead.
 
 The `ripple_path_find` method is a simplified version of [`path_find`](#path-find) that provides a single response with a [payment path](concept-paths.html) you can use right away. It is available in both the WebSocket and JSON-RPC APIs. However, the results tend to become outdated as time passes. Instead of making many subsequent calls, you should use [`path_find`](#path-find) instead where possible.
 
-Although the `rippled` server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (__*Note:*__ A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)
+Although the `rippled` server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths.
+
+**Caution:** Be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. A server may also return poor results when under heavy load. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results.
 
 #### Request Format ####
 An example of the request format:
@@ -5970,7 +5972,7 @@ The request includes the following parameters:
 | source\_account | String | Unique address of the account that would send funds in a transaction |
 | destination\_account | String | Unique address of the account that would receive funds in a transaction |
 | destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [version 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
-| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Not compatible with `source_currencies`. _(New in [version 0.30.0][])_ |
+| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Cannot be used with `source_currencies`. _(New in [version 0.30.0][])_ |
 | source\_currencies | Array | (Optional) Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory `currency` field and optional `issuer` field, similar to [currency amounts](#specifying-currency-amounts). Cannot contain more than **18** source currencies. By default, uses all source currencies available up to a maximum of **88** different currency/issuer pairs. |
 | ledger\_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
@@ -6700,7 +6702,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 
 ### Sign-and-Submit Mode ###
 
-This mode is intended for testing. It signs a transaction and immediately submits it. You cannot use this mode for [multi-signed transactions](reference-transaction-format.html#multi-signing).
+This mode signs a transaction and immediately submits it. This mode is intended to be used for testing. You cannot use this mode for [multi-signed transactions](reference-transaction-format.html#multi-signing).
 
 You can provide the secret key used to sign the transaction in the following ways:
 
@@ -10971,9 +10973,9 @@ The response follows the [standard format](#response-formatting), with a success
 [version 0.26.0]: https://wiki.ripple.com/Rippled-0.26.0
 [version 0.26.4]: https://wiki.ripple.com/Rippled-0.26.4
 [version 0.26.4-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.4-sp1
-[version 0.28.0]: https://wiki.ripple.com/Rippled-0.28.0
-[version 0.28.2]: https://wiki.ripple.com/Rippled-0.28.2
-[version 0.29.0]: https://wiki.ripple.com/Rippled-0.29.0
-[version 0.30.0]: https://wiki.ripple.com/Rippled-0.30.0
-[version 0.30.1]: https://wiki.ripple.com/Rippled-0.30.1
-[version 0.31.0]: https://wiki.ripple.com/Rippled-0.31.0
+[version 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0
+[version 0.28.2]: https://github.com/ripple/rippled/releases/tag/0.28.2
+[version 0.29.0]: https://github.com/ripple/rippled/releases/tag/0.29.0
+[version 0.30.0]: https://github.com/ripple/rippled/releases/tag/0.30.0
+[version 0.30.1]: https://github.com/ripple/rippled/releases/tag/0.30.1
+[version 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1053,9 +1053,14 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <td>String or Unsigned Integer</td>
 <td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
+<tr>
+<td>signer_lists</td>
+<td>Boolean</td>
+<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></td>
+</tr>
 </tbody>
 </table>
-<p>The following fields are deprecated and should not be provided: <code>ident</code>, <code>account_index</code>, <code>ledger</code>.</p>
+<p>The following fields are deprecated and should not be provided: <code>ident</code>, <code>ledger</code>.</p>
 <h4 id="response-format-1">Response Format</h4>
 <p>An example of a successful response:</p>
 <div class="multicode">
@@ -1095,6 +1100,11 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <td>account_data</td>
 <td>Object</td>
 <td>The <a href="reference-ledger-format.html#accountroot">AccountRoot ledger node</a> with this account's information, as stored in the ledger.</td>
+</tr>
+<tr>
+<td>signer_lists</td>
+<td>Array</td>
+<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></td>
 </tr>
 <tr>
 <td>ledger_current_index</td>
@@ -3441,8 +3451,9 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </ul>
 <h2 id="wallet-propose">wallet_propose</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp" title="Source">[Source]<br/></a></p>
-<p>Use the <code>wallet_propose</code> method to generate the keys needed for a new account. The account created this way will only become officially included in the Ripple network when it receives a transaction that provides enough XRP to meet the account reserve. (The <code>wallet_propose</code> command does not affect the global network. Technically, it is not strictly necessary for creating a new account: you could generate keys some other way, but that is not recommended.)</p>
-<p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em> (Since admin commands are not transmitted over the outside network this command is protected against people sniffing the network for account secrets.)</p>
+<p><em>(Updated in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded account in the Ripple Consensus Ledger, an address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
+<p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em> (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)</p>
 <h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -3467,7 +3478,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 rippled wallet_propose test
 </code></pre>
 </div>
-<p>The request can contain the following parameter:</p>
+<p>The request can contain the following parameters:</p>
 <table>
 <thead>
 <tr>
@@ -3480,10 +3491,27 @@ rippled wallet_propose test
 <tr>
 <td>passphrase</td>
 <td>String</td>
-<td>(Optional) Specify a passphrase, for testing purposes. If omitted, the server will use a random number to generate the master key. Outside of testing purposes, keys should always be randomly generated. Some values, which resemble Ripple addresses and some other formats, are prohibited.</td>
+<td>(Optional) Generate the key pair and address from this passphrase. (For example: <code>masterpassphrase</code>) Cannot be used with <code>seed</code> or <code>seed_hex</code>.</td>
+</tr>
+<tr>
+<td>seed</td>
+<td>String</td>
+<td>(Optional) Generate the address from this base-58-encoded seed value. (For example: <code>ssyXjRurNo75TjXjubby65cD96ak8</code>.) Cannot be used with <code>passphrase</code> or <code>seed_hex</code>.</td>
+</tr>
+<tr>
+<td>seed_hex</td>
+<td>String</td>
+<td>(Optional) Generate the address from this seed value in hexadecimal format. Cannot be used with <code>passphrase</code> or <code>seed</code>. (For example: <code>02CF23BCB1252D153713954AF374F44F82C255170ECAEDB059783128F53288F34F</code>.)</td>
+</tr>
+<tr>
+<td>key_type</td>
+<td>String</td>
+<td>(Optional) Which elliptic curve to use for this key pair. Valid values are <code>ed25519</code> and <code>secp256k1</code>. Defaults to <code>secp256k1</code>. <strong>Caution:</strong> <a href="https://ed25519.cr.yp.to/">Ed25519</a> support is experimental.</td>
 </tr>
 </tbody>
 </table>
+<p>You can specify at most one of the parameters <code>passphrase</code>, <code>seed</code>, or <code>seed_hex</code>. By default, the <code>wallet_propose</code> command generates a keys and an address from a random seed value.</p>
+<p><strong>Caution: Always generate a seed value with a strong source of randomness and keep your seed value secret.</strong> Anyone who knows the seed value for an address has full power to <a href="reference-transaction-format.html#authorizing-transactions">send transactions signed by that address</a>. Generally, running this command with no parameters is a good way to generate a random seed.</p>
 <h4 id="response-format-8">Response Format</h4>
 <p>An example of a successful response:</p>
 <div class="multicode">
@@ -3491,6 +3519,7 @@ rippled wallet_propose test
 <pre><code>{
    "result" : {
       "account_id" : "rp2YHP5k3bSd6LRFT4phDjVMLXQjH4hiaG",
+      "key_type" : "secp256k1",
       "master_key" : "AHOY CLAD JUDD NOON MINI CHAD CUBA JAN KANT AMID DEL LETS",
       "master_seed" : "ssyXjRurNo75TjXjubby65cD96ak8",
       "master_seed_hex" : "5BDD10A694F2E36CCAC0CBE28CE2AC49",
@@ -3541,16 +3570,22 @@ rippled wallet_propose test
 <td>String</td>
 <td>The public key of the account, in hex format.</td>
 </tr>
+<tr>
+<td>warning</td>
+<td>String</td>
+<td>(May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure.</td>
+</tr>
 </tbody>
 </table>
 <p>The key generated by this method can also be used as a regular key for an account if you use the <a href="reference-transaction-format.html#setregularkey">SetRegularKey transaction type</a> to do so.</p>
 <h4 id="possible-errors-8">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
-<li><code>badSeed</code> - The <code>passphrase</code> field of the request has an invalid value, such as an empty string, or a format resembling a Ripple address or Ripple secret.</li>
+<li><code>invalidParams</code> - One or more fields are specified incorrectly.</li>
+<li><code>badSeed</code> - The request specified a disallowed seed value (in the <code>passphrase</code>, <code>seed</code>, or <code>seed_hex</code> fields), such as an empty string, or a string resembling a Ripple address.</li>
 </ul>
 <h1 id="ledger-information">Ledger Information</h1>
-<p>The globally-shared ledger is the core of the Ripple Network. Each <code>rippled</code> server keeps a current version of the ledger, which contains all the accounts, transactions, offers, and other data in the network in an optimized tree format. As transactions and offers are proposed, each server incorporates them into its current copy of the ledger, closes it periodically, and (if configured) participates in the process of advancing the globally-validated version. After concensus is reached in the network, that ledger version is validated and becomes permanently immutable. Any transactions that were not included in one ledger become candidates to be included in the next validated version.</p>
+<p>The globally-shared ledger is the core of the Ripple Network. Each <code>rippled</code> server keeps a current version of the ledger, which contains all the accounts, transactions, offers, and other data in the network in an optimized tree format. As transactions and offers are proposed, each server incorporates them into its current copy of the ledger, closes it periodically, and (if configured) participates in the process of advancing the globally-validated version. After the network reaches consensus, that ledger version is validated and becomes permanently immutable. Any transactions that were not included in one ledger become candidates to be included in the next validated version.</p>
 <h2 id="ledger">ledger</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerHandler.cpp" title="Source">[Source]<br/></a></p>
 <p>Retrieve information about the public ledger.</p>
@@ -6854,7 +6889,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <tr>
 <td>source_currencies</td>
 <td>Array</td>
-<td>(Optional, defaults to all available) Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory <code>currency</code> field and optional <code>issuer</code> field, similar to <a href="#specifying-currency-amounts">currency amounts</a>.</td>
+<td>(Optional) Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory <code>currency</code> field and optional <code>issuer</code> field, similar to <a href="#specifying-currency-amounts">currency amounts</a>. Cannot contain more than <strong>18</strong> source currencies. By default, uses all source currencies available up to a maximum of <strong>88</strong> different currency/issuer pairs.</td>
 </tr>
 <tr>
 <td>ledger_hash</td>
@@ -8607,12 +8642,14 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tbody>
 </table>
 <h3 id="validations-stream">Validations Stream</h3>
+<p><em>(New in <a href="https://wiki.ripple.com/Rippled-0.29.0">version 0.29.0</a>)</em></p>
 <p>The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:</p>
 <pre><code>{
   "type": "validationReceived",
-  "ledger_hash": "7B0B865DC3B648E35B1EB21FAD9501A765E6523B382CB182AC63DBE7D3DA5CC2",
-  "signature": "3045022100FA33615FCE1DDF56D0EEE0B750414D9C41FBE31B59A17B6A139F65A500ACA11702205B1129FFE78E2A4BC6BE98213C8172E2416780AB6F757D9067A2DBE224865495",
-  "validation_public_key": "n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj"
+  "ledger_hash": "8F77146B9DFE3E48213677DA0826839DFA3666228322684DF5D775A8A4F76401",
+  "ledger_index": "20504721",
+  "signature": "3045022100DFFE4A50B4BD3BD33C280E3DEC9897413C299036531F3156FFDEEDED9E47005702202725D2DDF8F7F8E7C0D89787C0291D3CBE5FE3BF66503FC3AE77ADE15A78B0D9",
+  "validation_public_key": "n9LDGC4SaEgtVXSjFNKHh6BPSUAuccZ8uKdEAoQUDQ1x2jqunEXr"
 }
 </code></pre>
 <p>The fields from a validations stream message are as follows:</p>
@@ -8633,7 +8670,12 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>The identifying hash of the proposed ledger that this server declares validated by consensus.</td>
+<td>The identifying hash of the proposed ledger is being validated. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+</tr>
+<tr>
+<td>ledger_index</td>
+<td>String - Integer</td>
+<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger.</td>
 </tr>
 <tr>
 <td>signature</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1056,7 +1056,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>signer_lists</td>
 <td>Boolean</td>
-<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></td>
+<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -1104,7 +1104,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>signer_lists</td>
 <td>Array</td>
-<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></td>
+<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></td>
 </tr>
 <tr>
 <td>ledger_current_index</td>
@@ -1642,12 +1642,12 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>quality</td>
 <td>Number</td>
-<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.29.0">version 0.29.0</a>)</em></td>
+<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0">version 0.29.0</a>)</em></td>
 </tr>
 <tr>
 <td>expiration</td>
 <td>Unsigned integer</td>
-<td>(May be omitted) A time after which this offer is considered unfunded, as <a href="#specifying-time">the number of seconds since the Ripple Epoch</a>. See also: <a href="reference-transaction-format.html#expiration">Offer Expiration</a>. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>(May be omitted) A time after which this offer is considered unfunded, as <a href="#specifying-time">the number of seconds since the Ripple Epoch</a>. See also: <a href="reference-transaction-format.html#expiration">Offer Expiration</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -3197,7 +3197,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </ul>
 <h2 id="gateway-balances">gateway_balances</h2>
 <p><a href="https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by specific "hot wallet" addresses. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.28.2">version 0.28.2</a>.)</em></p>
+<p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by specific "hot wallet" addresses. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.2">version 0.28.2</a>.)</em></p>
 <h4 id="request-format-7">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -3451,9 +3451,9 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </ul>
 <h2 id="wallet-propose">wallet_propose</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp" title="Source">[Source]<br/></a></p>
-<p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded account in the Ripple Consensus Ledger, an address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
+<p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded address stored in the ledger, the address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
 <p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em> (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)</p>
-<p><em>(Updated in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p><em>(Updated in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
 <h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -3751,7 +3751,7 @@ rippled ledger current
 <tr>
 <td>binary</td>
 <td>Boolean</td>
-<td>(Optional, defaults to false) If <code>transactions</code> and <code>expand</code> are both true, and this option is also true, return transaction information in binary format instead of JSON format. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.28.0">version 0.28.0</a>)</em></td>
+<td>(Optional, defaults to false) If <code>transactions</code> and <code>expand</code> are both true, and this option is also true, return transaction information in binary format instead of JSON format. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0">version 0.28.0</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -4804,7 +4804,7 @@ Connecting to 127.0.0.1:5005
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing. This error can also occur if you specify a ledger index equal or higher than the current in-progress ledger.</li>
-<li><code>lgrNotFound</code> - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. <em>(<strong>Note:</strong> Prior to <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>, this error used the code <code>ledgerNotFound</code> instead.)</em></li>
+<li><code>lgrNotFound</code> - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. <em>(<strong>Note:</strong> Prior to <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>, this error used the code <code>ledgerNotFound</code> instead.)</em></li>
 </ul>
 <h2 id="ledger-accept">ledger_accept</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp" title="Source">[Source]<br/></a></p>
@@ -6284,12 +6284,12 @@ rippled tx_history 0
 <tr>
 <td>destination_amount</td>
 <td>String or Object</td>
-<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.0">version 0.30.0</a>)</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
+<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
 </tr>
 <tr>
 <td>send_max</td>
 <td>String or Object</td>
-<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.0">version 0.30.0</a>)</em></td>
+<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em></td>
 </tr>
 <tr>
 <td>paths</td>
@@ -6706,7 +6706,7 @@ rippled tx_history 0
 <tr>
 <td>full_reply</td>
 <td>Boolean</td>
-<td>If <code>false</code>, this is the result of an incomplete search, and a subsequent reply may have a better path. If <code>true</code>, then this is the best path found. (It is still theoretically possible that a better path could exist, but rippled won't find it.) Until you close the pathfinding request, rippled will continue to send updates each time a new ledger closes. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.29.0">version 0.29.0</a>)</em></td>
+<td>If <code>false</code>, this is the result of an incomplete search, and a subsequent reply may have a better path. If <code>true</code>, then this is the best path found. (It is still theoretically possible that a better path could exist, but rippled won't find it.) Until you close the pathfinding request, rippled will continue to send updates each time a new ledger closes. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0">version 0.29.0</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -6877,7 +6877,8 @@ rippled tx_history 0
 <h2 id="ripple-path-find">ripple_path_find</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/RipplePathFind.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ripple_path_find</code> method is a simplified version of <a href="#path-find"><code>path_find</code></a> that provides a single response with a <a href="concept-paths.html">payment path</a> you can use right away. It is available in both the WebSocket and JSON-RPC APIs. However, the results tend to become outdated as time passes. Instead of making many subsequent calls, you should use <a href="#path-find"><code>path_find</code></a> instead where possible.</p>
-<p>Although the <code>rippled</code> server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (<strong><em>Note:</em></strong> A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)</p>
+<p>Although the <code>rippled</code> server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths.</p>
+<p><strong>Caution:</strong> Be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. A server may also return poor results when under heavy load. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results.</p>
 <h4 id="request-format-22">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -6955,12 +6956,12 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <tr>
 <td>destination_amount</td>
 <td>String or Object</td>
-<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.0">version 0.30.0</a>)</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
+<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
 </tr>
 <tr>
 <td>send_max</td>
 <td>String or Object</td>
-<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.0">version 0.30.0</a>)</em></td>
+<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em></td>
 </tr>
 <tr>
 <td>source_currencies</td>
@@ -7371,7 +7372,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, signing fails. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>(Optional) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, signing fails. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -7478,7 +7479,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <h2 id="sign-for">sign_for</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SignFor.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>sign_for</code> command provides one signature for a <a href="reference-transaction-format.html#multi-signing">multi-signed transaction</a>.</p>
-<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
 <h4 id="request-format-24">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -7784,7 +7785,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 </div>
 <p><a class="button" href="ripple-api-tool.html#submit">Try it! &gt;</a></p>
 <h3 id="sign-and-submit-mode">Sign-and-Submit Mode</h3>
-<p>This mode is intended for testing. It signs a transaction and immediately submits it. You cannot use this mode for <a href="reference-transaction-format.html#multi-signing">multi-signed transactions</a>.</p>
+<p>This mode signs a transaction and immediately submits it. This mode is intended to be used for testing. You cannot use this mode for <a href="reference-transaction-format.html#multi-signing">multi-signed transactions</a>.</p>
 <p>You can provide the secret key used to sign the transaction in the following ways:</p>
 <ul>
 <li>Provide a <code>secret</code> value and omit the <code>key_type</code> field. This value can be formatted as base-58 seed, RFC-1751, hexadecimal, or as a string passphrase. (secp256k1 keys only)</li>
@@ -7853,7 +7854,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>(Optional) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -8023,7 +8024,7 @@ submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"r
 <h2 id="submit-multisigned">submit_multisigned</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SubmitMultiSigned.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>submit_multisigned</code> command applies a <a href="reference-transaction-format.html#multi-signing">multi-signed</a> transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the <a href="#submit-only-mode"><code>submit</code> command in submit-only mode</a>.)</p>
-<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
 <h4 id="request-format-27">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -8769,7 +8770,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tbody>
 </table>
 <h3 id="validations-stream">Validations Stream</h3>
-<p><em>(New in <a href="https://wiki.ripple.com/Rippled-0.29.0">version 0.29.0</a>)</em></p>
+<p><em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0">version 0.29.0</a>)</em></p>
 <p>The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:</p>
 <pre><code>{
   "type": "validationReceived",
@@ -8802,7 +8803,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>ledger_index</td>
 <td>String - Integer</td>
-<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></td>
+<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></td>
 </tr>
 <tr>
 <td>signature</td>
@@ -9639,22 +9640,22 @@ rippled server_info
 <tr>
 <td>state_accounting</td>
 <td>Object</td>
-<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.duration_us</td>
 <td>String</td>
-<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.transitions</td>
 <td>Number</td>
-<td>The number of times the server has transitioned into this state. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of times the server has transitioned into this state. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>Number of consecutive seconds that the server has been operational. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>Number of consecutive seconds that the server has been operational. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -9994,22 +9995,22 @@ rippled server_state
 <tr>
 <td>state_accounting</td>
 <td>Object</td>
-<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.duration_us</td>
 <td>String</td>
-<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.transitions</td>
 <td>Number</td>
-<td>The number of times the server has transitioned into this state. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of times the server has transitioned into this state. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>Number of consecutive seconds that the server has been operational. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>Number of consecutive seconds that the server has been operational. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -10562,7 +10563,7 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="feature">feature</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Feature1.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
 <p>You can use the <code>feature</code> command to temporarily configure the server to vote against or in favor of an amendment. This change does not persist if you restart the server. To make lasting changes in amendment voting, use the <code>rippled.cfg</code> file. See <a href="concept-amendments.html#configuring-amendment-voting">Configuring Amendment Voting</a> for more information.</p>
 <p><em>The <code>feature</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-36">Request Format</h4>
@@ -10752,7 +10753,7 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="fee">fee</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
 <p><em>The <code>fee</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users.</em></p>
 <h4 id="request-format-37">Request Format</h4>
 <p>An example of the request format:</p>
@@ -11993,7 +11994,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>cluster</td>
 <td>Object</td>
-<td>Summary of other <code>rippled</code> servers in the same cluster, if <a href="tutorial-rippled-setup.html#clustering">configured as a cluster</a>. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>Summary of other <code>rippled</code> servers in the same cluster, if <a href="tutorial-rippled-setup.html#clustering">configured as a cluster</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -12102,7 +12103,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>The number of seconds that your <code>rippled</code> server has been continuously connected to this peer. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of seconds that your <code>rippled</code> server has been continuously connected to this peer. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 <tr>
 <td>version</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -7258,8 +7258,8 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 </ul>
 <h2 id="sign">sign</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/SignHandler.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>sign</code> method takes a transaction, specified as JSON, and a secret key, and returns a signed binary representation of the transaction that can be submitted. The result is always different, even when you provide the same transaction JSON and secret key.</p>
-<p><strong><em>Note:</em></strong> It is possible and preferable to sign a transaction without connecting to a server instead of using this command, by using <a href="https://github.com/ripple/ripple-lib">ripple-lib</a>. You should prefer to do offline signing of a transaction, especially when you do not control the server you are sending a transaction to. An untrustworthy server can abuse its position to change the transaction before signing it, or worse, use your secret to sign additional arbitrary transactions as if they came from you.</p>
+<p>The <code>sign</code> method takes a <a href="reference-transaction-format.html">transaction in JSON format</a> and a secret key, and returns a signed binary representation of the transaction. The result is always different, even when you provide the same transaction JSON and secret key. To contribute one signature to a multi-signed transaction, use the <a href="#sign-for"><code>sign_for</code> command</a> instead.</p>
+<p><strong>Caution:</strong> Unless you operate the <code>rippled</code> server, you should do <a href="reference-rippleapi.html#sign">local signing with RippleAPI</a> instead of using this command. An untrustworthy server could change the transaction before signing it, or use your secret key to sign additional arbitrary transactions as if they came from you.</p>
 <h4 id="request-format-23">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
@@ -7308,6 +7308,11 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 </code></pre>
 </div>
 <p><a class="button" href="ripple-api-tool.html#sign">Try it! &gt;</a></p>
+<p>To sign a transaction, you must provide a secret key that can <a href="reference-transaction-format.html#authorizing-transactions">authorize the transaction</a>. You can do this in a few ways:</p>
+<ul>
+<li>Provide a <code>secret</code> value and omit the <code>key_type</code> field. This value can be formatted as base-58 seed, RFC-1751, hexadecimal, or as a string passphrase. (secp256k1 keys only)</li>
+<li>Provide a <code>key_type</code> value and exactly one of <code>seed</code>, <code>seed_hex</code>, or <code>passphrase</code>. Omit the <code>secret</code> field. (Not supported by the commandline syntax.)</li>
+</ul>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -7326,7 +7331,27 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <tr>
 <td>secret</td>
 <td>String</td>
-<td>Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections.</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections. Cannot be used with <code>key_type</code>, <code>seed</code>, seed_hex<code>, or</code>passphrase`.</td>
+</tr>
+<tr>
+<td>seed</td>
+<td>String</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in base-58 format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
+</tr>
+<tr>
+<td>seed_hex</td>
+<td>String</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in hexadecimal format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>passphrase</code>.</td>
+</tr>
+<tr>
+<td>passphrase</td>
+<td>String</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>seed_hex</code>.</td>
+</tr>
+<tr>
+<td>key_type</td>
+<td>String</td>
+<td>(Optional) Type of cryptographic key provided in this request. Valid types are <code>secp256k1</code> or <code>ed25519</code>. Defaults to <code>secp256k1</code>. Cannot be used with <code>secret</code>. <strong>Caution:</strong> Ed25519 support is experimental.</td>
 </tr>
 <tr>
 <td>offline</td>
@@ -7724,7 +7749,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>tx_blob</td>
 <td>String</td>
-<td>Hex representation of the signed transaction to submit.</td>
+<td>Hex representation of the signed transaction to submit. This can be a <a href="reference-transaction-format.html#multi-signing">multi-signed transaction</a>.</td>
 </tr>
 <tr>
 <td>fail_hard</td>
@@ -7759,7 +7784,13 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 </div>
 <p><a class="button" href="ripple-api-tool.html#submit">Try it! &gt;</a></p>
 <h3 id="sign-and-submit-mode">Sign-and-Submit Mode</h3>
-<p>A sign-and-submit request includes the following parameters:</p>
+<p>This mode is intended for testing. It signs a transaction and immediately submits it. You cannot use this mode for <a href="reference-transaction-format.html#multi-signing">multi-signed transactions</a>.</p>
+<p>You can provide the secret key used to sign the transaction in the following ways:</p>
+<ul>
+<li>Provide a <code>secret</code> value and omit the <code>key_type</code> field. This value can be formatted as base-58 seed, RFC-1751, hexadecimal, or as a string passphrase. (secp256k1 keys only)</li>
+<li>Provide a <code>key_type</code> value and exactly one of <code>seed</code>, <code>seed_hex</code>, or <code>passphrase</code>. Omit the <code>secret</code> field. (Not supported by the commandline syntax.)</li>
+</ul>
+<p>The request includes the following parameters:</p>
 <table>
 <thead>
 <tr>
@@ -7777,7 +7808,27 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td>secret</td>
 <td>String</td>
-<td>(Required if <code>tx_json</code> is supplied) Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections.</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections. Cannot be used with <code>key_type</code>, <code>seed</code>, seed_hex<code>, or</code>passphrase`.</td>
+</tr>
+<tr>
+<td>seed</td>
+<td>String</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in base-58 format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
+</tr>
+<tr>
+<td>seed_hex</td>
+<td>String</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in hexadecimal format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>passphrase</code>.</td>
+</tr>
+<tr>
+<td>passphrase</td>
+<td>String</td>
+<td>(Optional) Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>seed_hex</code>.</td>
+</tr>
+<tr>
+<td>key_type</td>
+<td>String</td>
+<td>(Optional) Type of cryptographic key provided in this request. Valid types are <code>secp256k1</code> or <code>ed25519</code>. Defaults to <code>secp256k1</code>. Cannot be used with <code>secret</code>. <strong>Caution:</strong> Ed25519 support is experimental.</td>
 </tr>
 <tr>
 <td>fail_hard</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -8797,12 +8797,12 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>The identifying hash of the proposed ledger is being validated. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.30.1">version 0.30.1</a>)</em></td>
+<td>The identifying hash of the proposed ledger is being validated.</td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>String - Integer</td>
-<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger.</td>
+<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></td>
 </tr>
 <tr>
 <td>signature</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -3451,34 +3451,52 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </ul>
 <h2 id="wallet-propose">wallet_propose</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp" title="Source">[Source]<br/></a></p>
-<p><em>(Updated in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
 <p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded account in the Ripple Consensus Ledger, an address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
 <p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unpriviledged users!</em> (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)</p>
+<p><em>(Updated in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
 <h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode">
-<p><em>WebSocket</em></p>
+<p><em>WebSocket (with key type)</em></p>
 <pre><code>{
     "command": "wallet_propose",
-    "passphrase": "test"
+    "seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
+    "key_type": "secp256k1"
 }
 </code></pre>
-<p><em>JSON-RPC</em></p>
+<p><em>WebSocket (no key type)</em></p>
+<pre><code>{
+    "command": "wallet_propose",
+    "passphrase": "masterpassphrase"
+}
+</code></pre>
+<p><em>JSON-RPC (with key type)</em></p>
 <pre><code>{
     "method": "wallet_propose",
     "params": [
         {
-            "passphrase": "test"
+            "seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
+            "key_type": "secp256k1"
+        }
+    ]
+}
+</code></pre>
+<p><em>JSON-RPC (no key type)</em></p>
+<pre><code>{
+    "method": "wallet_propose",
+    "params": [
+        {
+            "passphrase": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb"
         }
     ]
 }
 </code></pre>
 <p><em>Commandline</em></p>
 <pre><code>#Syntax: wallet_propose [passphrase]
-rippled wallet_propose test
+rippled wallet_propose masterpassphrase
 </code></pre>
 </div>
-<p>The request can contain the following parameters:</p>
+<p>There are two valid modes for this command, depending on whether the request specifies the <code>key_type</code> parameter. If you omit the <code>key_type</code>, the request takes <em>only</em> the following parameter (ignoring others):</p>
 <table>
 <thead>
 <tr>
@@ -3491,40 +3509,103 @@ rippled wallet_propose test
 <tr>
 <td>passphrase</td>
 <td>String</td>
-<td>(Optional) Generate the key pair and address from this passphrase. (For example: <code>masterpassphrase</code>) Cannot be used with <code>seed</code> or <code>seed_hex</code>.</td>
+<td>(Optional) Generate a key pair and address from this seed value using the elliptic curve secp256k1. This value can be formatted in hexadecimal, base-58, RFC-1751, or as an arbitrary string. If omitted, use a random seed.</td>
+</tr>
+</tbody>
+</table>
+<p>If you specify the <code>key_type</code>, you must provide at most one of the following fields: <code>passphrase</code>, <code>seed</code>, or <code>seed_hex</code>. (If you omit all three, <code>rippled</code> uses a random seed.) In this mode, the request parameters are as follows:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>key_type</td>
+<td>String</td>
+<td>Which elliptic curve to use for this key pair. Valid values are <code>ed25519</code> and <code>secp256k1</code>. <strong>Caution:</strong> <a href="https://ed25519.cr.yp.to/">Ed25519</a> support is experimental.</td>
+</tr>
+<tr>
+<td>passphrase</td>
+<td>String</td>
+<td>(Optional) Generate the key pair and address from this seed value. This is interpreted as a string only. Cannot be used with <code>seed</code> or <code>seed_hex</code>.</td>
 </tr>
 <tr>
 <td>seed</td>
 <td>String</td>
-<td>(Optional) Generate the address from this base-58-encoded seed value. (For example: <code>ssyXjRurNo75TjXjubby65cD96ak8</code>.) Cannot be used with <code>passphrase</code> or <code>seed_hex</code>.</td>
+<td>(Optional) Generate the key pair and address from this base-58-encoded seed value. Cannot be used with <code>passphrase</code> or <code>seed_hex</code>. Ignored unless <code>key_type</code> is provided.</td>
 </tr>
 <tr>
 <td>seed_hex</td>
 <td>String</td>
-<td>(Optional) Generate the address from this seed value in hexadecimal format. Cannot be used with <code>passphrase</code> or <code>seed</code>. (For example: <code>02CF23BCB1252D153713954AF374F44F82C255170ECAEDB059783128F53288F34F</code>.)</td>
-</tr>
-<tr>
-<td>key_type</td>
-<td>String</td>
-<td>(Optional) Which elliptic curve to use for this key pair. Valid values are <code>ed25519</code> and <code>secp256k1</code>. Defaults to <code>secp256k1</code>. <strong>Caution:</strong> <a href="https://ed25519.cr.yp.to/">Ed25519</a> support is experimental.</td>
+<td>(Optional) Generate the key pair and address from this seed value in hexadecimal format. Cannot be used with <code>passphrase</code> or <code>seed</code>. Ignored unless <code>key_type</code> is provided.</td>
 </tr>
 </tbody>
 </table>
-<p>You can specify at most one of the parameters <code>passphrase</code>, <code>seed</code>, or <code>seed_hex</code>. By default, the <code>wallet_propose</code> command generates a keys and an address from a random seed value.</p>
-<p><strong>Caution: Always generate a seed value with a strong source of randomness and keep your seed value secret.</strong> Anyone who knows the seed value for an address has full power to <a href="reference-transaction-format.html#authorizing-transactions">send transactions signed by that address</a>. Generally, running this command with no parameters is a good way to generate a random seed.</p>
+<p>The commandline version of this command cannot generate Ed25519 keys.</p>
+<h5 id="specifying-a-seed">Specifying a Seed</h5>
+<p><strong>Caution:</strong> For most cases, you should use a seed value generated from a strong source of randomness. Anyone who knows the seed value for an address has full power to <a href="reference-transaction-format.html#authorizing-transactions">send transactions signed by that address</a>. Generally, running this command with no parameters is a good way to generate a random seed.</p>
+<p>Cases where you would specify a known seed include:</p>
+<ul>
+<li>Re-calculating your address when you only know the seed associated with that address</li>
+<li>Testing <code>rippled</code> functionality</li>
+<li><a href="tutorial-rippled-setup.html#account-domain">Validator domain verification</a></li>
+</ul>
+<p>If you do specify a seed, you can specify it in any of the following formats:</p>
+<ul>
+<li>As a <a href="https://en.wikipedia.org/wiki/Base58">base-58</a> secret key format string. Example: <code>snoPBrXtMeMyMHUVTgbuqAfg1SUTb</code>.</li>
+<li>As an <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a> format string (secp256k1 key pairs only). Example: <code>I IRE BOND BOW TRIO LAID SEAT GOAL HEN IBIS IBIS DARE</code>.</li>
+<li>As a 128-bit <a href="https://en.wikipedia.org/wiki/Hexadecimal">hexadecimal</a> string. Example: <code>DEDCE9CE67B451D852FD4E846FCDE31C</code>.</li>
+<li>An arbitrary string to use as a seed value. For example: <code>masterpassphrase</code>.</li>
+</ul>
 <h4 id="response-format-8">Response Format</h4>
 <p>An example of a successful response:</p>
 <div class="multicode">
 <p><em>WebSocket</em></p>
 <pre><code>{
+  "id": 2,
+  "status": "success",
+  "type": "response",
+  "result": {
+    "account_id": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    "key_type": "secp256k1",
+    "master_key": "I IRE BOND BOW TRIO LAID SEAT GOAL HEN IBIS IBIS DARE",
+    "master_seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
+    "master_seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
+    "public_key": "aBQG8RQAzjs1eTKFEAQXr2gS4utcDiEC9wmi7pfUPTi27VCahwgw",
+    "public_key_hex": "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020"
+  }
+}
+</code></pre>
+<p><em>JSON-RPC</em></p>
+<pre><code>{
+    "result": {
+        "account_id": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "key_type": "secp256k1",
+        "master_key": "I IRE BOND BOW TRIO LAID SEAT GOAL HEN IBIS IBIS DARE",
+        "master_seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
+        "master_seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
+        "public_key": "aBQG8RQAzjs1eTKFEAQXr2gS4utcDiEC9wmi7pfUPTi27VCahwgw",
+        "public_key_hex": "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+        "status": "success"
+    }
+}
+</code></pre>
+<p><em>Commandline</em></p>
+<pre><code>Loading: "/etc/rippled.cfg"
+Connecting to 127.0.0.1:5005
+{
    "result" : {
-      "account_id" : "rp2YHP5k3bSd6LRFT4phDjVMLXQjH4hiaG",
+      "account_id" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
       "key_type" : "secp256k1",
-      "master_key" : "AHOY CLAD JUDD NOON MINI CHAD CUBA JAN KANT AMID DEL LETS",
-      "master_seed" : "ssyXjRurNo75TjXjubby65cD96ak8",
-      "master_seed_hex" : "5BDD10A694F2E36CCAC0CBE28CE2AC49",
-      "public_key" : "aBPXjfsA7fY2LLPxRuZ7Sj2ADzoSEGDW4Atd5MgxdHz5FQvGPbqU",
-      "public_key_hex" : "02CF23BCB1252D153713954AF374F44F82C255170ECAEDB059783128F53288F34F",
+      "master_key" : "I IRE BOND BOW TRIO LAID SEAT GOAL HEN IBIS IBIS DARE",
+      "master_seed" : "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
+      "master_seed_hex" : "DEDCE9CE67B451D852FD4E846FCDE31C",
+      "public_key" : "aBQG8RQAzjs1eTKFEAQXr2gS4utcDiEC9wmi7pfUPTi27VCahwgw",
+      "public_key_hex" : "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
       "status" : "success"
    }
 }
@@ -3543,7 +3624,7 @@ rippled wallet_propose test
 <tr>
 <td>master_seed</td>
 <td>String</td>
-<td>The master seed from which all other information about this account is derived, in Ripple's base-58 encoded string format.</td>
+<td>The master seed from which all other information about this account is derived, in Ripple's base-58 encoded string format. This is the private key of the key pair.</td>
 </tr>
 <tr>
 <td>master_seed_hex</td>
@@ -3569,11 +3650,6 @@ rippled wallet_propose test
 <td>public_key_hex</td>
 <td>String</td>
 <td>The public key of the account, in hex format.</td>
-</tr>
-<tr>
-<td>warning</td>
-<td>String</td>
-<td>(May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
This edit documents the following changes which are in rippled 0.31.0 (as well as containing a few other minor corrections/improvements):
- RIPD-1030 wallet_propose should allow random seed when key_type is provided
- RIPD-1061 Add RegularKey and SignersList to account_info response
- RIPD-1062 Limit source currencies in Path Find request.
- DEC-564 Collect ledger_index for each validation 
