### PR TITLE
amendments - clarify flowv2 status, add flow

### DIFF
--- a/concept-amendments.html
+++ b/concept-amendments.html
@@ -178,7 +178,7 @@
 <p>Every amendment has a unique identifying hex value and a short name. The short name is for human use, and is not used in the amendment process. Two servers can support the same amendment ID while using different names to describe it. An amendment's name is not guaranteed to be unique.</p>
 <p>See also: <a href="#known-amendments">Known Amendments</a></p>
 <h2 id="amendment-process">Amendment Process</h2>
-<p>Every 256th ledger is called a "flag" ledger. The process of approving an amendment starts in the ledger version immediately before the flag ledger. When <code>rippled</code> validator servers send validation messages for that ledger, those servers also submit votes in favor of specific amendments. (<a href="concept-fee-voting.html">Fee Voting</a> also occurs around flag ledgers.)</p>
+<p>Every 256th ledger is called a "flag" ledger. The process of approving an amendment starts in the ledger version immediately before the flag ledger. When <code>rippled</code> validator servers send validation messages for that ledger, those servers also submit votes in favor of specific amendments. If a validator does not vote in favor of an amendment, that is the same as voting against the amendment. (<a href="concept-fee-voting.html">Fee Voting</a> also occurs around flag ledgers.)</p>
 <p>The flag ledger itself has no special contents. However, during that time, the servers look at the votes of the validators they trust, and decide whether to insert an <a href="reference-transaction-format.html#enableamendment"><code>EnableAmendment</code> pseudo-transaction</a> into the following ledger. The flags of an EnableAmendment pseudo-transaction show what the server thinks happened:</p>
 <ul>
 <li>The <code>tfGotMajority</code> flag means that support for the amendment has increased to at least 80% of trusted validators.</li>
@@ -195,10 +195,9 @@
 </ul>
 <p>Theoretically, a <code>tfLostMajority</code> EnableAmendment pseudo-transaction could be included in the same ledger as the pseudo-transaction to enable an amendment. In this case, the pseudo-transaction with the <code>tfLostMajority</code> pseudo-transaction has no effect.</p>
 <h2 id="amendment-voting">Amendment Voting</h2>
-<p>Operators of <code>rippled</code> validators can choose which amendments to support or reject using the <a href="reference-rippled.html#feature"><code>feature</code> command</a>. This decides which amendments the validator votes for in the <a href="#amendment-process">amendment process</a>. By default, <code>rippled</code> votes in favor of every amendment it knows about.</p>
-<p>The operator of a <code>rippled</code> validator can "veto" an amendment. In this case, that validator never sends a vote in favor of the amendment. If enough servers veto an amendment, that prevents it from reaching consistent 80% support, so the amendment does not apply. The amendment can still become enabled later if an 80% majority of trusted validators support the amendment, either because validator operators changed their minds or new validators that support the amendment became trusted.</p>
-<p>An amendment can gain and lose a majority an unlimited number of times before it becomes permanently enabled. As long as there are servers voting in favor of an amendment, the amendment is not permanently rejected. New versions of <code>rippled</code> can remove an amendment to ensure that they do not vote for it.</p>
-<p>As with all aspects of the consensus process, amendment votes are only taken into account by servers that trust the validators sending those votes. Ripple (the company) recommends only trusting the 5 default validators that Ripple (the company) operates. For now, trusting only those validators is enough to coordinate with Ripple (the company) on releasing new features.</p>
+<p>Each version of <code>rippled</code> is compiled with a list of known amendments and the code to implement those amendments. By default, <code>rippled</code> supports known amendments and opposes unknown amendments. Operators of <code>rippled</code> validators can <a href="#configuring-amendment-voting">configure their servers</a> to explicitly support or oppose certain amendments, even if those amendments are not known to their <code>rippled</code> versions.</p>
+<p>To become enabled, an amendment must be supported by at least 80% of trusted validators continuously for two weeks. If support for an amendment goes below 80% of trusted validators, the amendment is temporarily rejected. The two week period starts over if the amendment regains support of at least 80% of trusted validators. (This can occur if validators vote differently, or if there is a change in which validators are trusted.) An amendment can gain and lose a majority an unlimited number of times before it becomes permanently enabled. An amendment cannot be permanently rejected, but it becomes very unlikely for an amendment to become enabled if new versions of <code>rippled</code> do not have the amendment in their known amendments list.</p>
+<p>As with all aspects of the consensus process, amendment votes are only taken into account by servers that trust the validators sending those votes. At this time, Ripple (the company) recommends only trusting the 5 default validators that Ripple (the company) operates. For now, trusting only those validators is enough to coordinate with Ripple (the company) on releasing new features.</p>
 <h3 id="configuring-amendment-voting">Configuring Amendment Voting</h3>
 <p>You can temporarily configure an amendment using the <a href="reference-rippled.html#feature"><code>feature</code> command</a>. To make a persistent change to your server's support for an amendment, change your server's <code>rippled.cfg</code> file.</p>
 <p>Use the <code>[veto_amendments]</code> stanza to list amendments you do not want the server to vote for. Each line should contain one amendment's unique ID, optionally followed by the short name for the amendment. For example:</p>
