### PR TITLE
rippled sign, sign-and-submit updates (DOC-380)

### DIFF
--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -148,6 +148,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated true
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -297,7 +298,7 @@ HTTP Status: 200 OK
 | status | String | `"error"` if the request caused an error |
 | type | String | Typically `"response"`, which indicates a successful response to a command. |
 | error | String | A unique code for the type of error that occurred |
-| request | Object | A copy of the request that prompted this error, in JSON format. __*Caution:*__ If the request contained any account secrets, they are copied here! |
+| request | Object | A copy of the request that prompted this error, in JSON format. **Caution:** If the request contained any account secrets, they are copied here! |
 
 #### JSON-RPC API Error Response Format ####
 Some JSON-RPC requests will respond with an error code on the HTTP layer. In these cases, the response is a plain-text explanation in the response body. For example, if you forgot to specify the command in the `method` parameter, the response is like this:
@@ -388,7 +389,7 @@ Many API methods require you to specify an instance of the ledger, with the data
 
 There is also a deprecated `ledger` parameter which accepts any of the above three formats. *Do not* use this parameter; it may be removed without further notice.
 
-If you do not specify a ledger, the `current` (in-progress) ledger will be chosen by default. If you provide more than one field specifying ledgers, the deprecated `ledger` field will be used first if it exists, falling back to `ledger_hash`. The `ledger_index` field is ignored unless neither of the other two are present. __*Note:*__ Do not rely on this default behavior; it is subject to change. Instead, you should always specify a ledger version in each call.
+If you do not specify a ledger, the `current` (in-progress) ledger will be chosen by default. If you provide more than one field specifying ledgers, the deprecated `ledger` field will be used first if it exists, falling back to `ledger_hash`. The `ledger_index` field is ignored unless neither of the other two are present. **Note:** Do not rely on this default behavior; it is subject to change. Instead, you should always specify a ledger version in each call.
 
 
 ## Currencies ##
@@ -477,7 +478,7 @@ Depending on how the `rippled` server is configured, how long it has been runnin
 | validating | The server is currently participating in validation of the ledger |
 | proposing | The server is participating in validation of the ledger and currently proposing its own version. |
 
-__*Note:*__ The distinction between `full`, `validating`, and `proposing` is based on synchronization with the rest of the global network, and it is normal for a server to fluctuate between these states as a course of general operation.
+**Note:** The distinction between `full`, `validating`, and `proposing` is based on synchronization with the rest of the global network, and it is normal for a server to fluctuate between these states as a course of general operation.
 
 ## Markers and Pagination ##
 
@@ -737,6 +738,7 @@ An example of an account_info request:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -748,6 +750,7 @@ An example of an account_info request:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "account_info",
@@ -762,6 +765,7 @@ An example of an account_info request:
 ```
 
 *Commandline*
+
 ```
 #Syntax: account_info account [ledger_index|ledger_hash] [strict]
 rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
@@ -790,6 +794,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 5,
@@ -893,6 +898,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -1832,6 +1838,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -1847,6 +1854,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "account_tx",
@@ -1867,6 +1875,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax account_tx account [ledger_index_min [ledger_index_max [limit]]] [binary] [count] [forward]
 rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
