### PR TITLE
cleanup

### DIFF
--- a/concept-amendments.html
+++ b/concept-amendments.html
@@ -166,7 +166,7 @@
       <main class="main" role="main">
     <div class='content'>
         <h1 id="amendments">Amendments</h1>
-<p><em>(Introduced in <a href="https://wiki.ripple.com/Rippled-0.31.0">version 0.31.0</a>)</em></p>
+<p><em>(Introduced in [version 0.31.0][])</em></p>
 <p>The Amendments system provides a means of introducing new features to the decentralized Ripple consensus network without causing disruptions. The amendments system works by utilizing the core consensus process of the network to approve any changes by showing continuous support before those changes go into effect. An amendment normally requires <strong>80% support for two weeks</strong> before it can apply.</p>
 <p>When an Amendment has been enabled, it applies permanently to all ledger versions after the one that included it. You cannot disable an Amendment, unless you introduce a new Amendment to do so.</p>
 <h2 id="background">Background</h2>
@@ -415,7 +415,8 @@ TrustSetAuth
 </tbody>
 </table>
 <p>Introduces Tickets as a way to reserve a transaction sequence number for later execution. Creates the <code>Ticket</code> ledger node type and the transaction types <code>TicketCreate</code> and <code>TicketCancel</code>.</p>
-<p>This amendment is still in development.</p>
+<p>This amendment is still in development.
+ <!---- rippled release notes links ----></p>
     </div>
       </main>
   </div>

--- a/content/concept-amendments.md
+++ b/content/concept-amendments.md
@@ -1,6 +1,6 @@
 # Amendments #
 