@@ -238,7 +237,7 @@ TrustSetAuth
 <tr>
 <th>Name</th>
 <th>Introduced</th>
-<th>Enabled</th>
+<th>Status</th>
 </tr>
 </thead>
 <tbody>
@@ -250,7 +249,7 @@ TrustSetAuth
 <tr>
 <td><a href="#flowv2">FlowV2</a></td>
 <td>v0.32.1</td>
-<td>Vetoed</td>
+<td>To be removed</td>
 </tr>
 <tr>
 <td><a href="#tickets">Tickets</a></td>
@@ -265,17 +264,17 @@ TrustSetAuth
 <tr>
 <td><a href="#trustsetauth">TrustSetAuth</a></td>
 <td>v0.30.0</td>
-<td><a href="https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF">2016-07-19T10:10:32Z in ledger 22721281</a></td>
+<td><a href="https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF">Enabled 2016-07-19T10:10:32Z in ledger 22721281</a></td>
 </tr>
 <tr>
 <td><a href="#multisign">MultiSign</a></td>
 <td>v0.31.0</td>
-<td><a href="https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7">2016-06-27T11:34:41Z in ledger 22178817</a></td>
+<td><a href="https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7">Enabled 2016-06-27T11:34:41Z in ledger 22178817</a></td>
 </tr>
 <tr>
 <td><a href="#feeescalation">FeeEscalation</a></td>
 <td>v0.31.0</td>
-<td><a href="https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3">2016-05-19T16:44:51Z in ledger 21225473</a></td>
+<td><a href="https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3">Enabled 2016-05-19T16:44:51Z in ledger 21225473</a></td>
 </tr>
 </tbody>
 </table>
@@ -319,7 +318,7 @@ TrustSetAuth
 </tr>
 </tbody>
 </table>
-<p>Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment was created to replace the <a href="#flowv2">FlowV2</a> amendment when a critical bug was found in the FlowV2 amendment.</p>
+<p>Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment supersedes the <a href="#flowv2">FlowV2</a> amendment.</p>
 <p>The Flow Engine also makes it easier to improve and expand the payment engine with further Amendments.</p>
 <h2 id="flowv2">FlowV2</h2>
 <table>
@@ -336,7 +335,7 @@ TrustSetAuth
 </tr>
 </tbody>
 </table>
-<p>This amendment was intended to replace the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. However, a critical bug was found during the voting period, so key validators vetoed the Amendment and it lost its majority. Ripple plans to remove the FlowV2 amendment in future versions of <code>rippled</code> and replace it with the <a href="#flow">Flow</a> amendment.</p>
+<p>This amendment was intended to replace the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. However, Ripple <a href="https://github.com/ripple/rippled/commit/b92a7d415eecb07ace2b72b6792d9dfa489c5a04">found a flaw in the FlowV2 amendment</a> during the voting period, so key validators vetoed the Amendment and it lost its majority. Ripple plans to remove the FlowV2 amendment in future versions of <code>rippled</code> and replace it with the <a href="#flow">Flow</a> amendment.</p>
 <h2 id="multisign">MultiSign</h2>
 <table>
 <thead>

