### PR TITLE
update contact information to support

### DIFF
--- a/content/tutorial-gateway-guide.md
+++ b/content/tutorial-gateway-guide.md
@@ -14,7 +14,7 @@ This document explains the concepts and steps necessary to become a Ripple gatew
 You are not on your own. Ripple depends on the success of individual gateways, so we are here to help. Please contact us if you need help building and growing your gateway.
 
 * Contact [partners@ripple.com](mailto:partners@ripple.com) for enterprise-class integrations, infrastructure advice, and other business development needs.
-* Contact [developers@ripple.com](mailto:developers@ripple.com) for technical questions, clarifications, bug reports, and feature requests.
+* Contact [support@ripple.com](mailto:support@ripple.com) for technical questions, clarifications, bug reports, and feature requests.
 
 
 ## Ripple Gateways Explained ##

--- a/tutorial-gateway-guide.html
+++ b/tutorial-gateway-guide.html
@@ -196,7 +196,7 @@
 <p>You are not on your own. Ripple depends on the success of individual gateways, so we are here to help. Please contact us if you need help building and growing your gateway.</p>
 <ul>
 <li>Contact <a href="mailto:partners@ripple.com">partners@ripple.com</a> for enterprise-class integrations, infrastructure advice, and other business development needs.</li>
-<li>Contact <a href="mailto:developers@ripple.com">developers@ripple.com</a> for technical questions, clarifications, bug reports, and feature requests.</li>
+<li>Contact <a href="mailto:support@ripple.com">support@ripple.com</a> for technical questions, clarifications, bug reports, and feature requests.</li>
 </ul>
 <h2 id="ripple-gateways-explained">Ripple Gateways Explained</h2>
 <p>Gateways are businesses that provide a way for money and other forms of value to move in and out of the Ripple Consensus Ledger. There are three major models that gateways can follow, with different purposes and modes of operation.</p>


### PR DESCRIPTION
Per https://ripplelabs.atlassian.net/browse/SUPP-216, changed second contact email to support@ripple.com instead of developers@ripple.com, since the latter is an alias for the former anyway.