-_(Introduced in [version 0.31.0](https://wiki.ripple.com/Rippled-0.31.0))_
+_(Introduced in [version 0.31.0][])_
 
 The Amendments system provides a means of introducing new features to the decentralized Ripple consensus network without causing disruptions. The amendments system works by utilizing the core consensus process of the network to approve any changes by showing continuous support before those changes go into effect. An amendment normally requires **80% support for two weeks** before it can apply.
 
@@ -221,3 +221,4 @@ With this amendment enabled, a `TrustSet` transaction with [`tfSetfAuth` enabled
 Introduces Tickets as a way to reserve a transaction sequence number for later execution. Creates the `Ticket` ledger node type and the transaction types `TicketCreate` and `TicketCancel`.
 
 This amendment is still in development.
+ {% include 'snippets/rippled_versions.md' %}

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -44,7 +44,7 @@ Every ledger version has a unique header that describes the contents. You can lo
 | close\_time\_resolution | Number | Uint8        | An integer in the range \[2,120\] indicating the maximum number of seconds by which the `close_time` could be rounded. |
 | [closeFlags](#close-flags) | (Omitted) | UInt8             | A bit-map of flags relating to the closing of this ledger. |
 
-[Internal Type]: https://wiki.ripple.com/Binary_Format
+[Internal Type]: https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp
 
 
 ### Ledger Index ###
@@ -345,7 +345,7 @@ A RippleState node has the following fields:
 |-----------------|-----------|---------------|-------------|
 | LedgerEntryType | String    | UInt16 | The value `0x72`, mapped to the string `RippleState`, indicates that this node is a RippleState object. |
 | Flags           | Number    | UInt32 | A bit-map of boolean options enabled for this node. |
-| Balance         | Object    | Amount | The balance of the trust line, from the perspective of the low account. A negative balance indicates that the low account has issued currency to the high account. The issuer in this is always set to the neutral value [ACCOUNT_ONE](https://wiki.ripple.com/Accounts#ACCOUNT_ONE). |
+| Balance         | Object    | Amount | The balance of the trust line, from the perspective of the low account. A negative balance indicates that the low account has issued currency to the high account. The issuer in this is always set to the neutral value [ACCOUNT_ONE](reference-rippled.html#special-addresses). |
 | LowLimit        | Object    | Amount | The limit that the low account has set on the trust line. The `issuer` is the address of the low account that set this limit. |
 | HighLimit       | Object    | Amount | The limit that the high account has set on the trust line. The `issuer` is the address of the high account that set this limit. |
 | PreviousTxnID   | String    | Hash256 | The identifying hash of the transaction that most recently modified this node. |

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -793,7 +793,7 @@ The request contains the following parameters:
 | strict | Boolean | (Optional, defaults to False) If set to True, then the `account` field only accepts a public key or Ripple address. |
 | ledger_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
-| signer\_lists | Boolean | (Optional) If `true`, and the [MultiSign amendment](concept-amendments.html#multisign) is enabled, also returns any [SignerList objects](reference-ledger-format.html#signerlist) associated with this account. _(New in [version 0.31.0][])_ |
+| signer\_lists | Boolean | (Optional) If `true`, and the [MultiSign amendment](concept-amendments.html#multisign) is enabled, also returns any [SignerList objects](reference-ledger-format.html#signerlist) associated with this account. _(New in [`rippled` 0.31.0][])_ |
 
 The following fields are deprecated and should not be provided: `ident`, `ledger`.
 
@@ -834,10 +834,10 @@ The response follows the [standard format](#response-formatting), with the resul
 | Field | Type | Description |
 |-------|------|-------------|
 | account_data | Object | The [AccountRoot ledger node](reference-ledger-format.html#accountroot) with this account's information, as stored in the ledger. |
-| signer\_lists | Array | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. _(New in [version 0.31.0][])_ |
+| signer\_lists | Array | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. _(New in [`rippled` 0.31.0][])_ |
 | ledger\_current\_index | Integer | (Omitted if `ledger_index` is provided instead) The sequence number of the most-current ledger, which was used when retrieving this information. The information does not contain any changes from ledgers newer than this one.  |
 | ledger\_index | Integer | (Omitted if `ledger_current_index` is provided instead) The sequence number of the ledger used when retrieving this information. The information does not contain any changes from ledgers newer than this one. |
-| validated | Boolean | True if this data is from a validated ledger version; if omitted or set to false, this data is not final. _(New in [version 0.26.0][])_ |
+| validated | Boolean | True if this data is from a validated ledger version; if omitted or set to false, this data is not final. _(New in [`rippled` 0.26.0][])_ |
 
 #### Possible Errors ####
 
@@ -896,8 +896,8 @@ The request accepts the following paramters:
 | ledger\_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | peer | String | (Optional) The [Address][] of a second account. If provided, show only lines of trust connecting the two accounts. |
-| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. _(New in [version 0.26.4][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Server-provided value to specify where to resume retrieving data from. _(New in [version 0.26.4][])_ |
+| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. _(New in [`rippled` 0.26.4][])_ |
+| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Server-provided value to specify where to resume retrieving data from. _(New in [`rippled` 0.26.4][])_ |
 
 The following parameters are deprecated and may be removed without further notice: `ledger` and `peer_index`.
 
@@ -1004,10 +1004,10 @@ The response follows the [standard format](#response-formatting), with a success
 |-------|------|-------------|
 | account | String | Unique [Address][] of the account this request corresponds to. This is the "perspective account" for purpose of the trust lines. |
 | lines | Array | Array of trust-line objects, as described below. If the number of trust-lines is large, only returns up to the `limit` at a time. |
-| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. _(New in [version 0.26.4-sp1][])_ |
-| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. _(New in [version 0.26.4-sp1][])_ |
-| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. _(New in [version 0.26.4-sp1][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. _(New in [version 0.26.4][])_ |
+| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
+| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
+| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
+| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. _(New in [`rippled` 0.26.4][])_ |
 
 Each trust-line object has some combination of the following fields:
 
@@ -1089,8 +1089,8 @@ A request can include the following parameters:
 | ledger | Unsigned integer, or String | (Deprecated, Optional) A unique identifier for the ledger version to use, such as a ledger sequence number, a hash, or a shortcut such as "validated". |
 | ledger\_hash | String | (Optional) A 20-byte hex string identifying the ledger version to use. |
 | ledger\_index | (Optional) [Ledger Index][] | (Optional, defaults to `current`) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See [Specifying Ledgers](#specifying-ledgers)) |
-| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. _(New in [version 0.26.4][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. _(New in [version 0.26.4][])_ |
+| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. _(New in [`rippled` 0.26.4][])_ |
+| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. _(New in [`rippled` 0.26.4][])_ |
 
 The following parameter is deprecated and may be removed without further notice: `ledger`.
 
@@ -1199,10 +1199,10 @@ The response follows the [standard format](#response-formatting), with a success
 |-------|------|-------------|
 | account | String | Unique [Address][] identifying the account that made the offers |
 | offers | Array | Array of objects, where each object represents an offer made by this account that is outstanding as of the requested ledger version. If the number of offers is large, only returns up to `limit` at a time. |
-| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. _(New in [version 0.26.4-sp1][])_ |
-| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. _(New in [version 0.26.4-sp1][])_ |
-| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. _(New in [version 0.26.4-sp1][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. _(New in [version 0.26.4][])_ |
+| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
+| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
+| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
+| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. _(New in [`rippled` 0.26.4][])_ |
 
 
 Each offer object contains the following fields:
@@ -1213,8 +1213,8 @@ Each offer object contains the following fields:
 | seq | Unsigned integer | Sequence number of the transaction that created this entry. (Transaction [sequence numbers](#account-sequence) are relative to accounts.) |
 | taker_gets | String or Object | The amount the account accepting the offer receives, as a String representing an amount in XRP, or a currency specification object. (See [Specifying Currency Amounts](#specifying-currency-amounts)) |
 | taker_pays | String or Object | The amount the account accepting the offer provides, as a String representing an amount in XRP, or a currency specification object. (See [Specifying Currency Amounts](#specifying-currency-amounts)) |
-| quality | Number | The exchange rate of the offer, as the ratio of the original `taker_pays` divided by the original `taker_gets`. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. _(New in [version 0.29.0][])_ |
-| expiration | Unsigned integer | (May be omitted) A time after which this offer is considered unfunded, as [the number of seconds since the Ripple Epoch](#specifying-time). See also: [Offer Expiration](reference-transaction-format.html#expiration). _(New in [version 0.30.1][])_ |
+| quality | Number | The exchange rate of the offer, as the ratio of the original `taker_pays` divided by the original `taker_gets`. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. _(New in [`rippled` 0.29.0][])_ |
+| expiration | Unsigned integer | (May be omitted) A time after which this offer is considered unfunded, as [the number of seconds since the Ripple Epoch](#specifying-time). See also: [Offer Expiration](reference-transaction-format.html#expiration). _(New in [`rippled` 0.30.1][])_ |
 
 #### Possible Errors ####
 
@@ -2619,7 +2619,7 @@ The response follows the [standard format](#response-formatting), with a success
 ## gateway_balances ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp "Source")
 
-The `gateway_balances` command calculates the total balances issued by a given account, optionally excluding amounts held by [operational addresses](concept-issuing-and-operational-addresses.html). _(New in [version 0.28.2][].)_
+The `gateway_balances` command calculates the total balances issued by a given account, optionally excluding amounts held by [operational addresses](concept-issuing-and-operational-addresses.html). _(New in [`rippled` 0.28.2][].)_
 
 #### Request Format ####
 An example of the request format:
@@ -2843,7 +2843,7 @@ Use the `wallet_propose` method to generate a key pair and Ripple [address]. Thi
 
 *The `wallet_propose` request is an [admin command](#connecting-to-rippled) that cannot be run by unprivileged users!* (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)
 
-_(Updated in [version 0.31.0][])_
+_(Updated in [`rippled` 0.31.0][])_
 
 #### Request Format ####
 
@@ -3013,7 +3013,7 @@ The response follows the [standard format](#response-formatting), with a success
 | account\_id | String | The [Address][] of the account. |
 | public\_key | String | The public key of the account, in encoded string format. |
 | public\_key\_hex | String | The public key of the account, in hex format. |
-| warning | String | (May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. _(New in [version 0.32.0][])_ |
+| warning | String | (May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. _(New in [`rippled` 0.32.0][])_ |
 
 The key generated by this method can also be used as a regular key for an account if you use the [SetRegularKey transaction type](reference-transaction-format.html#setregularkey) to do so.
 
@@ -3096,7 +3096,7 @@ The request can contain the following parameters:
 | transactions | Boolean | (Optional, defaults to false) If true, return information on transactions in the specified ledger version. Ignored if you did not specify a ledger. |
 | expand | Boolean | (Optional, defaults to false) Provide full JSON-formatted information for transaction/account information instead of only hashes. Ignored unless you requested transactions, accounts, or both. |
 | owner\_funds | Boolean | (Optional, defaults to false) Include `owner_funds` field in the metadata of OfferCreate transactions in the response. Ignored unless transactions are included and `expand` is true. |
-| binary | Boolean | (Optional, defaults to false) If `transactions` and `expand` are both true, and this option is also true, return transaction information in binary format instead of JSON format. _(New in [version 0.28.0][])_ |
+| binary | Boolean | (Optional, defaults to false) If `transactions` and `expand` are both true, and this option is also true, return transaction information in binary format instead of JSON format. _(New in [`rippled` 0.28.0][])_ |
 
 The `ledger` field is deprecated and may be removed without further notice.
 
@@ -3973,7 +3973,7 @@ When the server is in the progress of fetching a ledger, but has not yet finishe
 
 * Any of the [universal error types](#universal-errors).
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing. This error can also occur if you specify a ledger index equal or higher than the current in-progress ledger.
-* `lgrNotFound` - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. _(**Note:** Prior to [version 0.30.1][], this error used the code `ledgerNotFound` instead.)_
+* `lgrNotFound` - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. _(**Note:** Prior to [`rippled` 0.30.1][], this error used the code `ledgerNotFound` instead.)_
 
 
 ## ledger_accept ##
@@ -5421,8 +5421,8 @@ The request includes the following parameters:
 | subcommand | String | Use `"create"` to send the create subcommand |
 | source\_account | String | Unique address of the account to find a path from. (In other words, the account that would be sending a payment.) |
 | destination\_account | String | Unique address of the account to find a path to. (In other words, the account that would receive a payment.) |
-| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [version 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
-| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Not compatible with `source_currencies`. _(New in [version 0.30.0][])_ |
+| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [`rippled` 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
+| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Not compatible with `source_currencies`. _(New in [`rippled` 0.30.0][])_ |
 | paths | Array | (Optional) Array of arrays of objects, representing [payment paths](concept-paths.html) to check. You can use this to keep updated on changes to particular paths you already know about, or to check the overall cost to make a payment along a certain path. |
 
 The server also recognizes the following fields, but the results of using them are not guaranteed: `source_currencies`, `bridges`. These fields should be considered reserved for future use.
@@ -5812,7 +5812,7 @@ The initial response follows the [standard format](#response-formatting), with a
 | destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination would receive in a transaction |
 | id | (Various) | (WebSocket only) The ID provided in the WebSocket request is included again at this level. |
 | source\_account | String | Unique address that would send a transaction |
-| full\_reply | Boolean | If `false`, this is the result of an incomplete search. A later reply may have a better path. If `true`, then this is the best path found. (It is still theoretically possible that a better path could exist, but `rippled` won't find it.) Until you close the pathfinding request, `rippled` continues to send updates each time a new ledger closes. _(New in [version 0.29.0][])_ |
+| full\_reply | Boolean | If `false`, this is the result of an incomplete search. A later reply may have a better path. If `true`, then this is the best path found. (It is still theoretically possible that a better path could exist, but `rippled` won't find it.) Until you close the pathfinding request, `rippled` continues to send updates each time a new ledger closes. _(New in [`rippled` 0.29.0][])_ |
 
 Each element in the `alternatives` array is an object that represents a path from one possible source currency (held by the initiating account) to the destination account and currency. This object has the following fields:
 
@@ -6031,8 +6031,8 @@ The request includes the following parameters:
 |-------|------|-------------|
 | source\_account | String | Unique address of the account that would send funds in a transaction |
 | destination\_account | String | Unique address of the account that would receive funds in a transaction |
-| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [version 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
-| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Cannot be used with `source_currencies`. _(New in [version 0.30.0][])_ |
+| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [`rippled` 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
+| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Cannot be used with `source_currencies`. _(New in [`rippled` 0.30.0][])_ |
 | source\_currencies | Array | (Optional) Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory `currency` field and optional `issuer` field, like how [currency amounts](#specifying-currency-amounts) are specified. Cannot contain more than **18** source currencies. By default, uses all source currencies available up to a maximum of **88** different currency/issuer pairs. |
 | ledger\_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
@@ -6382,7 +6382,7 @@ The request includes the following parameters:
 | offline | Boolean | (Optional, defaults to false) If true, when constructing the transaction, do not try to automatically fill in or validate values. |
 | build_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. **Caution:** The server looks for the presence or absence of this field, not its value. This behavior may change. |
 | fee\_mult\_max | Integer | (Optional, defaults to 10; recommended value 1000) Limits how high the [automatically-provided `Fee` field](reference-transaction-format.html#auto-fillable-fields) can be. Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). |
-| fee\_div\_max | Integer | (Optional, defaults to 1) Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). _(New in [version 0.30.1][])_ |
+| fee\_div\_max | Integer | (Optional, defaults to 1) Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). _(New in [`rippled` 0.30.1][])_ |
 
 ### Auto-Fillable Fields ###
 
@@ -6517,7 +6517,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 The `sign_for` command provides one signature for a [multi-signed transaction](reference-transaction-format.html#multi-signing).
 
-This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. _(New in [version 0.31.0][])_
+This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. _(New in [`rippled` 0.31.0][])_
 
 #### Request Format ####
 An example of the request format:
@@ -6827,7 +6827,7 @@ The request includes the following parameters:
 | offline | Boolean | (Optional, defaults to false) If true, when constructing the transaction, do not try to automatically fill in or validate values. |
 | build\_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. **Caution:** The server looks for the presence or absence of this field, not its value. This behavior may change. |
 | fee\_mult\_max | Integer | (Optional, defaults to 10, recommended value 1000) If the `Fee` parameter is omitted, this field limits the automatically-provided `Fee` value so that it is less than or equal to the long-term base transaction cost times this value. |
-| fee\_div\_max | Integer | (Optional, defaults to 1) Used with `fee_mult_max` to create a fractional multiplier for the limit. Specifically, the server multiplies its base [transaction cost](concept-transaction-cost.html) by `fee_mult_max`, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided `Fee` value would be over the limit, the submit command fails. _(New in [version 0.30.1][])_ |
+| fee\_div\_max | Integer | (Optional, defaults to 1) Used with `fee_mult_max` to create a fractional multiplier for the limit. Specifically, the server multiplies its base [transaction cost](concept-transaction-cost.html) by `fee_mult_max`, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided `Fee` value would be over the limit, the submit command fails. _(New in [`rippled` 0.30.1][])_ |
 
 See the [sign command](#sign) for detailed information on how the server automatically fills in certain fields.
 
@@ -7033,7 +7033,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 The `submit_multisigned` command applies a [multi-signed](reference-transaction-format.html#multi-signing) transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the [`submit` command in submit-only mode](#submit-only-mode).)
 
-This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. _(New in [version 0.31.0][])_
+This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. _(New in [`rippled` 0.31.0][])_
 
 #### Request Format ####
 An example of the request format:
@@ -7643,7 +7643,7 @@ The fields from a ledger stream message are as follows:
 
 ### Validations Stream ###
 
-_(New in [version 0.29.0][])_
+_(New in [`rippled` 0.29.0][])_
 
 The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:
 
@@ -7677,17 +7677,17 @@ The fields from a validations stream message are as follows:
 | Field | Type | Description |
 |-------|------|-------------|
 | `type` | String | The value `validationReceived` indicates this is from the validations stream. |
-| `amendments` | Array of Strings | (May be omitted) The [amendments](concept-amendments.html) this server wants to be added to the protocol. _(New in [version 0.32.0][])_ |
-| `base_fee` | Integer | (May be omitted) The unscaled transaction cost (`reference_fee` value) this server wants to set by [Fee Voting](concept-fee-voting.html). _(New in [version 0.32.0][])_ |
-| `flags` | Number | Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. _(New in [version 0.32.0][])_ |
-| `full` | Boolean | If `true`, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. _(New in [version 0.32.0][])_ |
+| `amendments` | Array of Strings | (May be omitted) The [amendments](concept-amendments.html) this server wants to be added to the protocol. _(New in [`rippled` 0.32.0][])_ |
+| `base_fee` | Integer | (May be omitted) The unscaled transaction cost (`reference_fee` value) this server wants to set by [Fee Voting](concept-fee-voting.html). _(New in [`rippled` 0.32.0][])_ |
+| `flags` | Number | Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. _(New in [`rippled` 0.32.0][])_ |
+| `full` | Boolean | If `true`, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. _(New in [`rippled` 0.32.0][])_ |
 | `ledger_hash` | String | The identifying hash of the proposed ledger is being validated. |
-| `ledger_index` | String - Integer | The [Ledger Index][] of the proposed ledger. _(New in [version 0.31.0][])_ |
-| `load_fee` | Integer | (May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. _(New in [version 0.32.0][])_ |
-| `reserve_base` | Integer | (May be omitted) The minimum reserve requirement (`account_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). _(New in [version 0.32.0][])_ |
-| `reserve_inc` | Integer | (May be omitted) The increment in the reserve requirement (`owner_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). _(New in [version 0.32.0][])_ |
+| `ledger_index` | String - Integer | The [Ledger Index][] of the proposed ledger. _(New in [`rippled` 0.31.0][])_ |
+| `load_fee` | Integer | (May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. _(New in [`rippled` 0.32.0][])_ |
+| `reserve_base` | Integer | (May be omitted) The minimum reserve requirement (`account_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). _(New in [`rippled` 0.32.0][])_ |
+| `reserve_inc` | Integer | (May be omitted) The increment in the reserve requirement (`owner_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). _(New in [`rippled` 0.32.0][])_ |
 | `signature` | String | The signature that the validator used to sign its vote for this ledger. |
-| `signing_time` | Number | When this validation vote was signed, in seconds since the [Ripple Epoch](#specifying-time). _(New in [version 0.32.0][])_ |
+| `signing_time` | Number | When this validation vote was signed, in seconds since the [Ripple Epoch](#specifying-time). _(New in [`rippled` 0.32.0][])_ |
 | `validation_public_key` | String | The base-58 encoded public key from the key-pair that the validator used to sign the message. This identifies the validator sending the message and can also be used to verify the `signature`. |
 
 
@@ -8372,16 +8372,16 @@ The `info` object may have some arrangement of the following fields:
 | load\_factor\_local | Number | (May be omitted) Current multiplier to the [transaction cost][] based on load to this server. |
 | load\_factor\_net | Number | (May be omitted) Current multiplier to the [transaction cost][] being used by the rest of the network (estimated from other servers' reported load values). |
 | load\_factor\_cluster | Number | (May be omitted) Current multiplier to the [transaction cost][] based on load to servers in [this cluster](tutorial-rippled-setup.html#clustering). |
-| load\_factor\_fee\_escalation | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the open ledger. _(New in [version 0.32.0][])_ |
-| load\_factor\_fee\_queue | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the queue, if the queue is full. _(New in [version 0.32.0][])_ |
+| load\_factor\_fee\_escalation | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the open ledger. _(New in [`rippled` 0.32.0][])_ |
+| load\_factor\_fee\_queue | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the queue, if the queue is full. _(New in [`rippled` 0.32.0][])_ |
 | peers | Number | How many other `rippled` servers the node is currently connected to. |
 | pubkey_node | String | Public key used to verify this node for internal communications; this key is automatically generated by the server the first time it starts up. (If deleted, the node can create a new pair of keys.) |
 | pubkey\_validator | String | *Admin only* Public key used by this node to sign ledger validations. |
 | server\_state | String | A string indicating to what extent the server is participating in the network. See [Possible Server States](#possible-server-states) for more details. |
-| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. _(New in [version 0.30.1][])_ |
-| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) _(New in [version 0.30.1][])_ |
-| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. _(New in [version 0.30.1][])_ |
-| uptime | Number | Number of consecutive seconds that the server has been operational. _(New in [version 0.30.1][])_ |
+| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. _(New in [`rippled` 0.30.1][])_ |
+| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) _(New in [`rippled` 0.30.1][])_ |
+| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. _(New in [`rippled` 0.30.1][])_ |
+| uptime | Number | Number of consecutive seconds that the server has been operational. _(New in [`rippled` 0.30.1][])_ |
 | validated\_ledger | Object | Information about the fully-validated ledger with the highest [Ledger Index][] (the most recent) |
 | validated\_ledger.age | Number | The time since the ledger was closed, in seconds |
 | validated\_ledger.base\_fee\_xrp | Number | Base fee, in XRP. This may be represented in scientific notation such as 1e-05 for 0.00005 |
@@ -8657,17 +8657,17 @@ The `state` object may have some arrangement of the following fields:
 | load.threads | Number | *Admin only* The number of threads in the server's main job pool. |
 | load\_base | Integer | This is the baseline amount of server load used in [transaction cost](concept-transaction-cost.html) calculations. If the `load_factor` is equal to the `load_base` then only the base transaction cost is enforced. If the `load_factor` is higher than the `load_base`, then transaction costs are multiplied by the ratio between them. For example, if the `load_factor` is double the `load_base`, then transaction costs are doubled. |
 | load\_factor | Number | The load factor the server is currently enforcing. The ratio between this value and the `load_base` determines the multiplier for transaction costs. The load factor is determined by the highest of the individual server's load factor, cluster's load factor, and the overall network's load factor. |
-| load\_factor\_fee\_escalation | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the open ledger, in [fee levels][]. _(New in [version 0.32.0][])_ |
-| load\_factor\_fee\_queue | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the queue, if the queue is full, in [fee levels][]. _(New in [version 0.32.0][])_ |
-| load\_factor\_fee\_reference | Integer | (May be omitted) The [transaction cost][] with no load scaling, in [fee levels][]. _(New in [version 0.32.0][])_ |
+| load\_factor\_fee\_escalation | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the open ledger, in [fee levels][]. _(New in [`rippled` 0.32.0][])_ |
+| load\_factor\_fee\_queue | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the queue, if the queue is full, in [fee levels][]. _(New in [`rippled` 0.32.0][])_ |
+| load\_factor\_fee\_reference | Integer | (May be omitted) The [transaction cost][] with no load scaling, in [fee levels][]. _(New in [`rippled` 0.32.0][])_ |
 | peers | Number | How many other `rippled` servers the node is currently connected to. |
 | pubkey\_node | String | Public key used by this server (along with the corresponding private key) for secure communications between nodes. This key pair is automatically created and stored in `rippled`'s local database the first time it starts up; if lost or deleted, a new key pair can be generated with no ill effects. |
 | pubkey\_validator | String | *Admin only* Public key of the keypair used by this server to sign proposed ledgers for validation. |
 | server\_state | String | A string indicating to what extent the server is participating in the network. See [Possible Server States](#possible-server-states) for more details. |
-| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. _(New in [version 0.30.1][])_ |
-| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) _(New in [version 0.30.1][])_ |
-| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. _(New in [version 0.30.1][])_ |
-| uptime | Number | Number of consecutive seconds that the server has been operational. _(New in [version 0.30.1][])_ |
+| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. _(New in [`rippled` 0.30.1][])_ |
+| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) _(New in [`rippled` 0.30.1][])_ |
+| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. _(New in [`rippled` 0.30.1][])_ |
+| uptime | Number | Number of consecutive seconds that the server has been operational. _(New in [`rippled` 0.30.1][])_ |
 | validated\_ledger | Object | Information about the fully-validated ledger with the highest sequence number (the most recent) |
 | validated\_ledger.base\_fee | Unsigned Integer | Base fee, in drops of XRP, for propagating a transaction to the network.
 | validated\_ledger.close_time | Number | Time this ledger was closed, in seconds since the [Ripple Epoch](#specifying-time) |
@@ -9148,7 +9148,7 @@ The fields describing a fetch in progress are subject to change without notice. 
 ## feature ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Feature1.cpp "Source")
 
-The `feature` command returns information about [amendments](concept-amendments.html) this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the [amendment process](concept-amendments.html#amendment-process). _(New in [version 0.31.0][])_
+The `feature` command returns information about [amendments](concept-amendments.html) this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the [amendment process](concept-amendments.html#amendment-process). _(New in [`rippled` 0.31.0][])_
 
 You can use the `feature` command to temporarily configure the server to vote against or in favor of an amendment. This change does not persist if you restart the server. To make lasting changes in amendment voting, use the `rippled.cfg` file. See [Configuring Amendment Voting](concept-amendments.html#configuring-amendment-voting) for more information.
 
@@ -9339,9 +9339,9 @@ The response follows the [standard format](#response-formatting), with a success
 ## fee ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp "Source")
 
-The `fee` command reports the current state of the open-ledger requirements for the [transaction cost](concept-transaction-cost.html). This requires the [FeeEscalation amendment](concept-amendments.html#feeescalation) to be enabled. _(New in [version 0.31.0][])_
+The `fee` command reports the current state of the open-ledger requirements for the [transaction cost](concept-transaction-cost.html). This requires the [FeeEscalation amendment](concept-amendments.html#feeescalation) to be enabled. _(New in [`rippled` 0.31.0][])_
 
-_As of [version 0.32.0][], this is a public command available to unprivileged users._
+_As of [`rippled` 0.32.0][], this is a public command available to unprivileged users._
 
 #### Request Format ####
 An example of the request format:
@@ -10495,7 +10495,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 | Field   | Type   | Description |
 |---------|--------|-------------|
-| cluster | Object | Summary of other `rippled` servers in the same cluster, if [configured as a cluster](tutorial-rippled-setup.html#clustering). _(New in [version 0.30.1][])_ |
+| cluster | Object | Summary of other `rippled` servers in the same cluster, if [configured as a cluster](tutorial-rippled-setup.html#clustering). _(New in [`rippled` 0.30.1][])_ |
 | peers   | Array  | Array of peer objects. |
 
 Each field of the `cluster` object is the public key of that `rippled` server's identifying keypair. (This is the same value that that server returns as `pubkey_node` in the [`server_info` command](#server-info).) The contents of that field are an object with the following fields:
@@ -10522,7 +10522,7 @@ Each member of the `peers` array is a peer object with the following fields:
 | public\_key | String | (May be omitted) A public key that can be used to verify the integrity of the peer's messages. This is not the same key that is used for validations, but it follows the same format. |
 | sanity | String | (May be omitted) Whether this peer is following the same rules and ledger sequence as the current server. A value of `insane` probably indicates that the peer is part of a parallel network. The value `unknown` indicates that the current server is unsure whether the peer is compatible. <!-- STYLE_OVERRIDE: insane --> |
 | status | String | (May be omitted) The most recent status message from the peer. Could be `connecting`, `connected`, `monitoring`, `validating`, or `shutting`. |
-| uptime | Number | The number of seconds that your `rippled` server has been continuously connected to this peer. _(New in [version 0.30.1][])_ |
+| uptime | Number | The number of seconds that your `rippled` server has been continuously connected to this peer. _(New in [`rippled` 0.30.1][])_ |
 | version | string | (May be omitted) The `rippled` version number of the peer server |
 
 #### Possible Errors ####
@@ -11334,24 +11334,4 @@ Example:
 ```
 
 
-<!---- rippled release notes links ---->
-[version 0.26.0]: https://github.com/ripple/rippled/releases/tag/0.26.0
-[version 0.26.1]: https://github.com/ripple/rippled/releases/tag/0.26.1
-[version 0.26.2]: https://github.com/ripple/rippled/releases/tag/0.26.2
-[version 0.26.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.3-sp1
-[version 0.26.4]: https://github.com/ripple/rippled/releases/tag/0.26.4
-[version 0.26.4-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.4-sp1
-[version 0.27.0]: https://github.com/ripple/rippled/releases/tag/0.27.0
-[version 0.27.1]: https://github.com/ripple/rippled/releases/tag/0.27.1
-[version 0.27.2]: https://github.com/ripple/rippled/releases/tag/0.27.2
-[version 0.27.3]: https://github.com/ripple/rippled/releases/tag/0.27.3
-[version 0.27.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp1
-[version 0.27.3-sp2]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp2
-[version 0.27.4]: https://github.com/ripple/rippled/releases/tag/0.27.4
-[version 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0
-[version 0.28.2]: https://github.com/ripple/rippled/releases/tag/0.28.2
-[version 0.29.0]: https://github.com/ripple/rippled/releases/tag/0.29.0
-[version 0.30.0]: https://github.com/ripple/rippled/releases/tag/0.30.0
-[version 0.30.1]: https://github.com/ripple/rippled/releases/tag/0.30.1
-[version 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0
-[version 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0
+{% include 'snippets/rippled_versions.md' %}

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -230,26 +230,34 @@ The transaction hash can be used as a "proof of payment" since anyone can [look 
 
 ## Common Fields ##
 
+[Internal Type]: https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp
+
 Every transaction type has the same set of fundamental fields. Field names are case-sensitive. The common fields for all transactions are:
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|---------------|-------------|
-| Account | String | Account | The unique address of the account that initiated the transaction. |
-| [AccountTxnID](#accounttxnid) | String | Hash256 | (Optional) Hash value identifying another transaction. This transaction is only valid if the sending account's previously-sent transaction matches the provided hash. |
-| [Fee](#transaction-cost) | String | Amount | (Required, but [auto-fillable](#auto-fillable-fields)) Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network. |
-| [Flags](#flags) | Unsigned Integer | UInt32 | (Optional) Set of bit-flags for this transaction. |
-| [LastLedgerSequence](#lastledgersequence) | Number | UInt32 | (Optional, but strongly recommended) Highest ledger sequence number that a transaction can appear in. |
-| [Memos](#memos) | Array of Objects | Array | (Optional) Additional arbitrary information used to identify this transaction. |
-| [Sequence](#canceling-or-skipping-a-transaction) | Unsigned Integer | UInt32 | (Required, but [auto-fillable](#auto-fillable-fields)) The sequence number, relative to the initiating account, of this transaction. A transaction is only valid if the `Sequence` number is exactly 1 greater than the last-valided transaction from the same account. |
-| SigningPubKey | String | PubKey | (Automatically added when signing) Hex representation of the public key that corresponds to the private key used to sign this transaction. If an empty string, indicates a multi-signature is present in the `Signers` field instead. |
-| [Signers](#signers-field) | Array | Array | (Optional) Array of objects that represent a [multi-signature](#multi-signing) which authorizes this transaction. |
-| SourceTag | Unsigned Integer | UInt32 | (Optional) Arbitrary integer used to identify the reason for this payment, or a sender on whose behalf this transaction is made. Conventionally, a refund should specify the initial payment's `SourceTag` as the refund payment's `DestinationTag`. |
-| TransactionType | String | UInt16 | The type of transaction. Valid types include: `Payment`, `OfferCreate`, `OfferCancel`, `TrustSet`, `AccountSet`, `SetRegularKey`, and `SignerListSet`. |
-| TxnSignature | String | VariableLength | (Automatically added when signing) The signature that verifies this transaction as originating from the account it says it is from. |
+| Field                  | JSON Type        | [Internal Type][] | Description  |
+|:-----------------------|:-----------------|:------------------|:-------------|
+| Account                | String           | Account           | The unique address of the account that initiated the transaction. |
+| [AccountTxnID][]       | String           | Hash256           | (Optional) Hash value identifying another transaction. This transaction is only valid if the sending account's previously-sent transaction matches the provided hash. |
+| [Fee][]                | String           | Amount            | (Required, but [auto-fillable](#auto-fillable-fields)) Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network. |
+| [Flags][]              | Unsigned Integer | UInt32            | (Optional) Set of bit-flags for this transaction. |
+| [LastLedgerSequence][] | Number           | UInt32            | (Optional, but strongly recommended) Highest ledger sequence number that a transaction can appear in. |
+| [Memos][]              | Array of Objects | Array             | (Optional) Additional arbitrary information used to identify this transaction. |
+| [Sequence][]           | Unsigned Integer | UInt32            | (Required, but [auto-fillable](#auto-fillable-fields)) The sequence number, relative to the initiating account, of this transaction. A transaction is only valid if the `Sequence` number is exactly 1 greater than the last-valided transaction from the same account. |
+| SigningPubKey          | String           | PubKey            | (Automatically added when signing) Hex representation of the public key that corresponds to the private key used to sign this transaction. If an empty string, indicates a multi-signature is present in the `Signers` field instead. |
+| [Signers][]            | Array            | Array             | (Optional) Array of objects that represent a [multi-signature](#multi-signing) which authorizes this transaction. |
+| SourceTag              | Unsigned Integer | UInt32            | (Optional) Arbitrary integer used to identify the reason for this payment, or a sender on whose behalf this transaction is made. Conventionally, a refund should specify the initial payment's `SourceTag` as the refund payment's `DestinationTag`. |
+| TransactionType        | String           | UInt16            | The type of transaction. Valid types include: `Payment`, `OfferCreate`, `OfferCancel`, `TrustSet`, `AccountSet`, `SetRegularKey`, and `SignerListSet`. |
+| TxnSignature           | String           | VariableLength    | (Automatically added when signing) The signature that verifies this transaction as originating from the account it says it is from. |
 
-**Note:** The deprecated `PreviousTxnID` transaction parameter was removed entirely in [rippled 0.28.0][]. Use `AccountTxnID` instead.
+[AccountTxnID]: #accounttxnid
+[Fee]: #transaction-cost
+[Flags]: #flags
+[LastLedgerSequence]: #lastledgersequence
+[Memos]: #memos
+[Sequence]: #canceling-or-skipping-a-transaction
+[Signers]: #signers-field
 
-[rippled 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0-rc1
+**Note:** The deprecated `PreviousTxnID` transaction parameter was removed entirely in [`rippled` 0.28.0][]. Use `AccountTxnID` instead.
 
 ### Auto-fillable Fields ###
 
@@ -267,7 +275,7 @@ The [`Paths` field](#paths) of the [Payment](#payment) transaction type can also
 
 To protect the Ripple Consensus Ledger from being disrupted by spam and denial-of-service attacks, each transaction must destroy a small amount of XRP. This _[transaction cost](concept-transaction-cost.html)_ is designed to increase along with the load on the network, making it very expensive to deliberately or inadvertently overload the network.
 
-The `Fee` field specifies an amount, in [drops of XRP](reference-rippled.html#specifying-currency-amounts), to destroy as the cost for relaying this transaction. If the transaction is included in a validated ledger (whether or not it achieves its intended purpose), then the amount of XRP specified in the `Fee` parameter is destroyed forever. You can [look up the transaction cost](concept-transaction-cost.html#querying-the-transaction-cost) in advance, or [let `rippled` set it automatically](concept-transaction-cost.html#automatically-specifying-the-transaction-cost) when you sign a transaction.
+The `Fee` field specifies an amount, in [drops of XRP][Currency Amount], to destroy as the cost for relaying this transaction. If the transaction is included in a validated ledger (whether or not it achieves its intended purpose), then the amount of XRP specified in the `Fee` parameter is destroyed forever. You can [look up the transaction cost](concept-transaction-cost.html#querying-the-transaction-cost) in advance, or [let `rippled` set it automatically](concept-transaction-cost.html#automatically-specifying-the-transaction-cost) when you sign a transaction.
 
 **Note:** [Multi-signed transactions](#multi-signing) require additional fees to relay to the network.
 
@@ -302,11 +310,11 @@ To use AccountTxnID, you must first set the [asfAccountTxnID](#accountset-flags)
 
 The `Memos` field includes arbitrary messaging data with the transaction. It is presented as an array of objects. Each object has only one field, `Memo`, which in turn contains another object with *one or more* of the following fields:
 
-| Field | Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|------|--------------------------------------------------------|-------------|
-| MemoData | String | VariableLength | Arbitrary hex value, conventionally containing the content of the memo. |
-| MemoFormat | String | VariableLength | Hex value representing characters allowed in URLs. Conventionally containing information on how the memo is encoded, for example as a [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml). |
-| MemoType | String | VariableLength | Hex value representing characters allowed in URLs. Conventionally, a unique relation (according to [RFC 5988](http://tools.ietf.org/html/rfc5988#section-4)) that defines the format of this memo. |
+| Field      | Type   | [Internal Type][] | Description                        |
+|:-----------|:-------|:------------------|:-----------------------------------|
+| MemoData   | String | VariableLength    | Arbitrary hex value, conventionally containing the content of the memo. |
+| MemoFormat | String | VariableLength    | Hex value representing characters allowed in URLs. Conventionally containing information on how the memo is encoded, for example as a [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml). |
+| MemoType   | String | VariableLength    | Hex value representing characters allowed in URLs. Conventionally, a unique relation (according to [RFC 5988](http://tools.ietf.org/html/rfc5988#section-4)) that defines the format of this memo. |
 
 The MemoType and MemoFormat fields should only consist of the following characters: `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%`
 
@@ -335,11 +343,11 @@ Example of a transaction with a Memos field:
 
 The `Signers` field contains a [multi-signature](#multi-signing), which has signatures from up to 8 key pairs, that together should authorize the transaction. The `Signers` list is an array of objects, each with one field, `Signer`. The `Signer` field has the following nested fields:
 
-| Field | Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|------|--------------------------------------------------------|-------------|
-| Account | String | AccountID | The address associated with this signature, as it appears in the SignerList. |
-| TxnSignature | String | Blob | A signature for this transaction, verifiable using the `SigningPubKey`. |
-| SigningPubKey | String | PubKey | The public key used to create this signature. |
+| Field         | Type   | [Internal Type][] | Description                     |
+|:--------------|:-------|:------------------|:--------------------------------|
+| Account       | String | AccountID         | The address associated with this signature, as it appears in the SignerList. |
+| TxnSignature  | String | Blob              | A signature for this transaction, verifiable using the `SigningPubKey`. |
+| SigningPubKey | String | PubKey            | The public key used to create this signature. |
 
 The `SigningPubKey` must be a key that is associated with the `Account` address. If the referenced `Account` is a funded account in the ledger, then the SigningPubKey can be that account's current Regular Key if one is set. It could also be that account's Master Key, unless the [lsfDisableMaster](reference-ledger-format.html#accountroot-flags) flag is enabled. If the referenced `Account` address is not a funded account in the ledger, then the `SigningPubKey` must be the master key associated with that address.
 
@@ -355,9 +363,9 @@ Most flags only have meaning for a specific transaction type. The same bitwise v
 
 The only flag that applies globally to all transactions is as follows:
 
-| Flag Name | Hex Value | Decimal Value | Description |
-|-----------|-----------|---------------|-------------|
-| tfFullyCanonicalSig | 0x80000000 | 2147483648 | Require a fully-canonical signature, to protect a transaction from [transaction malleability](https://wiki.ripple.com/Transaction_Malleability) exploits. |
+| Flag Name           | Hex Value  | Decimal Value | Description               |
+|:--------------------|:-----------|:--------------|:--------------------------|
+| tfFullyCanonicalSig | 0x80000000 | 2147483648    | Require a fully-canonical signature, to protect a transaction from [transaction malleability](https://wiki.ripple.com/Transaction_Malleability) exploits. |
 
 
 
@@ -386,19 +394,19 @@ Example payment:
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| Amount | String (XRP)<br/>Object (Otherwise) | Amount | The amount of currency to deliver. Formatted as per [Specifying Currency Amounts](reference-rippled.html#specifying-currency-amounts). For non-XRP amounts, the nested field names are lower-case. If the [*tfPartialPayment* flag](#payment-flags) is set, deliver _up to_ this amount instead. |
-| Destination | String | Account | The unique address of the account receiving the payment. |
-| DestinationTag | Unsigned Integer | UInt32 | (Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay. |
-| InvoiceID | String | Hash256 | (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment. |
-| Paths | Array of path arrays | PathSet | (Optional, auto-fillable) Array of [payment paths](https://ripple.com/wiki/Payment_paths) to be used for this transaction. Must be omitted for XRP-to-XRP transactions. |
-| SendMax | String/Object | Amount | (Optional) Highest amount of source currency this transaction is allowed to cost, including [transfer fees](concept-transfer-fees.html), exchange rates, and [slippage](http://en.wikipedia.org/wiki/Slippage_%28finance%29). Does not include the [XRP destroyed as a cost for submitting the transaction](#transaction-cost). See also: [Specifying Currency Amounts](reference-rippled.html#specifying-currency-amounts). For non-XRP amounts, the nested field names are lower-case. Must be supplied for cross-currency/cross-issue payments. Must be omitted for XRP-to-XRP payments. |
-| DeliverMin | String/Object | Amount | (Optional) Minimum amount of destination currency this transaction should deliver. Only valid if this is a [partial payment](#partial-payments). For non-XRP amounts, the nested field names are lower-case. |
+| Field          | JSON Type            | [Internal Type][] | Description      |
+|:---------------|:---------------------|:------------------|:-----------------|
+| Amount         | [Currency Amount][]  | Amount            | The amount of currency to deliver. For non-XRP amounts, the nested field names MUST be lower-case. If the [**tfPartialPayment** flag](#payment-flags) is set, deliver _up to_ this amount instead. |
+| Destination    | String               | Account           | The unique address of the account receiving the payment. |
+| DestinationTag | Unsigned Integer     | UInt32            | (Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay. |
+| InvoiceID      | String               | Hash256           | (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment. |
+| Paths          | Array of path arrays | PathSet           | (Optional, auto-fillable) Array of [payment paths](concept-paths.html) to be used for this transaction. Must be omitted for XRP-to-XRP transactions. |
+| SendMax        | [Currency Amount][]  | Amount            | (Optional) Highest amount of source currency this transaction is allowed to cost, including [transfer fees](concept-transfer-fees.html), exchange rates, and [slippage](http://en.wikipedia.org/wiki/Slippage_%28finance%29). Does not include the [XRP destroyed as a cost for submitting the transaction](#transaction-cost). For non-XRP amounts, the nested field names MUST be lower-case. Must be supplied for cross-currency/cross-issue payments. Must be omitted for XRP-to-XRP payments. |
+| DeliverMin     | [Currency Amount][]  | Amount            | (Optional) Minimum amount of destination currency this transaction should deliver. Only valid if this is a [partial payment](#partial-payments). For non-XRP amounts, the nested field names are lower-case. |
 
 ### Special issuer Values for SendMax and Amount ###
 
-Most of the time, the `issuer` field of a non-XRP [currency amount](reference-rippled.html#specifying-currency-amounts) indicates a financial institution's [issuing address](concept-issuing-and-operational-addresses.html). However, when describing payments, there are special rules for the `issuer` field in the `Amount` and `SendMax` fields of a payment.
+Most of the time, the `issuer` field of a non-XRP [Currency Amount][] indicates a financial institution's [issuing address](concept-issuing-and-operational-addresses.html). However, when describing payments, there are special rules for the `issuer` field in the `Amount` and `SendMax` fields of a payment.
 
 * There is only ever one balance for the same currency between two addresses. This means that, sometimes, the `issuer` field of an amount actually refers to a counterparty that is redeeming issuances, instead of the address that created the issuances.
 * When the `issuer` field of the destination `Amount` field matches the `Destination` address, it is treated as a special case meaning "any issuer that the destination accepts." This includes all addresses to which the destination has extended trust lines, as well as issuances created by the destination which are held on other trust lines.
@@ -431,15 +439,15 @@ For more information, see [Paths](concept-paths.html).
 
 Transactions of the Payment type support additional values in the [`Flags` field](#flags), as follows:
 
-| Flag Name | Hex Value | Decimal Value | Description |
-|-----------|-----------|---------------|-------------|
-| tfNoDirectRipple | 0x00010000 | 65536 | Do not use the default path; only use paths included in the `Paths` field. This is intended to force the transaction to take arbitrage opportunities. Most clients do not need this. |
-| tfPartialPayment | 0x00020000 | 131072 | If the specified `Amount` cannot be sent without spending more than `SendMax`, reduce the received amount instead of failing outright. See [Partial Payments](#partial-payments) for more details. |
-| tfLimitQuality | 0x00040000 | 262144 | Only take paths where all the conversions have an input:output ratio that is equal or better than the ratio of `Amount`:`SendMax`. See [Limit Quality](#limit-quality) for details. |
+| Flag Name        | Hex Value  | Decimal Value | Description                  |
+|:-----------------|:-----------|:--------------|:-----------------------------|
+| tfNoDirectRipple | 0x00010000 | 65536         | Do not use the default path; only use paths included in the `Paths` field. This is intended to force the transaction to take arbitrage opportunities. Most clients do not need this. |
+| tfPartialPayment | 0x00020000 | 131072        | If the specified `Amount` cannot be sent without spending more than `SendMax`, reduce the received amount instead of failing outright. See [Partial Payments](#partial-payments) for more details. |
+| tfLimitQuality   | 0x00040000 | 262144        | Only take paths where all the conversions have an input:output ratio that is equal or better than the ratio of `Amount`:`SendMax`. See [Limit Quality](#limit-quality) for details. |
 
 ### Partial Payments ###
 
-A partial payment allows a payment to succeed by reducing the amount received, instead of increasing the `SendMax`. Partial payments are useful for [returning payments](https://wiki.ripple.com/Returning_payments) without incurring additional costs to oneself.
+A partial payment allows a payment to succeed by reducing the amount received, instead of increasing the `SendMax`. Partial payments are useful for [returning payments](tutorial-gateway-guide.html#bouncing-payments) without incurring additional costs to oneself.
 
 By default, the `Amount` field of a Payment transaction specifies the amount of currency that is *received* by the account that is the destination of the payment. Any additional amount needed for fees or currency exchange is deducted from the sending account's balances, up to the `SendMax` amount. (If `SendMax` is not specified, that is equivalent to setting the `SendMax` to the `Amount` field.) If the amount needed to make the payment exceeds the `SendMax` parameter, or the full amount cannot be delivered for any other reason, the transaction fails.
 
@@ -492,16 +500,16 @@ Example AccountSet:
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| [ClearFlag](#accountset-flags) | Unsigned Integer | UInt32 | (Optional) Unique identifier of a flag to disable for this account. |
-| [Domain](#domain) | String | VariableLength | (Optional) The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase. |
-| EmailHash | String | Hash128 | (Optional) Hash of an email address to be used for generating an avatar image. Conventionally, clients use [Gravatar](http://en.gravatar.com/site/implement/hash/) to display this image. |
-| MessageKey | String | PubKey | (Optional) Public key for sending encrypted messages to this account. Conventionally, it should be a secp256k1 key, the same encryption that is used by the rest of Ripple. |
-| [SetFlag](#accountset-flags) | Unsigned Integer | UInt32 | (Optional) Integer flag to enable for this account. |
-| [TransferRate](#transferrate) | Unsigned Integer | UInt32 | (Optional) The fee to charge when users transfer this account's issuances, represented as billionths of a unit. Use `0` to set no fee. |
-| WalletLocator | String | Hash256 | (Optional) Not used. |
-| WalletSize | Unsigned Integer | UInt32 | (Optional) Not used. |
+| Field                          | JSON Type        | [Internal Type][] | Description |
+|:-------------------------------|:-----------------|:------------------|:-----|
+| [ClearFlag](#accountset-flags) | Unsigned Integer | UInt32            | (Optional) Unique identifier of a flag to disable for this account. |
+| [Domain](#domain)              | String           | VariableLength    | (Optional) The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase. |
+| EmailHash                      | String           | Hash128           | (Optional) Hash of an email address to be used for generating an avatar image. Conventionally, clients use [Gravatar](http://en.gravatar.com/site/implement/hash/) to display this image. |
+| MessageKey                     | String           | PubKey            | (Optional) Public key for sending encrypted messages to this account. Conventionally, it should be a secp256k1 key, the same encryption that is used by the rest of Ripple. |
+| [SetFlag](#accountset-flags)   | Unsigned Integer | UInt32            | (Optional) Integer flag to enable for this account. |
+| [TransferRate](#transferrate)  | Unsigned Integer | UInt32            | (Optional) The fee to charge when users transfer this account's issuances, represented as billionths of a unit. Use `0` to set no fee. |
+| WalletLocator                  | String           | Hash256           | (Optional) Not used. |
+| WalletSize                     | Unsigned Integer | UInt32            | (Optional) Not used. |
 
 If none of these options are provided, then the AccountSet transaction has no effect (beyond destroying the transaction cost). See [Canceling or Skipping a Transaction](#canceling-or-skipping-a-transaction) for more details.
 
@@ -511,7 +519,7 @@ The `Domain` field is represented as the hex string of the lowercase ASCII of th
 
 To remove the `Domain` field from an account, send an AccountSet with the Domain set to an empty string.
 
-Client applications can use the [ripple.txt](https://ripple.com/wiki/Ripple.txt) file hosted by the domain to confirm that the account is actually operated by that domain.
+Client applications can use the [ripple.txt](https://wiki.ripple.com/Ripple.txt) file hosted by the domain to confirm that the account is actually operated by that domain.
 
 ### AccountSet Flags ###
 
@@ -527,29 +535,29 @@ All flags are off by default.
 
 The available AccountSet flags are:
 
-| Flag Name | Decimal Value | Description | Corresponding Ledger Flag |
-|-----------|---------------|-------------|---------------------------|
-| asfRequireDest | 1 | Require a destination tag to send transactions to this account. | lsfRequireDestTag |
-| asfRequireAuth | 2 | Require authorization for users to hold balances issued by this address. Can only be enabled if the address has no trust lines connected to it. | lsfRequireAuth |
-| asfDisallowXRP | 3 | XRP should not be sent to this account. (Enforced by client applications, not by `rippled`) | lsfDisallowXRP |
-| asfDisableMaster | 4 | Disallow use of the master key. Can only be enabled if the account has configured another way to sign transactions, such as a [Regular Key](#setregularkey) or a [Signer List](#signerlistset). | lsfDisableMaster |
-| asfAccountTxnID | 5 | Track the ID of this account's most recent transaction. Required for [AccountTxnID](#accounttxnid) | (None) |
-| asfNoFreeze | 6 | Permanently give up the ability to [freeze individual trust lines or disable Global Freeze](concept-freeze.html). This flag can never be disabled after being enabled. | lsfNoFreeze |
-| asfGlobalFreeze | 7 | [Freeze](concept-freeze.html) all assets issued by this account. | lsfGlobalFreeze |
-| asfDefaultRipple | 8 | Enable [rippling](concept-noripple.html) on this account's trust lines by default. _(New in [rippled 0.27.3](https://github.com/ripple/rippled/releases/tag/0.27.3))_ | lsfDefaultRipple |
+| Flag Name        | Decimal Value | Corresponding Ledger Flag | Description   |
+|:-----------------|:--------------|:--------------------------|:--------------|
+| asfRequireDest   | 1             | lsfRequireDestTag         | Require a destination tag to send transactions to this account. |
+| asfRequireAuth   | 2             | lsfRequireAuth            | Require authorization for users to hold balances issued by this address. Can only be enabled if the address has no trust lines connected to it. |
+| asfDisallowXRP   | 3             | lsfDisallowXRP            | XRP should not be sent to this account. (Enforced by client applications, not by `rippled`) |
+| asfDisableMaster | 4             | lsfDisableMaster          | Disallow use of the master key. Can only be enabled if the account has configured another way to sign transactions, such as a [Regular Key](#setregularkey) or a [Signer List](#signerlistset). |
+| asfAccountTxnID  | 5             | (None)                    | Track the ID of this account's most recent transaction. Required for [AccountTxnID](#accounttxnid) |
+| asfNoFreeze      | 6             | lsfNoFreeze               | Permanently give up the ability to [freeze individual trust lines or disable Global Freeze](concept-freeze.html). This flag can never be disabled after being enabled. |
+| asfGlobalFreeze  | 7             | lsfGlobalFreeze           | [Freeze](concept-freeze.html) all assets issued by this account. |
+| asfDefaultRipple | 8             | lsfDefaultRipple          | Enable [rippling](concept-noripple.html) on this account's trust lines by default. _(New in [`rippled` 0.27.3][])_ |
 
-_New in [rippled 0.28.0][]:_ To enable the `asfDisableMaster` or `asfNoFreeze` flags, you must [authorize the transaction](#authorizing-transactions) by signing it with the master key. You cannot use a regular key or a multi-signature.
+_New in [`rippled` 0.28.0][]:_ To enable the `asfDisableMaster` or `asfNoFreeze` flags, you must [authorize the transaction](#authorizing-transactions) by signing it with the master key. You cannot use a regular key or a multi-signature.
 
 The following [Transaction flags](#flags), specific to the AccountSet transaction type, serve the same purpose, but are discouraged:
 
-| Flag Name | Hex Value | Decimal Value | Replaced by AccountSet Flag |
-|-----------|-----------|---------------|-----------------------------|
-| tfRequireDestTag | 0x00010000 | 65536 | asfRequireDest (SetFlag) |
-| tfOptionalDestTag | 0x00020000 | 131072 | asfRequireDest (ClearFlag) |
-| tfRequireAuth | 0x00040000 | 262144 | asfRequireAuth (SetFlag) |
-| tfOptionalAuth | 0x00080000 | 524288 | asfRequireAuth (ClearFlag) |
-| tfDisallowXRP | 0x00100000 | 1048576 | asfDisallowXRP (SetFlag) |
-| tfAllowXRP | 0x00200000 | 2097152 | asfDisallowXRP (ClearFlag) |
+| Flag Name         | Hex Value  | Decimal Value | Replaced by AccountSet Flag |
+|:------------------|:-----------|:--------------|:----------------------------|
+| tfRequireDestTag  | 0x00010000 | 65536         | asfRequireDest (SetFlag)    |
+| tfOptionalDestTag | 0x00020000 | 131072        | asfRequireDest (ClearFlag)  |
+| tfRequireAuth     | 0x00040000 | 262144        | asfRequireAuth (SetFlag)    |
+| tfOptionalAuth    | 0x00080000 | 524288        | asfRequireAuth (ClearFlag)  |
+| tfDisallowXRP     | 0x00100000 | 1048576       | asfDisallowXRP (SetFlag)    |
+| tfAllowXRP        | 0x00200000 | 2097152       | asfDisallowXRP (ClearFlag)  |
 
 
 
@@ -585,9 +593,9 @@ A SetRegularKey transaction changes the regular key associated with an address.
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| RegularKey | String | AccountID | (Optional) A base-58-encoded [Ripple address](reference-rippled.html#addresses) to use as the regular key. If omitted, removes the existing regular key. |
+| Field      | JSON Type | [Internal Type][] | Description                     |
+|:-----------|:----------|:------------------|:--------------------------------|
+| RegularKey | String    | AccountID         | (Optional) A base-58-encoded [Ripple address](reference-rippled.html#addresses) to use as the regular key. If omitted, removes the existing regular key. |
 
 In addition to the master key, which is mathematically-related to an address, you can associate **at most 1 additional key pair** with an address using this type of transaction. The additional key pair is called a _regular key_. If your address has a regular key pair defined, you can use the secret key of the regular key pair to [authorize transactions](#authorizing-transactions).
 
@@ -622,12 +630,12 @@ An OfferCreate transaction is effectively a [limit order](http://en.wikipedia.or
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| [Expiration](#expiration) | Unsigned Integer | UInt32 | (Optional) Time after which the offer is no longer active, in [seconds since the Ripple Epoch](reference-rippled.html#specifying-time). |
-| OfferSequence | Unsigned Integer | UInt32 | (Optional) An offer to delete first, specified in the same way as [OfferCancel](#offercancel). |
-| TakerGets | Object (Non-XRP), or <br/>String (XRP) | Amount | The amount and type of currency being provided by the offer creator. |
-| TakerPays | Object (Non-XRP), or <br/>String (XRP) | Amount | The amount and type of currency being requested by the offer creator. |
+| Field                     | JSON Type           | [Internal Type][] | Description |
+|:--------------------------|:--------------------|:------------------|:-------|
+| [Expiration](#expiration) | Unsigned Integer    | UInt32            | (Optional) Time after which the offer is no longer active, in [seconds since the Ripple Epoch](reference-rippled.html#specifying-time). |
+| OfferSequence             | Unsigned Integer    | UInt32            | (Optional) An offer to delete first, specified in the same way as [OfferCancel](#offercancel). |
+| TakerGets                 | [Currency Amount][] | Amount            | The amount and type of currency being provided by the offer creator. |
+| TakerPays                 | [Currency Amount][] | Amount            | The amount and type of currency being requested by the offer creator. |
 
 ### Lifecycle of an Offer ###
 
@@ -699,12 +707,12 @@ Auto-bridging happens automatically on any OfferCreate transaction. [Payment tra
 
 Transactions of the OfferCreate type support additional values in the [`Flags` field](#flags), as follows:
 
-| Flag Name | Hex Value | Decimal Value | Description |
-|-----------|-----------|---------------|-------------|
-| tfPassive | 0x00010000 | 65536 | If enabled, the offer does not consume offers that exactly match it, and instead becomes an Offer node in the ledger. It still consumes offers that cross it. |
-| tfImmediateOrCancel | 0x00020000 | 131072 | Treat the offer as an [Immediate or Cancel order](http://en.wikipedia.org/wiki/Immediate_or_cancel). If enabled, the offer never becomes a ledger node: it only tries to match existing offers in the ledger. |
-| tfFillOrKill | 0x00040000 | 262144 | Treat the offer as a [Fill or Kill order](http://en.wikipedia.org/wiki/Fill_or_kill). Only try to match existing offers in the ledger, and only do so if the entire `TakerPays` quantity can be obtained. |
-| tfSell | 0x00080000 | 524288 | Exchange the entire `TakerGets` amount, even if it means obtaining more than the `TakerPays` amount in exchange. |
+| Flag Name           | Hex Value  | Decimal Value | Description               |
+|:--------------------|:-----------|:--------------|:--------------------------|
+| tfPassive           | 0x00010000 | 65536         | If enabled, the offer does not consume offers that exactly match it, and instead becomes an Offer node in the ledger. It still consumes offers that cross it. |
+| tfImmediateOrCancel | 0x00020000 | 131072        | Treat the offer as an [Immediate or Cancel order](http://en.wikipedia.org/wiki/Immediate_or_cancel). If enabled, the offer never becomes a ledger node: it only tries to match existing offers in the ledger. |
+| tfFillOrKill        | 0x00040000 | 262144        | Treat the offer as a [Fill or Kill order](http://en.wikipedia.org/wiki/Fill_or_kill). Only try to match existing offers in the ledger, and only do so if the entire `TakerPays` quantity can be obtained. |
+| tfSell              | 0x00080000 | 524288        | Exchange the entire `TakerGets` amount, even if it means obtaining more than the `TakerPays` amount in exchange. |
 
 The following invalid flag combination prompts a temINVALID_FLAG error:
 
@@ -731,9 +739,9 @@ An OfferCancel transaction removes an Offer node from the Ripple Consensus Ledge
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| OfferSequence | Unsigned Integer | UInt32 | The sequence number of a previous OfferCreate transaction. If specified, cancel any offer node in the ledger that was created by that transaction. It is not considered an error if the offer specified does not exist. |
+| Field         | JSON Type        | [Internal Type][] | Description           |
+|:--------------|:-----------------|:------------------|:----------------------|
+| OfferSequence | Unsigned Integer | UInt32            | The sequence number of a previous OfferCreate transaction. If specified, cancel any offer node in the ledger that was created by that transaction. It is not considered an error if the offer specified does not exist. |
 
 *Tip:* To remove an old offer and replace it with a new one, you can use an [OfferCreate](#offercreate) transaction with an `OfferSequence` parameter, instead of using OfferCancel and another OfferCreate.
 
@@ -762,14 +770,14 @@ Create or modify a trust line linking two accounts.
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|---------------|-------------|
-| [LimitAmount](#trust-limits) | Object | Amount | Object defining the trust line to create or modify, in the same format as [currency amounts](reference-rippled.html#specifying-currency-amounts). |
-| LimitAmount.currency | String | (Amount.currency) | The currency to this trust line applies to, as a three-letter [ISO 4217 Currency Code](http://www.xe.com/iso4217.php) or a 160-bit hex value according to [currency format](https://wiki.ripple.com/Currency_format). "XRP" is invalid. |
-| LimitAmount.value | String | (Amount.value) | Quoted decimal representation of the limit to set on this trust line. |
-| LimitAmount.issuer | String | (Amount.issuer) | The address of the account to extend trust to. |
-| QualityIn | Unsigned Integer | UInt32 | (Optional) Value incoming balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of `0` is shorthand for treating balances at face value. |
-| QualityOut | Unsigned Integer | UInt32 | (Optional) Value outgoing balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of `0` is shorthand for treating balances at face value. |
+| Field                        | JSON Type        | [Internal Type][] | Description |
+|:-----------------------------|:-----------------|:------------------|:-------|
+| [LimitAmount](#trust-limits) | Object           | Amount            | Object defining the trust line to create or modify, in the format of a [Currency Amount][]. |
+| LimitAmount.currency         | String           | (Amount.currency) | The currency to this trust line applies to, as a three-letter [ISO 4217 Currency Code](http://www.xe.com/iso4217.php) or a 160-bit hex value according to [currency format](https://wiki.ripple.com/Currency_format). "XRP" is invalid. |
+| LimitAmount.value            | String           | (Amount.value)    | Quoted decimal representation of the limit to set on this trust line. |
+| LimitAmount.issuer           | String           | (Amount.issuer)   | The address of the account to extend trust to. |
+| QualityIn                    | Unsigned Integer | UInt32            | (Optional) Value incoming balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of `0` is shorthand for treating balances at face value. |
+| QualityOut                   | Unsigned Integer | UInt32            | (Optional) Value outgoing balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of `0` is shorthand for treating balances at face value. |
 
 ### Trust Limits ###
 
@@ -791,22 +799,20 @@ The Auth flag of a trust line does not determine whether the trust line counts t
 
 Transactions of the TrustSet type support additional values in the [`Flags` field](#flags), as follows:
 
-| Flag Name | Hex Value | Decimal Value | Description |
-|-----------|-----------|---------------|-------------|
-| tfSetfAuth | 0x00010000 | 65536 | Authorize the other party to hold issuances from this account. (No effect unless using the [*asfRequireAuth* AccountSet flag](#accountset-flags).) Cannot be unset. |
-| tfSetNoRipple | 0x00020000 | 131072 | Blocks rippling between two trustlines of the same currency, if this flag is set on both. (See [No Ripple](concept-noripple.html) for details.) |
-| tfClearNoRipple | 0x00040000 | 262144 | Clears the No-Rippling flag. (See [No Ripple](concept-noripple.html) for details.) |
-| tfSetFreeze | 0x00100000 | 1048576 | [Freeze](concept-freeze.html) the trustline.
-| tfClearFreeze | 0x00200000 | 2097152 | [Unfreeze](concept-freeze.html) the trustline. |
+| Flag Name       | Hex Value  | Decimal Value | Description                   |
+|:----------------|:-----------|:--------------|:------------------------------|
+| tfSetfAuth      | 0x00010000 | 65536         | Authorize the other party to hold issuances from this account. (No effect unless using the [*asfRequireAuth* AccountSet flag](#accountset-flags).) Cannot be unset. |
+| tfSetNoRipple   | 0x00020000 | 131072        | Blocks rippling between two trustlines of the same currency, if this flag is set on both. (See [No Ripple](concept-noripple.html) for details.) |
+| tfClearNoRipple | 0x00040000 | 262144        | Clears the No-Rippling flag. (See [No Ripple](concept-noripple.html) for details.) |
+| tfSetFreeze     | 0x00100000 | 1048576       | [Freeze](concept-freeze.html) the trustline. |
+| tfClearFreeze   | 0x00200000 | 2097152       | [Unfreeze](concept-freeze.html) the trustline. |
 
 
 
 ## SignerListSet ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/ef511282709a6a0721b504c6b7703f9de3eecf38/src/ripple/app/tx/impl/SetSignerList.cpp "Source")
 
-The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to [multi-sign](#multi-signing) a transaction. This transaction type was introduced by the [MultiSign amendment](concept-amendments.html#multisign). _(New in [rippled 0.31.0][])_
-
-[rippled 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0
+The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to [multi-sign](#multi-signing) a transaction. This transaction type was introduced by the [MultiSign amendment](concept-amendments.html#multisign). _(New in [`rippled` 0.31.0][])_
 
 Example SignerListSet:
 
@@ -840,10 +846,10 @@ Example SignerListSet:
 }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| SignerQuorum | Number | UInt32 | A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of the signatures provided is greater than or equal to this value. To delete a SignerList, use the value `0`. |
-| SignerEntries | Array | Array | (Omitted when deleting) Array of [SignerEntry objects](reference-ledger-format.html#signerentry-object), indicating the addresses and weights of signers in this list. A SignerList must have at least 1 member and no more than 8 members. No address may appear more than once in the list, nor may the `Account` submitting the transaction appear in the list. |
+| Field         | JSON Type | [Internal Type][] | Description                  |
+|:--------------|:----------|:------------------|:-----------------------------|
+| SignerQuorum  | Number    | UInt32            | A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of the signatures provided is greater than or equal to this value. To delete a SignerList, use the value `0`. |
+| SignerEntries | Array     | Array             | (Omitted when deleting) Array of [SignerEntry objects](reference-ledger-format.html#signerentry-object), indicating the addresses and weights of signers in this list. A SignerList must have at least 1 member and no more than 8 members. No address may appear more than once in the list, nor may the `Account` submitting the transaction appear in the list. |
 
 An account may not have more than one SignerList. A successful SignerListSet transaction replaces the existing SignerList, if one exists. To delete a SignerList, you must set `SignerQuorum` to `0` _and_ omit the `SignerEntries` field. Otherwise, the transaction fails with the error [temMALFORMED](#tem-codes). A transaction to delete a SignerList is considered successful even if there was no SignerList to delete.
 
@@ -860,13 +866,13 @@ Pseudo-Transactions are never submitted by users, nor propagated through the net
 
 Some of the fields that are mandatory for normal transactions do not make sense for pseudo-transactions. In those cases, the pseudo-transaction has the following default values:
 
-| Field | Default Value |
-|-------|---------------|
-| Account | [ACCOUNT_ZERO](https://wiki.ripple.com/Accounts#ACCOUNT_ZERO) |
-| Sequence | 0 |
-| Fee | 0 |
-| SigningPubKey | "" |
-| Signature | "" |
+| Field         | Default Value                                            |
+|:--------------|:---------------------------------------------------------|
+| Account       | [ACCOUNT_ZERO](reference-rippled.html#special-addresses) |
+| Sequence      | 0                                                        |
+| Fee           | 0                                                        |
+| SigningPubKey | ""                                                       |
+| Signature     | ""                                                       |
 
 ## SetFee ##
 
@@ -891,13 +897,13 @@ A change in [transaction cost](concept-transaction-cost.html) or [account reserv
   }
 ```
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| BaseFee | String | UInt64 | The charge, in drops of XRP, for the reference transaction, as hex. (This is the [transaction cost](concept-transaction-cost.html) before scaling for load.) |
-| ReferenceFeeUnits | Unsigned Integer | UInt32 | The cost, in fee units, of the reference transaction |
-| ReserveBase | Unsigned Integer | UInt32 | The base reserve, in drops |
-| ReserveIncrement | Unsigned Integer | UInt32 | The incremental reserve, in drops |
-| LedgerSequence | Number | UInt32 | The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
+| Field             | JSON Type        | [Internal Type][] | Description       |
+|:------------------|:-----------------|:------------------|:------------------|
+| BaseFee           | String           | UInt64            | The charge, in drops of XRP, for the reference transaction, as hex. (This is the [transaction cost](concept-transaction-cost.html) before scaling for load.) |
+| ReferenceFeeUnits | Unsigned Integer | UInt32            | The cost, in fee units, of the reference transaction |
+| ReserveBase       | Unsigned Integer | UInt32            | The base reserve, in drops |
+| ReserveIncrement  | Unsigned Integer | UInt32            | The incremental reserve, in drops |
+| LedgerSequence    | Number           | UInt32            | The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
 
 ## EnableAmendment ##
 
@@ -905,10 +911,10 @@ Tracks the progress of the [amendment process](concept-amendments.html#amendment
 
 **Note:** You cannot send a pseudo-transaction, but you may find one when processing ledgers.
 
-| Field | JSON Type | [Internal Type](https://wiki.ripple.com/Binary_Format) | Description |
-|-------|-----------|--------------------------------------------------------|-------------|
-| Amendment | String | Hash256 | A unique identifier for the amendment. This is not intended to be a human-readable name. See [Amendments](concept-amendments.html) for a list of known amendments. |
-| LedgerSequence | Number | UInt32 | The index of the ledger version where this amendment appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
+| Field          | JSON Type | [Internal Type][] | Description                 |
+|:---------------|:----------|:------------------|:----------------------------|
+| Amendment      | String    | Hash256           | A unique identifier for the amendment. This is not intended to be a human-readable name. See [Amendments](concept-amendments.html) for a list of known amendments. |
+| LedgerSequence | Number    | UInt32            | The index of the ledger version where this amendment appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
 
 ### EnableAmendment Flags ###
 
@@ -916,10 +922,10 @@ The `Flags` value of the EnableAmendment pseudo-transaction indicates the status
 
 A `Flags` value of `0` (no flags) indicates that the amendment has been enabled, and applies to all ledgers afterward. Other `Flags` values are as follows:
 
-| Flag Name | Hex Value | Decimal Value | Description |
-|-----------|-----------|---------------|-------------|
-| tfGotMajority | 0x00010000 | 65536 | Support for this amendment increased to at least 80% of trusted validators starting with this ledger version. |
-| tfLostMajority | 0x00020000 | 131072 | Support for this amendment decreased to less than 80% of trusted validators starting with this ledger version. |
+| Flag Name      | Hex Value  | Decimal Value | Description                    |
+|:---------------|:-----------|:--------------|:-------------------------------|
+| tfGotMajority  | 0x00010000 | 65536         | Support for this amendment increased to at least 80% of trusted validators starting with this ledger version. |
+| tfLostMajority | 0x00020000 | 131072        | Support for this amendment decreased to less than 80% of trusted validators starting with this ledger version. |
 
 
 
@@ -931,11 +937,11 @@ The response from the [`submit` command](reference-rippled.html#submit) contains
 
 The response from `submit` contains the following fields:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| engine\_result | String | A code that categorizes the result, such as `tecPATH_DRY` |
-| engine\_result\_code | Signed Integer | A number that corresponds to the `engine_result`, although exact values are subject to change. |
-| engine\_result\_message | String | A human-readable message explaining what happened. This message is intended for developers to diagnose problems, and is subject to change without notice. |
+| Field                   | Value          | Description                       |
+|:------------------------|:---------------|:----------------------------------|
+| engine\_result          | String         | A code that categorizes the result, such as `tecPATH_DRY` |
+| engine\_result\_code    | Signed Integer | A number that corresponds to the `engine_result`, although exact values are subject to change. |
+| engine\_result\_message | String         | A human-readable message explaining what happened. This message is intended for developers to diagnose problems, and is subject to change without notice. |
 
 If nothing went wrong when submitting and applying the transaction locally, the response looks like this:
 
@@ -951,10 +957,10 @@ If nothing went wrong when submitting and applying the transaction locally, the 
 
 To see the final result of a transaction, use the [`tx` command](reference-rippled.html#tx), [`account_tx` command](reference-rippled.html#account-tx), or other response from `rippled`. Look for `"validated": true` to indicate that this response uses a ledger version that has been validated by consensus.
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| meta.TransactionResult | String | A code that categorizes the result, such as `tecPATH_DRY` |
-| validated | Boolean | Whether or not this result comes from a validated ledger. If `false`, then the result is provisional. If `true`, then the result is final. |
+| Field                  | Value   | Description                               |
+|:-----------------------|:--------|:------------------------------------------|
+| meta.TransactionResult | String  | A code that categorizes the result, such as `tecPATH_DRY` |
+| validated              | Boolean | Whether or not this result comes from a validated ledger. If `false`, then the result is provisional. If `true`, then the result is final. |
 
 ```js
     "hash": "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7",
@@ -969,15 +975,14 @@ To see the final result of a transaction, use the [`tx` command](reference-rippl
 
 Both the `engine_result` and the `meta.TransactionResult` use standard codes to identify the results of transactions, as follows:
 
-| Category              | Prefix            | Description |
-|-----------------------|-------------------|-------------|
-| Local error           | [tel](#tel-codes) | The rippled server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time. |
-| Malformed transaction | [tem](#tem-codes) | The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else. |
-| Failure               | [tef](#tef-codes) | The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future. |
-| Retry                 | [ter](#ter-codes) | The transaction could not be applied, but it might be possible to apply later. |
+| Category              | Prefix              | Description                    |
+|:----------------------|:--------------------|:-------------------------------|
+| Local error           | [tel](#tel-codes)   | The rippled server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time. |
+| Malformed transaction | [tem](#tem-codes)   | The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else. |
+| Failure               | [tef](#tef-codes)   | The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future. |
+| Retry                 | [ter](#ter-codes)   | The transaction could not be applied, but it might be possible to apply later. |
 | Success               | [tes](#tes-success) | (Not an error) The transaction succeeded. This result only final in a validated ledger. |
-| Claimed cost only     | [tec](#tec-codes) | The transaction did not achieve its intended purpose, but the [transaction cost](concept-transaction-cost.html) was destroyed. This result is only final in a validated ledger. |
-| Client library error  | [tej](#tej-codes) | (ripple-lib only) The transaction was not submitted, because the client library blocked it, as part of its additional error checking. |
+| Claimed cost only     | [tec](#tec-codes)   | The transaction did not achieve its intended purpose, but the [transaction cost](concept-transaction-cost.html) was destroyed. This result is only final in a validated ledger. |
 
 The distinction between a local error (`tel`) and a malformed transaction (`tem`) is a matter of protocol-level rules. For example, the protocol sets no limit on the maximum number of paths that can be included in a transaction. However, a server may define a finite limit of paths it can process. If two different servers are configured differently, then one of them may return a `tel` error for a transaction with many paths, while the other server could successfully process the transaction. If enough servers are able to process the transaction that it survives consensus, then it can still be included in a validated ledger.
 
@@ -999,12 +1004,12 @@ A validated ledger can include successful transactions (`tes` result codes) as w
 
 For any other result code, it can be difficult to determine if the result is final. The following table summarizes when a transaction's outcome is final, based on the result code from submitting the transaction:
 
-| Error Code | Finality |
-|------------|----------|
-| `tesSUCCESS` | Final when included in a validated ledger |
-| Any `tec` code | Final when included in a validated ledger |
-| Any `tem` code | Final unless the protocol changes to make the transaction valid |
-| `tefPAST_SEQ` | Final when another transaction with the same sequence number is included in a validated ledger |
+| Error Code      | Finality                                                   |
+|:----------------|:-----------------------------------------------------------|
+| `tesSUCCESS`    | Final when included in a validated ledger                  |
+| Any `tec` code  | Final when included in a validated ledger                  |
+| Any `tem` code  | Final unless the protocol changes to make the transaction valid |
+| `tefPAST_SEQ`   | Final when another transaction with the same sequence number is included in a validated ledger |
 | `tefMAX_LEDGER` | Final when a validated ledger has a sequence number higher than the transaction's `LastLedgerSequence` field, and no validated ledger includes the transaction |
 
 Any other transaction result is potentially not final. In that case, the transaction could still succeed or fail later, especially if conditions change such that the transaction is no longer prevented from applying. For example, trying to send a non-XRP currency to an account that does not exist yet would fail, but it could succeed if another transaction sends enough XRP to create the destination account. A server might even store a temporarily-failed, signed transaction and then successfully apply it later without asking first.
@@ -1017,13 +1022,13 @@ The metadata section of a transaction includes detailed information about all th
 
 Some fields that may appear in transaction metadata include:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| AffectedNodes | Array | List of nodes that were created, deleted, or modified by this transaction, and specific changes to each. |
-| DeliveredAmount | String or Object | **DEPRECATED.** Replaced by `delivered_amount`. Omitted if not a partial payment. |
-| TransactionIndex | Unsigned Integer | The transaction's position within the ledger that included it. (For example, the value `2` means it was the 2nd transaction in that ledger.) |
-| TransactionResult | String | A [result code](#result-categories) indicating whether the transaction succeeded or how it failed. |
-| [delivered_amount](#delivered-amount) | Object or String | (New in [rippled 0.27.0](https://github.com/ripple/rippled/releases/tag/0.27.0)) The [amount](reference-rippled.html#specifying-currency-amounts) actually received by the `Destination` account. Use this field to determine how much was delivered, regardless of whether the transaction is a [partial payment](#partial-payments). |
+| Field                                 | Value               | Description    |
+|:--------------------------------------|:--------------------|:---------------|
+| AffectedNodes                         | Array               | List of nodes that were created, deleted, or modified by this transaction, and specific changes to each. |
+| DeliveredAmount                       | [Currency Amount][] | **DEPRECATED.** Replaced by `delivered_amount`. Omitted if not a partial payment. |
+| TransactionIndex                      | Unsigned Integer    | The transaction's position within the ledger that included it. (For example, the value `2` means it was the 2nd transaction in that ledger.) |
+| TransactionResult                     | String              | A [result code](#result-categories) indicating whether the transaction succeeded or how it failed. |
+| [delivered_amount](#delivered-amount) | [Currency Amount][] | The [Currency Amount][] actually received by the `Destination` account. Use this field to determine how much was delivered, regardless of whether the transaction is a [partial payment](#partial-payments). _(New in [`rippled` 0.27.0][])_ |
 
 ### delivered_amount ###
 
@@ -1046,158 +1051,146 @@ If both conditions are true, then `delivered_amount` contains the string value `
 
 These codes indicate an error in the local server processing the transaction; it is possible that another server with a different configuration or load level could process the transaction successfully. They have numerical values in the range -399 to -300. The exact code for any given error is subject to change, so don't rely on it.
 
-| Code | Explanation |
-|------|-------------|
-| telBAD\_DOMAIN | The transaction specified a domain value (for example, the `Domain` field of an [AccountSet transaction](#accountset)) that cannot be used, probably because it is too long to store in the ledger. |
-| telBAD\_PATH_COUNT | The transaction contains too many paths for the local server to process. |
-| telBAD\_PUBLIC\_KEY | The transaction specified a public key value (for example, as the `MessageKey` field of an [AccountSet transaction](#accountset)) that cannot be used, probably because it is too long. |
-| telCAN\_NOT\_QUEUE | The transaction did not meet the [open ledger cost](concept-transaction-cost.html), but this server did not queue this transaction because it did not meet the [queuing restrictions](concept-transaction-cost.html#queuing-restrictions). You can try again later or sign and submit a replacement transaction with a higher transaction cost in the `Fee` field. |
+| Code                  | Explanation                                          |
+|:----------------------|:-----------------------------------------------------|
+| telBAD\_DOMAIN        | The transaction specified a domain value (for example, the `Domain` field of an [AccountSet transaction](#accountset)) that cannot be used, probably because it is too long to store in the ledger. |
+| telBAD\_PATH_COUNT    | The transaction contains too many paths for the local server to process. |
+| telBAD\_PUBLIC\_KEY   | The transaction specified a public key value (for example, as the `MessageKey` field of an [AccountSet transaction](#accountset)) that cannot be used, probably because it is too long. |
+| telCAN\_NOT\_QUEUE    | The transaction did not meet the [open ledger cost](concept-transaction-cost.html), but this server did not queue this transaction because it did not meet the [queuing restrictions](concept-transaction-cost.html#queuing-restrictions). You can try again later or sign and submit a replacement transaction with a higher transaction cost in the `Fee` field. |
 | telFAILED\_PROCESSING | An unspecified error occurred when processing the transaction. |
-| telINSUF\_FEE_P | The `Fee` from the transaction is not high enough to meet the server's current [transaction cost](concept-transaction-cost.html) requirement, which is derived from its load level. |
-| telLOCAL_ERROR | Unspecified local error. |
-| telNO\_DST\_PARTIAL | The transaction is an XRP payment that would fund a new account, but the [tfPartialPayment flag](#partial-payments) was enabled. This is disallowed. |
+| telINSUF\_FEE_P       | The `Fee` from the transaction is not high enough to meet the server's current [transaction cost](concept-transaction-cost.html) requirement, which is derived from its load level. |
+| telLOCAL_ERROR        | Unspecified local error.                             |
+| telNO\_DST\_PARTIAL   | The transaction is an XRP payment that would fund a new account, but the [tfPartialPayment flag](#partial-payments) was enabled. This is disallowed. |
 
 ### tem Codes ###
 
 These codes indicate that the transaction was malformed, and cannot succeed according to the Ripple protocol. They have numerical values in the range -299 to -200. The exact code for any given error is subject to change, so don't rely on it.
 
-| Code | Explanation |
-|------|-------------|
-| temBAD\_AMOUNT | An amount specified by the transaction (for example the destination `Amount` or `SendMax` values of a [Payment](#payment)) was invalid, possibly because it was a negative number. |
-| temBAD\_AUTH\_MASTER | The key used to sign this transaction does not match the master key for the account sending it, and the account does not have a [Regular Key](#setregularkey) set. |
-| temBAD\_CURRENCY | The transaction improperly specified a currency field. See [Specifying Currency Amounts](reference-rippled.html#specifying-currency-amounts) for the correct format. |
-| temBAD\_EXPIRATION | The transaction improperly specified an expiration value, for example as part of an [OfferCreate transaction](#offercreate). |
-| temBAD\_FEE | The transaction improperly specified its `Fee` value, for example by listing a non-XRP currency or some negative amount of XRP. |
-| temBAD\_ISSUER | The transaction improperly specified the `issuer` field of some currency included in the request. |
-| temBAD\_LIMIT | The [TrustSet](#trustset) transaction improperly specified the `LimitAmount` value of a trustline. |
-| temBAD\_OFFER | The [OfferCreate](#offercreate) transaction specifies an invalid offer, such as offering to trade XRP for itself, or offering a negative amount. |
-| temBAD\_PATH | The [Payment](#payment) transaction specifies one or more [Paths](#paths) improperly, for example including an issuer for XRP, or specifying an account differently. |
-| temBAD\_PATH\_LOOP | One of the [Paths](#paths) in the [Payment](#payment) transaction was flagged as a loop, so it cannot be processed in a bounded amount of time. |
-| temBAD\_SEND\_XRP\_LIMIT | The [Payment](#payment) transaction used the [tfLimitQuality](#limit-quality) flag in a direct XRP-to-XRP payment, even though XRP-to-XRP payments do not involve any conversions. |
-| temBAD\_SEND\_XRP\_MAX | The [Payment](#payment) transaction included a `SendMax` field in a direct XRP-to-XRP payment, even though sending XRP should never require SendMax. (XRP is only valid in SendMax if the destination `Amount` is not XRP.) |
+| Code                         | Explanation                                   |
+|:-----------------------------|:----------------------------------------------|
+| temBAD\_AMOUNT               | An amount specified by the transaction (for example the destination `Amount` or `SendMax` values of a [Payment](#payment)) was invalid, possibly because it was a negative number. |
+| temBAD\_AUTH\_MASTER         | The key used to sign this transaction does not match the master key for the account sending it, and the account does not have a [Regular Key](#setregularkey) set. |
+| temBAD\_CURRENCY             | The transaction improperly specified a currency field. See [Specifying Currency Amounts][Currency Amount] for the correct format. |
+| temBAD\_EXPIRATION           | The transaction improperly specified an expiration value, for example as part of an [OfferCreate transaction](#offercreate). |
+| temBAD\_FEE                  | The transaction improperly specified its `Fee` value, for example by listing a non-XRP currency or some negative amount of XRP. |
+| temBAD\_ISSUER               | The transaction improperly specified the `issuer` field of some currency included in the request. |
+| temBAD\_LIMIT                | The [TrustSet](#trustset) transaction improperly specified the `LimitAmount` value of a trustline. |
+| temBAD\_OFFER                | The [OfferCreate](#offercreate) transaction specifies an invalid offer, such as offering to trade XRP for itself, or offering a negative amount. |
+| temBAD\_PATH                 | The [Payment](#payment) transaction specifies one or more [Paths](#paths) improperly, for example including an issuer for XRP, or specifying an account differently. |
+| temBAD\_PATH\_LOOP           | One of the [Paths](#paths) in the [Payment](#payment) transaction was flagged as a loop, so it cannot be processed in a bounded amount of time. |
+| temBAD\_SEND\_XRP\_LIMIT     | The [Payment](#payment) transaction used the [tfLimitQuality](#limit-quality) flag in a direct XRP-to-XRP payment, even though XRP-to-XRP payments do not involve any conversions. |
+| temBAD\_SEND\_XRP\_MAX       | The [Payment](#payment) transaction included a `SendMax` field in a direct XRP-to-XRP payment, even though sending XRP should never require SendMax. (XRP is only valid in SendMax if the destination `Amount` is not XRP.) |
 | temBAD\_SEND\_XRP\_NO_DIRECT | The [Payment](#payment) transaction used the [tfNoDirectRipple](#payment-flags) flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments are always direct. |
-| temBAD\_SEND\_XRP\_PARTIAL | The [Payment](#payment) transaction used the [tfPartialPayment](#partial-payments) flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments should always deliver the full amount. |
-| temBAD\_SEND\_XRP\_PATHS | The [Payment](#payment) transaction included `Paths` while sending XRP, even though XRP-to-XRP payments should always be direct. |
-| temBAD\_SEQUENCE | The transaction is references a sequence number that is higher than its own `Sequence` number, for example trying to cancel an offer that would have to be placed after the transaction that cancels it. |
-| temBAD\_SIGNATURE | The signature to authorize this transaction is either missing, or formed in a way that is not a properly-formed signature. (See [tecNO_PERMISSION](#tec-codes) for the case where the signature is properly formed, but not authorized for this account.)  |
-| temBAD\_SRC\_ACCOUNT | The `Account` on whose behalf this transaction is being sent (the "source account") is not a properly-formed Ripple account. |
-| temBAD\_TRANSFER\_RATE | The [`TransferRate` field of an AccountSet transaction](#transferrate) is not properly formatted. |
-| temDST\_IS\_SRC | The [TrustSet](#trustset) transaction improperly specified the destination of the trust line (the `issuer` field of `LimitAmount`) as the `Account` sending the transaction. You cannot extend a trust line to yourself. (In the future, this code could also apply to other cases where the destination of a transaction is not allowed to be the account sending it.) |
-| temDST\_NEEDED | The transaction improperly omitted a destination. This could be the `Destination` field of a [Payment](#payment) transaction, or the `issuer` sub-field of the `LimitAmount` field fo a `TrustSet` transaction. |
-| temINVALID | The transaction is otherwise invalid. For example, the transaction ID may not be the right format, the signature may not be formed properly, or something else went wrong in understanding the transaction. |
-| temINVALID\_FLAG | The transaction includes a [Flag](#flags) that does not exist, or includes a contradictory combination of flags. |
-| temMALFORMED | Unspecified problem with the format of the transaction. |
-| temREDUNDANT | The transaction would do nothing; for example, it is sending a payment directly to the sending account, or creating an offer to buy and sell the same currency from the same issuer. |
-| temREDUNDANT\_SEND\_MAX | _(Removed in [rippled 0.28.0][])_ |
-| temRIPPLE\_EMPTY | The [Payment](#payment) transaction includes an empty `Paths` field, but paths are necessary to complete this payment. |
-| temBAD_WEIGHT | The [SignerListSet](#signerlistset) transaction includes a `SignerWeight` that is invalid, for example a zero or negative value. |
-| temBAD_SIGNER | The [SignerListSet](#signerlistset) transaction includes a signer who is invalid. For example, there may be duplicate entries, or the owner of the SignerList may also be a member. |
-| temBAD_QUORUM | The [SignerListSet](#signerlistset) transaction has an invalid `SignerQuorum` value. Either the value is not greater than zero, or it is more than the sum of all signers in the list. |
-| temUNCERTAIN | Used internally only. This code should never be returned. |
-| temUNKNOWN | Used internally only. This code should never be returned. |
-| temDISABLED | The transaction requires logic that is disabled. Typically this means you are trying to use an [amendment](concept-amendments.html) that is not enabled for the current ledger. |
+| temBAD\_SEND\_XRP\_PARTIAL   | The [Payment](#payment) transaction used the [tfPartialPayment](#partial-payments) flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments should always deliver the full amount. |
+| temBAD\_SEND\_XRP\_PATHS     | The [Payment](#payment) transaction included `Paths` while sending XRP, even though XRP-to-XRP payments should always be direct. |
+| temBAD\_SEQUENCE             | The transaction is references a sequence number that is higher than its own `Sequence` number, for example trying to cancel an offer that would have to be placed after the transaction that cancels it. |
+| temBAD\_SIGNATURE            | The signature to authorize this transaction is either missing, or formed in a way that is not a properly-formed signature. (See [tecNO_PERMISSION](#tec-codes) for the case where the signature is properly formed, but not authorized for this account.) |
+| temBAD\_SRC\_ACCOUNT         | The `Account` on whose behalf this transaction is being sent (the "source account") is not a properly-formed Ripple account. |
+| temBAD\_TRANSFER\_RATE       | The [`TransferRate` field of an AccountSet transaction](#transferrate) is not properly formatted. |
+| temDST\_IS\_SRC              | The [TrustSet](#trustset) transaction improperly specified the destination of the trust line (the `issuer` field of `LimitAmount`) as the `Account` sending the transaction. You cannot extend a trust line to yourself. (In the future, this code could also apply to other cases where the destination of a transaction is not allowed to be the account sending it.) |
+| temDST\_NEEDED               | The transaction improperly omitted a destination. This could be the `Destination` field of a [Payment](#payment) transaction, or the `issuer` sub-field of the `LimitAmount` field fo a `TrustSet` transaction. |
+| temINVALID                   | The transaction is otherwise invalid. For example, the transaction ID may not be the right format, the signature may not be formed properly, or something else went wrong in understanding the transaction. |
+| temINVALID\_FLAG             | The transaction includes a [Flag](#flags) that does not exist, or includes a contradictory combination of flags. |
+| temMALFORMED                 | Unspecified problem with the format of the transaction. |
+| temREDUNDANT                 | The transaction would do nothing; for example, it is sending a payment directly to the sending account, or creating an offer to buy and sell the same currency from the same issuer. |
+| temREDUNDANT\_SEND\_MAX      | _(Removed in [`rippled` 0.28.0][])_             |
+| temRIPPLE\_EMPTY             | The [Payment](#payment) transaction includes an empty `Paths` field, but paths are necessary to complete this payment. |
+| temBAD_WEIGHT                | The [SignerListSet](#signerlistset) transaction includes a `SignerWeight` that is invalid, for example a zero or negative value. |
+| temBAD_SIGNER                | The [SignerListSet](#signerlistset) transaction includes a signer who is invalid. For example, there may be duplicate entries, or the owner of the SignerList may also be a member. |
+| temBAD_QUORUM                | The [SignerListSet](#signerlistset) transaction has an invalid `SignerQuorum` value. Either the value is not greater than zero, or it is more than the sum of all signers in the list. |
+| temUNCERTAIN                 | Used internally only. This code should never be returned. |
+| temUNKNOWN                   | Used internally only. This code should never be returned. |
+| temDISABLED                  | The transaction requires logic that is disabled. Typically this means you are trying to use an [amendment](concept-amendments.html) that is not enabled for the current ledger. |
 
 
 ### tef Codes ###
 
 These codes indicate that the transaction failed and was not included in a ledger, but the transaction could have succeeded in some theoretical ledger. Typically this means that the transaction can no longer succeed in any future ledger. They have numerical values in the range -199 to -100. The exact code for any given error is subject to change, so don't rely on it.
 
-| Code | Explanation |
-|------|-------------|
-| tefALREADY | The same exact transaction has already been applied. |
-| tefBAD\_ADD\_AUTH | **DEPRECATED.** |
-| tefBAD\_AUTH | The key used to sign this account is not authorized to modify this account. (It could be authorized if the account had the same key set as the [Regular Key](#setregularkey).) |
-| tefBAD\_AUTH\_MASTER | The single signature provided to authorize this transaction does not match the master key, but no regular key is associated with this address. |
-| tefBAD\_LEDGER | While processing the transaction, the ledger was discovered in an unexpected state. If you can reproduce this error, please [report an issue](https://github.com/ripple/rippled/issues) to get it fixed. |
-| tefBAD\_QUORUM | The transaction was [multi-signed](#multi-signing), but the total weights of all included signatures did not meet the quorum. |
-| tefBAD\_SIGNATURE | The transaction was [multi-signed](#multi-signing), but contained a signature for an address not part of a SignerList associated with the sending account. |
-| tefCREATED |**DEPRECATED.** |
-| tefEXCEPTION | While processing the transaction, the server entered an unexpected state. This may be caused by unexpected inputs, for example if the binary data for the transaction is grossly malformed. If you can reproduce this error, please [report an issue](https://github.com/ripple/rippled/issues) to get it fixed. |
-| tefFAILURE | Unspecified failure in applying the transaction. |
-| tefINTERNAL | When trying to apply the transaction, the server entered an unexpected state. If you can reproduce this error, please [report an issue](https://github.com/ripple/rippled/issues) to get it fixed. |
-| tefMASTER\_DISABLED | The transaction was signed with the account's master key, but the account has the `lsfDisableMaster` field set. |
-| tefMAX\_LEDGER | The transaction included a [`LastLedgerSequence`](#lastledgersequence) parameter, but the current ledger's sequence number is already higher than the specified value. |
-| tefNO\_AUTH\_REQUIRED | The [TrustSet](#trustset) transaction tried to mark a trustline as authorized, but the `lsfRequireAuth` flag is not enabled for the corresponding account, so authorization is not necessary. |
+| Code                   | Explanation                                         |
+|:-----------------------|:----------------------------------------------------|
+| tefALREADY             | The same exact transaction has already been applied. |
+| tefBAD\_ADD\_AUTH      | **DEPRECATED.**                                     |
+| tefBAD\_AUTH           | The key used to sign this account is not authorized to modify this account. (It could be authorized if the account had the same key set as the [Regular Key](#setregularkey).) |
+| tefBAD\_AUTH\_MASTER   | The single signature provided to authorize this transaction does not match the master key, but no regular key is associated with this address. |
+| tefBAD\_LEDGER         | While processing the transaction, the ledger was discovered in an unexpected state. If you can reproduce this error, please [report an issue](https://github.com/ripple/rippled/issues) to get it fixed. |
+| tefBAD\_QUORUM         | The transaction was [multi-signed](#multi-signing), but the total weights of all included signatures did not meet the quorum. |
+| tefBAD\_SIGNATURE      | The transaction was [multi-signed](#multi-signing), but contained a signature for an address not part of a SignerList associated with the sending account. |
+| tefCREATED             | **DEPRECATED.**                                     |
+| tefEXCEPTION           | While processing the transaction, the server entered an unexpected state. This may be caused by unexpected inputs, for example if the binary data for the transaction is grossly malformed. If you can reproduce this error, please [report an issue](https://github.com/ripple/rippled/issues) to get it fixed. |
+| tefFAILURE             | Unspecified failure in applying the transaction.    |
+| tefINTERNAL            | When trying to apply the transaction, the server entered an unexpected state. If you can reproduce this error, please [report an issue](https://github.com/ripple/rippled/issues) to get it fixed. |
+| tefMASTER\_DISABLED    | The transaction was signed with the account's master key, but the account has the `lsfDisableMaster` field set. |
+| tefMAX\_LEDGER         | The transaction included a [`LastLedgerSequence`](#lastledgersequence) parameter, but the current ledger's sequence number is already higher than the specified value. |
+| tefNO\_AUTH\_REQUIRED  | The [TrustSet](#trustset) transaction tried to mark a trustline as authorized, but the `lsfRequireAuth` flag is not enabled for the corresponding account, so authorization is not necessary. |
 | tefNOT\_MULTI\_SIGNING | The transaction was [multi-signed](#multi-signing), but the sending account has no SignerList defined. |
-| tefPAST\_SEQ | The sequence number of the transaction is lower than the current sequence number of the account sending the transaction. |
-| tefWRONG\_PRIOR | The transaction contained an `AccountTxnID` field (or the deprecated `PreviousTxnID` field), but the transaction specified there does not match the account's previous transaction. |
+| tefPAST\_SEQ           | The sequence number of the transaction is lower than the current sequence number of the account sending the transaction. |
+| tefWRONG\_PRIOR        | The transaction contained an `AccountTxnID` field (or the deprecated `PreviousTxnID` field), but the transaction specified there does not match the account's previous transaction. |
 
 ### ter Codes ###
 
 These codes indicate that the transaction failed, but it could apply successfully in the future, usually if some other hypothetical transaction applies first. They have numerical values in the range -99 to -1. The exact code for any given error is subject to change, so don't rely on it.
 
-| Code | Explanation |
-|------|-------------|
-| terFUNDS\_SPENT | **DEPRECATED.** |
+| Code             | Explanation                                               |
+|:-----------------|:----------------------------------------------------------|
+| terFUNDS\_SPENT  | **DEPRECATED.**                                           |
 | terINSUF\_FEE\_B | The account sending the transaction does not have enough XRP to pay the `Fee` specified in the transaction. |
-| terLAST | Used internally only. This code should never be returned. |
-| terNO\_ACCOUNT | The address sending the transaction is not funded in the ledger (yet). |
-| terNO\_AUTH | The transaction would involve adding currency issued by an account with `lsfRequireAuth` enabled to a trust line that is not authorized. For example, you placed an offer to buy a currency you aren't authorized to hold. |
-| terNO\_LINE | Used internally only. This code should never be returned. |
-| terNO\_RIPPLE | Used internally only. This code should never be returned. |
-| terOWNERS | The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the [`lsfRequireAuth`](#accountset-flags) flag if it has any trust lines or available offers. |
-| terPRE\_SEQ | The `Sequence` number of the current transaction is higher than the current sequence number of the account sending the transaction. |
-| terRETRY | Unspecified retriable error. |
-| terQUEUED | The transaction met the load-scaled [transaction cost](concept-transaction-cost.html) but did not meet the open ledger requirement, so the transaction has been queued for a future ledger. |
+| terLAST          | Used internally only. This code should never be returned. |
+| terNO\_ACCOUNT   | The address sending the transaction is not funded in the ledger (yet). |
+| terNO\_AUTH      | The transaction would involve adding currency issued by an account with `lsfRequireAuth` enabled to a trust line that is not authorized. For example, you placed an offer to buy a currency you aren't authorized to hold. |
+| terNO\_LINE      | Used internally only. This code should never be returned. |
+| terNO\_RIPPLE    | Used internally only. This code should never be returned. |
+| terOWNERS        | The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the [`lsfRequireAuth`](#accountset-flags) flag if it has any trust lines or available offers. |
+| terPRE\_SEQ      | The `Sequence` number of the current transaction is higher than the current sequence number of the account sending the transaction. |
+| terRETRY         | Unspecified retriable error.                              |
+| terQUEUED        | The transaction met the load-scaled [transaction cost](concept-transaction-cost.html) but did not meet the open ledger requirement, so the transaction has been queued for a future ledger. |
 
 ### tes Success ###
 
 The code `tesSUCCESS` is the only code that indicates a transaction succeeded. This does not always mean it did what it was supposed to do. (For example, an [OfferCancel](#offercancel) can "succeed" even if there is no offer for it to cancel.) Success uses the numerical value 0.
 
-| Code | Explanation |
-|------|-------------|
+| Code       | Explanation                                                     |
+|:-----------|:----------------------------------------------------------------|
 | tesSUCCESS | The transaction was applied and forwarded to other servers. If this appears in a validated ledger, then the transaction's success is final. |
 
 ### tec Codes ###
 
 These codes indicate that the transaction failed, but it was applied to a ledger to apply the [transaction cost](concept-transaction-cost.html). They have numerical values in the range 100 to 199. The exact codes sometimes appear in ledger data, so they do not change, but we recommend not relying on the numeric value regardless.
 
-| Code | Value | Explanation |
-|------|-------|-------------|
-| tecCLAIM | 100 | Unspecified failure, with transaction cost destroyed. |
-| tecDIR\_FULL | 121 | The address sending the transaction cannot own any more objects in the ledger. |
-| tecDST\_TAG\_NEEDED | 143 | The [Payment](#payment) transaction omitted a destination tag, but the destination account has the `lsfRequireDestTag` flag enabled. _(New in [rippled 0.28.0][])_ |
-| tecFAILED\_PROCESSING | 105 | An unspecified error occurred when processing the transaction. |
-| tecFROZEN | 137 | The [OfferCreate transaction](#offercreate) failed because one or both of the assets involved are subject to a [global freeze](concept-freeze.html). |
-| tecINSUF\_RESERVE\_LINE | 122 | The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: [Reserves](concept-reserves.html)) This error occurs when the counterparty already has a trust line in a non-default state to the sending account for the same currency. (See tecNO\_LINE\_INSUF\_RESERVE for the other case.) |
-| tecINSUF\_RESERVE\_OFFER | 123 | The transaction failed because the sending account does not have enough XRP to create a new Offer. (See: [Reserves](concept-reserves.html)) |
-| tecINSUFFICIENT\_RESERVE | 141 | The [SignerListSet](#signerlistset) or other transaction would increase the [reserve requirement](concept-reserves.html) higher than the sending account's balance. See [SignerLists and Reserves](reference-ledger-format.html#signerlists-and-reserves) for more information. |
-| tecINTERNAL | 144 | Unspecified internal error, with transaction cost applied. This error code should not normally be returned. |
-| tecNEED\_MASTER\_KEY | 142 | This transaction tried to cause changes that require the master key, such as [disabling the master key or giving up the ability to freeze balances](#accountset-flags). _(New in [rippled 0.28.0](https://github.com/ripple/rippled/releases/tag/0.28.0-rc1))_ |
-| tecNO\_ALTERNATIVE\_KEY | 130 | The transaction tried to remove the only available method of [authorizing transactions](#authorizing-transactions). This could be a [SetRegularKey transaction](#setregularkey) to remove the regular key, a [SignerListSet transaction](#signerlistset) to delete a SignerList, or an [AccountSet transaction](#accountset) to disable the master key. (Prior to [rippled 0.30.0](https://github.com/ripple/rippled/releases/tag/0.30.0), this was called `tecMASTER_DISABLED`.) |
-| tecNO\_AUTH | 134 | The transaction failed because it needs to add a balance on a trust line to an account with the `lsfRequireAuth` flag enabled, and that trust line has not been authorized. If the trust line does not exist at all, tecNO\_LINE occurs instead. |
-| tecNO\_DST | 124 | The account on the receiving end of the transaction does not exist. This includes Payment and TrustSet transaction types. (It could be created if it received enough XRP.) |
-| tecNO\_DST\_INSUF_XRP | 125 | The account on the receiving end of the transaction does not exist, and the transaction is not sending enough XRP to create it. |
-| tecNO\_ENTRY | 140 | Reserved for future use. |
-| tecNO\_ISSUER | 133 | The account specified in the `issuer` field of a currency amount does not exist. |
-| tecNO\_LINE | 135 | The `TakerPays` field of the [OfferCreate transaction](#offercreate) specifies an asset whose issuer has `lsfRequireAuth` enabled, and the account making the offer does not have a trust line for that asset. (Normally, making an offer implicitly creates a trust line if necessary, but in this case it does not bother because you cannot hold the asset without authorization.) If the trust line exists, but is not authorized, `tecNO_AUTH` occurs instead. |
-| tecNO\_LINE\_INSUF\_RESERVE | 126 | The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: [Reserves](concept-reserves.html)) This error occurs when the counterparty does not have a trust line to this account for the same currency. (See tecINSUF\_RESERVE\_LINE for the other case.) |
-| tecNO\_LINE\_REDUNDANT | 127 | The transaction failed because it tried to set a trust line to its default state, but the trust line did not exist. |
-| tecNO\_PERMISSION | 139 | Reserved for future use. |
-| tecNO\_REGULAR\_KEY | 131 | The [AccountSet transaction](#accountset) tried to disable the master key, but the account does not have another way to [authorize transactions](#authorizing-transactions). If [multi-signing](#multi-signing) is enabled, this code is deprecated and `tecNO_ALTERNATIVE_KEY` is used instead. |
-| tecNO\_TARGET | 138 | Reserved for future use. |
-| tecOVERSIZE | 145 | This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. _(New in [rippled 0.29.0-hf1](https://github.com/ripple/rippled/releases/tag/0.29.0-hf1) )_ |
-| tecOWNERS | 132 | The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the [`lsfRequireAuth`](#accountset-flags) flag if it has any trust lines or available offers. |
-| tecPATH\_DRY | 128 | The transaction failed because the provided paths did not have enough liquidity to send anything at all. This could mean that the source and destination accounts are not linked by trust lines. |
-| tecPATH\_PARTIAL | 101 | The transaction failed because the provided paths did not have enough liquidity to send the full amount. |
-| tecUNFUNDED | 129 | **DEPRECATED.** Replaced by tecUNFUNDED\_OFFER and tecUNFUNDED\_PAYMENT. |
-| tecUNFUNDED\_ADD | 102 | **DEPRECATED.** |
-| tecUNFUNDED\_PAYMENT | 104 | The transaction failed because the sending account is trying to send more XRP than it holds, not counting the reserve. (See: [Reserves](concept-reserves.html)) |
-| tecUNFUNDED\_OFFER | 103 | The [OfferCreate transaction](#offercreate) failed because the account creating the offer does not have any of the `TakerGets` currency. |
+| Code                        | Value | Explanation                            |
+|:----------------------------|:------|:---------------------------------------|
+| tecCLAIM                    | 100   | Unspecified failure, with transaction cost destroyed. |
+| tecDIR\_FULL                | 121   | The address sending the transaction cannot own any more objects in the ledger. |
+| tecDST\_TAG\_NEEDED         | 143   | The [Payment](#payment) transaction omitted a destination tag, but the destination account has the `lsfRequireDestTag` flag enabled. _(New in [`rippled` 0.28.0][])_ |
+| tecFAILED\_PROCESSING       | 105   | An unspecified error occurred when processing the transaction. |
+| tecFROZEN                   | 137   | The [OfferCreate transaction](#offercreate) failed because one or both of the assets involved are subject to a [global freeze](concept-freeze.html). |
+| tecINSUF\_RESERVE\_LINE     | 122   | The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: [Reserves](concept-reserves.html)) This error occurs when the counterparty already has a trust line in a non-default state to the sending account for the same currency. (See tecNO\_LINE\_INSUF\_RESERVE for the other case.) |
+| tecINSUF\_RESERVE\_OFFER    | 123   | The transaction failed because the sending account does not have enough XRP to create a new Offer. (See: [Reserves](concept-reserves.html)) |
+| tecINSUFFICIENT\_RESERVE    | 141   | The [SignerListSet](#signerlistset) or other transaction would increase the [reserve requirement](concept-reserves.html) higher than the sending account's balance. See [SignerLists and Reserves](reference-ledger-format.html#signerlists-and-reserves) for more information. |
+| tecINTERNAL                 | 144   | Unspecified internal error, with transaction cost applied. This error code should not normally be returned. |
+| tecNEED\_MASTER\_KEY        | 142   | This transaction tried to cause changes that require the master key, such as [disabling the master key or giving up the ability to freeze balances](#accountset-flags). _(New in [`rippled` 0.28.0][])_ |
+| tecNO\_ALTERNATIVE\_KEY     | 130   | The transaction tried to remove the only available method of [authorizing transactions](#authorizing-transactions). This could be a [SetRegularKey transaction](#setregularkey) to remove the regular key, a [SignerListSet transaction](#signerlistset) to delete a SignerList, or an [AccountSet transaction](#accountset) to disable the master key. (Prior to [`rippled` 0.30.0][], this was called `tecMASTER_DISABLED`.) |
+| tecNO\_AUTH                 | 134   | The transaction failed because it needs to add a balance on a trust line to an account with the `lsfRequireAuth` flag enabled, and that trust line has not been authorized. If the trust line does not exist at all, tecNO\_LINE occurs instead. |
+| tecNO\_DST                  | 124   | The account on the receiving end of the transaction does not exist. This includes Payment and TrustSet transaction types. (It could be created if it received enough XRP.) |
+| tecNO\_DST\_INSUF_XRP       | 125   | The account on the receiving end of the transaction does not exist, and the transaction is not sending enough XRP to create it. |
+| tecNO\_ENTRY                | 140   | Reserved for future use.               |
+| tecNO\_ISSUER               | 133   | The account specified in the `issuer` field of a currency amount does not exist. |
+| tecNO\_LINE                 | 135   | The `TakerPays` field of the [OfferCreate transaction](#offercreate) specifies an asset whose issuer has `lsfRequireAuth` enabled, and the account making the offer does not have a trust line for that asset. (Normally, making an offer implicitly creates a trust line if necessary, but in this case it does not bother because you cannot hold the asset without authorization.) If the trust line exists, but is not authorized, `tecNO_AUTH` occurs instead. |
+| tecNO\_LINE\_INSUF\_RESERVE | 126   | The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: [Reserves](concept-reserves.html)) This error occurs when the counterparty does not have a trust line to this account for the same currency. (See tecINSUF\_RESERVE\_LINE for the other case.) |
+| tecNO\_LINE\_REDUNDANT      | 127   | The transaction failed because it tried to set a trust line to its default state, but the trust line did not exist. |
+| tecNO\_PERMISSION           | 139   | Reserved for future use.               |
+| tecNO\_REGULAR\_KEY         | 131   | The [AccountSet transaction](#accountset) tried to disable the master key, but the account does not have another way to [authorize transactions](#authorizing-transactions). If [multi-signing](#multi-signing) is enabled, this code is deprecated and `tecNO_ALTERNATIVE_KEY` is used instead. |
+| tecNO\_TARGET               | 138   | Reserved for future use.               |
+| tecOVERSIZE                 | 145   | This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. _(New in [`rippled` 0.29.0-hf1][] )_ |
+| tecOWNERS                   | 132   | The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the [`lsfRequireAuth`](#accountset-flags) flag if it has any trust lines or available offers. |
+| tecPATH\_DRY                | 128   | The transaction failed because the provided paths did not have enough liquidity to send anything at all. This could mean that the source and destination accounts are not linked by trust lines. |
+| tecPATH\_PARTIAL            | 101   | The transaction failed because the provided paths did not have enough liquidity to send the full amount. |
+| tecUNFUNDED                 | 129   | **DEPRECATED.** Replaced by tecUNFUNDED\_OFFER and tecUNFUNDED\_PAYMENT. |
+| tecUNFUNDED\_ADD            | 102   | **DEPRECATED.**                        |
+| tecUNFUNDED\_PAYMENT        | 104   | The transaction failed because the sending account is trying to send more XRP than it holds, not counting the reserve. (See: [Reserves](concept-reserves.html)) |
+| tecUNFUNDED\_OFFER          | 103   | The [OfferCreate transaction](#offercreate) failed because the account creating the offer does not have any of the `TakerGets` currency. |
 
-### tej Codes ###
 
-These codes are only ever returned by the `ripple-lib` client library, not by `rippled` itself.
+{% include 'snippets/rippled_versions.md' %}
 
-| Code | Explanation |
-|------|-------------|
-| tejAbort | The transaction was manually canceled by calling `transaction.abort()`. |
-| tejAttemptsExceeded | The transaction was submitted multiple times, up to a total equal to the max attempts setting, without being successfully included in a ledger. |
-| tejInvalidFlag | One of the flags specified was invalid, or does not apply to this transaction type. |
-| tejLocalSigningRequired | The transaction could not be resubmitted because local signing is disabled. |
-| tejMaxFeeExceeded | The [transaction cost](concept-transaction-cost.html) that would be necessary to send the transaction is higher than the maximum transaction cost setting, which is either the `_MaxFee` parameter of the Transaction (if provided) or the maximum transaction cost configured for the remote. The default value is 1 XRP (100000 drops). |
-| tejMaxLedger | Validated ledgers have surpassed the `LastLedgerSequence` parameter of the transaction without including it, so it can no longer succeed. (Also see [Reliable Transaction Submission](tutorial-reliable-transaction-submission.html).) When using ripple-lib, this error effectively replaces all non-final errors, including tel-, tef-, and ter-class response codes. |
-| tejSecretInvalid | The secret included for signing this transaction was not a properly-formatted secret. |
-| tejSecretUnknown | The secret for a given account was omitted from the transaction, and ripple-lib was unable to automatically fill it in from saved data. |
-| tejServerUntrusted | The application attempted to submit an account secret to an untrusted server for transaction signing. |
-| tejUnconnected | The application is not connected to a `rippled` server, but it needs to be to process the transaction. |
+[Currency Amount]: reference-rippled.html#specifying-currency-amounts

--- a/content/snippets/rippled_versions.md
+++ b/content/snippets/rippled_versions.md
@@ -1,0 +1,22 @@
+<!---- rippled release notes links ---->
+[`rippled` 0.26.0]: https://github.com/ripple/rippled/releases/tag/0.26.0
+[`rippled` 0.26.1]: https://github.com/ripple/rippled/releases/tag/0.26.1
+[`rippled` 0.26.2]: https://github.com/ripple/rippled/releases/tag/0.26.2
+[`rippled` 0.26.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.3-sp1
+[`rippled` 0.26.4]: https://github.com/ripple/rippled/releases/tag/0.26.4
+[`rippled` 0.26.4-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.4-sp1
+[`rippled` 0.27.0]: https://github.com/ripple/rippled/releases/tag/0.27.0
+[`rippled` 0.27.1]: https://github.com/ripple/rippled/releases/tag/0.27.1
+[`rippled` 0.27.2]: https://github.com/ripple/rippled/releases/tag/0.27.2
+[`rippled` 0.27.3]: https://github.com/ripple/rippled/releases/tag/0.27.3
+[`rippled` 0.27.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp1
+[`rippled` 0.27.3-sp2]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp2
+[`rippled` 0.27.4]: https://github.com/ripple/rippled/releases/tag/0.27.4
+[`rippled` 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0
+[`rippled` 0.28.2]: https://github.com/ripple/rippled/releases/tag/0.28.2
+[`rippled` 0.29.0]: https://github.com/ripple/rippled/releases/tag/0.29.0
+[`rippled` 0.29.0-hf1]: https://github.com/ripple/rippled/releases/tag/0.29.0-hf1
+[`rippled` 0.30.0]: https://github.com/ripple/rippled/releases/tag/0.30.0
+[`rippled` 0.30.1]: https://github.com/ripple/rippled/releases/tag/0.30.1
+[`rippled` 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0
+[`rippled` 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0

--- a/reference-ledger-format.html
+++ b/reference-ledger-format.html
@@ -189,7 +189,7 @@
 <tr>
 <th>Field</th>
 <th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
+<th><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
 <th>Description</th>
 </tr>
 </thead>
@@ -302,7 +302,7 @@
 <tr>
 <th>Field</th>
 <th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
+<th><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
 <th>Description</th>
 </tr>
 </thead>
@@ -528,7 +528,7 @@
 <tr>
 <th>Name</th>
 <th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
+<th><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
 <th>Description</th>
 </tr>
 </thead>
@@ -664,7 +664,7 @@
 <tr>
 <th>Name</th>
 <th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
+<th><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
 <th>Description</th>
 </tr>
 </thead>
@@ -837,7 +837,7 @@
 <td>Balance</td>
 <td>Object</td>
 <td>Amount</td>
-<td>The balance of the trust line, from the perspective of the low account. A negative balance indicates that the low account has issued currency to the high account. The issuer in this is always set to the neutral value <a href="https://wiki.ripple.com/Accounts#ACCOUNT_ONE">ACCOUNT_ONE</a>.</td>
+<td>The balance of the trust line, from the perspective of the low account. A negative balance indicates that the low account has issued currency to the high account. The issuer in this is always set to the neutral value <a href="reference-rippled.html#special-addresses">ACCOUNT_ONE</a>.</td>
 </tr>
 <tr>
 <td>LowLimit</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1161,7 +1161,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>signer_lists</td>
 <td>Boolean</td>
-<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></td>
+<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1209,7 +1209,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>signer_lists</td>
 <td>Array</td>
-<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></td>
+<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
 </tr>
 <tr>
 <td>ledger_current_index</td>
@@ -1224,7 +1224,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>validated</td>
 <td>Boolean</td>
-<td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.0">version 0.26.0</a>)</em></td>
+<td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. <em>(New in [<code>rippled</code> 0.26.0][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1295,12 +1295,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4">version 0.26.4</a>)</em></td>
+<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>(Optional) Server-provided value to specify where to resume retrieving data from. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4">version 0.26.4</a>)</em></td>
+<td>(Optional) Server-provided value to specify where to resume retrieving data from. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1415,22 +1415,22 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>ledger_current_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">version 0.26.4-sp1</a>)</em></td>
+<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">version 0.26.4-sp1</a>)</em></td>
+<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">version 0.26.4-sp1</a>)</em></td>
+<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4">version 0.26.4</a>)</em></td>
+<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1573,12 +1573,12 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4">version 0.26.4</a>)</em></td>
+<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-provided value to specify where to resume retrieving data from. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4">version 0.26.4</a>)</em></td>
+<td>Server-provided value to specify where to resume retrieving data from. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1695,22 +1695,22 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>ledger_current_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">version 0.26.4-sp1</a>)</em></td>
+<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">version 0.26.4-sp1</a>)</em></td>
+<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1">version 0.26.4-sp1</a>)</em></td>
+<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.26.4">version 0.26.4</a>)</em></td>
+<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1747,12 +1747,12 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>quality</td>
 <td>Number</td>
-<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0">version 0.29.0</a>)</em></td>
+<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. <em>(New in [<code>rippled</code> 0.29.0][])</em></td>
 </tr>
 <tr>
 <td>expiration</td>
 <td>Unsigned integer</td>
-<td>(May be omitted) A time after which this offer is considered unfunded, as <a href="#specifying-time">the number of seconds since the Ripple Epoch</a>. See also: <a href="reference-transaction-format.html#expiration">Offer Expiration</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>(May be omitted) A time after which this offer is considered unfunded, as <a href="#specifying-time">the number of seconds since the Ripple Epoch</a>. See also: <a href="reference-transaction-format.html#expiration">Offer Expiration</a>. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -3302,7 +3302,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </ul>
 <h2 id="gateway-balances">gateway_balances</h2>
 <p><a href="https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by <a href="concept-issuing-and-operational-addresses.html">operational addresses</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.2">version 0.28.2</a>.)</em></p>
+<p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by <a href="concept-issuing-and-operational-addresses.html">operational addresses</a>. <em>(New in [<code>rippled</code> 0.28.2][].)</em></p>
 <h4 id="request-format-7">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-17"><ul class="codetabs"><li><a href="#code-17-0">WebSocket</a></li><li><a href="#code-17-1">JSON-RPC</a></li></ul>
@@ -3558,7 +3558,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp" title="Source">[Source]<br/></a></p>
 <p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded address stored in the ledger, the address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
 <p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em> (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)</p>
-<p><em>(Updated in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
+<p><em>(Updated in [<code>rippled</code> 0.31.0][])</em></p>
 <h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-19"><ul class="codetabs"><li><a href="#code-19-0">WebSocket (with key type)</a></li><li><a href="#code-19-1">WebSocket (no key type)</a></li><li><a href="#code-19-2">JSON-RPC (with key type)</a></li><li><a href="#code-19-3">JSON-RPC (no key type)</a></li><li><a href="#code-19-4">Commandline</a></li></ul>
@@ -3743,7 +3743,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>warning</td>
 <td>String</td>
-<td>(May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -3845,7 +3845,7 @@ rippled ledger current
 <tr>
 <td>binary</td>
 <td>Boolean</td>
-<td>(Optional, defaults to false) If <code>transactions</code> and <code>expand</code> are both true, and this option is also true, return transaction information in binary format instead of JSON format. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0">version 0.28.0</a>)</em></td>
+<td>(Optional, defaults to false) If <code>transactions</code> and <code>expand</code> are both true, and this option is also true, return transaction information in binary format instead of JSON format. <em>(New in [<code>rippled</code> 0.28.0][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -4898,7 +4898,7 @@ Connecting to 127.0.0.1:5005
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing. This error can also occur if you specify a ledger index equal or higher than the current in-progress ledger.</li>
-<li><code>lgrNotFound</code> - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. <em>(<strong>Note:</strong> Prior to <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>, this error used the code <code>ledgerNotFound</code> instead.)</em></li>
+<li><code>lgrNotFound</code> - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. <em>(<strong>Note:</strong> Prior to [<code>rippled</code> 0.30.1][], this error used the code <code>ledgerNotFound</code> instead.)</em></li>
 </ul>
 <h2 id="ledger-accept">ledger_accept</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp" title="Source">[Source]<br/></a></p>
@@ -6378,12 +6378,12 @@ rippled tx_history 0
 <tr>
 <td>destination_amount</td>
 <td>String or Object</td>
-<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
+<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in [<code>rippled</code> 0.30.0][])</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
 </tr>
 <tr>
 <td>send_max</td>
 <td>String or Object</td>
-<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em></td>
+<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <em>(New in [<code>rippled</code> 0.30.0][])</em></td>
 </tr>
 <tr>
 <td>paths</td>
@@ -6800,7 +6800,7 @@ rippled tx_history 0
 <tr>
 <td>full_reply</td>
 <td>Boolean</td>
-<td>If <code>false</code>, this is the result of an incomplete search. A later reply may have a better path. If <code>true</code>, then this is the best path found. (It is still theoretically possible that a better path could exist, but <code>rippled</code> won't find it.) Until you close the pathfinding request, <code>rippled</code> continues to send updates each time a new ledger closes. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0">version 0.29.0</a>)</em></td>
+<td>If <code>false</code>, this is the result of an incomplete search. A later reply may have a better path. If <code>true</code>, then this is the best path found. (It is still theoretically possible that a better path could exist, but <code>rippled</code> won't find it.) Until you close the pathfinding request, <code>rippled</code> continues to send updates each time a new ledger closes. <em>(New in [<code>rippled</code> 0.29.0][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -7050,12 +7050,12 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <tr>
 <td>destination_amount</td>
 <td>String or Object</td>
-<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
+<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in [<code>rippled</code> 0.30.0][])</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
 </tr>
 <tr>
 <td>send_max</td>
 <td>String or Object</td>
-<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">version 0.30.0</a>)</em></td>
+<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <em>(New in [<code>rippled</code> 0.30.0][])</em></td>
 </tr>
 <tr>
 <td>source_currencies</td>
@@ -7468,7 +7468,7 @@ rippled sign s██████████████████████
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional, defaults to 1) Signing fails with the error <code>rpcHIGH_FEE</code> if the current <a href="concept-transaction-cost.html#local-load-cost">load multiplier on the transaction cost</a> is greater than (<code>fee_mult_max</code> ÷ <code>fee_div_max</code>). Ignored if you specify the <code>Fee</code> field of the transaction (<a href="concept-transaction-cost.html">transaction cost</a>). <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>(Optional, defaults to 1) Signing fails with the error <code>rpcHIGH_FEE</code> if the current <a href="concept-transaction-cost.html#local-load-cost">load multiplier on the transaction cost</a> is greater than (<code>fee_mult_max</code> ÷ <code>fee_div_max</code>). Ignored if you specify the <code>Fee</code> field of the transaction (<a href="concept-transaction-cost.html">transaction cost</a>). <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -7607,7 +7607,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="sign-for">sign_for</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SignFor.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>sign_for</code> command provides one signature for a <a href="reference-transaction-format.html#multi-signing">multi-signed transaction</a>.</p>
-<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
+<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
 <h4 id="request-format-24">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-49"><ul class="codetabs"><li><a href="#code-49-0">WebSocket</a></li><li><a href="#code-49-1">JSON-RPC</a></li><li><a href="#code-49-2">Commandline</a></li></ul>
@@ -7982,7 +7982,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional, defaults to 1) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>(Optional, defaults to 1) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -8185,7 +8185,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="submit-multisigned">submit_multisigned</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SubmitMultiSigned.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>submit_multisigned</code> command applies a <a href="reference-transaction-format.html#multi-signing">multi-signed</a> transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the <a href="#submit-only-mode"><code>submit</code> command in submit-only mode</a>.)</p>
-<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
+<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
 <h4 id="request-format-27">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-54"><ul class="codetabs"><li><a href="#code-54-0">WebSocket</a></li><li><a href="#code-54-1">JSON-RPC</a></li><li><a href="#code-54-2">Commandline</a></li></ul>
@@ -8932,7 +8932,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tbody>
 </table>
 <h3 id="validations-stream">Validations Stream</h3>
-<p><em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0">version 0.29.0</a>)</em></p>
+<p><em>(New in [<code>rippled</code> 0.29.0][])</em></p>
 <p>The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:</p>
 <pre><code>{
     "type": "validationReceived",
@@ -8975,22 +8975,22 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td><code>amendments</code></td>
 <td>Array of Strings</td>
-<td>(May be omitted) The <a href="concept-amendments.html">amendments</a> this server wants to be added to the protocol. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The <a href="concept-amendments.html">amendments</a> this server wants to be added to the protocol. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>base_fee</code></td>
 <td>Integer</td>
-<td>(May be omitted) The unscaled transaction cost (<code>reference_fee</code> value) this server wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The unscaled transaction cost (<code>reference_fee</code> value) this server wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>flags</code></td>
 <td>Number</td>
-<td>Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>full</code></td>
 <td>Boolean</td>
-<td>If <code>true</code>, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>If <code>true</code>, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>ledger_hash</code></td>
@@ -9000,22 +9000,22 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td><code>ledger_index</code></td>
 <td>String - Integer</td>
-<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></td>
+<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
 </tr>
 <tr>
 <td><code>load_fee</code></td>
 <td>Integer</td>
-<td>(May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>reserve_base</code></td>
 <td>Integer</td>
-<td>(May be omitted) The minimum reserve requirement (<code>account_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The minimum reserve requirement (<code>account_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>reserve_inc</code></td>
 <td>Integer</td>
-<td>(May be omitted) The increment in the reserve requirement (<code>owner_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The increment in the reserve requirement (<code>owner_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>signature</code></td>
@@ -9025,7 +9025,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td><code>signing_time</code></td>
 <td>Number</td>
-<td>When this validation vote was signed, in seconds since the <a href="#specifying-time">Ripple Epoch</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>When this validation vote was signed, in seconds since the <a href="#specifying-time">Ripple Epoch</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td><code>validation_public_key</code></td>
@@ -9855,12 +9855,12 @@ rippled server_info
 <tr>
 <td>load_factor_fee_escalation</td>
 <td>Number</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the open ledger. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the open ledger. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td>load_factor_fee_queue</td>
 <td>Number</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the queue, if the queue is full. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the queue, if the queue is full. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -9885,22 +9885,22 @@ rippled server_info
 <tr>
 <td>state_accounting</td>
 <td>Object</td>
-<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.duration_us</td>
 <td>String</td>
-<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.transitions</td>
 <td>Number</td>
-<td>The number of times the server has transitioned into this state. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of times the server has transitioned into this state. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>Number of consecutive seconds that the server has been operational. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>Number of consecutive seconds that the server has been operational. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -10220,17 +10220,17 @@ rippled server_state
 <tr>
 <td>load_factor_fee_escalation</td>
 <td>Integer</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the open ledger, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the open ledger, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td>load_factor_fee_queue</td>
 <td>Integer</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the queue, if the queue is full, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the queue, if the queue is full, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td>load_factor_fee_reference</td>
 <td>Integer</td>
-<td>(May be omitted) The <a href="concept-transaction-cost.html">transaction cost</a> with no load scaling, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>)</em></td>
+<td>(May be omitted) The <a href="concept-transaction-cost.html">transaction cost</a> with no load scaling, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -10255,22 +10255,22 @@ rippled server_state
 <tr>
 <td>state_accounting</td>
 <td>Object</td>
-<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.duration_us</td>
 <td>String</td>
-<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>state_accounting.*.transitions</td>
 <td>Number</td>
-<td>The number of times the server has transitioned into this state. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of times the server has transitioned into this state. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>Number of consecutive seconds that the server has been operational. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>Number of consecutive seconds that the server has been operational. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -10823,7 +10823,7 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="feature">feature</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Feature1.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
+<p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
 <p>You can use the <code>feature</code> command to temporarily configure the server to vote against or in favor of an amendment. This change does not persist if you restart the server. To make lasting changes in amendment voting, use the <code>rippled.cfg</code> file. See <a href="concept-amendments.html#configuring-amendment-voting">Configuring Amendment Voting</a> for more information.</p>
 <p><em>The <code>feature</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
 <h4 id="request-format-36">Request Format</h4>
@@ -11013,8 +11013,8 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="fee">fee</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
-<p><em>As of <a href="https://github.com/ripple/rippled/releases/tag/0.32.0">version 0.32.0</a>, this is a public command available to unprivileged users.</em></p>
+<p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
+<p><em>As of [<code>rippled</code> 0.32.0][], this is a public command available to unprivileged users.</em></p>
 <h4 id="request-format-37">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-73"><ul class="codetabs"><li><a href="#code-73-0">WebSocket</a></li><li><a href="#code-73-1">JSON-RPC</a></li><li><a href="#code-73-2">Commandline</a></li></ul>
@@ -12216,7 +12216,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>cluster</td>
 <td>Object</td>
-<td>Summary of other <code>rippled</code> servers in the same cluster, if <a href="tutorial-rippled-setup.html#clustering">configured as a cluster</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>Summary of other <code>rippled</code> servers in the same cluster, if <a href="tutorial-rippled-setup.html#clustering">configured as a cluster</a>. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -12325,7 +12325,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>The number of seconds that your <code>rippled</code> server has been continuously connected to this peer. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.30.1">version 0.30.1</a>)</em></td>
+<td>The number of seconds that your <code>rippled</code> server has been continuously connected to this peer. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
 </tr>
 <tr>
 <td>version</td>

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -196,7 +196,6 @@
 <li class="level-3"><a href="#ter-codes">ter Codes</a></li>
 <li class="level-3"><a href="#tes-success">tes Success</a></li>
 <li class="level-3"><a href="#tec-codes">tec Codes</a></li>
-<li class="level-3"><a href="#tej-codes">tej Codes</a></li>
 
             </ul>
         </div>
@@ -416,88 +415,88 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Account</td>
-<td>String</td>
-<td>Account</td>
-<td>The unique address of the account that initiated the transaction.</td>
+<td align="left">Account</td>
+<td align="left">String</td>
+<td align="left">Account</td>
+<td align="left">The unique address of the account that initiated the transaction.</td>
 </tr>
 <tr>
-<td><a href="#accounttxnid">AccountTxnID</a></td>
-<td>String</td>
-<td>Hash256</td>
-<td>(Optional) Hash value identifying another transaction. This transaction is only valid if the sending account's previously-sent transaction matches the provided hash.</td>
+<td align="left"><a href="#accounttxnid">AccountTxnID</a></td>
+<td align="left">String</td>
+<td align="left">Hash256</td>
+<td align="left">(Optional) Hash value identifying another transaction. This transaction is only valid if the sending account's previously-sent transaction matches the provided hash.</td>
 </tr>
 <tr>
-<td><a href="#transaction-cost">Fee</a></td>
-<td>String</td>
-<td>Amount</td>
-<td>(Required, but <a href="#auto-fillable-fields">auto-fillable</a>) Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.</td>
+<td align="left"><a href="#transaction-cost">Fee</a></td>
+<td align="left">String</td>
+<td align="left">Amount</td>
+<td align="left">(Required, but <a href="#auto-fillable-fields">auto-fillable</a>) Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.</td>
 </tr>
 <tr>
-<td><a href="#flags">Flags</a></td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Set of bit-flags for this transaction.</td>
+<td align="left"><a href="#flags">Flags</a></td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Set of bit-flags for this transaction.</td>
 </tr>
 <tr>
-<td><a href="#lastledgersequence">LastLedgerSequence</a></td>
-<td>Number</td>
-<td>UInt32</td>
-<td>(Optional, but strongly recommended) Highest ledger sequence number that a transaction can appear in.</td>
+<td align="left"><a href="#lastledgersequence">LastLedgerSequence</a></td>
+<td align="left">Number</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional, but strongly recommended) Highest ledger sequence number that a transaction can appear in.</td>
 </tr>
 <tr>
-<td><a href="#memos">Memos</a></td>
-<td>Array of Objects</td>
-<td>Array</td>
-<td>(Optional) Additional arbitrary information used to identify this transaction.</td>
+<td align="left"><a href="#memos">Memos</a></td>
+<td align="left">Array of Objects</td>
+<td align="left">Array</td>
+<td align="left">(Optional) Additional arbitrary information used to identify this transaction.</td>
 </tr>
 <tr>
-<td><a href="#canceling-or-skipping-a-transaction">Sequence</a></td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Required, but <a href="#auto-fillable-fields">auto-fillable</a>) The sequence number, relative to the initiating account, of this transaction. A transaction is only valid if the <code>Sequence</code> number is exactly 1 greater than the last-valided transaction from the same account.</td>
+<td align="left"><a href="#canceling-or-skipping-a-transaction">Sequence</a></td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Required, but <a href="#auto-fillable-fields">auto-fillable</a>) The sequence number, relative to the initiating account, of this transaction. A transaction is only valid if the <code>Sequence</code> number is exactly 1 greater than the last-valided transaction from the same account.</td>
 </tr>
 <tr>
-<td>SigningPubKey</td>
-<td>String</td>
-<td>PubKey</td>
-<td>(Automatically added when signing) Hex representation of the public key that corresponds to the private key used to sign this transaction. If an empty string, indicates a multi-signature is present in the <code>Signers</code> field instead.</td>
+<td align="left">SigningPubKey</td>
+<td align="left">String</td>
+<td align="left">PubKey</td>
+<td align="left">(Automatically added when signing) Hex representation of the public key that corresponds to the private key used to sign this transaction. If an empty string, indicates a multi-signature is present in the <code>Signers</code> field instead.</td>
 </tr>
 <tr>
-<td><a href="#signers-field">Signers</a></td>
-<td>Array</td>
-<td>Array</td>
-<td>(Optional) Array of objects that represent a <a href="#multi-signing">multi-signature</a> which authorizes this transaction.</td>
+<td align="left"><a href="#signers-field">Signers</a></td>
+<td align="left">Array</td>
+<td align="left">Array</td>
+<td align="left">(Optional) Array of objects that represent a <a href="#multi-signing">multi-signature</a> which authorizes this transaction.</td>
 </tr>
 <tr>
-<td>SourceTag</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Arbitrary integer used to identify the reason for this payment, or a sender on whose behalf this transaction is made. Conventionally, a refund should specify the initial payment's <code>SourceTag</code> as the refund payment's <code>DestinationTag</code>.</td>
+<td align="left">SourceTag</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Arbitrary integer used to identify the reason for this payment, or a sender on whose behalf this transaction is made. Conventionally, a refund should specify the initial payment's <code>SourceTag</code> as the refund payment's <code>DestinationTag</code>.</td>
 </tr>
 <tr>
-<td>TransactionType</td>
-<td>String</td>
-<td>UInt16</td>
-<td>The type of transaction. Valid types include: <code>Payment</code>, <code>OfferCreate</code>, <code>OfferCancel</code>, <code>TrustSet</code>, <code>AccountSet</code>, <code>SetRegularKey</code>, and <code>SignerListSet</code>.</td>
+<td align="left">TransactionType</td>
+<td align="left">String</td>
+<td align="left">UInt16</td>
+<td align="left">The type of transaction. Valid types include: <code>Payment</code>, <code>OfferCreate</code>, <code>OfferCancel</code>, <code>TrustSet</code>, <code>AccountSet</code>, <code>SetRegularKey</code>, and <code>SignerListSet</code>.</td>
 </tr>
 <tr>
-<td>TxnSignature</td>
-<td>String</td>
-<td>VariableLength</td>
-<td>(Automatically added when signing) The signature that verifies this transaction as originating from the account it says it is from.</td>
+<td align="left">TxnSignature</td>
+<td align="left">String</td>
+<td align="left">VariableLength</td>
+<td align="left">(Automatically added when signing) The signature that verifies this transaction as originating from the account it says it is from.</td>
 </tr>
 </tbody>
 </table>
-<p class="devportal-callout note"><strong>Note:</strong> The deprecated <code>PreviousTxnID</code> transaction parameter was removed entirely in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0-rc1">rippled 0.28.0</a>. Use <code>AccountTxnID</code> instead.</p>
+<p class="devportal-callout note"><strong>Note:</strong> The deprecated <code>PreviousTxnID</code> transaction parameter was removed entirely in [<code>rippled</code> 0.28.0][]. Use <code>AccountTxnID</code> instead.</p>
 <h3 id="auto-fillable-fields">Auto-fillable Fields</h3>
 <p>Some fields can be automatically filled in before the transaction is signed, either by a <code>rippled</code> server or by the library used for offline signing. Both <a href="https://github.com/ripple/ripple-lib">ripple-lib</a> and <code>rippled</code> can automatically provide the following values:</p>
 <ul>
@@ -528,30 +527,30 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>MemoData</td>
-<td>String</td>
-<td>VariableLength</td>
-<td>Arbitrary hex value, conventionally containing the content of the memo.</td>
+<td align="left">MemoData</td>
+<td align="left">String</td>
+<td align="left">VariableLength</td>
+<td align="left">Arbitrary hex value, conventionally containing the content of the memo.</td>
 </tr>
 <tr>
-<td>MemoFormat</td>
-<td>String</td>
-<td>VariableLength</td>
-<td>Hex value representing characters allowed in URLs. Conventionally containing information on how the memo is encoded, for example as a <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">MIME type</a>.</td>
+<td align="left">MemoFormat</td>
+<td align="left">String</td>
+<td align="left">VariableLength</td>
+<td align="left">Hex value representing characters allowed in URLs. Conventionally containing information on how the memo is encoded, for example as a <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">MIME type</a>.</td>
 </tr>
 <tr>
-<td>MemoType</td>
-<td>String</td>
-<td>VariableLength</td>
-<td>Hex value representing characters allowed in URLs. Conventionally, a unique relation (according to <a href="http://tools.ietf.org/html/rfc5988#section-4">RFC 5988</a>) that defines the format of this memo.</td>
+<td align="left">MemoType</td>
+<td align="left">String</td>
+<td align="left">VariableLength</td>
+<td align="left">Hex value representing characters allowed in URLs. Conventionally, a unique relation (according to <a href="http://tools.ietf.org/html/rfc5988#section-4">RFC 5988</a>) that defines the format of this memo.</td>
 </tr>
 </tbody>
 </table>
@@ -578,30 +577,30 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Account</td>
-<td>String</td>
-<td>AccountID</td>
-<td>The address associated with this signature, as it appears in the SignerList.</td>
+<td align="left">Account</td>
+<td align="left">String</td>
+<td align="left">AccountID</td>
+<td align="left">The address associated with this signature, as it appears in the SignerList.</td>
 </tr>
 <tr>
-<td>TxnSignature</td>
-<td>String</td>
-<td>Blob</td>
-<td>A signature for this transaction, verifiable using the <code>SigningPubKey</code>.</td>
+<td align="left">TxnSignature</td>
+<td align="left">String</td>
+<td align="left">Blob</td>
+<td align="left">A signature for this transaction, verifiable using the <code>SigningPubKey</code>.</td>
 </tr>
 <tr>
-<td>SigningPubKey</td>
-<td>String</td>
-<td>PubKey</td>
-<td>The public key used to create this signature.</td>
+<td align="left">SigningPubKey</td>
+<td align="left">String</td>
+<td align="left">PubKey</td>
+<td align="left">The public key used to create this signature.</td>
 </tr>
 </tbody>
 </table>
@@ -614,18 +613,18 @@
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Hex Value</th>
-<th>Decimal Value</th>
-<th>Description</th>
+<th align="left">Flag Name</th>
+<th align="left">Hex Value</th>
+<th align="left">Decimal Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tfFullyCanonicalSig</td>
-<td>0x80000000</td>
-<td>2147483648</td>
-<td>Require a fully-canonical signature, to protect a transaction from <a href="https://wiki.ripple.com/Transaction_Malleability">transaction malleability</a> exploits.</td>
+<td align="left">tfFullyCanonicalSig</td>
+<td align="left">0x80000000</td>
+<td align="left">2147483648</td>
+<td align="left">Require a fully-canonical signature, to protect a transaction from <a href="https://wiki.ripple.com/Transaction_Malleability">transaction malleability</a> exploits.</td>
 </tr>
 </tbody>
 </table>
@@ -651,59 +650,59 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Amount</td>
-<td>String (XRP)<br/>Object (Otherwise)</td>
-<td>Amount</td>
-<td>The amount of currency to deliver. Formatted as per <a href="reference-rippled.html#specifying-currency-amounts">Specifying Currency Amounts</a>. For non-XRP amounts, the nested field names are lower-case. If the <a href="#payment-flags"><em>tfPartialPayment</em> flag</a> is set, deliver <em>up to</em> this amount instead.</td>
+<td align="left">Amount</td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left">Amount</td>
+<td align="left">The amount of currency to deliver. For non-XRP amounts, the nested field names MUST be lower-case. If the <a href="#payment-flags"><strong>tfPartialPayment</strong> flag</a> is set, deliver <em>up to</em> this amount instead.</td>
 </tr>
 <tr>
-<td>Destination</td>
-<td>String</td>
-<td>Account</td>
-<td>The unique address of the account receiving the payment.</td>
+<td align="left">Destination</td>
+<td align="left">String</td>
+<td align="left">Account</td>
+<td align="left">The unique address of the account receiving the payment.</td>
 </tr>
 <tr>
-<td>DestinationTag</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.</td>
+<td align="left">DestinationTag</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.</td>
 </tr>
 <tr>
-<td>InvoiceID</td>
-<td>String</td>
-<td>Hash256</td>
-<td>(Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.</td>
+<td align="left">InvoiceID</td>
+<td align="left">String</td>
+<td align="left">Hash256</td>
+<td align="left">(Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.</td>
 </tr>
 <tr>
-<td>Paths</td>
-<td>Array of path arrays</td>
-<td>PathSet</td>
-<td>(Optional, auto-fillable) Array of <a href="https://ripple.com/wiki/Payment_paths">payment paths</a> to be used for this transaction. Must be omitted for XRP-to-XRP transactions.</td>
+<td align="left">Paths</td>
+<td align="left">Array of path arrays</td>
+<td align="left">PathSet</td>
+<td align="left">(Optional, auto-fillable) Array of <a href="concept-paths.html">payment paths</a> to be used for this transaction. Must be omitted for XRP-to-XRP transactions.</td>
 </tr>
 <tr>
-<td>SendMax</td>
-<td>String/Object</td>
-<td>Amount</td>
-<td>(Optional) Highest amount of source currency this transaction is allowed to cost, including <a href="concept-transfer-fees.html">transfer fees</a>, exchange rates, and <a href="http://en.wikipedia.org/wiki/Slippage_%28finance%29">slippage</a>. Does not include the <a href="#transaction-cost">XRP destroyed as a cost for submitting the transaction</a>. See also: <a href="reference-rippled.html#specifying-currency-amounts">Specifying Currency Amounts</a>. For non-XRP amounts, the nested field names are lower-case. Must be supplied for cross-currency/cross-issue payments. Must be omitted for XRP-to-XRP payments.</td>
+<td align="left">SendMax</td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left">Amount</td>
+<td align="left">(Optional) Highest amount of source currency this transaction is allowed to cost, including <a href="concept-transfer-fees.html">transfer fees</a>, exchange rates, and <a href="http://en.wikipedia.org/wiki/Slippage_%28finance%29">slippage</a>. Does not include the <a href="#transaction-cost">XRP destroyed as a cost for submitting the transaction</a>. For non-XRP amounts, the nested field names MUST be lower-case. Must be supplied for cross-currency/cross-issue payments. Must be omitted for XRP-to-XRP payments.</td>
 </tr>
 <tr>
-<td>DeliverMin</td>
-<td>String/Object</td>
-<td>Amount</td>
-<td>(Optional) Minimum amount of destination currency this transaction should deliver. Only valid if this is a <a href="#partial-payments">partial payment</a>. For non-XRP amounts, the nested field names are lower-case.</td>
+<td align="left">DeliverMin</td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left">Amount</td>
+<td align="left">(Optional) Minimum amount of destination currency this transaction should deliver. Only valid if this is a <a href="#partial-payments">partial payment</a>. For non-XRP amounts, the nested field names are lower-case.</td>
 </tr>
 </tbody>
 </table>
 <h3 id="special-issuer-values-for-sendmax-and-amount">Special issuer Values for SendMax and Amount</h3>
-<p>Most of the time, the <code>issuer</code> field of a non-XRP <a href="reference-rippled.html#specifying-currency-amounts">currency amount</a> indicates a financial institution's <a href="concept-issuing-and-operational-addresses.html">issuing address</a>. However, when describing payments, there are special rules for the <code>issuer</code> field in the <code>Amount</code> and <code>SendMax</code> fields of a payment.</p>
+<p>Most of the time, the <code>issuer</code> field of a non-XRP <a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a> indicates a financial institution's <a href="concept-issuing-and-operational-addresses.html">issuing address</a>. However, when describing payments, there are special rules for the <code>issuer</code> field in the <code>Amount</code> and <code>SendMax</code> fields of a payment.</p>
 <ul>
 <li>There is only ever one balance for the same currency between two addresses. This means that, sometimes, the <code>issuer</code> field of an amount actually refers to a counterparty that is redeeming issuances, instead of the address that created the issuances.</li>
 <li>When the <code>issuer</code> field of the destination <code>Amount</code> field matches the <code>Destination</code> address, it is treated as a special case meaning "any issuer that the destination accepts." This includes all addresses to which the destination has extended trust lines, as well as issuances created by the destination which are held on other trust lines.</li>
@@ -727,35 +726,35 @@
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Hex Value</th>
-<th>Decimal Value</th>
-<th>Description</th>
+<th align="left">Flag Name</th>
+<th align="left">Hex Value</th>
+<th align="left">Decimal Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tfNoDirectRipple</td>
-<td>0x00010000</td>
-<td>65536</td>
-<td>Do not use the default path; only use paths included in the <code>Paths</code> field. This is intended to force the transaction to take arbitrage opportunities. Most clients do not need this.</td>
+<td align="left">tfNoDirectRipple</td>
+<td align="left">0x00010000</td>
+<td align="left">65536</td>
+<td align="left">Do not use the default path; only use paths included in the <code>Paths</code> field. This is intended to force the transaction to take arbitrage opportunities. Most clients do not need this.</td>
 </tr>
 <tr>
-<td>tfPartialPayment</td>
-<td>0x00020000</td>
-<td>131072</td>
-<td>If the specified <code>Amount</code> cannot be sent without spending more than <code>SendMax</code>, reduce the received amount instead of failing outright. See <a href="#partial-payments">Partial Payments</a> for more details.</td>
+<td align="left">tfPartialPayment</td>
+<td align="left">0x00020000</td>
+<td align="left">131072</td>
+<td align="left">If the specified <code>Amount</code> cannot be sent without spending more than <code>SendMax</code>, reduce the received amount instead of failing outright. See <a href="#partial-payments">Partial Payments</a> for more details.</td>
 </tr>
 <tr>
-<td>tfLimitQuality</td>
-<td>0x00040000</td>
-<td>262144</td>
-<td>Only take paths where all the conversions have an input:output ratio that is equal or better than the ratio of <code>Amount</code>:<code>SendMax</code>. See <a href="#limit-quality">Limit Quality</a> for details.</td>
+<td align="left">tfLimitQuality</td>
+<td align="left">0x00040000</td>
+<td align="left">262144</td>
+<td align="left">Only take paths where all the conversions have an input:output ratio that is equal or better than the ratio of <code>Amount</code>:<code>SendMax</code>. See <a href="#limit-quality">Limit Quality</a> for details.</td>
 </tr>
 </tbody>
 </table>
 <h3 id="partial-payments">Partial Payments</h3>
-<p>A partial payment allows a payment to succeed by reducing the amount received, instead of increasing the <code>SendMax</code>. Partial payments are useful for <a href="https://wiki.ripple.com/Returning_payments">returning payments</a> without incurring additional costs to oneself.</p>
+<p>A partial payment allows a payment to succeed by reducing the amount received, instead of increasing the <code>SendMax</code>. Partial payments are useful for <a href="tutorial-gateway-guide.html#bouncing-payments">returning payments</a> without incurring additional costs to oneself.</p>
 <p>By default, the <code>Amount</code> field of a Payment transaction specifies the amount of currency that is <em>received</em> by the account that is the destination of the payment. Any additional amount needed for fees or currency exchange is deducted from the sending account's balances, up to the <code>SendMax</code> amount. (If <code>SendMax</code> is not specified, that is equivalent to setting the <code>SendMax</code> to the <code>Amount</code> field.) If the amount needed to make the payment exceeds the <code>SendMax</code> parameter, or the full amount cannot be delivered for any other reason, the transaction fails.</p>
 <p>The <a href="#payment-flags"><em>tfPartialPayment</em> flag</a> allows you to make a "partial payment" instead. When this flag is enabled for a payment, it delivers as much as possible, up to the <code>Amount</code> value, without exceeding the <code>SendMax</code> value. Fees and currency exchange rates are calculated the same way, but the amount being sent automatically scales down until the total amount deducted from the sending account's balances is within <code>SendMax</code>. The transaction is considered successful as long as it delivers equal or more than the <code>DeliverMin</code> value; if DeliverMin is omitted, then any positive amount is considered a success. This means that partial payments can succeed at sending <em>some</em> of the intended value despite limitations including fees, lack of liquidity, insufficient space in the receiving account's trustlines, or other reasons.</p>
 <p>A partial payment cannot provide the XRP to fund an address; this case returns the error code <code>telNO_DST_PARTIAL</code>. Direct XRP-to-XRP payments also cannot be partial payments <code>temBAD_SEND_XRP_PARTIAL</code>.</p>
@@ -787,60 +786,60 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><a href="#accountset-flags">ClearFlag</a></td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Unique identifier of a flag to disable for this account.</td>
+<td align="left"><a href="#accountset-flags">ClearFlag</a></td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Unique identifier of a flag to disable for this account.</td>
 </tr>
 <tr>
-<td><a href="#domain">Domain</a></td>
-<td>String</td>
-<td>VariableLength</td>
-<td>(Optional) The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase.</td>
+<td align="left"><a href="#domain">Domain</a></td>
+<td align="left">String</td>
+<td align="left">VariableLength</td>
+<td align="left">(Optional) The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase.</td>
 </tr>
 <tr>
-<td>EmailHash</td>
-<td>String</td>
-<td>Hash128</td>
-<td>(Optional) Hash of an email address to be used for generating an avatar image. Conventionally, clients use <a href="http://en.gravatar.com/site/implement/hash/">Gravatar</a> to display this image.</td>
+<td align="left">EmailHash</td>
+<td align="left">String</td>
+<td align="left">Hash128</td>
+<td align="left">(Optional) Hash of an email address to be used for generating an avatar image. Conventionally, clients use <a href="http://en.gravatar.com/site/implement/hash/">Gravatar</a> to display this image.</td>
 </tr>
 <tr>
-<td>MessageKey</td>
-<td>String</td>
-<td>PubKey</td>
-<td>(Optional) Public key for sending encrypted messages to this account. Conventionally, it should be a secp256k1 key, the same encryption that is used by the rest of Ripple.</td>
+<td align="left">MessageKey</td>
+<td align="left">String</td>
+<td align="left">PubKey</td>
+<td align="left">(Optional) Public key for sending encrypted messages to this account. Conventionally, it should be a secp256k1 key, the same encryption that is used by the rest of Ripple.</td>
 </tr>
 <tr>
-<td><a href="#accountset-flags">SetFlag</a></td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Integer flag to enable for this account.</td>
+<td align="left"><a href="#accountset-flags">SetFlag</a></td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Integer flag to enable for this account.</td>
 </tr>
 <tr>
-<td><a href="#transferrate">TransferRate</a></td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) The fee to charge when users transfer this account's issuances, represented as billionths of a unit. Use <code>0</code> to set no fee.</td>
+<td align="left"><a href="#transferrate">TransferRate</a></td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) The fee to charge when users transfer this account's issuances, represented as billionths of a unit. Use <code>0</code> to set no fee.</td>
 </tr>
 <tr>
-<td>WalletLocator</td>
-<td>String</td>
-<td>Hash256</td>
-<td>(Optional) Not used.</td>
+<td align="left">WalletLocator</td>
+<td align="left">String</td>
+<td align="left">Hash256</td>
+<td align="left">(Optional) Not used.</td>
 </tr>
 <tr>
-<td>WalletSize</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Not used.</td>
+<td align="left">WalletSize</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Not used.</td>
 </tr>
 </tbody>
 </table>
@@ -848,7 +847,7 @@
 <h3 id="domain">Domain</h3>
 <p>The <code>Domain</code> field is represented as the hex string of the lowercase ASCII of the domain. For example, the domain <em>example.com</em> would be represented as <code>"6578616d706c652e636f6d"</code>.</p>
 <p>To remove the <code>Domain</code> field from an account, send an AccountSet with the Domain set to an empty string.</p>
-<p>Client applications can use the <a href="https://ripple.com/wiki/Ripple.txt">ripple.txt</a> file hosted by the domain to confirm that the account is actually operated by that domain.</p>
+<p>Client applications can use the <a href="https://wiki.ripple.com/Ripple.txt">ripple.txt</a> file hosted by the domain to confirm that the account is actually operated by that domain.</p>
 <h3 id="accountset-flags">AccountSet Flags</h3>
 <p>There are several options which can be either enabled or disabled for an account. Account options are represented by different types of flags depending on the situation:</p>
 <ul>
@@ -862,110 +861,110 @@
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Decimal Value</th>
-<th>Description</th>
-<th>Corresponding Ledger Flag</th>
+<th align="left">Flag Name</th>
+<th align="left">Decimal Value</th>
+<th align="left">Corresponding Ledger Flag</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>asfRequireDest</td>
-<td>1</td>
-<td>Require a destination tag to send transactions to this account.</td>
-<td>lsfRequireDestTag</td>
+<td align="left">asfRequireDest</td>
+<td align="left">1</td>
+<td align="left">lsfRequireDestTag</td>
+<td align="left">Require a destination tag to send transactions to this account.</td>
 </tr>
 <tr>
-<td>asfRequireAuth</td>
-<td>2</td>
-<td>Require authorization for users to hold balances issued by this address. Can only be enabled if the address has no trust lines connected to it.</td>
-<td>lsfRequireAuth</td>
+<td align="left">asfRequireAuth</td>
+<td align="left">2</td>
+<td align="left">lsfRequireAuth</td>
+<td align="left">Require authorization for users to hold balances issued by this address. Can only be enabled if the address has no trust lines connected to it.</td>
 </tr>
 <tr>
-<td>asfDisallowXRP</td>
-<td>3</td>
-<td>XRP should not be sent to this account. (Enforced by client applications, not by <code>rippled</code>)</td>
-<td>lsfDisallowXRP</td>
+<td align="left">asfDisallowXRP</td>
+<td align="left">3</td>
+<td align="left">lsfDisallowXRP</td>
+<td align="left">XRP should not be sent to this account. (Enforced by client applications, not by <code>rippled</code>)</td>
 </tr>
 <tr>
-<td>asfDisableMaster</td>
-<td>4</td>
-<td>Disallow use of the master key. Can only be enabled if the account has configured another way to sign transactions, such as a <a href="#setregularkey">Regular Key</a> or a <a href="#signerlistset">Signer List</a>.</td>
-<td>lsfDisableMaster</td>
+<td align="left">asfDisableMaster</td>
+<td align="left">4</td>
+<td align="left">lsfDisableMaster</td>
+<td align="left">Disallow use of the master key. Can only be enabled if the account has configured another way to sign transactions, such as a <a href="#setregularkey">Regular Key</a> or a <a href="#signerlistset">Signer List</a>.</td>
 </tr>
 <tr>
-<td>asfAccountTxnID</td>
-<td>5</td>
-<td>Track the ID of this account's most recent transaction. Required for <a href="#accounttxnid">AccountTxnID</a></td>
-<td>(None)</td>
+<td align="left">asfAccountTxnID</td>
+<td align="left">5</td>
+<td align="left">(None)</td>
+<td align="left">Track the ID of this account's most recent transaction. Required for <a href="#accounttxnid">AccountTxnID</a></td>
 </tr>
 <tr>
-<td>asfNoFreeze</td>
-<td>6</td>
-<td>Permanently give up the ability to <a href="concept-freeze.html">freeze individual trust lines or disable Global Freeze</a>. This flag can never be disabled after being enabled.</td>
-<td>lsfNoFreeze</td>
+<td align="left">asfNoFreeze</td>
+<td align="left">6</td>
+<td align="left">lsfNoFreeze</td>
+<td align="left">Permanently give up the ability to <a href="concept-freeze.html">freeze individual trust lines or disable Global Freeze</a>. This flag can never be disabled after being enabled.</td>
 </tr>
 <tr>
-<td>asfGlobalFreeze</td>
-<td>7</td>
-<td><a href="concept-freeze.html">Freeze</a> all assets issued by this account.</td>
-<td>lsfGlobalFreeze</td>
+<td align="left">asfGlobalFreeze</td>
+<td align="left">7</td>
+<td align="left">lsfGlobalFreeze</td>
+<td align="left"><a href="concept-freeze.html">Freeze</a> all assets issued by this account.</td>
 </tr>
 <tr>
-<td>asfDefaultRipple</td>
-<td>8</td>
-<td>Enable <a href="concept-noripple.html">rippling</a> on this account's trust lines by default. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.27.3">rippled 0.27.3</a>)</em></td>
-<td>lsfDefaultRipple</td>
+<td align="left">asfDefaultRipple</td>
+<td align="left">8</td>
+<td align="left">lsfDefaultRipple</td>
+<td align="left">Enable <a href="concept-noripple.html">rippling</a> on this account's trust lines by default. <em>(New in [<code>rippled</code> 0.27.3][])</em></td>
 </tr>
 </tbody>
 </table>
-<p><em>New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0-rc1">rippled 0.28.0</a>:</em> To enable the <code>asfDisableMaster</code> or <code>asfNoFreeze</code> flags, you must <a href="#authorizing-transactions">authorize the transaction</a> by signing it with the master key. You cannot use a regular key or a multi-signature.</p>
+<p><em>New in [<code>rippled</code> 0.28.0][]:</em> To enable the <code>asfDisableMaster</code> or <code>asfNoFreeze</code> flags, you must <a href="#authorizing-transactions">authorize the transaction</a> by signing it with the master key. You cannot use a regular key or a multi-signature.</p>
 <p>The following <a href="#flags">Transaction flags</a>, specific to the AccountSet transaction type, serve the same purpose, but are discouraged:</p>
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Hex Value</th>
-<th>Decimal Value</th>
-<th>Replaced by AccountSet Flag</th>
+<th align="left">Flag Name</th>
+<th align="left">Hex Value</th>
+<th align="left">Decimal Value</th>
+<th align="left">Replaced by AccountSet Flag</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tfRequireDestTag</td>
-<td>0x00010000</td>
-<td>65536</td>
-<td>asfRequireDest (SetFlag)</td>
+<td align="left">tfRequireDestTag</td>
+<td align="left">0x00010000</td>
+<td align="left">65536</td>
+<td align="left">asfRequireDest (SetFlag)</td>
 </tr>
 <tr>
-<td>tfOptionalDestTag</td>
-<td>0x00020000</td>
-<td>131072</td>
-<td>asfRequireDest (ClearFlag)</td>
+<td align="left">tfOptionalDestTag</td>
+<td align="left">0x00020000</td>
+<td align="left">131072</td>
+<td align="left">asfRequireDest (ClearFlag)</td>
 </tr>
 <tr>
-<td>tfRequireAuth</td>
-<td>0x00040000</td>
-<td>262144</td>
-<td>asfRequireAuth (SetFlag)</td>
+<td align="left">tfRequireAuth</td>
+<td align="left">0x00040000</td>
+<td align="left">262144</td>
+<td align="left">asfRequireAuth (SetFlag)</td>
 </tr>
 <tr>
-<td>tfOptionalAuth</td>
-<td>0x00080000</td>
-<td>524288</td>
-<td>asfRequireAuth (ClearFlag)</td>
+<td align="left">tfOptionalAuth</td>
+<td align="left">0x00080000</td>
+<td align="left">524288</td>
+<td align="left">asfRequireAuth (ClearFlag)</td>
 </tr>
 <tr>
-<td>tfDisallowXRP</td>
-<td>0x00100000</td>
-<td>1048576</td>
-<td>asfDisallowXRP (SetFlag)</td>
+<td align="left">tfDisallowXRP</td>
+<td align="left">0x00100000</td>
+<td align="left">1048576</td>
+<td align="left">asfDisallowXRP (SetFlag)</td>
 </tr>
 <tr>
-<td>tfAllowXRP</td>
-<td>0x00200000</td>
-<td>2097152</td>
-<td>asfDisallowXRP (ClearFlag)</td>
+<td align="left">tfAllowXRP</td>
+<td align="left">0x00200000</td>
+<td align="left">2097152</td>
+<td align="left">asfDisallowXRP (ClearFlag)</td>
 </tr>
 </tbody>
 </table>
@@ -990,18 +989,18 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>RegularKey</td>
-<td>String</td>
-<td>AccountID</td>
-<td>(Optional) A base-58-encoded <a href="reference-rippled.html#addresses">Ripple address</a> to use as the regular key. If omitted, removes the existing regular key.</td>
+<td align="left">RegularKey</td>
+<td align="left">String</td>
+<td align="left">AccountID</td>
+<td align="left">(Optional) A base-58-encoded <a href="reference-rippled.html#addresses">Ripple address</a> to use as the regular key. If omitted, removes the existing regular key.</td>
 </tr>
 </tbody>
 </table>
@@ -1030,36 +1029,36 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><a href="#expiration">Expiration</a></td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Time after which the offer is no longer active, in <a href="reference-rippled.html#specifying-time">seconds since the Ripple Epoch</a>.</td>
+<td align="left"><a href="#expiration">Expiration</a></td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Time after which the offer is no longer active, in <a href="reference-rippled.html#specifying-time">seconds since the Ripple Epoch</a>.</td>
 </tr>
 <tr>
-<td>OfferSequence</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) An offer to delete first, specified in the same way as <a href="#offercancel">OfferCancel</a>.</td>
+<td align="left">OfferSequence</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) An offer to delete first, specified in the same way as <a href="#offercancel">OfferCancel</a>.</td>
 </tr>
 <tr>
-<td>TakerGets</td>
-<td>Object (Non-XRP), or <br/>String (XRP)</td>
-<td>Amount</td>
-<td>The amount and type of currency being provided by the offer creator.</td>
+<td align="left">TakerGets</td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left">Amount</td>
+<td align="left">The amount and type of currency being provided by the offer creator.</td>
 </tr>
 <tr>
-<td>TakerPays</td>
-<td>Object (Non-XRP), or <br/>String (XRP)</td>
-<td>Amount</td>
-<td>The amount and type of currency being requested by the offer creator.</td>
+<td align="left">TakerPays</td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left">Amount</td>
+<td align="left">The amount and type of currency being requested by the offer creator.</td>
 </tr>
 </tbody>
 </table>
@@ -1111,36 +1110,36 @@
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Hex Value</th>
-<th>Decimal Value</th>
-<th>Description</th>
+<th align="left">Flag Name</th>
+<th align="left">Hex Value</th>
+<th align="left">Decimal Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tfPassive</td>
-<td>0x00010000</td>
-<td>65536</td>
-<td>If enabled, the offer does not consume offers that exactly match it, and instead becomes an Offer node in the ledger. It still consumes offers that cross it.</td>
+<td align="left">tfPassive</td>
+<td align="left">0x00010000</td>
+<td align="left">65536</td>
+<td align="left">If enabled, the offer does not consume offers that exactly match it, and instead becomes an Offer node in the ledger. It still consumes offers that cross it.</td>
 </tr>
 <tr>
-<td>tfImmediateOrCancel</td>
-<td>0x00020000</td>
-<td>131072</td>
-<td>Treat the offer as an <a href="http://en.wikipedia.org/wiki/Immediate_or_cancel">Immediate or Cancel order</a>. If enabled, the offer never becomes a ledger node: it only tries to match existing offers in the ledger.</td>
+<td align="left">tfImmediateOrCancel</td>
+<td align="left">0x00020000</td>
+<td align="left">131072</td>
+<td align="left">Treat the offer as an <a href="http://en.wikipedia.org/wiki/Immediate_or_cancel">Immediate or Cancel order</a>. If enabled, the offer never becomes a ledger node: it only tries to match existing offers in the ledger.</td>
 </tr>
 <tr>
-<td>tfFillOrKill</td>
-<td>0x00040000</td>
-<td>262144</td>
-<td>Treat the offer as a <a href="http://en.wikipedia.org/wiki/Fill_or_kill">Fill or Kill order</a>. Only try to match existing offers in the ledger, and only do so if the entire <code>TakerPays</code> quantity can be obtained.</td>
+<td align="left">tfFillOrKill</td>
+<td align="left">0x00040000</td>
+<td align="left">262144</td>
+<td align="left">Treat the offer as a <a href="http://en.wikipedia.org/wiki/Fill_or_kill">Fill or Kill order</a>. Only try to match existing offers in the ledger, and only do so if the entire <code>TakerPays</code> quantity can be obtained.</td>
 </tr>
 <tr>
-<td>tfSell</td>
-<td>0x00080000</td>
-<td>524288</td>
-<td>Exchange the entire <code>TakerGets</code> amount, even if it means obtaining more than the <code>TakerPays</code> amount in exchange.</td>
+<td align="left">tfSell</td>
+<td align="left">0x00080000</td>
+<td align="left">524288</td>
+<td align="left">Exchange the entire <code>TakerGets</code> amount, even if it means obtaining more than the <code>TakerPays</code> amount in exchange.</td>
 </tr>
 </tbody>
 </table>
@@ -1164,18 +1163,18 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>OfferSequence</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>The sequence number of a previous OfferCreate transaction. If specified, cancel any offer node in the ledger that was created by that transaction. It is not considered an error if the offer specified does not exist.</td>
+<td align="left">OfferSequence</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">The sequence number of a previous OfferCreate transaction. If specified, cancel any offer node in the ledger that was created by that transaction. It is not considered an error if the offer specified does not exist.</td>
 </tr>
 </tbody>
 </table>
@@ -1201,48 +1200,48 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><a href="#trust-limits">LimitAmount</a></td>
-<td>Object</td>
-<td>Amount</td>
-<td>Object defining the trust line to create or modify, in the same format as <a href="reference-rippled.html#specifying-currency-amounts">currency amounts</a>.</td>
+<td align="left"><a href="#trust-limits">LimitAmount</a></td>
+<td align="left">Object</td>
+<td align="left">Amount</td>
+<td align="left">Object defining the trust line to create or modify, in the format of a <a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a>.</td>
 </tr>
 <tr>
-<td>LimitAmount.currency</td>
-<td>String</td>
-<td>(Amount.currency)</td>
-<td>The currency to this trust line applies to, as a three-letter <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Code</a> or a 160-bit hex value according to <a href="https://wiki.ripple.com/Currency_format">currency format</a>. "XRP" is invalid.</td>
+<td align="left">LimitAmount.currency</td>
+<td align="left">String</td>
+<td align="left">(Amount.currency)</td>
+<td align="left">The currency to this trust line applies to, as a three-letter <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Code</a> or a 160-bit hex value according to <a href="https://wiki.ripple.com/Currency_format">currency format</a>. "XRP" is invalid.</td>
 </tr>
 <tr>
-<td>LimitAmount.value</td>
-<td>String</td>
-<td>(Amount.value)</td>
-<td>Quoted decimal representation of the limit to set on this trust line.</td>
+<td align="left">LimitAmount.value</td>
+<td align="left">String</td>
+<td align="left">(Amount.value)</td>
+<td align="left">Quoted decimal representation of the limit to set on this trust line.</td>
 </tr>
 <tr>
-<td>LimitAmount.issuer</td>
-<td>String</td>
-<td>(Amount.issuer)</td>
-<td>The address of the account to extend trust to.</td>
+<td align="left">LimitAmount.issuer</td>
+<td align="left">String</td>
+<td align="left">(Amount.issuer)</td>
+<td align="left">The address of the account to extend trust to.</td>
 </tr>
 <tr>
-<td>QualityIn</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Value incoming balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of <code>0</code> is shorthand for treating balances at face value.</td>
+<td align="left">QualityIn</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Value incoming balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of <code>0</code> is shorthand for treating balances at face value.</td>
 </tr>
 <tr>
-<td>QualityOut</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>(Optional) Value outgoing balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of <code>0</code> is shorthand for treating balances at face value.</td>
+<td align="left">QualityOut</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">(Optional) Value outgoing balances on this trust line at the ratio of this number per 1,000,000,000 units. A value of <code>0</code> is shorthand for treating balances at face value.</td>
 </tr>
 </tbody>
 </table>
@@ -1259,48 +1258,48 @@
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Hex Value</th>
-<th>Decimal Value</th>
-<th>Description</th>
+<th align="left">Flag Name</th>
+<th align="left">Hex Value</th>
+<th align="left">Decimal Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tfSetfAuth</td>
-<td>0x00010000</td>
-<td>65536</td>
-<td>Authorize the other party to hold issuances from this account. (No effect unless using the <a href="#accountset-flags"><em>asfRequireAuth</em> AccountSet flag</a>.) Cannot be unset.</td>
+<td align="left">tfSetfAuth</td>
+<td align="left">0x00010000</td>
+<td align="left">65536</td>
+<td align="left">Authorize the other party to hold issuances from this account. (No effect unless using the <a href="#accountset-flags"><em>asfRequireAuth</em> AccountSet flag</a>.) Cannot be unset.</td>
 </tr>
 <tr>
-<td>tfSetNoRipple</td>
-<td>0x00020000</td>
-<td>131072</td>
-<td>Blocks rippling between two trustlines of the same currency, if this flag is set on both. (See <a href="concept-noripple.html">No Ripple</a> for details.)</td>
+<td align="left">tfSetNoRipple</td>
+<td align="left">0x00020000</td>
+<td align="left">131072</td>
+<td align="left">Blocks rippling between two trustlines of the same currency, if this flag is set on both. (See <a href="concept-noripple.html">No Ripple</a> for details.)</td>
 </tr>
 <tr>
-<td>tfClearNoRipple</td>
-<td>0x00040000</td>
-<td>262144</td>
-<td>Clears the No-Rippling flag. (See <a href="concept-noripple.html">No Ripple</a> for details.)</td>
+<td align="left">tfClearNoRipple</td>
+<td align="left">0x00040000</td>
+<td align="left">262144</td>
+<td align="left">Clears the No-Rippling flag. (See <a href="concept-noripple.html">No Ripple</a> for details.)</td>
 </tr>
 <tr>
-<td>tfSetFreeze</td>
-<td>0x00100000</td>
-<td>1048576</td>
-<td><a href="concept-freeze.html">Freeze</a> the trustline.</td>
+<td align="left">tfSetFreeze</td>
+<td align="left">0x00100000</td>
+<td align="left">1048576</td>
+<td align="left"><a href="concept-freeze.html">Freeze</a> the trustline.</td>
 </tr>
 <tr>
-<td>tfClearFreeze</td>
-<td>0x00200000</td>
-<td>2097152</td>
-<td><a href="concept-freeze.html">Unfreeze</a> the trustline.</td>
+<td align="left">tfClearFreeze</td>
+<td align="left">0x00200000</td>
+<td align="left">2097152</td>
+<td align="left"><a href="concept-freeze.html">Unfreeze</a> the trustline.</td>
 </tr>
 </tbody>
 </table>
 <h2 id="signerlistset">SignerListSet</h2>
 <p><a href="https://github.com/ripple/rippled/blob/ef511282709a6a0721b504c6b7703f9de3eecf38/src/ripple/app/tx/impl/SetSignerList.cpp" title="Source">[Source]<br/></a></p>
-<p>The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to <a href="#multi-signing">multi-sign</a> a transaction. This transaction type was introduced by the <a href="concept-amendments.html#multisign">MultiSign amendment</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">rippled 0.31.0</a>)</em></p>
+<p>The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to <a href="#multi-signing">multi-sign</a> a transaction. This transaction type was introduced by the <a href="concept-amendments.html#multisign">MultiSign amendment</a>. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
 <p>Example SignerListSet:</p>
 <pre><code>{
     "Flags": 0,
@@ -1333,24 +1332,24 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>SignerQuorum</td>
-<td>Number</td>
-<td>UInt32</td>
-<td>A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of the signatures provided is greater than or equal to this value. To delete a SignerList, use the value <code>0</code>.</td>
+<td align="left">SignerQuorum</td>
+<td align="left">Number</td>
+<td align="left">UInt32</td>
+<td align="left">A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of the signatures provided is greater than or equal to this value. To delete a SignerList, use the value <code>0</code>.</td>
 </tr>
 <tr>
-<td>SignerEntries</td>
-<td>Array</td>
-<td>Array</td>
-<td>(Omitted when deleting) Array of <a href="reference-ledger-format.html#signerentry-object">SignerEntry objects</a>, indicating the addresses and weights of signers in this list. A SignerList must have at least 1 member and no more than 8 members. No address may appear more than once in the list, nor may the <code>Account</code> submitting the transaction appear in the list.</td>
+<td align="left">SignerEntries</td>
+<td align="left">Array</td>
+<td align="left">Array</td>
+<td align="left">(Omitted when deleting) Array of <a href="reference-ledger-format.html#signerentry-object">SignerEntry objects</a>, indicating the addresses and weights of signers in this list. A SignerList must have at least 1 member and no more than 8 members. No address may appear more than once in the list, nor may the <code>Account</code> submitting the transaction appear in the list.</td>
 </tr>
 </tbody>
 </table>
@@ -1364,30 +1363,30 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>Default Value</th>
+<th align="left">Field</th>
+<th align="left">Default Value</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Account</td>
-<td><a href="https://wiki.ripple.com/Accounts#ACCOUNT_ZERO">ACCOUNT_ZERO</a></td>
+<td align="left">Account</td>
+<td align="left"><a href="reference-rippled.html#special-addresses">ACCOUNT_ZERO</a></td>
 </tr>
 <tr>
-<td>Sequence</td>
-<td>0</td>
+<td align="left">Sequence</td>
+<td align="left">0</td>
 </tr>
 <tr>
-<td>Fee</td>
-<td>0</td>
+<td align="left">Fee</td>
+<td align="left">0</td>
 </tr>
 <tr>
-<td>SigningPubKey</td>
-<td>""</td>
+<td align="left">SigningPubKey</td>
+<td align="left">""</td>
 </tr>
 <tr>
-<td>Signature</td>
-<td>""</td>
+<td align="left">Signature</td>
+<td align="left">""</td>
 </tr>
 </tbody>
 </table>
@@ -1412,42 +1411,42 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>BaseFee</td>
-<td>String</td>
-<td>UInt64</td>
-<td>The charge, in drops of XRP, for the reference transaction, as hex. (This is the <a href="concept-transaction-cost.html">transaction cost</a> before scaling for load.)</td>
+<td align="left">BaseFee</td>
+<td align="left">String</td>
+<td align="left">UInt64</td>
+<td align="left">The charge, in drops of XRP, for the reference transaction, as hex. (This is the <a href="concept-transaction-cost.html">transaction cost</a> before scaling for load.)</td>
 </tr>
 <tr>
-<td>ReferenceFeeUnits</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>The cost, in fee units, of the reference transaction</td>
+<td align="left">ReferenceFeeUnits</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">The cost, in fee units, of the reference transaction</td>
 </tr>
 <tr>
-<td>ReserveBase</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>The base reserve, in drops</td>
+<td align="left">ReserveBase</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">The base reserve, in drops</td>
 </tr>
 <tr>
-<td>ReserveIncrement</td>
-<td>Unsigned Integer</td>
-<td>UInt32</td>
-<td>The incremental reserve, in drops</td>
+<td align="left">ReserveIncrement</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">UInt32</td>
+<td align="left">The incremental reserve, in drops</td>
 </tr>
 <tr>
-<td>LedgerSequence</td>
-<td>Number</td>
-<td>UInt32</td>
-<td>The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change.</td>
+<td align="left">LedgerSequence</td>
+<td align="left">Number</td>
+<td align="left">UInt32</td>
+<td align="left">The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change.</td>
 </tr>
 </tbody>
 </table>
@@ -1457,24 +1456,24 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>JSON Type</th>
-<th><a href="https://wiki.ripple.com/Binary_Format">Internal Type</a></th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">JSON Type</th>
+<th align="left"><a href="https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp">Internal Type</a></th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Amendment</td>
-<td>String</td>
-<td>Hash256</td>
-<td>A unique identifier for the amendment. This is not intended to be a human-readable name. See <a href="concept-amendments.html">Amendments</a> for a list of known amendments.</td>
+<td align="left">Amendment</td>
+<td align="left">String</td>
+<td align="left">Hash256</td>
+<td align="left">A unique identifier for the amendment. This is not intended to be a human-readable name. See <a href="concept-amendments.html">Amendments</a> for a list of known amendments.</td>
 </tr>
 <tr>
-<td>LedgerSequence</td>
-<td>Number</td>
-<td>UInt32</td>
-<td>The index of the ledger version where this amendment appears. This distinguishes the pseudo-transaction from other occurrences of the same change.</td>
+<td align="left">LedgerSequence</td>
+<td align="left">Number</td>
+<td align="left">UInt32</td>
+<td align="left">The index of the ledger version where this amendment appears. This distinguishes the pseudo-transaction from other occurrences of the same change.</td>
 </tr>
 </tbody>
 </table>
@@ -1484,24 +1483,24 @@
 <table>
 <thead>
 <tr>
-<th>Flag Name</th>
-<th>Hex Value</th>
-<th>Decimal Value</th>
-<th>Description</th>
+<th align="left">Flag Name</th>
+<th align="left">Hex Value</th>
+<th align="left">Decimal Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tfGotMajority</td>
-<td>0x00010000</td>
-<td>65536</td>
-<td>Support for this amendment increased to at least 80% of trusted validators starting with this ledger version.</td>
+<td align="left">tfGotMajority</td>
+<td align="left">0x00010000</td>
+<td align="left">65536</td>
+<td align="left">Support for this amendment increased to at least 80% of trusted validators starting with this ledger version.</td>
 </tr>
 <tr>
-<td>tfLostMajority</td>
-<td>0x00020000</td>
-<td>131072</td>
-<td>Support for this amendment decreased to less than 80% of trusted validators starting with this ledger version.</td>
+<td align="left">tfLostMajority</td>
+<td align="left">0x00020000</td>
+<td align="left">131072</td>
+<td align="left">Support for this amendment decreased to less than 80% of trusted validators starting with this ledger version.</td>
 </tr>
 </tbody>
 </table>
@@ -1512,26 +1511,26 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>Value</th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>engine_result</td>
-<td>String</td>
-<td>A code that categorizes the result, such as <code>tecPATH_DRY</code></td>
+<td align="left">engine_result</td>
+<td align="left">String</td>
+<td align="left">A code that categorizes the result, such as <code>tecPATH_DRY</code></td>
 </tr>
 <tr>
-<td>engine_result_code</td>
-<td>Signed Integer</td>
-<td>A number that corresponds to the <code>engine_result</code>, although exact values are subject to change.</td>
+<td align="left">engine_result_code</td>
+<td align="left">Signed Integer</td>
+<td align="left">A number that corresponds to the <code>engine_result</code>, although exact values are subject to change.</td>
 </tr>
 <tr>
-<td>engine_result_message</td>
-<td>String</td>
-<td>A human-readable message explaining what happened. This message is intended for developers to diagnose problems, and is subject to change without notice.</td>
+<td align="left">engine_result_message</td>
+<td align="left">String</td>
+<td align="left">A human-readable message explaining what happened. This message is intended for developers to diagnose problems, and is subject to change without notice.</td>
 </tr>
 </tbody>
 </table>
@@ -1546,21 +1545,21 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>Value</th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>meta.TransactionResult</td>
-<td>String</td>
-<td>A code that categorizes the result, such as <code>tecPATH_DRY</code></td>
+<td align="left">meta.TransactionResult</td>
+<td align="left">String</td>
+<td align="left">A code that categorizes the result, such as <code>tecPATH_DRY</code></td>
 </tr>
 <tr>
-<td>validated</td>
-<td>Boolean</td>
-<td>Whether or not this result comes from a validated ledger. If <code>false</code>, then the result is provisional. If <code>true</code>, then the result is final.</td>
+<td align="left">validated</td>
+<td align="left">Boolean</td>
+<td align="left">Whether or not this result comes from a validated ledger. If <code>false</code>, then the result is provisional. If <code>true</code>, then the result is final.</td>
 </tr>
 </tbody>
 </table>
@@ -1576,46 +1575,41 @@
 <table>
 <thead>
 <tr>
-<th>Category</th>
-<th>Prefix</th>
-<th>Description</th>
+<th align="left">Category</th>
+<th align="left">Prefix</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Local error</td>
-<td><a href="#tel-codes">tel</a></td>
-<td>The rippled server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time.</td>
+<td align="left">Local error</td>
+<td align="left"><a href="#tel-codes">tel</a></td>
+<td align="left">The rippled server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time.</td>
 </tr>
 <tr>
-<td>Malformed transaction</td>
-<td><a href="#tem-codes">tem</a></td>
-<td>The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else.</td>
+<td align="left">Malformed transaction</td>
+<td align="left"><a href="#tem-codes">tem</a></td>
+<td align="left">The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else.</td>
 </tr>
 <tr>
-<td>Failure</td>
-<td><a href="#tef-codes">tef</a></td>
-<td>The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future.</td>
+<td align="left">Failure</td>
+<td align="left"><a href="#tef-codes">tef</a></td>
+<td align="left">The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future.</td>
 </tr>
 <tr>
-<td>Retry</td>
-<td><a href="#ter-codes">ter</a></td>
-<td>The transaction could not be applied, but it might be possible to apply later.</td>
+<td align="left">Retry</td>
+<td align="left"><a href="#ter-codes">ter</a></td>
+<td align="left">The transaction could not be applied, but it might be possible to apply later.</td>
 </tr>
 <tr>
-<td>Success</td>
-<td><a href="#tes-success">tes</a></td>
-<td>(Not an error) The transaction succeeded. This result only final in a validated ledger.</td>
+<td align="left">Success</td>
+<td align="left"><a href="#tes-success">tes</a></td>
+<td align="left">(Not an error) The transaction succeeded. This result only final in a validated ledger.</td>
 </tr>
 <tr>
-<td>Claimed cost only</td>
-<td><a href="#tec-codes">tec</a></td>
-<td>The transaction did not achieve its intended purpose, but the <a href="concept-transaction-cost.html">transaction cost</a> was destroyed. This result is only final in a validated ledger.</td>
-</tr>
-<tr>
-<td>Client library error</td>
-<td><a href="#tej-codes">tej</a></td>
-<td>(ripple-lib only) The transaction was not submitted, because the client library blocked it, as part of its additional error checking.</td>
+<td align="left">Claimed cost only</td>
+<td align="left"><a href="#tec-codes">tec</a></td>
+<td align="left">The transaction did not achieve its intended purpose, but the <a href="concept-transaction-cost.html">transaction cost</a> was destroyed. This result is only final in a validated ledger.</td>
 </tr>
 </tbody>
 </table>
@@ -1635,30 +1629,30 @@
 <table>
 <thead>
 <tr>
-<th>Error Code</th>
-<th>Finality</th>
+<th align="left">Error Code</th>
+<th align="left">Finality</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>tesSUCCESS</code></td>
-<td>Final when included in a validated ledger</td>
+<td align="left"><code>tesSUCCESS</code></td>
+<td align="left">Final when included in a validated ledger</td>
 </tr>
 <tr>
-<td>Any <code>tec</code> code</td>
-<td>Final when included in a validated ledger</td>
+<td align="left">Any <code>tec</code> code</td>
+<td align="left">Final when included in a validated ledger</td>
 </tr>
 <tr>
-<td>Any <code>tem</code> code</td>
-<td>Final unless the protocol changes to make the transaction valid</td>
+<td align="left">Any <code>tem</code> code</td>
+<td align="left">Final unless the protocol changes to make the transaction valid</td>
 </tr>
 <tr>
-<td><code>tefPAST_SEQ</code></td>
-<td>Final when another transaction with the same sequence number is included in a validated ledger</td>
+<td align="left"><code>tefPAST_SEQ</code></td>
+<td align="left">Final when another transaction with the same sequence number is included in a validated ledger</td>
 </tr>
 <tr>
-<td><code>tefMAX_LEDGER</code></td>
-<td>Final when a validated ledger has a sequence number higher than the transaction's <code>LastLedgerSequence</code> field, and no validated ledger includes the transaction</td>
+<td align="left"><code>tefMAX_LEDGER</code></td>
+<td align="left">Final when a validated ledger has a sequence number higher than the transaction's <code>LastLedgerSequence</code> field, and no validated ledger includes the transaction</td>
 </tr>
 </tbody>
 </table>
@@ -1669,36 +1663,36 @@
 <table>
 <thead>
 <tr>
-<th>Field</th>
-<th>Value</th>
-<th>Description</th>
+<th align="left">Field</th>
+<th align="left">Value</th>
+<th align="left">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>AffectedNodes</td>
-<td>Array</td>
-<td>List of nodes that were created, deleted, or modified by this transaction, and specific changes to each.</td>
+<td align="left">AffectedNodes</td>
+<td align="left">Array</td>
+<td align="left">List of nodes that were created, deleted, or modified by this transaction, and specific changes to each.</td>
 </tr>
 <tr>
-<td>DeliveredAmount</td>
-<td>String or Object</td>
-<td><strong>DEPRECATED.</strong> Replaced by <code>delivered_amount</code>. Omitted if not a partial payment.</td>
+<td align="left">DeliveredAmount</td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left"><strong>DEPRECATED.</strong> Replaced by <code>delivered_amount</code>. Omitted if not a partial payment.</td>
 </tr>
 <tr>
-<td>TransactionIndex</td>
-<td>Unsigned Integer</td>
-<td>The transaction's position within the ledger that included it. (For example, the value <code>2</code> means it was the 2nd transaction in that ledger.)</td>
+<td align="left">TransactionIndex</td>
+<td align="left">Unsigned Integer</td>
+<td align="left">The transaction's position within the ledger that included it. (For example, the value <code>2</code> means it was the 2nd transaction in that ledger.)</td>
 </tr>
 <tr>
-<td>TransactionResult</td>
-<td>String</td>
-<td>A <a href="#result-categories">result code</a> indicating whether the transaction succeeded or how it failed.</td>
+<td align="left">TransactionResult</td>
+<td align="left">String</td>
+<td align="left">A <a href="#result-categories">result code</a> indicating whether the transaction succeeded or how it failed.</td>
 </tr>
 <tr>
-<td><a href="#delivered-amount">delivered_amount</a></td>
-<td>Object or String</td>
-<td>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.27.0">rippled 0.27.0</a>) The <a href="reference-rippled.html#specifying-currency-amounts">amount</a> actually received by the <code>Destination</code> account. Use this field to determine how much was delivered, regardless of whether the transaction is a <a href="#partial-payments">partial payment</a>.</td>
+<td align="left"><a href="#delivered-amount">delivered_amount</a></td>
+<td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
+<td align="left">The <a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a> actually received by the <code>Destination</code> account. Use this field to determine how much was delivered, regardless of whether the transaction is a <a href="#partial-payments">partial payment</a>. <em>(New in [<code>rippled</code> 0.27.0][])</em></td>
 </tr>
 </tbody>
 </table>
@@ -1717,42 +1711,42 @@
 <table>
 <thead>
 <tr>
-<th>Code</th>
-<th>Explanation</th>
+<th align="left">Code</th>
+<th align="left">Explanation</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>telBAD_DOMAIN</td>
-<td>The transaction specified a domain value (for example, the <code>Domain</code> field of an <a href="#accountset">AccountSet transaction</a>) that cannot be used, probably because it is too long to store in the ledger.</td>
+<td align="left">telBAD_DOMAIN</td>
+<td align="left">The transaction specified a domain value (for example, the <code>Domain</code> field of an <a href="#accountset">AccountSet transaction</a>) that cannot be used, probably because it is too long to store in the ledger.</td>
 </tr>
 <tr>
-<td>telBAD_PATH_COUNT</td>
-<td>The transaction contains too many paths for the local server to process.</td>
+<td align="left">telBAD_PATH_COUNT</td>
+<td align="left">The transaction contains too many paths for the local server to process.</td>
 </tr>
 <tr>
-<td>telBAD_PUBLIC_KEY</td>
-<td>The transaction specified a public key value (for example, as the <code>MessageKey</code> field of an <a href="#accountset">AccountSet transaction</a>) that cannot be used, probably because it is too long.</td>
+<td align="left">telBAD_PUBLIC_KEY</td>
+<td align="left">The transaction specified a public key value (for example, as the <code>MessageKey</code> field of an <a href="#accountset">AccountSet transaction</a>) that cannot be used, probably because it is too long.</td>
 </tr>
 <tr>
-<td>telCAN_NOT_QUEUE</td>
-<td>The transaction did not meet the <a href="concept-transaction-cost.html">open ledger cost</a>, but this server did not queue this transaction because it did not meet the <a href="concept-transaction-cost.html#queuing-restrictions">queuing restrictions</a>. You can try again later or sign and submit a replacement transaction with a higher transaction cost in the <code>Fee</code> field.</td>
+<td align="left">telCAN_NOT_QUEUE</td>
+<td align="left">The transaction did not meet the <a href="concept-transaction-cost.html">open ledger cost</a>, but this server did not queue this transaction because it did not meet the <a href="concept-transaction-cost.html#queuing-restrictions">queuing restrictions</a>. You can try again later or sign and submit a replacement transaction with a higher transaction cost in the <code>Fee</code> field.</td>
 </tr>
 <tr>
-<td>telFAILED_PROCESSING</td>
-<td>An unspecified error occurred when processing the transaction.</td>
+<td align="left">telFAILED_PROCESSING</td>
+<td align="left">An unspecified error occurred when processing the transaction.</td>
 </tr>
 <tr>
-<td>telINSUF_FEE_P</td>
-<td>The <code>Fee</code> from the transaction is not high enough to meet the server's current <a href="concept-transaction-cost.html">transaction cost</a> requirement, which is derived from its load level.</td>
+<td align="left">telINSUF_FEE_P</td>
+<td align="left">The <code>Fee</code> from the transaction is not high enough to meet the server's current <a href="concept-transaction-cost.html">transaction cost</a> requirement, which is derived from its load level.</td>
 </tr>
 <tr>
-<td>telLOCAL_ERROR</td>
-<td>Unspecified local error.</td>
+<td align="left">telLOCAL_ERROR</td>
+<td align="left">Unspecified local error.</td>
 </tr>
 <tr>
-<td>telNO_DST_PARTIAL</td>
-<td>The transaction is an XRP payment that would fund a new account, but the <a href="#partial-payments">tfPartialPayment flag</a> was enabled. This is disallowed.</td>
+<td align="left">telNO_DST_PARTIAL</td>
+<td align="left">The transaction is an XRP payment that would fund a new account, but the <a href="#partial-payments">tfPartialPayment flag</a> was enabled. This is disallowed.</td>
 </tr>
 </tbody>
 </table>
@@ -1761,142 +1755,142 @@
 <table>
 <thead>
 <tr>
-<th>Code</th>
-<th>Explanation</th>
+<th align="left">Code</th>
+<th align="left">Explanation</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>temBAD_AMOUNT</td>
-<td>An amount specified by the transaction (for example the destination <code>Amount</code> or <code>SendMax</code> values of a <a href="#payment">Payment</a>) was invalid, possibly because it was a negative number.</td>
+<td align="left">temBAD_AMOUNT</td>
+<td align="left">An amount specified by the transaction (for example the destination <code>Amount</code> or <code>SendMax</code> values of a <a href="#payment">Payment</a>) was invalid, possibly because it was a negative number.</td>
 </tr>
 <tr>
-<td>temBAD_AUTH_MASTER</td>
-<td>The key used to sign this transaction does not match the master key for the account sending it, and the account does not have a <a href="#setregularkey">Regular Key</a> set.</td>
+<td align="left">temBAD_AUTH_MASTER</td>
+<td align="left">The key used to sign this transaction does not match the master key for the account sending it, and the account does not have a <a href="#setregularkey">Regular Key</a> set.</td>
 </tr>
 <tr>
-<td>temBAD_CURRENCY</td>
-<td>The transaction improperly specified a currency field. See <a href="reference-rippled.html#specifying-currency-amounts">Specifying Currency Amounts</a> for the correct format.</td>
+<td align="left">temBAD_CURRENCY</td>
+<td align="left">The transaction improperly specified a currency field. See <a href="reference-rippled.html#specifying-currency-amounts">Specifying Currency Amounts</a> for the correct format.</td>
 </tr>
 <tr>
-<td>temBAD_EXPIRATION</td>
-<td>The transaction improperly specified an expiration value, for example as part of an <a href="#offercreate">OfferCreate transaction</a>.</td>
+<td align="left">temBAD_EXPIRATION</td>
+<td align="left">The transaction improperly specified an expiration value, for example as part of an <a href="#offercreate">OfferCreate transaction</a>.</td>
 </tr>
 <tr>
-<td>temBAD_FEE</td>
-<td>The transaction improperly specified its <code>Fee</code> value, for example by listing a non-XRP currency or some negative amount of XRP.</td>
+<td align="left">temBAD_FEE</td>
+<td align="left">The transaction improperly specified its <code>Fee</code> value, for example by listing a non-XRP currency or some negative amount of XRP.</td>
 </tr>
 <tr>
-<td>temBAD_ISSUER</td>
-<td>The transaction improperly specified the <code>issuer</code> field of some currency included in the request.</td>
+<td align="left">temBAD_ISSUER</td>
+<td align="left">The transaction improperly specified the <code>issuer</code> field of some currency included in the request.</td>
 </tr>
 <tr>
-<td>temBAD_LIMIT</td>
-<td>The <a href="#trustset">TrustSet</a> transaction improperly specified the <code>LimitAmount</code> value of a trustline.</td>
+<td align="left">temBAD_LIMIT</td>
+<td align="left">The <a href="#trustset">TrustSet</a> transaction improperly specified the <code>LimitAmount</code> value of a trustline.</td>
 </tr>
 <tr>
-<td>temBAD_OFFER</td>
-<td>The <a href="#offercreate">OfferCreate</a> transaction specifies an invalid offer, such as offering to trade XRP for itself, or offering a negative amount.</td>
+<td align="left">temBAD_OFFER</td>
+<td align="left">The <a href="#offercreate">OfferCreate</a> transaction specifies an invalid offer, such as offering to trade XRP for itself, or offering a negative amount.</td>
 </tr>
 <tr>
-<td>temBAD_PATH</td>
-<td>The <a href="#payment">Payment</a> transaction specifies one or more <a href="#paths">Paths</a> improperly, for example including an issuer for XRP, or specifying an account differently.</td>
+<td align="left">temBAD_PATH</td>
+<td align="left">The <a href="#payment">Payment</a> transaction specifies one or more <a href="#paths">Paths</a> improperly, for example including an issuer for XRP, or specifying an account differently.</td>
 </tr>
 <tr>
-<td>temBAD_PATH_LOOP</td>
-<td>One of the <a href="#paths">Paths</a> in the <a href="#payment">Payment</a> transaction was flagged as a loop, so it cannot be processed in a bounded amount of time.</td>
+<td align="left">temBAD_PATH_LOOP</td>
+<td align="left">One of the <a href="#paths">Paths</a> in the <a href="#payment">Payment</a> transaction was flagged as a loop, so it cannot be processed in a bounded amount of time.</td>
 </tr>
 <tr>
-<td>temBAD_SEND_XRP_LIMIT</td>
-<td>The <a href="#payment">Payment</a> transaction used the <a href="#limit-quality">tfLimitQuality</a> flag in a direct XRP-to-XRP payment, even though XRP-to-XRP payments do not involve any conversions.</td>
+<td align="left">temBAD_SEND_XRP_LIMIT</td>
+<td align="left">The <a href="#payment">Payment</a> transaction used the <a href="#limit-quality">tfLimitQuality</a> flag in a direct XRP-to-XRP payment, even though XRP-to-XRP payments do not involve any conversions.</td>
 </tr>
 <tr>
-<td>temBAD_SEND_XRP_MAX</td>
-<td>The <a href="#payment">Payment</a> transaction included a <code>SendMax</code> field in a direct XRP-to-XRP payment, even though sending XRP should never require SendMax. (XRP is only valid in SendMax if the destination <code>Amount</code> is not XRP.)</td>
+<td align="left">temBAD_SEND_XRP_MAX</td>
+<td align="left">The <a href="#payment">Payment</a> transaction included a <code>SendMax</code> field in a direct XRP-to-XRP payment, even though sending XRP should never require SendMax. (XRP is only valid in SendMax if the destination <code>Amount</code> is not XRP.)</td>
 </tr>
 <tr>
-<td>temBAD_SEND_XRP_NO_DIRECT</td>
-<td>The <a href="#payment">Payment</a> transaction used the <a href="#payment-flags">tfNoDirectRipple</a> flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments are always direct.</td>
+<td align="left">temBAD_SEND_XRP_NO_DIRECT</td>
+<td align="left">The <a href="#payment">Payment</a> transaction used the <a href="#payment-flags">tfNoDirectRipple</a> flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments are always direct.</td>
 </tr>
 <tr>
-<td>temBAD_SEND_XRP_PARTIAL</td>
-<td>The <a href="#payment">Payment</a> transaction used the <a href="#partial-payments">tfPartialPayment</a> flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments should always deliver the full amount.</td>
+<td align="left">temBAD_SEND_XRP_PARTIAL</td>
+<td align="left">The <a href="#payment">Payment</a> transaction used the <a href="#partial-payments">tfPartialPayment</a> flag for a direct XRP-to-XRP payment, even though XRP-to-XRP payments should always deliver the full amount.</td>
 </tr>
 <tr>
-<td>temBAD_SEND_XRP_PATHS</td>
-<td>The <a href="#payment">Payment</a> transaction included <code>Paths</code> while sending XRP, even though XRP-to-XRP payments should always be direct.</td>
+<td align="left">temBAD_SEND_XRP_PATHS</td>
+<td align="left">The <a href="#payment">Payment</a> transaction included <code>Paths</code> while sending XRP, even though XRP-to-XRP payments should always be direct.</td>
 </tr>
 <tr>
-<td>temBAD_SEQUENCE</td>
-<td>The transaction is references a sequence number that is higher than its own <code>Sequence</code> number, for example trying to cancel an offer that would have to be placed after the transaction that cancels it.</td>
+<td align="left">temBAD_SEQUENCE</td>
+<td align="left">The transaction is references a sequence number that is higher than its own <code>Sequence</code> number, for example trying to cancel an offer that would have to be placed after the transaction that cancels it.</td>
 </tr>
 <tr>
-<td>temBAD_SIGNATURE</td>
-<td>The signature to authorize this transaction is either missing, or formed in a way that is not a properly-formed signature. (See <a href="#tec-codes">tecNO_PERMISSION</a> for the case where the signature is properly formed, but not authorized for this account.)</td>
+<td align="left">temBAD_SIGNATURE</td>
+<td align="left">The signature to authorize this transaction is either missing, or formed in a way that is not a properly-formed signature. (See <a href="#tec-codes">tecNO_PERMISSION</a> for the case where the signature is properly formed, but not authorized for this account.)</td>
 </tr>
 <tr>
-<td>temBAD_SRC_ACCOUNT</td>
-<td>The <code>Account</code> on whose behalf this transaction is being sent (the "source account") is not a properly-formed Ripple account.</td>
+<td align="left">temBAD_SRC_ACCOUNT</td>
+<td align="left">The <code>Account</code> on whose behalf this transaction is being sent (the "source account") is not a properly-formed Ripple account.</td>
 </tr>
 <tr>
-<td>temBAD_TRANSFER_RATE</td>
-<td>The <a href="#transferrate"><code>TransferRate</code> field of an AccountSet transaction</a> is not properly formatted.</td>
+<td align="left">temBAD_TRANSFER_RATE</td>
+<td align="left">The <a href="#transferrate"><code>TransferRate</code> field of an AccountSet transaction</a> is not properly formatted.</td>
 </tr>
 <tr>
-<td>temDST_IS_SRC</td>
-<td>The <a href="#trustset">TrustSet</a> transaction improperly specified the destination of the trust line (the <code>issuer</code> field of <code>LimitAmount</code>) as the <code>Account</code> sending the transaction. You cannot extend a trust line to yourself. (In the future, this code could also apply to other cases where the destination of a transaction is not allowed to be the account sending it.)</td>
+<td align="left">temDST_IS_SRC</td>
+<td align="left">The <a href="#trustset">TrustSet</a> transaction improperly specified the destination of the trust line (the <code>issuer</code> field of <code>LimitAmount</code>) as the <code>Account</code> sending the transaction. You cannot extend a trust line to yourself. (In the future, this code could also apply to other cases where the destination of a transaction is not allowed to be the account sending it.)</td>
 </tr>
 <tr>
-<td>temDST_NEEDED</td>
-<td>The transaction improperly omitted a destination. This could be the <code>Destination</code> field of a <a href="#payment">Payment</a> transaction, or the <code>issuer</code> sub-field of the <code>LimitAmount</code> field fo a <code>TrustSet</code> transaction.</td>
+<td align="left">temDST_NEEDED</td>
+<td align="left">The transaction improperly omitted a destination. This could be the <code>Destination</code> field of a <a href="#payment">Payment</a> transaction, or the <code>issuer</code> sub-field of the <code>LimitAmount</code> field fo a <code>TrustSet</code> transaction.</td>
 </tr>
 <tr>
-<td>temINVALID</td>
-<td>The transaction is otherwise invalid. For example, the transaction ID may not be the right format, the signature may not be formed properly, or something else went wrong in understanding the transaction.</td>
+<td align="left">temINVALID</td>
+<td align="left">The transaction is otherwise invalid. For example, the transaction ID may not be the right format, the signature may not be formed properly, or something else went wrong in understanding the transaction.</td>
 </tr>
 <tr>
-<td>temINVALID_FLAG</td>
-<td>The transaction includes a <a href="#flags">Flag</a> that does not exist, or includes a contradictory combination of flags.</td>
+<td align="left">temINVALID_FLAG</td>
+<td align="left">The transaction includes a <a href="#flags">Flag</a> that does not exist, or includes a contradictory combination of flags.</td>
 </tr>
 <tr>
-<td>temMALFORMED</td>
-<td>Unspecified problem with the format of the transaction.</td>
+<td align="left">temMALFORMED</td>
+<td align="left">Unspecified problem with the format of the transaction.</td>
 </tr>
 <tr>
-<td>temREDUNDANT</td>
-<td>The transaction would do nothing; for example, it is sending a payment directly to the sending account, or creating an offer to buy and sell the same currency from the same issuer.</td>
+<td align="left">temREDUNDANT</td>
+<td align="left">The transaction would do nothing; for example, it is sending a payment directly to the sending account, or creating an offer to buy and sell the same currency from the same issuer.</td>
 </tr>
 <tr>
-<td>temREDUNDANT_SEND_MAX</td>
-<td><em>(Removed in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0-rc1">rippled 0.28.0</a>)</em></td>
+<td align="left">temREDUNDANT_SEND_MAX</td>
+<td align="left"><em>(Removed in [<code>rippled</code> 0.28.0][])</em></td>
 </tr>
 <tr>
-<td>temRIPPLE_EMPTY</td>
-<td>The <a href="#payment">Payment</a> transaction includes an empty <code>Paths</code> field, but paths are necessary to complete this payment.</td>
+<td align="left">temRIPPLE_EMPTY</td>
+<td align="left">The <a href="#payment">Payment</a> transaction includes an empty <code>Paths</code> field, but paths are necessary to complete this payment.</td>
 </tr>
 <tr>
-<td>temBAD_WEIGHT</td>
-<td>The <a href="#signerlistset">SignerListSet</a> transaction includes a <code>SignerWeight</code> that is invalid, for example a zero or negative value.</td>
+<td align="left">temBAD_WEIGHT</td>
+<td align="left">The <a href="#signerlistset">SignerListSet</a> transaction includes a <code>SignerWeight</code> that is invalid, for example a zero or negative value.</td>
 </tr>
 <tr>
-<td>temBAD_SIGNER</td>
-<td>The <a href="#signerlistset">SignerListSet</a> transaction includes a signer who is invalid. For example, there may be duplicate entries, or the owner of the SignerList may also be a member.</td>
+<td align="left">temBAD_SIGNER</td>
+<td align="left">The <a href="#signerlistset">SignerListSet</a> transaction includes a signer who is invalid. For example, there may be duplicate entries, or the owner of the SignerList may also be a member.</td>
 </tr>
 <tr>
-<td>temBAD_QUORUM</td>
-<td>The <a href="#signerlistset">SignerListSet</a> transaction has an invalid <code>SignerQuorum</code> value. Either the value is not greater than zero, or it is more than the sum of all signers in the list.</td>
+<td align="left">temBAD_QUORUM</td>
+<td align="left">The <a href="#signerlistset">SignerListSet</a> transaction has an invalid <code>SignerQuorum</code> value. Either the value is not greater than zero, or it is more than the sum of all signers in the list.</td>
 </tr>
 <tr>
-<td>temUNCERTAIN</td>
-<td>Used internally only. This code should never be returned.</td>
+<td align="left">temUNCERTAIN</td>
+<td align="left">Used internally only. This code should never be returned.</td>
 </tr>
 <tr>
-<td>temUNKNOWN</td>
-<td>Used internally only. This code should never be returned.</td>
+<td align="left">temUNKNOWN</td>
+<td align="left">Used internally only. This code should never be returned.</td>
 </tr>
 <tr>
-<td>temDISABLED</td>
-<td>The transaction requires logic that is disabled. Typically this means you are trying to use an <a href="concept-amendments.html">amendment</a> that is not enabled for the current ledger.</td>
+<td align="left">temDISABLED</td>
+<td align="left">The transaction requires logic that is disabled. Typically this means you are trying to use an <a href="concept-amendments.html">amendment</a> that is not enabled for the current ledger.</td>
 </tr>
 </tbody>
 </table>
@@ -1905,78 +1899,78 @@
 <table>
 <thead>
 <tr>
-<th>Code</th>
-<th>Explanation</th>
+<th align="left">Code</th>
+<th align="left">Explanation</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tefALREADY</td>
-<td>The same exact transaction has already been applied.</td>
+<td align="left">tefALREADY</td>
+<td align="left">The same exact transaction has already been applied.</td>
 </tr>
 <tr>
-<td>tefBAD_ADD_AUTH</td>
-<td><strong>DEPRECATED.</strong></td>
+<td align="left">tefBAD_ADD_AUTH</td>
+<td align="left"><strong>DEPRECATED.</strong></td>
 </tr>
 <tr>
-<td>tefBAD_AUTH</td>
-<td>The key used to sign this account is not authorized to modify this account. (It could be authorized if the account had the same key set as the <a href="#setregularkey">Regular Key</a>.)</td>
+<td align="left">tefBAD_AUTH</td>
+<td align="left">The key used to sign this account is not authorized to modify this account. (It could be authorized if the account had the same key set as the <a href="#setregularkey">Regular Key</a>.)</td>
 </tr>
 <tr>
-<td>tefBAD_AUTH_MASTER</td>
-<td>The single signature provided to authorize this transaction does not match the master key, but no regular key is associated with this address.</td>
+<td align="left">tefBAD_AUTH_MASTER</td>
+<td align="left">The single signature provided to authorize this transaction does not match the master key, but no regular key is associated with this address.</td>
 </tr>
 <tr>
-<td>tefBAD_LEDGER</td>
-<td>While processing the transaction, the ledger was discovered in an unexpected state. If you can reproduce this error, please <a href="https://github.com/ripple/rippled/issues">report an issue</a> to get it fixed.</td>
+<td align="left">tefBAD_LEDGER</td>
+<td align="left">While processing the transaction, the ledger was discovered in an unexpected state. If you can reproduce this error, please <a href="https://github.com/ripple/rippled/issues">report an issue</a> to get it fixed.</td>
 </tr>
 <tr>
-<td>tefBAD_QUORUM</td>
-<td>The transaction was <a href="#multi-signing">multi-signed</a>, but the total weights of all included signatures did not meet the quorum.</td>
+<td align="left">tefBAD_QUORUM</td>
+<td align="left">The transaction was <a href="#multi-signing">multi-signed</a>, but the total weights of all included signatures did not meet the quorum.</td>
 </tr>
 <tr>
-<td>tefBAD_SIGNATURE</td>
-<td>The transaction was <a href="#multi-signing">multi-signed</a>, but contained a signature for an address not part of a SignerList associated with the sending account.</td>
+<td align="left">tefBAD_SIGNATURE</td>
+<td align="left">The transaction was <a href="#multi-signing">multi-signed</a>, but contained a signature for an address not part of a SignerList associated with the sending account.</td>
 </tr>
 <tr>
-<td>tefCREATED</td>
-<td><strong>DEPRECATED.</strong></td>
+<td align="left">tefCREATED</td>
+<td align="left"><strong>DEPRECATED.</strong></td>
 </tr>
 <tr>
-<td>tefEXCEPTION</td>
-<td>While processing the transaction, the server entered an unexpected state. This may be caused by unexpected inputs, for example if the binary data for the transaction is grossly malformed. If you can reproduce this error, please <a href="https://github.com/ripple/rippled/issues">report an issue</a> to get it fixed.</td>
+<td align="left">tefEXCEPTION</td>
+<td align="left">While processing the transaction, the server entered an unexpected state. This may be caused by unexpected inputs, for example if the binary data for the transaction is grossly malformed. If you can reproduce this error, please <a href="https://github.com/ripple/rippled/issues">report an issue</a> to get it fixed.</td>
 </tr>
 <tr>
-<td>tefFAILURE</td>
-<td>Unspecified failure in applying the transaction.</td>
+<td align="left">tefFAILURE</td>
+<td align="left">Unspecified failure in applying the transaction.</td>
 </tr>
 <tr>
-<td>tefINTERNAL</td>
-<td>When trying to apply the transaction, the server entered an unexpected state. If you can reproduce this error, please <a href="https://github.com/ripple/rippled/issues">report an issue</a> to get it fixed.</td>
+<td align="left">tefINTERNAL</td>
+<td align="left">When trying to apply the transaction, the server entered an unexpected state. If you can reproduce this error, please <a href="https://github.com/ripple/rippled/issues">report an issue</a> to get it fixed.</td>
 </tr>
 <tr>
-<td>tefMASTER_DISABLED</td>
-<td>The transaction was signed with the account's master key, but the account has the <code>lsfDisableMaster</code> field set.</td>
+<td align="left">tefMASTER_DISABLED</td>
+<td align="left">The transaction was signed with the account's master key, but the account has the <code>lsfDisableMaster</code> field set.</td>
 </tr>
 <tr>
-<td>tefMAX_LEDGER</td>
-<td>The transaction included a <a href="#lastledgersequence"><code>LastLedgerSequence</code></a> parameter, but the current ledger's sequence number is already higher than the specified value.</td>
+<td align="left">tefMAX_LEDGER</td>
+<td align="left">The transaction included a <a href="#lastledgersequence"><code>LastLedgerSequence</code></a> parameter, but the current ledger's sequence number is already higher than the specified value.</td>
 </tr>
 <tr>
-<td>tefNO_AUTH_REQUIRED</td>
-<td>The <a href="#trustset">TrustSet</a> transaction tried to mark a trustline as authorized, but the <code>lsfRequireAuth</code> flag is not enabled for the corresponding account, so authorization is not necessary.</td>
+<td align="left">tefNO_AUTH_REQUIRED</td>
+<td align="left">The <a href="#trustset">TrustSet</a> transaction tried to mark a trustline as authorized, but the <code>lsfRequireAuth</code> flag is not enabled for the corresponding account, so authorization is not necessary.</td>
 </tr>
 <tr>
-<td>tefNOT_MULTI_SIGNING</td>
-<td>The transaction was <a href="#multi-signing">multi-signed</a>, but the sending account has no SignerList defined.</td>
+<td align="left">tefNOT_MULTI_SIGNING</td>
+<td align="left">The transaction was <a href="#multi-signing">multi-signed</a>, but the sending account has no SignerList defined.</td>
 </tr>
 <tr>
-<td>tefPAST_SEQ</td>
-<td>The sequence number of the transaction is lower than the current sequence number of the account sending the transaction.</td>
+<td align="left">tefPAST_SEQ</td>
+<td align="left">The sequence number of the transaction is lower than the current sequence number of the account sending the transaction.</td>
 </tr>
 <tr>
-<td>tefWRONG_PRIOR</td>
-<td>The transaction contained an <code>AccountTxnID</code> field (or the deprecated <code>PreviousTxnID</code> field), but the transaction specified there does not match the account's previous transaction.</td>
+<td align="left">tefWRONG_PRIOR</td>
+<td align="left">The transaction contained an <code>AccountTxnID</code> field (or the deprecated <code>PreviousTxnID</code> field), but the transaction specified there does not match the account's previous transaction.</td>
 </tr>
 </tbody>
 </table>
@@ -1985,54 +1979,54 @@
 <table>
 <thead>
 <tr>
-<th>Code</th>
-<th>Explanation</th>
+<th align="left">Code</th>
+<th align="left">Explanation</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>terFUNDS_SPENT</td>
-<td><strong>DEPRECATED.</strong></td>
+<td align="left">terFUNDS_SPENT</td>
+<td align="left"><strong>DEPRECATED.</strong></td>
 </tr>
 <tr>
-<td>terINSUF_FEE_B</td>
-<td>The account sending the transaction does not have enough XRP to pay the <code>Fee</code> specified in the transaction.</td>
+<td align="left">terINSUF_FEE_B</td>
+<td align="left">The account sending the transaction does not have enough XRP to pay the <code>Fee</code> specified in the transaction.</td>
 </tr>
 <tr>
-<td>terLAST</td>
-<td>Used internally only. This code should never be returned.</td>
+<td align="left">terLAST</td>
+<td align="left">Used internally only. This code should never be returned.</td>
 </tr>
 <tr>
-<td>terNO_ACCOUNT</td>
-<td>The address sending the transaction is not funded in the ledger (yet).</td>
+<td align="left">terNO_ACCOUNT</td>
+<td align="left">The address sending the transaction is not funded in the ledger (yet).</td>
 </tr>
 <tr>
-<td>terNO_AUTH</td>
-<td>The transaction would involve adding currency issued by an account with <code>lsfRequireAuth</code> enabled to a trust line that is not authorized. For example, you placed an offer to buy a currency you aren't authorized to hold.</td>
+<td align="left">terNO_AUTH</td>
+<td align="left">The transaction would involve adding currency issued by an account with <code>lsfRequireAuth</code> enabled to a trust line that is not authorized. For example, you placed an offer to buy a currency you aren't authorized to hold.</td>
 </tr>
 <tr>
-<td>terNO_LINE</td>
-<td>Used internally only. This code should never be returned.</td>
+<td align="left">terNO_LINE</td>
+<td align="left">Used internally only. This code should never be returned.</td>
 </tr>
 <tr>
-<td>terNO_RIPPLE</td>
-<td>Used internally only. This code should never be returned.</td>
+<td align="left">terNO_RIPPLE</td>
+<td align="left">Used internally only. This code should never be returned.</td>
 </tr>
 <tr>
-<td>terOWNERS</td>
-<td>The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the <a href="#accountset-flags"><code>lsfRequireAuth</code></a> flag if it has any trust lines or available offers.</td>
+<td align="left">terOWNERS</td>
+<td align="left">The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the <a href="#accountset-flags"><code>lsfRequireAuth</code></a> flag if it has any trust lines or available offers.</td>
 </tr>
 <tr>
-<td>terPRE_SEQ</td>
-<td>The <code>Sequence</code> number of the current transaction is higher than the current sequence number of the account sending the transaction.</td>
+<td align="left">terPRE_SEQ</td>
+<td align="left">The <code>Sequence</code> number of the current transaction is higher than the current sequence number of the account sending the transaction.</td>
 </tr>
 <tr>
-<td>terRETRY</td>
-<td>Unspecified retriable error.</td>
+<td align="left">terRETRY</td>
+<td align="left">Unspecified retriable error.</td>
 </tr>
 <tr>
-<td>terQUEUED</td>
-<td>The transaction met the load-scaled <a href="concept-transaction-cost.html">transaction cost</a> but did not meet the open ledger requirement, so the transaction has been queued for a future ledger.</td>
+<td align="left">terQUEUED</td>
+<td align="left">The transaction met the load-scaled <a href="concept-transaction-cost.html">transaction cost</a> but did not meet the open ledger requirement, so the transaction has been queued for a future ledger.</td>
 </tr>
 </tbody>
 </table>
@@ -2041,14 +2035,14 @@
 <table>
 <thead>
 <tr>
-<th>Code</th>
-<th>Explanation</th>
+<th align="left">Code</th>
+<th align="left">Explanation</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tesSUCCESS</td>
-<td>The transaction was applied and forwarded to other servers. If this appears in a validated ledger, then the transaction's success is final.</td>
+<td align="left">tesSUCCESS</td>
+<td align="left">The transaction was applied and forwarded to other servers. If this appears in a validated ledger, then the transaction's success is final.</td>
 </tr>
 </tbody>
 </table>
@@ -2057,216 +2051,165 @@
 <table>
 <thead>
 <tr>
-<th>Code</th>
-<th>Value</th>
-<th>Explanation</th>
+<th align="left">Code</th>
+<th align="left">Value</th>
+<th align="left">Explanation</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>tecCLAIM</td>
-<td>100</td>
-<td>Unspecified failure, with transaction cost destroyed.</td>
+<td align="left">tecCLAIM</td>
+<td align="left">100</td>
+<td align="left">Unspecified failure, with transaction cost destroyed.</td>
 </tr>
 <tr>
-<td>tecDIR_FULL</td>
-<td>121</td>
-<td>The address sending the transaction cannot own any more objects in the ledger.</td>
+<td align="left">tecDIR_FULL</td>
+<td align="left">121</td>
+<td align="left">The address sending the transaction cannot own any more objects in the ledger.</td>
 </tr>
 <tr>
-<td>tecDST_TAG_NEEDED</td>
-<td>143</td>
-<td>The <a href="#payment">Payment</a> transaction omitted a destination tag, but the destination account has the <code>lsfRequireDestTag</code> flag enabled. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0-rc1">rippled 0.28.0</a>)</em></td>
+<td align="left">tecDST_TAG_NEEDED</td>
+<td align="left">143</td>
+<td align="left">The <a href="#payment">Payment</a> transaction omitted a destination tag, but the destination account has the <code>lsfRequireDestTag</code> flag enabled. <em>(New in [<code>rippled</code> 0.28.0][])</em></td>
 </tr>
 <tr>
-<td>tecFAILED_PROCESSING</td>
-<td>105</td>
-<td>An unspecified error occurred when processing the transaction.</td>
+<td align="left">tecFAILED_PROCESSING</td>
+<td align="left">105</td>
+<td align="left">An unspecified error occurred when processing the transaction.</td>
 </tr>
 <tr>
-<td>tecFROZEN</td>
-<td>137</td>
-<td>The <a href="#offercreate">OfferCreate transaction</a> failed because one or both of the assets involved are subject to a <a href="concept-freeze.html">global freeze</a>.</td>
+<td align="left">tecFROZEN</td>
+<td align="left">137</td>
+<td align="left">The <a href="#offercreate">OfferCreate transaction</a> failed because one or both of the assets involved are subject to a <a href="concept-freeze.html">global freeze</a>.</td>
 </tr>
 <tr>
-<td>tecINSUF_RESERVE_LINE</td>
-<td>122</td>
-<td>The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: <a href="concept-reserves.html">Reserves</a>) This error occurs when the counterparty already has a trust line in a non-default state to the sending account for the same currency. (See tecNO_LINE_INSUF_RESERVE for the other case.)</td>
+<td align="left">tecINSUF_RESERVE_LINE</td>
+<td align="left">122</td>
+<td align="left">The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: <a href="concept-reserves.html">Reserves</a>) This error occurs when the counterparty already has a trust line in a non-default state to the sending account for the same currency. (See tecNO_LINE_INSUF_RESERVE for the other case.)</td>
 </tr>
 <tr>
-<td>tecINSUF_RESERVE_OFFER</td>
-<td>123</td>
-<td>The transaction failed because the sending account does not have enough XRP to create a new Offer. (See: <a href="concept-reserves.html">Reserves</a>)</td>
+<td align="left">tecINSUF_RESERVE_OFFER</td>
+<td align="left">123</td>
+<td align="left">The transaction failed because the sending account does not have enough XRP to create a new Offer. (See: <a href="concept-reserves.html">Reserves</a>)</td>
 </tr>
 <tr>
-<td>tecINSUFFICIENT_RESERVE</td>
-<td>141</td>
-<td>The <a href="#signerlistset">SignerListSet</a> or other transaction would increase the <a href="concept-reserves.html">reserve requirement</a> higher than the sending account's balance. See <a href="reference-ledger-format.html#signerlists-and-reserves">SignerLists and Reserves</a> for more information.</td>
+<td align="left">tecINSUFFICIENT_RESERVE</td>
+<td align="left">141</td>
+<td align="left">The <a href="#signerlistset">SignerListSet</a> or other transaction would increase the <a href="concept-reserves.html">reserve requirement</a> higher than the sending account's balance. See <a href="reference-ledger-format.html#signerlists-and-reserves">SignerLists and Reserves</a> for more information.</td>
 </tr>
 <tr>
-<td>tecINTERNAL</td>
-<td>144</td>
-<td>Unspecified internal error, with transaction cost applied. This error code should not normally be returned.</td>
+<td align="left">tecINTERNAL</td>
+<td align="left">144</td>
+<td align="left">Unspecified internal error, with transaction cost applied. This error code should not normally be returned.</td>
 </tr>
 <tr>
-<td>tecNEED_MASTER_KEY</td>
-<td>142</td>
-<td>This transaction tried to cause changes that require the master key, such as <a href="#accountset-flags">disabling the master key or giving up the ability to freeze balances</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.28.0-rc1">rippled 0.28.0</a>)</em></td>
+<td align="left">tecNEED_MASTER_KEY</td>
+<td align="left">142</td>
+<td align="left">This transaction tried to cause changes that require the master key, such as <a href="#accountset-flags">disabling the master key or giving up the ability to freeze balances</a>. <em>(New in [<code>rippled</code> 0.28.0][])</em></td>
 </tr>
 <tr>
-<td>tecNO_ALTERNATIVE_KEY</td>
-<td>130</td>
-<td>The transaction tried to remove the only available method of <a href="#authorizing-transactions">authorizing transactions</a>. This could be a <a href="#setregularkey">SetRegularKey transaction</a> to remove the regular key, a <a href="#signerlistset">SignerListSet transaction</a> to delete a SignerList, or an <a href="#accountset">AccountSet transaction</a> to disable the master key. (Prior to <a href="https://github.com/ripple/rippled/releases/tag/0.30.0">rippled 0.30.0</a>, this was called <code>tecMASTER_DISABLED</code>.)</td>
+<td align="left">tecNO_ALTERNATIVE_KEY</td>
+<td align="left">130</td>
+<td align="left">The transaction tried to remove the only available method of <a href="#authorizing-transactions">authorizing transactions</a>. This could be a <a href="#setregularkey">SetRegularKey transaction</a> to remove the regular key, a <a href="#signerlistset">SignerListSet transaction</a> to delete a SignerList, or an <a href="#accountset">AccountSet transaction</a> to disable the master key. (Prior to [<code>rippled</code> 0.30.0][], this was called <code>tecMASTER_DISABLED</code>.)</td>
 </tr>
 <tr>
-<td>tecNO_AUTH</td>
-<td>134</td>
-<td>The transaction failed because it needs to add a balance on a trust line to an account with the <code>lsfRequireAuth</code> flag enabled, and that trust line has not been authorized. If the trust line does not exist at all, tecNO_LINE occurs instead.</td>
+<td align="left">tecNO_AUTH</td>
+<td align="left">134</td>
+<td align="left">The transaction failed because it needs to add a balance on a trust line to an account with the <code>lsfRequireAuth</code> flag enabled, and that trust line has not been authorized. If the trust line does not exist at all, tecNO_LINE occurs instead.</td>
 </tr>
 <tr>
-<td>tecNO_DST</td>
-<td>124</td>
-<td>The account on the receiving end of the transaction does not exist. This includes Payment and TrustSet transaction types. (It could be created if it received enough XRP.)</td>
+<td align="left">tecNO_DST</td>
+<td align="left">124</td>
+<td align="left">The account on the receiving end of the transaction does not exist. This includes Payment and TrustSet transaction types. (It could be created if it received enough XRP.)</td>
 </tr>
 <tr>
-<td>tecNO_DST_INSUF_XRP</td>
-<td>125</td>
-<td>The account on the receiving end of the transaction does not exist, and the transaction is not sending enough XRP to create it.</td>
+<td align="left">tecNO_DST_INSUF_XRP</td>
+<td align="left">125</td>
+<td align="left">The account on the receiving end of the transaction does not exist, and the transaction is not sending enough XRP to create it.</td>
 </tr>
 <tr>
-<td>tecNO_ENTRY</td>
-<td>140</td>
-<td>Reserved for future use.</td>
+<td align="left">tecNO_ENTRY</td>
+<td align="left">140</td>
+<td align="left">Reserved for future use.</td>
 </tr>
 <tr>
-<td>tecNO_ISSUER</td>
-<td>133</td>
-<td>The account specified in the <code>issuer</code> field of a currency amount does not exist.</td>
+<td align="left">tecNO_ISSUER</td>
+<td align="left">133</td>
+<td align="left">The account specified in the <code>issuer</code> field of a currency amount does not exist.</td>
 </tr>
 <tr>
-<td>tecNO_LINE</td>
-<td>135</td>
-<td>The <code>TakerPays</code> field of the <a href="#offercreate">OfferCreate transaction</a> specifies an asset whose issuer has <code>lsfRequireAuth</code> enabled, and the account making the offer does not have a trust line for that asset. (Normally, making an offer implicitly creates a trust line if necessary, but in this case it does not bother because you cannot hold the asset without authorization.) If the trust line exists, but is not authorized, <code>tecNO_AUTH</code> occurs instead.</td>
+<td align="left">tecNO_LINE</td>
+<td align="left">135</td>
+<td align="left">The <code>TakerPays</code> field of the <a href="#offercreate">OfferCreate transaction</a> specifies an asset whose issuer has <code>lsfRequireAuth</code> enabled, and the account making the offer does not have a trust line for that asset. (Normally, making an offer implicitly creates a trust line if necessary, but in this case it does not bother because you cannot hold the asset without authorization.) If the trust line exists, but is not authorized, <code>tecNO_AUTH</code> occurs instead.</td>
 </tr>
 <tr>
-<td>tecNO_LINE_INSUF_RESERVE</td>
-<td>126</td>
-<td>The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: <a href="concept-reserves.html">Reserves</a>) This error occurs when the counterparty does not have a trust line to this account for the same currency. (See tecINSUF_RESERVE_LINE for the other case.)</td>
+<td align="left">tecNO_LINE_INSUF_RESERVE</td>
+<td align="left">126</td>
+<td align="left">The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: <a href="concept-reserves.html">Reserves</a>) This error occurs when the counterparty does not have a trust line to this account for the same currency. (See tecINSUF_RESERVE_LINE for the other case.)</td>
 </tr>
 <tr>
-<td>tecNO_LINE_REDUNDANT</td>
-<td>127</td>
-<td>The transaction failed because it tried to set a trust line to its default state, but the trust line did not exist.</td>
+<td align="left">tecNO_LINE_REDUNDANT</td>
+<td align="left">127</td>
+<td align="left">The transaction failed because it tried to set a trust line to its default state, but the trust line did not exist.</td>
 </tr>
 <tr>
-<td>tecNO_PERMISSION</td>
-<td>139</td>
-<td>Reserved for future use.</td>
+<td align="left">tecNO_PERMISSION</td>
+<td align="left">139</td>
+<td align="left">Reserved for future use.</td>
 </tr>
 <tr>
-<td>tecNO_REGULAR_KEY</td>
-<td>131</td>
-<td>The <a href="#accountset">AccountSet transaction</a> tried to disable the master key, but the account does not have another way to <a href="#authorizing-transactions">authorize transactions</a>. If <a href="#multi-signing">multi-signing</a> is enabled, this code is deprecated and <code>tecNO_ALTERNATIVE_KEY</code> is used instead.</td>
+<td align="left">tecNO_REGULAR_KEY</td>
+<td align="left">131</td>
+<td align="left">The <a href="#accountset">AccountSet transaction</a> tried to disable the master key, but the account does not have another way to <a href="#authorizing-transactions">authorize transactions</a>. If <a href="#multi-signing">multi-signing</a> is enabled, this code is deprecated and <code>tecNO_ALTERNATIVE_KEY</code> is used instead.</td>
 </tr>
 <tr>
-<td>tecNO_TARGET</td>
-<td>138</td>
-<td>Reserved for future use.</td>
+<td align="left">tecNO_TARGET</td>
+<td align="left">138</td>
+<td align="left">Reserved for future use.</td>
 </tr>
 <tr>
-<td>tecOVERSIZE</td>
-<td>145</td>
-<td>This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.29.0-hf1">rippled 0.29.0-hf1</a> )</em></td>
+<td align="left">tecOVERSIZE</td>
+<td align="left">145</td>
+<td align="left">This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. <em>(New in [<code>rippled</code> 0.29.0-hf1][] )</em></td>
 </tr>
 <tr>
-<td>tecOWNERS</td>
-<td>132</td>
-<td>The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the <a href="#accountset-flags"><code>lsfRequireAuth</code></a> flag if it has any trust lines or available offers.</td>
+<td align="left">tecOWNERS</td>
+<td align="left">132</td>
+<td align="left">The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the <a href="#accountset-flags"><code>lsfRequireAuth</code></a> flag if it has any trust lines or available offers.</td>
 </tr>
 <tr>
-<td>tecPATH_DRY</td>
-<td>128</td>
-<td>The transaction failed because the provided paths did not have enough liquidity to send anything at all. This could mean that the source and destination accounts are not linked by trust lines.</td>
+<td align="left">tecPATH_DRY</td>
+<td align="left">128</td>
+<td align="left">The transaction failed because the provided paths did not have enough liquidity to send anything at all. This could mean that the source and destination accounts are not linked by trust lines.</td>
 </tr>
 <tr>
-<td>tecPATH_PARTIAL</td>
-<td>101</td>
-<td>The transaction failed because the provided paths did not have enough liquidity to send the full amount.</td>
+<td align="left">tecPATH_PARTIAL</td>
+<td align="left">101</td>
+<td align="left">The transaction failed because the provided paths did not have enough liquidity to send the full amount.</td>
 </tr>
 <tr>
-<td>tecUNFUNDED</td>
-<td>129</td>
-<td><strong>DEPRECATED.</strong> Replaced by tecUNFUNDED_OFFER and tecUNFUNDED_PAYMENT.</td>
+<td align="left">tecUNFUNDED</td>
+<td align="left">129</td>
+<td align="left"><strong>DEPRECATED.</strong> Replaced by tecUNFUNDED_OFFER and tecUNFUNDED_PAYMENT.</td>
 </tr>
 <tr>
-<td>tecUNFUNDED_ADD</td>
-<td>102</td>
-<td><strong>DEPRECATED.</strong></td>
+<td align="left">tecUNFUNDED_ADD</td>
+<td align="left">102</td>
+<td align="left"><strong>DEPRECATED.</strong></td>
 </tr>
 <tr>
-<td>tecUNFUNDED_PAYMENT</td>
-<td>104</td>
-<td>The transaction failed because the sending account is trying to send more XRP than it holds, not counting the reserve. (See: <a href="concept-reserves.html">Reserves</a>)</td>
+<td align="left">tecUNFUNDED_PAYMENT</td>
+<td align="left">104</td>
+<td align="left">The transaction failed because the sending account is trying to send more XRP than it holds, not counting the reserve. (See: <a href="concept-reserves.html">Reserves</a>)</td>
 </tr>
 <tr>
-<td>tecUNFUNDED_OFFER</td>
-<td>103</td>
-<td>The <a href="#offercreate">OfferCreate transaction</a> failed because the account creating the offer does not have any of the <code>TakerGets</code> currency.</td>
+<td align="left">tecUNFUNDED_OFFER</td>
+<td align="left">103</td>
+<td align="left">The <a href="#offercreate">OfferCreate transaction</a> failed because the account creating the offer does not have any of the <code>TakerGets</code> currency.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="tej-codes">tej Codes</h3>
-<p>These codes are only ever returned by the <code>ripple-lib</code> client library, not by <code>rippled</code> itself.</p>
-<table>
-<thead>
-<tr>
-<th>Code</th>
-<th>Explanation</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>tejAbort</td>
-<td>The transaction was manually canceled by calling <code>transaction.abort()</code>.</td>
-</tr>
-<tr>
-<td>tejAttemptsExceeded</td>
-<td>The transaction was submitted multiple times, up to a total equal to the max attempts setting, without being successfully included in a ledger.</td>
-</tr>
-<tr>
-<td>tejInvalidFlag</td>
-<td>One of the flags specified was invalid, or does not apply to this transaction type.</td>
-</tr>
-<tr>
-<td>tejLocalSigningRequired</td>
-<td>The transaction could not be resubmitted because local signing is disabled.</td>
-</tr>
-<tr>
-<td>tejMaxFeeExceeded</td>
-<td>The <a href="concept-transaction-cost.html">transaction cost</a> that would be necessary to send the transaction is higher than the maximum transaction cost setting, which is either the <code>_MaxFee</code> parameter of the Transaction (if provided) or the maximum transaction cost configured for the remote. The default value is 1 XRP (100000 drops).</td>
-</tr>
-<tr>
-<td>tejMaxLedger</td>
-<td>Validated ledgers have surpassed the <code>LastLedgerSequence</code> parameter of the transaction without including it, so it can no longer succeed. (Also see <a href="tutorial-reliable-transaction-submission.html">Reliable Transaction Submission</a>.) When using ripple-lib, this error effectively replaces all non-final errors, including tel-, tef-, and ter-class response codes.</td>
-</tr>
-<tr>
-<td>tejSecretInvalid</td>
-<td>The secret included for signing this transaction was not a properly-formatted secret.</td>
-</tr>
-<tr>
-<td>tejSecretUnknown</td>
-<td>The secret for a given account was omitted from the transaction, and ripple-lib was unable to automatically fill it in from saved data.</td>
-</tr>
-<tr>
-<td>tejServerUntrusted</td>
-<td>The application attempted to submit an account secret to an untrusted server for transaction signing.</td>
-</tr>
-<tr>
-<td>tejUnconnected</td>
-<td>The application is not connected to a <code>rippled</code> server, but it needs to be to process the transaction.</td>
-</tr>
-</tbody>
-</table>
+<!---- rippled release notes links ---->
     </div>
       </main>
   </div>


### PR DESCRIPTION
- Replace links to wiki with appropriate other links where possible
- Remove tej errors, which were only returned by the old ripple-lib, not the new RippleAPI.
- Standardize `rippled` version links to a snippet
- Reorganize some tables in transaction format to work better with the table formatter

Known issues: transaction field names still not in `code font` in most tables. (I'll get around to that later.)