--- a/concept-amendments.html
+++ b/concept-amendments.html
@@ -152,6 +152,7 @@
 <li class="level-2"><a href="#testing-amendments">Testing Amendments</a></li>
 <li class="level-1"><a href="#known-amendments">Known Amendments</a></li>
 <li class="level-2"><a href="#feeescalation">FeeEscalation</a></li>
+<li class="level-2"><a href="#flow">Flow</a></li>
 <li class="level-2"><a href="#flowv2">FlowV2</a></li>
 <li class="level-2"><a href="#multisign">MultiSign</a></li>
 <li class="level-2"><a href="#suspay">SusPay</a></li>
@@ -165,7 +166,7 @@
       <main class="main" role="main">
     <div class='content'>
         <h1 id="amendments">Amendments</h1>
-<p><em>(New in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p><em>(Introduced in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
 <p>The Amendments system provides a means of introducing new features to the decentralized Ripple consensus network without causing disruptions. The amendments system works by utilizing the core consensus process of the network to approve any changes by showing continuous support before those changes go into effect. An amendment normally requires <strong>80% support for two weeks</strong> before it can apply.</p>
 <p>When an Amendment has been enabled, it applies permanently to all ledger versions after the one that included it. You cannot disable an Amendment, unless you introduce a new Amendment to do so.</p>
 <h2 id="background">Background</h2>
@@ -195,7 +196,8 @@
 <p>Theoretically, a <code>tfLostMajority</code> EnableAmendment pseudo-transaction could be included in the same ledger as the pseudo-transaction to enable an amendment. In this case, the pseudo-transaction with the <code>tfLostMajority</code> pseudo-transaction has no effect.</p>
 <h2 id="amendment-voting">Amendment Voting</h2>
 <p>Operators of <code>rippled</code> validators can choose which amendments to support or reject using the <a href="reference-rippled.html#feature"><code>feature</code> command</a>. This decides which amendments the validator votes for in the <a href="#amendment-process">amendment process</a>. By default, <code>rippled</code> votes in favor of every amendment it knows about.</p>
-<p>The operator of a <code>rippled</code> validator can "veto" an amendment. In this case, that validator never sends a vote in favor of the amendment. If enough servers veto an amendment, that prevents it from reaching consistent 80% support, so the amendment does not apply.</p>
+<p>The operator of a <code>rippled</code> validator can "veto" an amendment. In this case, that validator never sends a vote in favor of the amendment. If enough servers veto an amendment, that prevents it from reaching consistent 80% support, so the amendment does not apply. The amendment can still become enabled later if an 80% majority of trusted validators support the amendment, either because validator operators changed their minds or new validators that support the amendment became trusted.</p>
+<p>An amendment can gain and lose a majority an unlimited number of times before it becomes permanently enabled. As long as there are servers voting in favor of an amendment, the amendment is not permanently rejected. New versions of <code>rippled</code> can remove an amendment to ensure that they do not vote for it.</p>
 <p>As with all aspects of the consensus process, amendment votes are only taken into account by servers that trust the validators sending those votes. Ripple (the company) recommends only trusting the 5 default validators that Ripple (the company) operates. For now, trusting only those validators is enough to coordinate with Ripple (the company) on releasing new features.</p>
 <h3 id="configuring-amendment-voting">Configuring Amendment Voting</h3>
 <p>You can temporarily configure an amendment using the <a href="reference-rippled.html#feature"><code>feature</code> command</a>. To make a persistent change to your server's support for an amendment, change your server's <code>rippled.cfg</code> file.</p>
@@ -241,9 +243,14 @@ TrustSetAuth
 </thead>
 <tbody>
 <tr>
+<td><a href="#flow">Flow</a></td>
+<td>TBD</td>
+<td>TBD</td>
+</tr>
+<tr>
 <td><a href="#flowv2">FlowV2</a></td>
 <td>v0.32.1</td>
-<td>Expected 2016-08-24</td>
+<td>Vetoed</td>
 </tr>
 <tr>
 <td><a href="#tickets">Tickets</a></td>
@@ -297,6 +304,23 @@ TrustSetAuth
 <li>It becomes invalid (for example, the <a href="reference-transaction-format.html#lastledgersequence"><code>LastLedgerSequence</code></a> causes it to expire)</li>
 <li>It gets dropped because there are too many transactions in the queue with a higher transaction cost.</li>
 </ul>
+<h2 id="flow">Flow</h2>
+<table>
+<thead>
+<tr>
+<th>Amendment ID</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11</td>
+<td>TBD</td>
+</tr>
+</tbody>
+</table>
+<p>Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment was created to replace the <a href="#flowv2">FlowV2</a> amendment when a critical bug was found in the FlowV2 amendment.</p>
+<p>The Flow Engine also makes it easier to improve and expand the payment engine with further Amendments.</p>
 <h2 id="flowv2">FlowV2</h2>
 <table>
 <thead>
@@ -308,12 +332,11 @@ TrustSetAuth
 <tbody>
 <tr>
 <td>5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26</td>
-<td>Planned for voting, expected to be enabled 2016-08-24</td>
+<td>Failed to hold a majority. To be removed.</td>
 </tr>
 </tbody>
 </table>
-<p>Replaces the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding.</p>
-<p>The FlowV2 Engine also makes it easier to improve and expand the payment engine with further Amendments.</p>
+<p>This amendment was intended to replace the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. However, a critical bug was found during the voting period, so key validators vetoed the Amendment and it lost its majority. Ripple plans to remove the FlowV2 amendment in future versions of <code>rippled</code> and replace it with the <a href="#flow">Flow</a> amendment.</p>
 <h2 id="multisign">MultiSign</h2>
 <table>
 <thead>

--- a/content/concept-amendments.md
+++ b/content/concept-amendments.md
@@ -1,6 +1,6 @@
 # Amendments #
 
-_(New in [version 0.31.0](https://wiki.ripple.com/Rippled-0.31.0))_
+_(Introduced in [version 0.31.0](https://wiki.ripple.com/Rippled-0.31.0))_
 
 The Amendments system provides a means of introducing new features to the decentralized Ripple consensus network without causing disruptions. The amendments system works by utilizing the core consensus process of the network to approve any changes by showing continuous support before those changes go into effect. An amendment normally requires **80% support for two weeks** before it can apply.
 
@@ -48,7 +48,9 @@ Theoretically, a `tfLostMajority` EnableAmendment pseudo-transaction could be in
 
 Operators of `rippled` validators can choose which amendments to support or reject using the [`feature` command](reference-rippled.html#feature). This decides which amendments the validator votes for in the [amendment process](#amendment-process). By default, `rippled` votes in favor of every amendment it knows about.
 
-The operator of a `rippled` validator can "veto" an amendment. In this case, that validator never sends a vote in favor of the amendment. If enough servers veto an amendment, that prevents it from reaching consistent 80% support, so the amendment does not apply.
+The operator of a `rippled` validator can "veto" an amendment. In this case, that validator never sends a vote in favor of the amendment. If enough servers veto an amendment, that prevents it from reaching consistent 80% support, so the amendment does not apply. The amendment can still become enabled later if an 80% majority of trusted validators support the amendment, either because validator operators changed their minds or new validators that support the amendment became trusted.
+
+An amendment can gain and lose a majority an unlimited number of times before it becomes permanently enabled. As long as there are servers voting in favor of an amendment, the amendment is not permanently rejected. New versions of `rippled` can remove an amendment to ensure that they do not vote for it.
 
 As with all aspects of the consensus process, amendment votes are only taken into account by servers that trust the validators sending those votes. Ripple (the company) recommends only trusting the 5 default validators that Ripple (the company) operates. For now, trusting only those validators is enough to coordinate with Ripple (the company) on releasing new features.
 
@@ -111,7 +113,8 @@ The following is a comprehensive list of all known amendments and their status o
 
 | Name                            | Introduced | Enabled |
 |---------------------------------|------------|---------|
-| [FlowV2](#flowv2)               | v0.32.1    | Expected 2016-08-24 |
+| [Flow](#flow)                   | TBD        | TBD |
+| [FlowV2](#flowv2)               | v0.32.1    | Vetoed |
 | [Tickets](#tickets)             | v0.31.0    | TBD |
 | [SusPay](#suspay)               | v0.31.0    | TBD |
 | [TrustSetAuth](#trustsetauth)   | v0.30.0    | [2016-07-19T10:10:32Z in ledger 22721281](https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF) |
@@ -138,16 +141,23 @@ A transaction remains in the queue until one of the following happens:
 * It becomes invalid (for example, the [`LastLedgerSequence`](reference-transaction-format.html#lastledgersequence) causes it to expire)
 * It gets dropped because there are too many transactions in the queue with a higher transaction cost.
 
+## Flow ##
+
+| Amendment ID | Status |
+|--------------|--------|
+| 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 | TBD |
+
+Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment was created to replace the [FlowV2](#flowv2) amendment when a critical bug was found in the FlowV2 amendment.
+
+The Flow Engine also makes it easier to improve and expand the payment engine with further Amendments.
+
 ## FlowV2 ##
 
 | Amendment ID | Status |
 |--------------|--------|
-| 5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26 | Planned for voting, expected to be enabled 2016-08-24 |
+| 5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26 | Failed to hold a majority. To be removed. |
 
-Replaces the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding.
-
-The FlowV2 Engine also makes it easier to improve and expand the payment engine with further Amendments.
-
+This amendment was intended to replace the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. However, a critical bug was found during the voting period, so key validators vetoed the Amendment and it lost its majority. Ripple plans to remove the FlowV2 amendment in future versions of `rippled` and replace it with the [Flow](#flow) amendment.
 
 ## MultiSign ##
 

--- a/content/concept-amendments.md
+++ b/content/concept-amendments.md
@@ -26,7 +26,7 @@ See also: [Known Amendments](#known-amendments)
 
 ## Amendment Process ##
 
-Every 256th ledger is called a "flag" ledger. The process of approving an amendment starts in the ledger version immediately before the flag ledger. When `rippled` validator servers send validation messages for that ledger, those servers also submit votes in favor of specific amendments. ([Fee Voting](concept-fee-voting.html) also occurs around flag ledgers.)
+Every 256th ledger is called a "flag" ledger. The process of approving an amendment starts in the ledger version immediately before the flag ledger. When `rippled` validator servers send validation messages for that ledger, those servers also submit votes in favor of specific amendments. If a validator does not vote in favor of an amendment, that is the same as voting against the amendment. ([Fee Voting](concept-fee-voting.html) also occurs around flag ledgers.)
 
 The flag ledger itself has no special contents. However, during that time, the servers look at the votes of the validators they trust, and decide whether to insert an [`EnableAmendment` pseudo-transaction](reference-transaction-format.html#enableamendment) into the following ledger. The flags of an EnableAmendment pseudo-transaction show what the server thinks happened:
 
@@ -46,13 +46,11 @@ Theoretically, a `tfLostMajority` EnableAmendment pseudo-transaction could be in
 
 ## Amendment Voting ##
 
-Operators of `rippled` validators can choose which amendments to support or reject using the [`feature` command](reference-rippled.html#feature). This decides which amendments the validator votes for in the [amendment process](#amendment-process). By default, `rippled` votes in favor of every amendment it knows about.
+Each version of `rippled` is compiled with a list of known amendments and the code to implement those amendments. By default, `rippled` supports known amendments and opposes unknown amendments. Operators of `rippled` validators can [configure their servers](#configuring-amendment-voting) to explicitly support or oppose certain amendments, even if those amendments are not known to their `rippled` versions.
 
-The operator of a `rippled` validator can "veto" an amendment. In this case, that validator never sends a vote in favor of the amendment. If enough servers veto an amendment, that prevents it from reaching consistent 80% support, so the amendment does not apply. The amendment can still become enabled later if an 80% majority of trusted validators support the amendment, either because validator operators changed their minds or new validators that support the amendment became trusted.
+To become enabled, an amendment must be supported by at least 80% of trusted validators continuously for two weeks. If support for an amendment goes below 80% of trusted validators, the amendment is temporarily rejected. The two week period starts over if the amendment regains support of at least 80% of trusted validators. (This can occur if validators vote differently, or if there is a change in which validators are trusted.) An amendment can gain and lose a majority an unlimited number of times before it becomes permanently enabled. An amendment cannot be permanently rejected, but it becomes very unlikely for an amendment to become enabled if new versions of `rippled` do not have the amendment in their known amendments list.
 
-An amendment can gain and lose a majority an unlimited number of times before it becomes permanently enabled. As long as there are servers voting in favor of an amendment, the amendment is not permanently rejected. New versions of `rippled` can remove an amendment to ensure that they do not vote for it.
-
-As with all aspects of the consensus process, amendment votes are only taken into account by servers that trust the validators sending those votes. Ripple (the company) recommends only trusting the 5 default validators that Ripple (the company) operates. For now, trusting only those validators is enough to coordinate with Ripple (the company) on releasing new features.
+As with all aspects of the consensus process, amendment votes are only taken into account by servers that trust the validators sending those votes. At this time, Ripple (the company) recommends only trusting the 5 default validators that Ripple (the company) operates. For now, trusting only those validators is enough to coordinate with Ripple (the company) on releasing new features.
 
 ### Configuring Amendment Voting ###
 
@@ -111,15 +109,15 @@ TrustSetAuth
 
 The following is a comprehensive list of all known amendments and their status on the production Ripple Consensus Ledger:
 
-| Name                            | Introduced | Enabled |
+| Name                            | Introduced | Status |
 |---------------------------------|------------|---------|
 | [Flow](#flow)                   | TBD        | TBD |
-| [FlowV2](#flowv2)               | v0.32.1    | Vetoed |
+| [FlowV2](#flowv2)               | v0.32.1    | To be removed |
 | [Tickets](#tickets)             | v0.31.0    | TBD |
 | [SusPay](#suspay)               | v0.31.0    | TBD |
-| [TrustSetAuth](#trustsetauth)   | v0.30.0    | [2016-07-19T10:10:32Z in ledger 22721281](https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF) |
-| [MultiSign](#multisign)         | v0.31.0    | [2016-06-27T11:34:41Z in ledger 22178817](https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7) |
-| [FeeEscalation](#feeescalation) | v0.31.0    | [2016-05-19T16:44:51Z in ledger 21225473](https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3) |
+| [TrustSetAuth](#trustsetauth)   | v0.30.0    | [Enabled 2016-07-19T10:10:32Z in ledger 22721281](https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF) |
+| [MultiSign](#multisign)         | v0.31.0    | [Enabled 2016-06-27T11:34:41Z in ledger 22178817](https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7) |
+| [FeeEscalation](#feeescalation) | v0.31.0    | [Enabled 2016-05-19T16:44:51Z in ledger 21225473](https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3) |
 
 **Note:** In many cases, an incomplete version of the code for an amendment is present in previous versions of the software. The "Introduced" version in the table above is the first stable version.
 
@@ -147,7 +145,7 @@ A transaction remains in the queue until one of the following happens:
 |--------------|--------|
 | 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 | TBD |
 
-Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment was created to replace the [FlowV2](#flowv2) amendment when a critical bug was found in the FlowV2 amendment.
+Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment supersedes the [FlowV2](#flowv2) amendment.
 
 The Flow Engine also makes it easier to improve and expand the payment engine with further Amendments.
 
@@ -157,7 +155,7 @@ The Flow Engine also makes it easier to improve and expand the payment engine wi
 |--------------|--------|
 | 5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26 | Failed to hold a majority. To be removed. |
 
-This amendment was intended to replace the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. However, a critical bug was found during the voting period, so key validators vetoed the Amendment and it lost its majority. Ripple plans to remove the FlowV2 amendment in future versions of `rippled` and replace it with the [Flow](#flow) amendment.
+This amendment was intended to replace the payment processing engine with a more robust and efficient rewrite called the FlowV2 engine. However, Ripple [found a flaw in the FlowV2 amendment](https://github.com/ripple/rippled/commit/b92a7d415eecb07ace2b72b6792d9dfa489c5a04) during the voting period, so key validators vetoed the Amendment and it lost its majority. Ripple plans to remove the FlowV2 amendment in future versions of `rippled` and replace it with the [Flow](#flow) amendment.
 
 ## MultiSign ##
 


### PR DESCRIPTION
Addresses [DOC-525](https://ripplelabs.atlassian.net/browse/DOC-525) and [DOC-526](https://ripplelabs.atlassian.net/browse/DOC-526):
- Clarifies how vetoing amendments works (voting goes on forever, but removing the amendment makes it unlikely to get a majority)
- Clarifies that FlowV2 was vetoed and Flow is coming to replace it.