@@ -1906,6 +1915,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 2,
@@ -2142,6 +2152,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -2391,7 +2402,7 @@ The response follows the [standard format](#response-formatting), with a success
 | transactions | Array | Array of transactions matching the request's criteria, as explained below. |
 | validated | Boolean | If included and set to `true`, the information in this request comes from a validated ledger version. Otherwise, the information is subject to change. |
 
-__*Note:*__ The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.
+**Note:** The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.
 
 Each transaction object includes the following fields, depending on whether it was requested in JSON or hex string (`"binary":true`) format.
 
@@ -2877,6 +2888,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: wallet_propose [passphrase]
 rippled wallet_propose masterpassphrase
@@ -2926,6 +2938,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -3085,6 +3098,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 4,
@@ -3117,6 +3131,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -3196,6 +3211,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
    "id": 2,
@@ -3204,6 +3220,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "ledger_closed",
@@ -3214,6 +3231,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: ledger_closed
 rippled ledger_closed
@@ -3231,6 +3249,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 1,
@@ -3244,6 +3263,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -3281,6 +3301,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
    "id": 2,
@@ -3289,6 +3310,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "ledger_current",
@@ -3299,6 +3321,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: ledger_current
 rippled ledger_current
@@ -3317,6 +3340,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -3329,6 +3353,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -3365,6 +3390,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
    "id": 2,
@@ -3376,6 +3402,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "ledger_data",
@@ -3391,7 +3418,7 @@ An example of the request format:
 
 <!-- MULTICODE_BLOCK_END -->
 
-__*Note:*__ There is no commandline syntax for `ledger_data`. You can use the [`json` command](#json) to access this method from the commandline instead.
+**Note:** There is no commandline syntax for `ledger_data`. You can use the [`json` command](#json) to access this method from the commandline instead.
 
 A request can include the following fields:
 
@@ -3413,6 +3440,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket (binary:true)*
+
 ```
 {
     "id": 2,
@@ -3449,6 +3477,7 @@ An example of a successful response:
 ```
 
 *WebSocket (binary:false)*
+
 ```
 {
     "id": 2,
@@ -3547,6 +3576,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC (binary:true)*
+
 ```
 200 OK
 {
@@ -3613,7 +3643,7 @@ The format of each object in the `state` array depends on whether `binary` was s
 
 The `ledger_entry` method returns a single ledger node from the Ripple Consensus Ledger in its raw format. See [ledger format][] for information on the different types of objects you can retrieve.
 
-__*Note:*__ There is no commandline version of this method. You can use the [`json` command](#json) to access this method from the commandline instead.
+**Note:** There is no commandline version of this method. You can use the [`json` command](#json) to access this method from the commandline instead.
 
 #### Request Format ####
 
@@ -3622,6 +3652,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 3,
@@ -3633,6 +3664,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "ledger_entry",
@@ -3689,6 +3721,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```{
     "id": 3,
     "result": {
@@ -3712,6 +3745,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -3947,6 +3981,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
    "id": "Accept my ledger!",
@@ -3955,6 +3990,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: ledger_accept
 rippled ledger_accept
@@ -4011,6 +4047,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 1,
@@ -4020,6 +4057,7 @@ An example of the request format:
 }
 ```
 *JSON-RPC*
+
 ```
 {
     "method": "tx",
@@ -4032,6 +4070,7 @@ An example of the request format:
 }
 ```
 *Commandline*
+
 ```
 #Syntax: tx transaction [binary]
 rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 false
@@ -4055,6 +4094,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -4257,7 +4297,7 @@ The request includes the following parameters:
 | ledger_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers)) |
 | tx_hash | String | Unique hash of the transaction you are looking up |
 
-__*Note:*__ This method does not support retrieving information from the current in-progress ledger. You must specify a ledger version in either `ledger_index` or `ledger_hash`.
+**Note:** This method does not support retrieving information from the current in-progress ledger. You must specify a ledger version in either `ledger_index` or `ledger_hash`.
 
 #### Response Format ####
 
@@ -4266,6 +4306,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 4,
@@ -4427,7 +4468,7 @@ There are a couple possible reasons the server may fail to find the transaction:
 
 The `tx_history` method retrieves a selection of the most recent transactions made.
 
-__*Caution:*__ This method is deprecated, and may be removed without further notice.
+**Caution:** This method is deprecated, and may be removed without further notice.
 
 #### Request Format ####
 An example of the request format:
@@ -4435,6 +4476,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 5,
@@ -4444,6 +4486,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "tx_history",
@@ -4456,6 +4499,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: tx_history [start]
 rippled tx_history 0
@@ -4478,6 +4522,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -4930,6 +4975,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -5324,7 +5370,7 @@ There are three different modes, or sub-commands, of the path_find command. Spec
 * `close` - Stop sending pathfinding information
 * `status` - Get the information of the currently-open pathfinding request
 
-Although the `rippled` server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (__*Note:*__ A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)
+Although the `rippled` server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (**Note:** A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)
 
 ### path_find create ###
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L38 "Source")
@@ -5339,6 +5385,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 8,
@@ -5378,6 +5425,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 1,
@@ -5781,6 +5829,7 @@ Here is an example of an asychronous follow-up from a path_find create request:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -5811,6 +5860,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 57,
@@ -5855,6 +5905,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 58,
@@ -6244,11 +6295,10 @@ The `sign` method takes a [transaction in JSON format](reference-transaction-for
 #### Request Format ####
 An example of the request format:
 
-<!--{# TODO: update the examples here and in sign-and-submit #}-->
-
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -6263,19 +6313,21 @@ An example of the request format:
          "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
       }
    },
-   "secret" : "sssssssssssssssssssssssssssss",
-   "offline": false
+   "secret" : "s████████████████████████████",
+   "offline": false,
+   "fee_mult_max": 1000
 }
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "sign",
     "params": [
         {
             "offline": false,
-            "secret": "sssssssssssssssssssssssssssss",
+            "secret": "s████████████████████████████",
             "tx_json": {
                 "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "Amount": {
@@ -6285,16 +6337,18 @@ An example of the request format:
                 },
                 "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
                 "TransactionType": "Payment"
-            }
+            },
+            "fee_mult_max": 1000
         }
     ]
 }
 ```
 
 *Commandline*
+
 ```
 #Syntax: sign secret tx_json [offline]
-rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "Amount": { "currency": "USD", "value": "1", "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn" }}' false
+rippled sign s████████████████████████████ '{"TransactionType": "Payment", "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "Amount": { "currency": "USD", "value": "1", "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn" }, "Sequence": 360, "Fee": "10000"}' offline
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -6317,7 +6371,7 @@ The request includes the following parameters:
 | passphrase | String | (Optional) Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the `key_type`. Cannot be used with `secret`, `seed`, or `seed_hex`. |
 | key\_type | String | (Optional) Type of cryptographic key provided in this request. Valid types are `secp256k1` or `ed25519`. Defaults to `secp256k1`. Cannot be used with `secret`. **Caution:** Ed25519 support is experimental. |
 | offline | Boolean | (Optional, defaults to false) If true, when constructing the transaction, do not attempt to automatically fill in or validate values. |
-| build_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. __*Caution:*__ The server looks for the presence or absence of this field, not its value. This behavior may change. |
+| build_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. **Caution:** The server looks for the presence or absence of this field, not its value. This behavior may change. |
 | fee\_mult\_max | Integer | (Optional, defaults to 10; recommended value 1000) Limits how high the [automatically-provided `Fee` field](reference-transaction-format.html#auto-fillable-fields) can be. Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). |
 | fee\_div\_max | Integer | (Optional, defaults to 1) Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). _(New in [version 0.30.1][])_ |
 
@@ -6325,9 +6379,11 @@ The request includes the following parameters:
 
 The server automatically attempts to fill in certain fields in `tx_json` (the [Transaction object](reference-transaction-format.html)) automatically if you omit them. The server provides the following fields before signing, unless the request specified `offline` as `true`:
 
-* `Sequence` - The server automatically uses the next Sequence number from the sender's account information. Be careful: the next sequence number for the account is not incremented until this transaction is applied. If you sign multiple transactions without submitting and waiting for the response to each one, you must provide the correct sequence numbers in the request.
+* `Sequence` - The server automatically uses the next Sequence number from the sender's account information.
+    * **Caution:** The next sequence number for the account is not incremented until this transaction is applied. If you sign multiple transactions without submitting and waiting for the response to each one, you must manually provide the correct sequence numbers for each transaction after the first.
 * `Fee` - If you omit the `Fee` parameter, the server tries to fill in an appropriate transaction cost automatically. On the production Ripple Consensus Ledger, this fails with `rpcHIGH_FEE` unless you provide an appropriate `fee_mult_max` value.
-    * The `fee_mult_max` and `fee_div_max` parameters limit how high the automatically-provided transaction cost can be, in terms of the load-scaling multiplier that gets applied to the [reference transaction cost](concept-transaction-cost.html#reference-transaction-cost). The default values return an error if the automatically-provided value would use greater than a 10× multiplier. However, the production Ripple Consensus Ledger [typically has a 1000× load multiplier](concept-transaction-cost.html#current-transaction-cost).
+    * The `fee_mult_max` and `fee_div_max` parameters limit how high the automatically-provided transaction cost can be, in terms of the load-scaling multiplier that gets applied to the [reference transaction cost](concept-transaction-cost.html#reference-transaction-cost). The default settings return an error if the automatically-provided value would use greater than a 10× multiplier. However, the production Ripple Consensus Ledger [typically has a 1000× load multiplier](concept-transaction-cost.html#current-transaction-cost).
+    * The commandline syntax does not support `fee_mult_max` and `fee_div_max`. For the production Ripple Consensus Ledger, you must provide a `Fee` value.
     * **Caution:** A malicious server can specify an excessively high transaction cost, ignoring the values of `fee_mult_max` and `fee_div_max`.
 * `Paths` - For Payment-type transactions (excluding XRP-to-XRP transfers), the Paths field can be automatically filled, as if you did a [ripple_path_find](#ripple-path-find). Only filled if `build_path` is provided.
 
@@ -6338,57 +6394,88 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
-    "id": 2,
-    "result": {
-        "tx_blob": "1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100BF06B6C01646005DEDD8F4F6D458AF4EE4006205A623FF31E0B5BCCE42564BA1022063C372D476379C109E3C22C5C04071594CD9EF64615C00B048AFFA5D7D6701F981144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
-        "tx_json": {
-            "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "Amount": {
-                "currency": "USD",
-                "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "value": "1"
-            },
-            "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "Fee": "10",
-            "Flags": 2147483648,
-            "Sequence": 3,
-            "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
-            "TransactionType": "Payment",
-            "TxnSignature": "3045022100BF06B6C01646005DEDD8F4F6D458AF4EE4006205A623FF31E0B5BCCE42564BA1022063C372D476379C109E3C22C5C04071594CD9EF64615C00B048AFFA5D7D6701F9",
-            "hash": "B4CBEBBA9E65A5BED25205806797600149599AAF2FD8103B3B75AE97B1B5F3E2"
-        }
-    },
-    "status": "success",
-    "type": "response"
+  "id": 2,
+  "status": "success",
+  "type": "response",
+  "result": {
+    "tx_blob": "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7446304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F858081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+    "tx_json": {
+      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "Amount": {
+        "currency": "USD",
+        "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "value": "1"
+      },
+      "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+      "Fee": "10000",
+      "Flags": 2147483648,
+      "Sequence": 360,
+      "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+      "TransactionType": "Payment",
+      "TxnSignature": "304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F8580",
+      "hash": "4D5D90890F8D49519E4151938601EF3D0B30B16CD6A519D9C99102C9FA77F7E0"
+    }
+  }
 }
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
-    "result": {
-        "status": "success",
-        "tx_blob": "1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
-        "tx_json": {
-            "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "Amount": {
-                "currency": "USD",
-                "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "value": "1"
-            },
-            "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "Fee": "10",
-            "Flags": 2147483648,
-            "Sequence": 3,
-            "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
-            "TransactionType": "Payment",
-            "TxnSignature": "3045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE",
-            "hash": "82230B9D489370504B39BC2CE46216176CAC9E752E5C1774A8CBEC9FBB819208"
-        }
-    }
+	"result": {
+		"status": "success",
+		"tx_blob": "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7446304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F858081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+		"tx_json": {
+			"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+			"Amount": {
+				"currency": "USD",
+				"issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"value": "1"
+			},
+			"Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+			"Fee": "10000",
+			"Flags": 2147483648,
+			"Sequence": 360,
+			"SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+			"TransactionType": "Payment",
+			"TxnSignature": "304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F8580",
+			"hash": "4D5D90890F8D49519E4151938601EF3D0B30B16CD6A519D9C99102C9FA77F7E0"
+		}
+	}
+}
+```
+
+*Commandline*
+
+```
+Loading: "/etc/rippled.cfg"
+Connecting to 127.0.0.1:5005
+{
+   "result" : {
+      "status" : "success",
+      "tx_blob" : "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7447304502210094D24C795CFFA8E46FE338AF63421DA5CE5E171ED56F8E4CE70FFABA15D3CFA2022063994C52BF0393C8157EBFFCDE6A7E7EDC7B16A462CA53214F64CC8FCBB5E54A81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+      "tx_json" : {
+         "Account" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+         "Amount" : {
+            "currency" : "USD",
+            "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "value" : "1"
+         },
+         "Destination" : "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+         "Fee" : "10000",
+         "Flags" : 2147483648,
+         "Sequence" : 360,
+         "SigningPubKey" : "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+         "TransactionType" : "Payment",
+         "TxnSignature" : "304502210094D24C795CFFA8E46FE338AF63421DA5CE5E171ED56F8E4CE70FFABA15D3CFA2022063994C52BF0393C8157EBFFCDE6A7E7EDC7B16A462CA53214F64CC8FCBB5E54A",
+         "hash" : "DE80DA6FF9F93FE4CE87C99441F403E0290E35867FF48382204CB89975BF343E"
+      }
+   }
 }
 ```
 
@@ -6401,7 +6488,7 @@ The response follows the [standard format](#response-formatting), with a success
 | tx_blob | String | Binary representation of the fully-qualified, signed transaction, as hex |
 | tx_json | Object | JSON specification of the [complete transaction](reference-transaction-format.html) as signed, including any fields that were automatically filled in |
 
-__*Caution:*__ If this command results in an error messages, the message can contain the account secret from the request. Make sure that these errors are not visible to others, including:
+**Caution:** If this command results in an error messages, the message can contain the secret key from the request. Make sure that these errors are not visible to others, including:
 
 * Do not write this error to a log file that can be seen by multiple people
 * Do not paste this error to a public place for debugging
@@ -6674,6 +6761,7 @@ A submit-only request includes the following parameters:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 3,
@@ -6683,6 +6771,7 @@ A submit-only request includes the following parameters:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "submit",
@@ -6695,6 +6784,7 @@ A submit-only request includes the following parameters:
 ```
 
 *Commandline*
+
 ```
 #Syntax: submit tx_blob
 submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754
@@ -6726,9 +6816,9 @@ The request includes the following parameters:
 | key\_type | String | (Optional) Type of cryptographic key provided in this request. Valid types are `secp256k1` or `ed25519`. Defaults to `secp256k1`. Cannot be used with `secret`. **Caution:** Ed25519 support is experimental. |
 | fail\_hard | Boolean | (Optional, defaults to false) If true, and the transaction fails locally, do not retry or relay the transaction to other servers |
 | offline | Boolean | (Optional, defaults to false) If true, when constructing the transaction, do not attempt to automatically fill in or validate values. |
-| build\_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. __*Caution:*__ The server looks for the presence or absence of this field, not its value. This behavior may change. |
-| fee\_mult\_max | Integer | (Optional) If the `Fee` parameter is omitted, this field limits the automatically-provided `Fee` value so that it is less than or equal to the long-term base transaction cost times this value. |
-| fee\_div\_max | Integer | (Optional) Used with `fee_mult_max` to create a fractional multiplier for the limit. Specifically, the server multiplies its base [transaction cost](concept-transaction-cost.html) by `fee_mult_max`, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided `Fee` value would be over the limit, the submit command fails. _(New in [version 0.30.1][])_ |
+| build\_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. **Caution:** The server looks for the presence or absence of this field, not its value. This behavior may change. |
+| fee\_mult\_max | Integer | (Optional, defaults to 10, recommended value 1000) If the `Fee` parameter is omitted, this field limits the automatically-provided `Fee` value so that it is less than or equal to the long-term base transaction cost times this value. |
+| fee\_div\_max | Integer | (Optional, defaults to 1) Used with `fee_mult_max` to create a fractional multiplier for the limit. Specifically, the server multiplies its base [transaction cost](concept-transaction-cost.html) by `fee_mult_max`, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided `Fee` value would be over the limit, the submit command fails. _(New in [version 0.30.1][])_ |
 
 See the [sign command](#sign) for detailed information on how the server automatically fills in certain fields.
 
@@ -6738,6 +6828,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -6752,17 +6843,21 @@ An example of the request format:
          "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
       }
    },
-   "secret" : "sssssssssssssssssssssssssssss"
+   "secret" : "s████████████████████████████",
+   "offline": false,
+   "fee_mult_max": 1000
 }
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "submit",
     "params": [
         {
-            "secret": "sssssssssssssssssssssssssssss",
+            "offline": false,
+            "secret": "s████████████████████████████",
             "tx_json": {
                 "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "Amount": {
@@ -6772,16 +6867,18 @@ An example of the request format:
                 },
                 "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
                 "TransactionType": "Payment"
-            }
+            },
+            "fee_mult_max": 1000
         }
     ]
 }
 ```
 
 *Commandline*
+
 ```
 #Syntax: submit secret json [offline]
-submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"rJYMACXJd1eejwzZA53VncYmiK2kZSBxyD", "Amount":"200000000","Destination":"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV" }'
+rippled submit s████████████████████████████ '{"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Amount": { "currency": "USD", "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "value": "1" }, "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "TransactionType": "Payment", "Fee": "10000"}'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -6795,16 +6892,17 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
-  "id": 2,
+  "id": 1,
   "status": "success",
   "type": "response",
   "result": {
     "engine_result": "tesSUCCESS",
     "engine_result_code": 0,
-    "engine_result_message": "The transaction was applied.",
-    "tx_blob": "1200002280000000240000000161D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100F8A650C1D58325FE8D74634C1DC0802BB2271EB84773793EF34085CFC7E32B1302206ECE43AFE94B7F9F0359D53E6B195C2D526DFDFBBBF328D6FE3A598F1D51DEBA81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+    "engine_result_message": "The transaction was applied. Only final in a validated ledger.",
+    "tx_blob": "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7446304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F858081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
     "tx_json": {
       "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
       "Amount": {
@@ -6813,44 +6911,77 @@ An example of a successful response:
         "value": "1"
       },
       "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-      "Fee": "10",
+      "Fee": "10000",
       "Flags": 2147483648,
-      "Sequence": 1,
+      "Sequence": 360,
       "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
       "TransactionType": "Payment",
-      "TxnSignature": "3045022100F8A650C1D58325FE8D74634C1DC0802BB2271EB84773793EF34085CFC7E32B1302206ECE43AFE94B7F9F0359D53E6B195C2D526DFDFBBBF328D6FE3A598F1D51DEBA",
-      "hash": "7BF105CFE4EFE78ADB63FE4E03A851440551FE189FD4B51CAAD9279C9F534F0E"
+      "TxnSignature": "304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F8580",
+      "hash": "4D5D90890F8D49519E4151938601EF3D0B30B16CD6A519D9C99102C9FA77F7E0"
     }
   }
 }
 ```
 
 *JSON-RPC*
+
 ```
 {
-    "result": {
-        "engine_result": "tesSUCCESS",
-        "engine_result_code": 0,
-        "engine_result_message": "The transaction was applied.",
-        "status": "success",
-        "tx_blob": "1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
-        "tx_json": {
-            "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "Amount": {
-                "currency": "USD",
-                "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "value": "1"
-            },
-            "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "Fee": "10",
-            "Flags": 2147483648,
-            "Sequence": 3,
-            "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
-            "TransactionType": "Payment",
-            "TxnSignature": "3045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE",
-            "hash": "82230B9D489370504B39BC2CE46216176CAC9E752E5C1774A8CBEC9FBB819208"
-        }
-    }
+	"result": {
+		"engine_result": "tesSUCCESS",
+		"engine_result_code": 0,
+		"engine_result_message": "The transaction was applied. Only final in a validated ledger.",
+		"status": "success",
+		"tx_blob": "1200002280000000240000016961D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100A7CCD11455E47547FF617D5BFC15D120D9053DFD0536B044F10CA3631CD609E502203B61DEE4AC027C5743A1B56AF568D1E2B8E79BB9E9E14744AC87F38375C3C2F181144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+		"tx_json": {
+			"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+			"Amount": {
+				"currency": "USD",
+				"issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"value": "1"
+			},
+			"Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+			"Fee": "10000",
+			"Flags": 2147483648,
+			"Sequence": 361,
+			"SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+			"TransactionType": "Payment",
+			"TxnSignature": "3045022100A7CCD11455E47547FF617D5BFC15D120D9053DFD0536B044F10CA3631CD609E502203B61DEE4AC027C5743A1B56AF568D1E2B8E79BB9E9E14744AC87F38375C3C2F1",
+			"hash": "5B31A7518DC304D5327B4887CD1F7DC2C38D5F684170097020C7C9758B973847"
+		}
+	}
+}
+```
+
+*Commandline*
+
+```
+Loading: "/etc/rippled.cfg"
+Connecting to 127.0.0.1:5005
+{
+   "result" : {
+      "engine_result" : "tesSUCCESS",
+      "engine_result_code" : 0,
+      "engine_result_message" : "The transaction was applied. Only final in a validated ledger.",
+      "status" : "success",
+      "tx_blob" : "1200002280000000240000016A61D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100FBBF74057359EC31C3647AD3B33D8954730E9879C35034374858A76B7CFA643102200EAA08C61071396E9CF0987FBEA16CF113CBD8068AA221214D165F151285EECD81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+      "tx_json" : {
+         "Account" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+         "Amount" : {
+            "currency" : "USD",
+            "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "value" : "1"
+         },
+         "Destination" : "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+         "Fee" : "10000",
+         "Flags" : 2147483648,
+         "Sequence" : 362,
+         "SigningPubKey" : "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+         "TransactionType" : "Payment",
+         "TxnSignature" : "3045022100FBBF74057359EC31C3647AD3B33D8954730E9879C35034374858A76B7CFA643102200EAA08C61071396E9CF0987FBEA16CF113CBD8068AA221214D165F151285EECD",
+         "hash" : "CB98A6FA1FAC47F9FCC6A233EB46F8F9AF59CC69BD69AE6D06F298F6FF52162A"
+      }
+   }
 }
 ```
 
@@ -6866,9 +6997,9 @@ The response follows the [standard format](#response-formatting), with a success
 | tx_blob | String | The complete transaction in hex string format |
 | tx_json | Object | The complete transaction in JSON format |
 
-__*Caution:*__ Even if the WebSocket response has `"status":"success"`, indicating that the command was successfully received, that does _not_ indicate that the transaction executed successfully. Many situations can prevent a transaction from processing successfully, such as a lack of trust lines connecting the two accounts in a payment, or changes in the state of the ledger since the time the transaction was constructed. Even if nothing is wrong, it may take several seconds to close and validate the ledger version that includes the transaction. See the [full list of transaction responses](reference-transaction-format.html#full-transaction-response-list) for details, and do not consider the transaction's results final until they appear in a validated ledger version.
+**Caution:** Even if the WebSocket response has `"status":"success"`, indicating that the command was successfully received, that does _not_ indicate that the transaction executed successfully. Many situations can prevent a transaction from processing successfully, such as a lack of trust lines connecting the two accounts in a payment, or changes in the state of the ledger since the time the transaction was constructed. Even if nothing is wrong, it may take several seconds to close and validate the ledger version that includes the transaction. See the [full list of transaction responses](reference-transaction-format.html#full-transaction-response-list) for details, and do not consider the transaction's results final until they appear in a validated ledger version.
 
-__*Caution:*__ If this command results in an error messages, the message can contain an account secret, if one was provided in the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others, including:
+**Caution:** If this command results in an error messages, the message can contain an account secret, if one was provided in the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others, including:
 
 * Do not write an error including your secret to a log file that can be seen by multiple people
 * Do not paste an error including your secret to a public place for debugging
@@ -7221,6 +7352,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 11,
@@ -7281,6 +7413,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -7406,7 +7539,8 @@ The `streams` parameter provides access to the following default streams of info
 * `server` - Sends a message whenever the status of the `rippled` server (for example, network connectivity) changes
 * `ledger` - Sends a message whenever the consensus process declares a new validated ledger
 * `transactions` - Sends a message whenever a transaction is included in a closed ledger
-* `transactions_proposed` - Sends a message whenever a transaction is included in a closed ledger, as well as some transactions that have not yet been included in a validated ledger and may never be. Not all proposed transactions appear before validation, however. (__*Note:*__ [Even some transactions that don't succeed are included](reference-transaction-format.html#result-categories) in validated ledgers, because they take the anti-spam transaction fee.)
+* `transactions_proposed` - Sends a message whenever a transaction is included in a closed ledger, as well as some transactions that have not yet been included in a validated ledger and may never be. Not all proposed transactions appear before validation.
+    **Note:** [Even some transactions that don't succeed are included](reference-transaction-format.html#result-categories) in validated ledgers, because they take the anti-spam transaction fee.
 * `validations` - Sends a message whenever the server receives a validation message from a server it trusts. (An individual `rippled` declares a ledger validated when the server receives validation messages from at least a quorum of trusted validators.)
 * `peer_status` - **(Admin only)** Information about connected peer `rippled` servers, especially with regards to the consensus process.
 
@@ -7427,6 +7561,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": "Example watch Bitstamp's hot wallet",
@@ -7453,7 +7588,7 @@ The response follows the [standard format](#response-formatting). The fields con
 * `noPermission` - The request included the `url` field, but you are not connected as an admin.
 * `unknownStream` - One or more the members of the `streams` field in the request was not recognized as a valid stream name.
 * `malformedStream` - The `streams` field of the request was not formatted properly.
-* `malformedAccount` - One of the addresses in the `accounts` or `accounts_proposed` fields of the request is not a properly-formatted Ripple address. (__*Note*__: You _can_ subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)
+* `malformedAccount` - One of the addresses in the `accounts` or `accounts_proposed` fields of the request is not a properly-formatted Ripple address. (**Note:**: You _can_ subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)
 * `srcCurMalformed` - One or more `taker_pays` sub-fields of the `books` field in the request is not formatted properly.
 * `dstAmtMalformed` - One or more `taker_gets` sub-fields of the `books` field in the request is not formatted properly.
 * `srcIsrMalformed` - The `issuer` field of one or more `taker_pays` sub-fields of the `books` field in the request is not valid.
@@ -7854,6 +7989,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": "Unsubscribe a lot of stuff",
@@ -7906,6 +8042,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": "Unsubscribe a lot of stuff",
@@ -7925,7 +8062,7 @@ The response follows the [standard format](#response-formatting), with a success
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
 * `noPermission` - The request included the `url` field, but you are not connected as an admin.
 * `malformedStream` - The `streams` field of the request was not formatted properly.
-* `malformedAccount` - One of the addresses in the `accounts` or `accounts_proposed` fields of the request is not a properly-formatted Ripple address. (__*Note*__: You _can_ subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)
+* `malformedAccount` - One of the addresses in the `accounts` or `accounts_proposed` fields of the request is not a properly-formatted Ripple address. (**Note:**: You _can_ subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)
 * `srcCurMalformed` - One or more `taker_pays` sub-fields of the `books` field in the request is not formatted properly.
 * `dstAmtMalformed` - One or more `taker_gets` sub-fields of the `books` field in the request is not formatted properly.
 * `srcIsrMalformed` - The `issuer` field of one or more `taker_pays` sub-fields of the `books` field in the request is not valid.
@@ -7990,6 +8127,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 1,
@@ -8094,6 +8232,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -8514,6 +8653,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
   "id": 2,
@@ -8523,6 +8663,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "can_delete",
@@ -8535,6 +8676,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax can_delete [<ledger_index>|<ledger_hash>|now|always|never]
 rippled can_delete 11320417
@@ -10592,6 +10734,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -10600,6 +10743,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "ping",
@@ -10610,6 +10754,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: ping
 rippled ping
@@ -10628,6 +10773,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -10638,6 +10784,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -10667,6 +10814,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -10675,6 +10823,7 @@ An example of the request format:
 ```
 
 *JSON-RPC*
+
 ```
 {
     "method": "random",
@@ -10685,6 +10834,7 @@ An example of the request format:
 ```
 
 *Commandline*
+
 ```
 #Syntax: random
 rippled random
@@ -10701,6 +10851,7 @@ An example of a successful response:
 <!-- MULTICODE_BLOCK_START -->
 
 *WebSocket*
+
 ```
 {
     "id": 1,
@@ -10713,6 +10864,7 @@ An example of a successful response:
 ```
 
 *JSON-RPC*
+
 ```
 200 OK
 {
@@ -10747,6 +10899,7 @@ An example of the request format:
 <!-- MULTICODE_BLOCK_START -->
 
 *Commandline*
+
 ```
 # Syntax: json method json_stanza
 rippled -q json ledger_closed '{}'

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -6488,11 +6488,11 @@ The response follows the [standard format](#response-formatting), with a success
 | tx_blob | String | Binary representation of the fully-qualified, signed transaction, as hex |
 | tx_json | Object | JSON specification of the [complete transaction](reference-transaction-format.html) as signed, including any fields that were automatically filled in |
 
-**Caution:** If this command results in an error messages, the message can contain the secret key from the request. Make sure that these errors are not visible to others, including:
+**Caution:** If this command results in an error messages, the message can contain the secret key from the request. Make sure that these errors are not visible to others.
 
-* Do not write this error to a log file that can be seen by multiple people
-* Do not paste this error to a public place for debugging
-* Do not display the error message on a website, even by accident
+* Do not write this error to a log file that can be seen by multiple people.
+* Do not paste this error to a public place for debugging.
+* Do not display the error message on a website, even by accident.
 
 #### Possible Errors ####
 
@@ -6999,11 +6999,11 @@ The response follows the [standard format](#response-formatting), with a success
 
 **Caution:** Even if the WebSocket response has `"status":"success"`, indicating that the command was successfully received, that does _not_ indicate that the transaction executed successfully. Many situations can prevent a transaction from processing successfully, such as a lack of trust lines connecting the two accounts in a payment, or changes in the state of the ledger since the time the transaction was constructed. Even if nothing is wrong, it may take several seconds to close and validate the ledger version that includes the transaction. See the [full list of transaction responses](reference-transaction-format.html#full-transaction-response-list) for details, and do not consider the transaction's results final until they appear in a validated ledger version.
 
-**Caution:** If this command results in an error messages, the message can contain an account secret, if one was provided in the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others, including:
+**Caution:** If this command results in an error messages, the message can contain the secret key from the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others.
 
-* Do not write an error including your secret to a log file that can be seen by multiple people
-* Do not paste an error including your secret to a public place for debugging
-* Do not display an error message including your secret on a website, even by accident
+* Do not write an error including your secret key to a log file that can be seen by multiple people.
+* Do not paste an error including your secret key to a public place for debugging.
+* Do not display an error message including your secret key on a website, even by accident.
 
 
 #### Possible Errors ####

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -192,6 +192,7 @@
 <li class="level-3"><a href="#path-find-status">path_find status</a></li>
 <li class="level-2"><a href="#ripple-path-find">ripple_path_find</a></li>
 <li class="level-2"><a href="#sign">sign</a></li>
+<li class="level-3"><a href="#auto-fillable-fields">Auto-Fillable Fields</a></li>
 <li class="level-2"><a href="#sign-for">sign_for</a></li>
 <li class="level-2"><a href="#submit">submit</a></li>
 <li class="level-3"><a href="#submit-only-mode">Submit-Only Mode</a></li>
@@ -7460,20 +7461,22 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <tr>
 <td>fee_mult_max</td>
 <td>Integer</td>
-<td>(Optional) If the <code>Fee</code> parameter (<a href="concept-transaction-cost.html">transaction cost</a>) is omitted, this field limits the automatically-provided value so that it is less than or equal to the base transaction cost times this value.</td>
+<td>(Optional, defaults to 10; recommended value 1000) Limits how high the <a href="reference-transaction-format.html#auto-fillable-fields">automatically-provided <code>Fee</code> field</a> can be. Signing fails with the error <code>rpcHIGH_FEE</code> if the current <a href="concept-transaction-cost.html#local-load-cost">load multiplier on the transaction cost</a> is greater than (<code>fee_mult_max</code> ÷ <code>fee_div_max</code>). Ignored if you specify the <code>Fee</code> field of the transaction (<a href="concept-transaction-cost.html">transaction cost</a>).</td>
 </tr>
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, signing fails. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>(Optional, defaults to 1) Signing fails with the error <code>rpcHIGH_FEE</code> if the current <a href="concept-transaction-cost.html#local-load-cost">load multiplier on the transaction cost</a> is greater than (<code>fee_mult_max</code> ÷ <code>fee_div_max</code>). Ignored if you specify the <code>Fee</code> field of the transaction (<a href="concept-transaction-cost.html">transaction cost</a>). <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 </tbody>
 </table>
-<p>The server automatically attempts to fill in certain fields from the <code>tx_json</code> object if they are omitted, unless you specified <code>offline</code> as true. Otherwise, the following fields from the <a href="reference-transaction-format.html">transaction format</a> are automatically filled in:</p>
+<h3 id="auto-fillable-fields">Auto-Fillable Fields</h3>
+<p>The server automatically attempts to fill in certain fields in <code>tx_json</code> (the <a href="reference-transaction-format.html">Transaction object</a>) automatically if you omit them. The server provides the following fields before signing, unless the request specified <code>offline</code> as <code>true</code>:</p>
 <ul>
-<li><code>Sequence</code> - The server automatically uses the next Sequence number from the sender's account information. Be careful: the next sequence number for the account is not incremented until this transaction is applied. If you sign multiple transactions without submitting and waiting for the response to each one, you must provide the correct sequence numbers in the request. Automatically filled unless <code>offline</code> is true.</li>
-<li><code>Fee</code> - If you omit the <code>Fee</code> parameter, the server <a href="concept-transaction-cost.html#automatically-specifying-the-transaction-cost">automatically provides an appropriate transaction cost</a> unless you specified <code>offline</code> as true. If you specify <code>offline</code> as true, you must fill in the transaction cost in the <code>Fee</code> parameter. Be careful: a malicious server can specify an excessively high transaction cost.<ul>
-<li>If <code>fee_mult_max</code> is included, and the automatically provided <code>Fee</code> value is greater than the long-term base transaction cost times <code>fee_mult_max</code>, then the transaction fails with the error <code>rpcHIGH_FEE</code>. This way, you can let the server fill in the current minimum <code>Fee</code> value as long as the current load-based transaction cost is not too high.</li>
+<li><code>Sequence</code> - The server automatically uses the next Sequence number from the sender's account information. Be careful: the next sequence number for the account is not incremented until this transaction is applied. If you sign multiple transactions without submitting and waiting for the response to each one, you must provide the correct sequence numbers in the request.</li>
+<li><code>Fee</code> - If you omit the <code>Fee</code> parameter, the server tries to fill in an appropriate transaction cost automatically. On the production Ripple Consensus Ledger, this fails with <code>rpcHIGH_FEE</code> unless you provide an appropriate <code>fee_mult_max</code> value.<ul>
+<li>The <code>fee_mult_max</code> and <code>fee_div_max</code> parameters limit how high the automatically-provided transaction cost can be, in terms of the load-scaling multiplier that gets applied to the <a href="concept-transaction-cost.html#reference-transaction-cost">reference transaction cost</a>. The default values return an error if the automatically-provided value would use greater than a 10× multiplier. However, the production Ripple Consensus Ledger <a href="concept-transaction-cost.html#current-transaction-cost">typically has a 1000× load multiplier</a>.</li>
+<li><strong>Caution:</strong> A malicious server can specify an excessively high transaction cost, ignoring the values of <code>fee_mult_max</code> and <code>fee_div_max</code>.</li>
 </ul>
 </li>
 <li><code>Paths</code> - For Payment-type transactions (excluding XRP-to-XRP transfers), the Paths field can be automatically filled, as if you did a <a href="#ripple-path-find">ripple_path_find</a>. Only filled if <code>build_path</code> is provided.</li>
@@ -7565,7 +7568,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>highFee</code> - The <code>fee_mult_max</code> parameter was specified, but the server's current transaction cost multiplier exceeds the specified one.</li>
+<li><code>highFee</code> - The current load-based multiplier to the transaction cost exceeds the limit for an automatically-provided transaction cost. Either specify a higher <code>fee_mult_max</code> (at least 1000) in the request or manually provide a value in the <code>Fee</code> field of the <code>tx_json</code>.</li>
 <li><code>tooBusy</code> - The transaction did not include paths, but the server is too busy to do pathfinding right now. Does not occur if you are connected as an admin.</li>
 <li><code>noPath</code> - The transaction did not include paths, and the server was unable to find a path by which this payment can occur.</li>
 </ul>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -7590,11 +7590,11 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<p><strong>Caution:</strong> If this command results in an error messages, the message can contain the secret key from the request. Make sure that these errors are not visible to others, including:</p>
+<p><strong>Caution:</strong> If this command results in an error messages, the message can contain the secret key from the request. Make sure that these errors are not visible to others.</p>
 <ul>
-<li>Do not write this error to a log file that can be seen by multiple people</li>
-<li>Do not paste this error to a public place for debugging</li>
-<li>Do not display the error message on a website, even by accident</li>
+<li>Do not write this error to a log file that can be seen by multiple people.</li>
+<li>Do not paste this error to a public place for debugging.</li>
+<li>Do not display the error message on a website, even by accident.</li>
 </ul>
 <h4 id="possible-errors-23">Possible Errors</h4>
 <ul>
@@ -8164,11 +8164,11 @@ Connecting to 127.0.0.1:5005
 </tbody>
 </table>
 <p><strong>Caution:</strong> Even if the WebSocket response has <code>"status":"success"</code>, indicating that the command was successfully received, that does <em>not</em> indicate that the transaction executed successfully. Many situations can prevent a transaction from processing successfully, such as a lack of trust lines connecting the two accounts in a payment, or changes in the state of the ledger since the time the transaction was constructed. Even if nothing is wrong, it may take several seconds to close and validate the ledger version that includes the transaction. See the <a href="reference-transaction-format.html#full-transaction-response-list">full list of transaction responses</a> for details, and do not consider the transaction's results final until they appear in a validated ledger version.</p>
-<p><strong>Caution:</strong> If this command results in an error messages, the message can contain an account secret, if one was provided in the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others, including:</p>
+<p><strong>Caution:</strong> If this command results in an error messages, the message can contain the secret key from the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others.</p>
 <ul>
-<li>Do not write an error including your secret to a log file that can be seen by multiple people</li>
-<li>Do not paste an error including your secret to a public place for debugging</li>
-<li>Do not display an error message including your secret on a website, even by accident</li>
+<li>Do not write an error including your secret key to a log file that can be seen by multiple people.</li>
+<li>Do not paste an error including your secret key to a public place for debugging.</li>
+<li>Do not display an error message including your secret key on a website, even by accident.</li>
 </ul>
 <h4 id="possible-errors-25">Possible Errors</h4>
 <ul>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -543,7 +543,7 @@
 <tr>
 <td>request</td>
 <td>Object</td>
-<td>A copy of the request that prompted this error, in JSON format. <strong><em>Caution:</em></strong> If the request contained any account secrets, they are copied here!</td>
+<td>A copy of the request that prompted this error, in JSON format. <strong>Caution:</strong> If the request contained any account secrets, they are copied here!</td>
 </tr>
 </tbody>
 </table>
@@ -699,7 +699,7 @@ Null method
 </li>
 </ol>
 <p>There is also a deprecated <code>ledger</code> parameter which accepts any of the above three formats. <em>Do not</em> use this parameter; it may be removed without further notice.</p>
-<p>If you do not specify a ledger, the <code>current</code> (in-progress) ledger will be chosen by default. If you provide more than one field specifying ledgers, the deprecated <code>ledger</code> field will be used first if it exists, falling back to <code>ledger_hash</code>. The <code>ledger_index</code> field is ignored unless neither of the other two are present. <strong><em>Note:</em></strong> Do not rely on this default behavior; it is subject to change. Instead, you should always specify a ledger version in each call.</p>
+<p>If you do not specify a ledger, the <code>current</code> (in-progress) ledger will be chosen by default. If you provide more than one field specifying ledgers, the deprecated <code>ledger</code> field will be used first if it exists, falling back to <code>ledger_hash</code>. The <code>ledger_index</code> field is ignored unless neither of the other two are present. <strong>Note:</strong> Do not rely on this default behavior; it is subject to change. Instead, you should always specify a ledger version in each call.</p>
 <h2 id="currencies">Currencies</h2>
 <p>There are two kinds of currencies in the Ripple Consensus Ledger: XRP, and everything else. There are many differences between the two:</p>
 <table>
@@ -833,7 +833,7 @@ Null method
 </tr>
 </tbody>
 </table>
-<p><strong><em>Note:</em></strong> The distinction between <code>full</code>, <code>validating</code>, and <code>proposing</code> is based on synchronization with the rest of the global network, and it is normal for a server to fluctuate between these states as a course of general operation.</p>
+<p><strong>Note:</strong> The distinction between <code>full</code>, <code>validating</code>, and <code>proposing</code> is based on synchronization with the rest of the global network, and it is normal for a server to fluctuate between these states as a course of general operation.</p>
 <h2 id="markers-and-pagination">Markers and Pagination</h2>
 <p>Some methods return more data than can efficiently fit into one response. When there are more results than contained, the response includes a <code>marker</code> field. You can use this to retrieve more pages of data across multiple calls. In each subsequent request, pass the <code>marker</code> value from the previous response in order to resume from the point where you left off. If the <code>marker</code> is omitted from a response, then you have reached the end of the data set.</p>
 <p>The format of the <code>marker</code> field is intentionally undefined. Each server can define a <code>marker</code> field as desired, so it may take the form of a string, a nested object, or another type. Different servers, and different methods provided by the same server, can have different <code>marker</code> definitions. Each <code>marker</code> is ephemeral, and may not work as expected after 10 minutes.</p>
@@ -3033,7 +3033,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </tr>
 </tbody>
 </table>
-<p><strong><em>Note:</em></strong> The server may respond with different values of <code>ledger_index_min</code> and <code>ledger_index_max</code> than you provided in the request, for example if it did not have the versions you specified on hand.</p>
+<p><strong>Note:</strong> The server may respond with different values of <code>ledger_index_min</code> and <code>ledger_index_max</code> than you provided in the request, for example if it did not have the versions you specified on hand.</p>
 <p>Each transaction object includes the following fields, depending on whether it was requested in JSON or hex string (<code>"binary":true</code>) format.</p>
 <table>
 <thead>
@@ -4203,7 +4203,7 @@ rippled ledger_current
 }
 </code></pre></div>
 </div>
-<p><strong><em>Note:</em></strong> There is no commandline syntax for <code>ledger_data</code>. You can use the <a href="#json"><code>json</code> command</a> to access this method from the commandline instead.</p>
+<p><strong>Note:</strong> There is no commandline syntax for <code>ledger_data</code>. You can use the <a href="#json"><code>json</code> command</a> to access this method from the commandline instead.</p>
 <p>A request can include the following fields:</p>
 <table>
 <thead>
@@ -4487,7 +4487,7 @@ rippled ledger_current
 <h2 id="ledger-entry">ledger_entry</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerEntry.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_entry</code> method returns a single ledger node from the Ripple Consensus Ledger in its raw format. See <a href="reference-ledger-format.html">ledger format</a> for information on the different types of objects you can retrieve.</p>
-<p><strong><em>Note:</em></strong> There is no commandline version of this method. You can use the <a href="#json"><code>json</code> command</a> to access this method from the commandline instead.</p>
+<p><strong>Note:</strong> There is no commandline version of this method. You can use the <a href="#json"><code>json</code> command</a> to access this method from the commandline instead.</p>
 <h4 id="request-format-13">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-29"><ul class="codetabs"><li><a href="#code-29-0">WebSocket</a></li><li><a href="#code-29-1">JSON-RPC</a></li></ul>
@@ -5244,7 +5244,7 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 </tr>
 </tbody>
 </table>
-<p><strong><em>Note:</em></strong> This method does not support retrieving information from the current in-progress ledger. You must specify a ledger version in either <code>ledger_index</code> or <code>ledger_hash</code>.</p>
+<p><strong>Note:</strong> This method does not support retrieving information from the current in-progress ledger. You must specify a ledger version in either <code>ledger_index</code> or <code>ledger_hash</code>.</p>
 <h4 id="response-format-17">Response Format</h4>
 <p>An example of a successful response:</p>
 <div class="multicode" id="code-37"><ul class="codetabs"><li><a href="#code-37-0">WebSocket</a></li></ul>
@@ -5426,7 +5426,7 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 <h2 id="tx-history">tx_history</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TxHistory.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>tx_history</code> method retrieves a selection of the most recent transactions made.</p>
-<p><strong><em>Caution:</em></strong> This method is deprecated, and may be removed without further notice.</p>
+<p><strong>Caution:</strong> This method is deprecated, and may be removed without further notice.</p>
 <h4 id="request-format-18">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-38"><ul class="codetabs"><li><a href="#code-38-0">WebSocket</a></li><li><a href="#code-38-1">JSON-RPC</a></li><li><a href="#code-38-2">Commandline</a></li></ul>
@@ -6326,7 +6326,7 @@ rippled tx_history 0
 <li><code>close</code> - Stop sending pathfinding information</li>
 <li><code>status</code> - Get the information of the currently-open pathfinding request</li>
 </ul>
-<p>Although the <code>rippled</code> server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (<strong><em>Note:</em></strong> A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)</p>
+<p>Although the <code>rippled</code> server attempts to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths in order to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers operated by different parties, to minimize the risk of a single server returning poor results. (<strong>Note:</strong> A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)</p>
 <h3 id="path-find-create">path_find create</h3>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L38" title="Source">[Source]<br/></a></p>
 <p>The <code>create</code> subcommand of <code>path_find</code> creates an ongoing request to find possible paths along which a payment transaction could be made from one specified account such that another account receives a desired amount of some currency. The initial response contains a suggested path between the two addresses that would result in the desired amount being received. After that, the server sends additional messages, with <code>"type": "path_find"</code>, with updates to the potential paths. The frequency of updates is left to the discretion of the server, but it usually means once every few seconds when there is a new ledger version.</p>
@@ -7372,8 +7372,9 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
          "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
       }
    },
-   "secret" : "sssssssssssssssssssssssssssss",
-   "offline": false
+   "secret" : "s████████████████████████████",
+   "offline": false,
+   "fee_mult_max": 1000
 }
 </code></pre></div>
 
@@ -7382,7 +7383,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
     "params": [
         {
             "offline": false,
-            "secret": "sssssssssssssssssssssssssssss",
+            "secret": "s████████████████████████████",
             "tx_json": {
                 "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "Amount": {
@@ -7392,14 +7393,15 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
                 },
                 "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
                 "TransactionType": "Payment"
-            }
+            },
+            "fee_mult_max": 1000
         }
     ]
 }
 </code></pre></div>
 
 <div class="code_sample" id="code-47-2" style="position: static;"><pre><code>#Syntax: sign secret tx_json [offline]
-rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "Amount": { "currency": "USD", "value": "1", "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn" }}' false
+rippled sign s████████████████████████████ '{"TransactionType": "Payment", "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "Amount": { "currency": "USD", "value": "1", "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn" }, "Sequence": 360, "Fee": "10000"}' offline
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#sign">Try it! &gt;</a></p>
@@ -7456,7 +7458,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <tr>
 <td>build_path</td>
 <td>Boolean</td>
-<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. <strong><em>Caution:</em></strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
+<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. <strong>Caution:</strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
 </tr>
 <tr>
 <td>fee_mult_max</td>
@@ -7473,9 +7475,13 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 <h3 id="auto-fillable-fields">Auto-Fillable Fields</h3>
 <p>The server automatically attempts to fill in certain fields in <code>tx_json</code> (the <a href="reference-transaction-format.html">Transaction object</a>) automatically if you omit them. The server provides the following fields before signing, unless the request specified <code>offline</code> as <code>true</code>:</p>
 <ul>
-<li><code>Sequence</code> - The server automatically uses the next Sequence number from the sender's account information. Be careful: the next sequence number for the account is not incremented until this transaction is applied. If you sign multiple transactions without submitting and waiting for the response to each one, you must provide the correct sequence numbers in the request.</li>
+<li><code>Sequence</code> - The server automatically uses the next Sequence number from the sender's account information.<ul>
+<li><strong>Caution:</strong> The next sequence number for the account is not incremented until this transaction is applied. If you sign multiple transactions without submitting and waiting for the response to each one, you must manually provide the correct sequence numbers for each transaction after the first.</li>
+</ul>
+</li>
 <li><code>Fee</code> - If you omit the <code>Fee</code> parameter, the server tries to fill in an appropriate transaction cost automatically. On the production Ripple Consensus Ledger, this fails with <code>rpcHIGH_FEE</code> unless you provide an appropriate <code>fee_mult_max</code> value.<ul>
-<li>The <code>fee_mult_max</code> and <code>fee_div_max</code> parameters limit how high the automatically-provided transaction cost can be, in terms of the load-scaling multiplier that gets applied to the <a href="concept-transaction-cost.html#reference-transaction-cost">reference transaction cost</a>. The default values return an error if the automatically-provided value would use greater than a 10× multiplier. However, the production Ripple Consensus Ledger <a href="concept-transaction-cost.html#current-transaction-cost">typically has a 1000× load multiplier</a>.</li>
+<li>The <code>fee_mult_max</code> and <code>fee_div_max</code> parameters limit how high the automatically-provided transaction cost can be, in terms of the load-scaling multiplier that gets applied to the <a href="concept-transaction-cost.html#reference-transaction-cost">reference transaction cost</a>. The default settings return an error if the automatically-provided value would use greater than a 10× multiplier. However, the production Ripple Consensus Ledger <a href="concept-transaction-cost.html#current-transaction-cost">typically has a 1000× load multiplier</a>.</li>
+<li>The commandline syntax does not support <code>fee_mult_max</code> and <code>fee_div_max</code>. For the production Ripple Consensus Ledger, you must provide a <code>Fee</code> value.</li>
 <li><strong>Caution:</strong> A malicious server can specify an excessively high transaction cost, ignoring the values of <code>fee_mult_max</code> and <code>fee_div_max</code>.</li>
 </ul>
 </li>
@@ -7483,31 +7489,31 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 </ul>
 <h4 id="response-format-23">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-48"><ul class="codetabs"><li><a href="#code-48-0">WebSocket</a></li><li><a href="#code-48-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-48"><ul class="codetabs"><li><a href="#code-48-0">WebSocket</a></li><li><a href="#code-48-1">JSON-RPC</a></li><li><a href="#code-48-2">Commandline</a></li></ul>
 
 <div class="code_sample" id="code-48-0" style="position: static;"><pre><code>{
-    "id": 2,
-    "result": {
-        "tx_blob": "1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100BF06B6C01646005DEDD8F4F6D458AF4EE4006205A623FF31E0B5BCCE42564BA1022063C372D476379C109E3C22C5C04071594CD9EF64615C00B048AFFA5D7D6701F981144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
-        "tx_json": {
-            "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "Amount": {
-                "currency": "USD",
-                "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "value": "1"
-            },
-            "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "Fee": "10",
-            "Flags": 2147483648,
-            "Sequence": 3,
-            "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
-            "TransactionType": "Payment",
-            "TxnSignature": "3045022100BF06B6C01646005DEDD8F4F6D458AF4EE4006205A623FF31E0B5BCCE42564BA1022063C372D476379C109E3C22C5C04071594CD9EF64615C00B048AFFA5D7D6701F9",
-            "hash": "B4CBEBBA9E65A5BED25205806797600149599AAF2FD8103B3B75AE97B1B5F3E2"
-        }
-    },
-    "status": "success",
-    "type": "response"
+  "id": 2,
+  "status": "success",
+  "type": "response",
+  "result": {
+    "tx_blob": "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7446304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F858081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+    "tx_json": {
+      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "Amount": {
+        "currency": "USD",
+        "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "value": "1"
+      },
+      "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+      "Fee": "10000",
+      "Flags": 2147483648,
+      "Sequence": 360,
+      "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+      "TransactionType": "Payment",
+      "TxnSignature": "304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F8580",
+      "hash": "4D5D90890F8D49519E4151938601EF3D0B30B16CD6A519D9C99102C9FA77F7E0"
+    }
+  }
 }
 </code></pre></div>
 
@@ -7515,7 +7521,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 {
     "result": {
         "status": "success",
-        "tx_blob": "1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+        "tx_blob": "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7446304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F858081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
         "tx_json": {
             "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount": {
@@ -7524,15 +7530,41 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
                 "value": "1"
             },
             "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "Fee": "10",
+            "Fee": "10000",
             "Flags": 2147483648,
-            "Sequence": 3,
+            "Sequence": 360,
             "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
             "TransactionType": "Payment",
-            "TxnSignature": "3045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE",
-            "hash": "82230B9D489370504B39BC2CE46216176CAC9E752E5C1774A8CBEC9FBB819208"
+            "TxnSignature": "304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F8580",
+            "hash": "4D5D90890F8D49519E4151938601EF3D0B30B16CD6A519D9C99102C9FA77F7E0"
         }
     }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-48-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+Connecting to 127.0.0.1:5005
+{
+   "result" : {
+      "status" : "success",
+      "tx_blob" : "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7447304502210094D24C795CFFA8E46FE338AF63421DA5CE5E171ED56F8E4CE70FFABA15D3CFA2022063994C52BF0393C8157EBFFCDE6A7E7EDC7B16A462CA53214F64CC8FCBB5E54A81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+      "tx_json" : {
+         "Account" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+         "Amount" : {
+            "currency" : "USD",
+            "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "value" : "1"
+         },
+         "Destination" : "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+         "Fee" : "10000",
+         "Flags" : 2147483648,
+         "Sequence" : 360,
+         "SigningPubKey" : "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+         "TransactionType" : "Payment",
+         "TxnSignature" : "304502210094D24C795CFFA8E46FE338AF63421DA5CE5E171ED56F8E4CE70FFABA15D3CFA2022063994C52BF0393C8157EBFFCDE6A7E7EDC7B16A462CA53214F64CC8FCBB5E54A",
+         "hash" : "DE80DA6FF9F93FE4CE87C99441F403E0290E35867FF48382204CB89975BF343E"
+      }
+   }
 }
 </code></pre></div>
 </div>
@@ -7558,7 +7590,7 @@ rippled sign sssssssssssssssssssssssssssss '{"TransactionType": "Payment", "Acco
 </tr>
 </tbody>
 </table>
-<p><strong><em>Caution:</em></strong> If this command results in an error messages, the message can contain the account secret from the request. Make sure that these errors are not visible to others, including:</p>
+<p><strong>Caution:</strong> If this command results in an error messages, the message can contain the secret key from the request. Make sure that these errors are not visible to others, including:</p>
 <ul>
 <li>Do not write this error to a log file that can be seen by multiple people</li>
 <li>Do not paste this error to a public place for debugging</li>
@@ -7940,17 +7972,17 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td>build_path</td>
 <td>Boolean</td>
-<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. <strong><em>Caution:</em></strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
+<td>(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. <strong>Caution:</strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
 </tr>
 <tr>
 <td>fee_mult_max</td>
 <td>Integer</td>
-<td>(Optional) If the <code>Fee</code> parameter is omitted, this field limits the automatically-provided <code>Fee</code> value so that it is less than or equal to the long-term base transaction cost times this value.</td>
+<td>(Optional, defaults to 10, recommended value 1000) If the <code>Fee</code> parameter is omitted, this field limits the automatically-provided <code>Fee</code> value so that it is less than or equal to the long-term base transaction cost times this value.</td>
 </tr>
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>(Optional, defaults to 1) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
 </tr>
 </tbody>
 </table>
@@ -7972,7 +8004,9 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
          "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
       }
    },
-   "secret" : "sssssssssssssssssssssssssssss"
+   "secret" : "s████████████████████████████",
+   "offline": false,
+   "fee_mult_max": 1000
 }
 </code></pre></div>
 
@@ -7980,7 +8014,8 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
     "method": "submit",
     "params": [
         {
-            "secret": "sssssssssssssssssssssssssssss",
+            "offline": false,
+            "secret": "s████████████████████████████",
             "tx_json": {
                 "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "Amount": {
@@ -7990,30 +8025,31 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
                 },
                 "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
                 "TransactionType": "Payment"
-            }
+            },
+            "fee_mult_max": 1000
         }
     ]
 }
 </code></pre></div>
 
 <div class="code_sample" id="code-52-2" style="position: static;"><pre><code>#Syntax: submit secret json [offline]
-submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"rJYMACXJd1eejwzZA53VncYmiK2kZSBxyD", "Amount":"200000000","Destination":"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV" }'
+rippled submit s████████████████████████████ '{"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Amount": { "currency": "USD", "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "value": "1" }, "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "TransactionType": "Payment", "Fee": "10000"}'
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#submit">Try it! &gt;</a></p>
 <h4 id="response-format-25">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-53"><ul class="codetabs"><li><a href="#code-53-0">WebSocket</a></li><li><a href="#code-53-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-53"><ul class="codetabs"><li><a href="#code-53-0">WebSocket</a></li><li><a href="#code-53-1">JSON-RPC</a></li><li><a href="#code-53-2">Commandline</a></li></ul>
 
 <div class="code_sample" id="code-53-0" style="position: static;"><pre><code>{
-  "id": 2,
+  "id": 1,
   "status": "success",
   "type": "response",
   "result": {
     "engine_result": "tesSUCCESS",
     "engine_result_code": 0,
-    "engine_result_message": "The transaction was applied.",
-    "tx_blob": "1200002280000000240000000161D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100F8A650C1D58325FE8D74634C1DC0802BB2271EB84773793EF34085CFC7E32B1302206ECE43AFE94B7F9F0359D53E6B195C2D526DFDFBBBF328D6FE3A598F1D51DEBA81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+    "engine_result_message": "The transaction was applied. Only final in a validated ledger.",
+    "tx_blob": "1200002280000000240000016861D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7446304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F858081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
     "tx_json": {
       "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
       "Amount": {
@@ -8022,13 +8058,13 @@ submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"r
         "value": "1"
       },
       "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-      "Fee": "10",
+      "Fee": "10000",
       "Flags": 2147483648,
-      "Sequence": 1,
+      "Sequence": 360,
       "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
       "TransactionType": "Payment",
-      "TxnSignature": "3045022100F8A650C1D58325FE8D74634C1DC0802BB2271EB84773793EF34085CFC7E32B1302206ECE43AFE94B7F9F0359D53E6B195C2D526DFDFBBBF328D6FE3A598F1D51DEBA",
-      "hash": "7BF105CFE4EFE78ADB63FE4E03A851440551FE189FD4B51CAAD9279C9F534F0E"
+      "TxnSignature": "304402200E5C2DD81FDF0BE9AB2A8D797885ED49E804DBF28E806604D878756410CA98B102203349581946B0DDA06B36B35DBC20EDA27552C1F167BCF5C6ECFF49C6A46F8580",
+      "hash": "4D5D90890F8D49519E4151938601EF3D0B30B16CD6A519D9C99102C9FA77F7E0"
     }
   }
 }
@@ -8038,9 +8074,9 @@ submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"r
     "result": {
         "engine_result": "tesSUCCESS",
         "engine_result_code": 0,
-        "engine_result_message": "The transaction was applied.",
+        "engine_result_message": "The transaction was applied. Only final in a validated ledger.",
         "status": "success",
-        "tx_blob": "1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+        "tx_blob": "1200002280000000240000016961D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100A7CCD11455E47547FF617D5BFC15D120D9053DFD0536B044F10CA3631CD609E502203B61DEE4AC027C5743A1B56AF568D1E2B8E79BB9E9E14744AC87F38375C3C2F181144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
         "tx_json": {
             "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount": {
@@ -8049,15 +8085,44 @@ submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"r
                 "value": "1"
             },
             "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "Fee": "10",
+            "Fee": "10000",
             "Flags": 2147483648,
-            "Sequence": 3,
+            "Sequence": 361,
             "SigningPubKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
             "TransactionType": "Payment",
-            "TxnSignature": "3045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE",
-            "hash": "82230B9D489370504B39BC2CE46216176CAC9E752E5C1774A8CBEC9FBB819208"
+            "TxnSignature": "3045022100A7CCD11455E47547FF617D5BFC15D120D9053DFD0536B044F10CA3631CD609E502203B61DEE4AC027C5743A1B56AF568D1E2B8E79BB9E9E14744AC87F38375C3C2F1",
+            "hash": "5B31A7518DC304D5327B4887CD1F7DC2C38D5F684170097020C7C9758B973847"
         }
     }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-53-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+Connecting to 127.0.0.1:5005
+{
+   "result" : {
+      "engine_result" : "tesSUCCESS",
+      "engine_result_code" : 0,
+      "engine_result_message" : "The transaction was applied. Only final in a validated ledger.",
+      "status" : "success",
+      "tx_blob" : "1200002280000000240000016A61D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA9684000000000002710732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100FBBF74057359EC31C3647AD3B33D8954730E9879C35034374858A76B7CFA643102200EAA08C61071396E9CF0987FBEA16CF113CBD8068AA221214D165F151285EECD81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754",
+      "tx_json" : {
+         "Account" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+         "Amount" : {
+            "currency" : "USD",
+            "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "value" : "1"
+         },
+         "Destination" : "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+         "Fee" : "10000",
+         "Flags" : 2147483648,
+         "Sequence" : 362,
+         "SigningPubKey" : "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB",
+         "TransactionType" : "Payment",
+         "TxnSignature" : "3045022100FBBF74057359EC31C3647AD3B33D8954730E9879C35034374858A76B7CFA643102200EAA08C61071396E9CF0987FBEA16CF113CBD8068AA221214D165F151285EECD",
+         "hash" : "CB98A6FA1FAC47F9FCC6A233EB46F8F9AF59CC69BD69AE6D06F298F6FF52162A"
+      }
+   }
 }
 </code></pre></div>
 </div>
@@ -8098,8 +8163,8 @@ submit sssssssssssssssssssssssssssss '{"TransactionType":"Payment", "Account":"r
 </tr>
 </tbody>
 </table>
-<p><strong><em>Caution:</em></strong> Even if the WebSocket response has <code>"status":"success"</code>, indicating that the command was successfully received, that does <em>not</em> indicate that the transaction executed successfully. Many situations can prevent a transaction from processing successfully, such as a lack of trust lines connecting the two accounts in a payment, or changes in the state of the ledger since the time the transaction was constructed. Even if nothing is wrong, it may take several seconds to close and validate the ledger version that includes the transaction. See the <a href="reference-transaction-format.html#full-transaction-response-list">full list of transaction responses</a> for details, and do not consider the transaction's results final until they appear in a validated ledger version.</p>
-<p><strong><em>Caution:</em></strong> If this command results in an error messages, the message can contain an account secret, if one was provided in the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others, including:</p>
+<p><strong>Caution:</strong> Even if the WebSocket response has <code>"status":"success"</code>, indicating that the command was successfully received, that does <em>not</em> indicate that the transaction executed successfully. Many situations can prevent a transaction from processing successfully, such as a lack of trust lines connecting the two accounts in a payment, or changes in the state of the ledger since the time the transaction was constructed. Even if nothing is wrong, it may take several seconds to close and validate the ledger version that includes the transaction. See the <a href="reference-transaction-format.html#full-transaction-response-list">full list of transaction responses</a> for details, and do not consider the transaction's results final until they appear in a validated ledger version.</p>
+<p><strong>Caution:</strong> If this command results in an error messages, the message can contain an account secret, if one was provided in the request. (This is not a problem if the request contained a signed tx_blob instead.) Make sure that these errors are not visible to others, including:</p>
 <ul>
 <li>Do not write an error including your secret to a log file that can be seen by multiple people</li>
 <li>Do not paste an error including your secret to a public place for debugging</li>
@@ -8712,7 +8777,8 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li><code>server</code> - Sends a message whenever the status of the <code>rippled</code> server (for example, network connectivity) changes</li>
 <li><code>ledger</code> - Sends a message whenever the consensus process declares a new validated ledger</li>
 <li><code>transactions</code> - Sends a message whenever a transaction is included in a closed ledger</li>
-<li><code>transactions_proposed</code> - Sends a message whenever a transaction is included in a closed ledger, as well as some transactions that have not yet been included in a validated ledger and may never be. Not all proposed transactions appear before validation, however. (<strong><em>Note:</em></strong> <a href="reference-transaction-format.html#result-categories">Even some transactions that don't succeed are included</a> in validated ledgers, because they take the anti-spam transaction fee.)</li>
+<li><code>transactions_proposed</code> - Sends a message whenever a transaction is included in a closed ledger, as well as some transactions that have not yet been included in a validated ledger and may never be. Not all proposed transactions appear before validation.
+    <strong>Note:</strong> <a href="reference-transaction-format.html#result-categories">Even some transactions that don't succeed are included</a> in validated ledgers, because they take the anti-spam transaction fee.</li>
 <li><code>validations</code> - Sends a message whenever the server receives a validation message from a server it trusts. (An individual <code>rippled</code> declares a ledger validated when the server receives validation messages from at least a quorum of trusted validators.)</li>
 <li><code>peer_status</code> - <strong>(Admin only)</strong> Information about connected peer <code>rippled</code> servers, especially with regards to the consensus process.</li>
 </ul>
@@ -8780,7 +8846,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li><code>noPermission</code> - The request included the <code>url</code> field, but you are not connected as an admin.</li>
 <li><code>unknownStream</code> - One or more the members of the <code>streams</code> field in the request was not recognized as a valid stream name.</li>
 <li><code>malformedStream</code> - The <code>streams</code> field of the request was not formatted properly.</li>
-<li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address. (<strong><em>Note</em></strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)</li>
+<li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address. (<strong>Note:</strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)</li>
 <li><code>srcCurMalformed</code> - One or more <code>taker_pays</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
 <li><code>dstAmtMalformed</code> - One or more <code>taker_gets</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
 <li><code>srcIsrMalformed</code> - The <code>issuer</code> field of one or more <code>taker_pays</code> sub-fields of the <code>books</code> field in the request is not valid.</li>
@@ -9430,7 +9496,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
 <li><code>noPermission</code> - The request included the <code>url</code> field, but you are not connected as an admin.</li>
 <li><code>malformedStream</code> - The <code>streams</code> field of the request was not formatted properly.</li>
-<li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address. (<strong><em>Note</em></strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)</li>
+<li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address. (<strong>Note:</strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger; if your subscription is still active, you will get a message when that account receives the payment that creates it.)</li>
 <li><code>srcCurMalformed</code> - One or more <code>taker_pays</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
 <li><code>dstAmtMalformed</code> - One or more <code>taker_gets</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
 <li><code>srcIsrMalformed</code> - The <code>issuer</code> field of one or more <code>taker_pays</code> sub-fields of the <code>books</code> field in the request is not valid.</li>


### PR DESCRIPTION
With the load multiplier regularly at 1000× or higher, the examples for the sign command and the submit command in sign-and-submit mode no longer work as advertised. Additionally, there were a few related typos. Cleaned up both sections with fresh (working) examples and more information.

Also changed some markdown syntax throughout the whole file for better consistency with other docs -- always a blank line between multicode label and code block, always two asterisks for Note / Warning labels. Doesn't affect the output in any significant way, but makes the source more consistent.
