### PR TITLE
rippled account queue stats; Dactyl badges

### DIFF
--- a/assets/css/devportal.css
+++ b/assets/css/devportal.css
@@ -74,6 +74,16 @@
   height: auto;
 }
 
+/* But badge images shouldn't be resized */
+.content img.dactyl_badge {
+    width: initial;
+}
+
+/* dev portal content h5 should stand out from paragraph text */
+.content h5 {
+    font-weight: bold;
+}
+
 /* Underline links in Dev Portal content */
 .page-template-template-dev-portal-php .main a {
   text-decoration: underline !important;

--- a/concept-amendments.html
+++ b/concept-amendments.html
@@ -484,7 +484,7 @@ TrustSetAuth
 </table>
 <p>Introduces Tickets as a way to reserve a transaction sequence number for later execution. Creates the <code>Ticket</code> ledger node type and the transaction types <code>TicketCreate</code> and <code>TicketCancel</code>.</p>
 <p>This amendment is still in development.
- <!---- rippled release notes links ----></p>
+ <!-- rippled release notes links --></p>
     </div>
       </main>
   </div>

--- a/concept-amendments.html
+++ b/concept-amendments.html
@@ -169,7 +169,7 @@
       <main class="main" role="main">
     <div class='content'>
         <h1 id="amendments">Amendments</h1>
-<p><em>(Introduced in [version 0.31.0][])</em></p>
+<p><a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="Introduced in: rippled 0.31.0"><img alt="Introduced in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/Introduced%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p>The Amendments system provides a means of introducing new features to the decentralized Ripple consensus network without causing disruptions. The amendments system works by utilizing the core consensus process of the network to approve any changes by showing continuous support before those changes go into effect. An amendment normally requires <strong>80% support for two weeks</strong> before it can apply.</p>
 <p>When an Amendment has been enabled, it applies permanently to all ledger versions after the one that included it. You cannot disable an Amendment, unless you introduce a new Amendment to do so.</p>
 <h2 id="background">Background</h2>
@@ -247,52 +247,52 @@ TrustSetAuth
 <tr>
 <td align="left"><a href="#shamapv2">SHAMapV2</a></td>
 <td align="left">TBD</td>
-<td align="left">TBD</td>
+<td align="left"><a title="Planned: TBD"><img alt="Planned: TBD" class="dactyl_badge" src="https://img.shields.io/badge/Planned-TBD-lightgrey.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#paychan">PayChan</a></td>
 <td align="left">TBD</td>
-<td align="left">TBD</td>
+<td align="left"><a title="Planned: TBD"><img alt="Planned: TBD" class="dactyl_badge" src="https://img.shields.io/badge/Planned-TBD-lightgrey.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#ownerpaysfee">OwnerPaysFee</a></td>
 <td align="left">TBD</td>
-<td align="left">TBD</td>
+<td align="left"><a title="Planned: TBD"><img alt="Planned: TBD" class="dactyl_badge" src="https://img.shields.io/badge/Planned-TBD-lightgrey.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#flow">Flow</a></td>
 <td align="left">TBD</td>
-<td align="left">TBD</td>
+<td align="left"><a title="Planned: TBD"><img alt="Planned: TBD" class="dactyl_badge" src="https://img.shields.io/badge/Planned-TBD-lightgrey.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#flowv2">FlowV2</a></td>
 <td align="left">v0.32.1</td>
-<td align="left">To be removed</td>
+<td align="left"><a href="https://ripple.com/dev-blog/flowv2-amendment-vetoed/" title="Vetoed: To be removed"><img alt="Vetoed: To be removed" class="dactyl_badge" src="https://img.shields.io/badge/Vetoed-To%20be%20removed-red.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#tickets">Tickets</a></td>
 <td align="left">v0.31.0</td>
-<td align="left">TBD</td>
+<td align="left"><a title="Planned: TBD"><img alt="Planned: TBD" class="dactyl_badge" src="https://img.shields.io/badge/Planned-TBD-lightgrey.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#suspay">SusPay</a></td>
 <td align="left">v0.31.0</td>
-<td align="left">TBD</td>
+<td align="left"><a title="Planned: TBD"><img alt="Planned: TBD" class="dactyl_badge" src="https://img.shields.io/badge/Planned-TBD-lightgrey.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#trustsetauth">TrustSetAuth</a></td>
 <td align="left">v0.30.0</td>
-<td align="left"><a href="https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF">Enabled 2016-07-19T10:10:32Z in ledger 22721281</a></td>
+<td align="left"><a href="https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF" title="Enabled: 2016-07-19"><img alt="Enabled: 2016-07-19" class="dactyl_badge" src="https://img.shields.io/badge/Enabled-2016--07--19-green.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#multisign">MultiSign</a></td>
 <td align="left">v0.31.0</td>
-<td align="left"><a href="https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7">Enabled 2016-06-27T11:34:41Z in ledger 22178817</a></td>
+<td align="left"><a href="https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7" title="Enabled: 2016-06-27"><img alt="Enabled: 2016-06-27" class="dactyl_badge" src="https://img.shields.io/badge/Enabled-2016--06--27-green.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><a href="#feeescalation">FeeEscalation</a></td>
 <td align="left">v0.31.0</td>
-<td align="left"><a href="https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3">Enabled 2016-05-19T16:44:51Z in ledger 21225473</a></td>
+<td align="left"><a href="https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3" title="Enabled: 2016-05-19"><img alt="Enabled: 2016-05-19" class="dactyl_badge" src="https://img.shields.io/badge/Enabled-2016--05--19-green.svg"/></a></td>
 </tr>
 </tbody>
 </table>

--- a/content/concept-amendments.md
+++ b/content/concept-amendments.md
@@ -1,6 +1,6 @@
 # Amendments #
 
-_(Introduced in [version 0.31.0][])_
+[Introduced in: rippled 0.31.0][New in: rippled 0.31.0]
 
 The Amendments system provides a means of introducing new features to the decentralized Ripple consensus network without causing disruptions. The amendments system works by utilizing the core consensus process of the network to approve any changes by showing continuous support before those changes go into effect. An amendment normally requires **80% support for two weeks** before it can apply.
 
@@ -111,16 +111,16 @@ The following is a comprehensive list of all known amendments and their status o
 
 | Name                            | Introduced | Status                        |
 |:--------------------------------|:-----------|:------------------------------|
-| [SHAMapV2](#shamapv2)           | TBD        | TBD                           |
-| [PayChan](#paychan)             | TBD        | TBD                           |
-| [OwnerPaysFee](#ownerpaysfee)   | TBD        | TBD                           |
-| [Flow](#flow)                   | TBD        | TBD                           |
-| [FlowV2](#flowv2)               | v0.32.1    | To be removed                 |
-| [Tickets](#tickets)             | v0.31.0    | TBD                           |
-| [SusPay](#suspay)               | v0.31.0    | TBD                           |
-| [TrustSetAuth](#trustsetauth)   | v0.30.0    | [Enabled 2016-07-19T10:10:32Z in ledger 22721281](https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF) |
-| [MultiSign](#multisign)         | v0.31.0    | [Enabled 2016-06-27T11:34:41Z in ledger 22178817](https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7) |
-| [FeeEscalation](#feeescalation) | v0.31.0    | [Enabled 2016-05-19T16:44:51Z in ledger 21225473](https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3) |
+| [SHAMapV2](#shamapv2)           | TBD        | [Planned: TBD]( "BADGE_LIGHTGREY") |
+| [PayChan](#paychan)             | TBD        | [Planned: TBD]( "BADGE_LIGHTGREY") |
+| [OwnerPaysFee](#ownerpaysfee)   | TBD        | [Planned: TBD]( "BADGE_LIGHTGREY") |
+| [Flow](#flow)                   | TBD        | [Planned: TBD]( "BADGE_LIGHTGREY") |
+| [FlowV2](#flowv2)               | v0.32.1    | [Vetoed: To be removed](https://ripple.com/dev-blog/flowv2-amendment-vetoed/ "BADGE_RED") |
+| [Tickets](#tickets)             | v0.31.0    | [Planned: TBD]( "BADGE_LIGHTGREY") |
+| [SusPay](#suspay)               | v0.31.0    | [Planned: TBD]( "BADGE_LIGHTGREY") |
+| [TrustSetAuth](#trustsetauth)   | v0.30.0    | [Enabled: 2016-07-19](https://www.ripplecharts.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF "BADGE_GREEN") |
+| [MultiSign](#multisign)         | v0.31.0    | [Enabled: 2016-06-27](https://www.ripplecharts.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7 "BADGE_GREEN") |
+| [FeeEscalation](#feeescalation) | v0.31.0    | [Enabled: 2016-05-19](https://www.ripplecharts.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3 "BADGE_GREEN") |
 
 **Note:** In many cases, an incomplete version of the code for an amendment is present in previous versions of the software. The "Introduced" version in the table above is the first stable version.
 

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -408,7 +408,7 @@ The `index` of a RippleState node is the SHA-512Half of the following values put
 ## SignerList ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/6d2e3da30696bd10e3bb11a5ff6d45d2c4dae90f/src/ripple/protocol/impl/LedgerFormats.cpp#L127 "Source")
 
-The `SignerList` node type represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a SignerList using the [SignerListSet transaction type](reference-transaction-format.html#signerlistset) This node type is introduced by the [MultiSign amendment](concept-amendments.html#multisign). _(New in [version 0.31.0][])_
+The `SignerList` node type represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a SignerList using the [SignerListSet transaction type](reference-transaction-format.html#signerlistset) This node type is introduced by the [MultiSign amendment](concept-amendments.html#multisign). [New in: rippled 0.31.0][]
 
 Example SignerList node:
 
@@ -474,6 +474,4 @@ When processing a multi-signed transaction, the server dereferences the `Account
 A SignerList contributes to its owner's [reserve requirement](concept-reserves.html). The SignerList itself counts as two objects, and each member of the list counts as one. As a result, the total owner reserve associated with a SignerList is anywhere from 3 times to 10 times the reserve required by a single trust line ([RippleState](#ripplestate)) or [Offer](#offer) node in the ledger.
 
 
-
-<!---- rippled release notes links ---->
-[version 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0
+{% include 'snippets/rippled_versions.md' %}

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -912,10 +912,10 @@ The response follows the [standard format](#response-formatting), with the resul
 | Field | Type | Description |
 |-------|------|-------------|
 | account_data | Object | The [AccountRoot ledger node](reference-ledger-format.html#accountroot) with this account's information, as stored in the ledger. |
-| signer\_lists | Array | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. [New in: rippled 0.31.0][] |
+| signer\_lists | Array | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most one SignerList, this array must have exactly one member if it is present. [New in: rippled 0.31.0][] |
 | ledger\_current\_index | Integer | (Omitted if `ledger_index` is provided instead) The sequence number of the most-current ledger, which was used when retrieving this information. The information does not contain any changes from ledgers newer than this one.  |
 | ledger\_index | Integer | (Omitted if `ledger_current_index` is provided instead) The sequence number of the ledger used when retrieving this information. The information does not contain any changes from ledgers newer than this one. |
-| queue\_data | Object | (Omitted unless `queue` specified as `true`) Information about [queued transactions](concept-transaction-cost.html#queued-transactions) sent by this account. Some information is calculated "lazily" and may not be available. This information describes the state of the local `rippled` server, which may be different from other servers in the consensus network. |
+| queue\_data | Object | (Omitted unless `queue` specified as `true` and querying the current open ledger.) Information about [queued transactions](concept-transaction-cost.html#queued-transactions) sent by this account. This information describes the state of the local `rippled` server, which may be different from other servers in the consensus network. Some fields may be omitted because the values are calculated "lazily" by the queuing mechanism. |
 | validated | Boolean | True if this data is from a validated ledger version; if omitted or set to false, this data is not final. [New in: rippled 0.26.0][] |
 
 The `queue_data` parameter, if present, contains the following fields:
@@ -997,7 +997,7 @@ The request accepts the following paramters:
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | peer | String | (Optional) The [Address][] of a second account. If provided, show only lines of trust connecting the two accounts. |
 | limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. [New in: rippled 0.26.4][] |
-| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Server-provided value to specify where to resume retrieving data from. [New in: rippled 0.26.4][] |
+| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Value from a previous response to specify where to resume retrieving data from. [New in: rippled 0.26.4][] |
 
 The following parameters are deprecated and may be removed without further notice: `ledger` and `peer_index`.
 
@@ -1190,7 +1190,7 @@ A request can include the following parameters:
 | ledger\_hash | String | (Optional) A 20-byte hex string identifying the ledger version to use. |
 | ledger\_index | (Optional) [Ledger Index][] | (Optional, defaults to `current`) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See [Specifying Ledgers](#specifying-ledgers)) |
 | limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. [New in: rippled 0.26.4][] |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. [New in: rippled 0.26.4][] |
+| marker | [(Not Specified)](#markers-and-pagination) | Value from a previous response value to specify where to resume retrieving data from. [New in: rippled 0.26.4][] |
 
 The following parameter is deprecated and may be removed without further notice: `ledger`.
 
@@ -1383,7 +1383,7 @@ The request includes the following parameters:
 | ledger_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | limit   | Unsigned Integer | (Optional) The maximum number of objects to include in the results. Cannot be less than 10 or higher than 400 on non-admin connections. Defaults to 200. |
-| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Server-provided value to specify where to resume retrieving data from. |
+| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Value from a previous response value to specify where to resume retrieving data from. |
 
 #### Response Format ####
 
@@ -2005,7 +2005,7 @@ The request includes the following parameters:
 | binary | Boolean | (Optional, defaults to False) If set to True, return transactions as hex strings instead of JSON. |
 | forward | boolean | (Optional, defaults to False) If set to True, return values indexed with the oldest ledger first. Otherwise, the results are indexed with the newest ledger first. (Each page of results may not be internally ordered, but the pages are overall ordered.) |
 | limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. This value is stable even if there is a change in the server's range of available ledgers. |
+| marker | [(Not Specified)](#markers-and-pagination) | Value from a previous response value to specify where to resume retrieving data from. This value is stable even if there is a change in the server's range of available ledgers. |
 
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTxSwitch.cpp "Source")
 There is also a deprecated legacy variation of the `account_tx` method. For that reason, we recommend *not using any of the following fields*: `offset`, `count`, `descending`, `ledger_max`, `ledger_min`.
@@ -3536,7 +3536,7 @@ A request can include the following fields:
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | binary | Boolean | (Optional, defaults to False) If set to true, return data nodes as hashed hex strings instead of JSON. |
 | limit | Integer | (Optional, default varies) Limit the number of nodes to retrieve. The server is not required to honor this value. |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. |
+| marker | [(Not Specified)](#markers-and-pagination) | Value from a previous response value to specify where to resume retrieving data from. |
 
 The `ledger` field is deprecated and may be removed without further notice.
 

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -4079,7 +4079,7 @@ When the server is in the progress of fetching a ledger, but has not yet finishe
 
 * Any of the [universal error types](#universal-errors).
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing. This error can also occur if you specify a ledger index equal or higher than the current in-progress ledger.
-* `lgrNotFound` - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. _(**Note:** Prior to [`rippled` 0.30.1][], this error used the code `ledgerNotFound` instead.)_
+* `lgrNotFound` - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. (Previously, this error used the code `ledgerNotFound` instead.) [Updated in: rippled 0.30.1][New in: rippled 0.30.1]
 
 
 ## ledger_accept ##
@@ -7454,7 +7454,7 @@ The request includes the following parameters:
 | ledger_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | limit | Unsigned Integer | (Optional) If provided, the server does not provide more than this many offers in the results. The total number of results returned may be fewer than the limit, because the server omits unfunded offers. |
-| taker | String | (Optional, defaults to [ACCOUNT\_ONE][]) The [Address][] of an account to use as a perspective. (This affects which unfunded offers are returned.) |
+| taker | String | (Optional, defaults to [ACCOUNT_ONE][]) The [Address][] of an account to use as a perspective. (This affects which unfunded offers are returned.) |
 | taker\_gets | Object | Specification of which currency the account taking the offer would receive, as an object with `currency` and `issuer` fields (omit issuer for XRP), like [currency amounts](#specifying-currency-amounts). |
 | taker\_pays | Object | Specification of which currency the account taking the offer would pay, as an object with `currency` and `issuer` fields (omit issuer for XRP), like [currency amounts](#specifying-currency-amounts). |
 
@@ -9447,7 +9447,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 The `fee` command reports the current state of the open-ledger requirements for the [transaction cost](concept-transaction-cost.html). This requires the [FeeEscalation amendment](concept-amendments.html#feeescalation) to be enabled. [New in: rippled 0.31.0][]
 
-_As of [`rippled` 0.32.0][], this is a public command available to unprivileged users._
+This is a public command available to unprivileged users. [Updated in: rippled 0.32.0][New in: rippled 0.32.0]
 
 #### Request Format ####
 An example of the request format:

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -796,8 +796,8 @@ The request contains the following parameters:
 | strict | Boolean | (Optional, defaults to False) If set to True, then the `account` field only accepts a public key or Ripple address. |
 | ledger_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger_index | String or Unsigned Integer | (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
-| queue | Boolean | (Optional) If `true`, and the [FeeEscalation amendment](concept-amendments.html#feeescalation) is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. _(New in [`rippled` 0.33.0][])_ |
-| signer\_lists | Boolean | (Optional) If `true`, and the [MultiSign amendment](concept-amendments.html#multisign) is enabled, also returns any [SignerList objects](reference-ledger-format.html#signerlist) associated with this account. _(New in [`rippled` 0.31.0][])_ |
+| queue | Boolean | (Optional) If `true`, and the [FeeEscalation amendment](concept-amendments.html#feeescalation) is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. [New in: rippled 0.33.0][] |
+| signer\_lists | Boolean | (Optional) If `true`, and the [MultiSign amendment](concept-amendments.html#multisign) is enabled, also returns any [SignerList objects](reference-ledger-format.html#signerlist) associated with this account. [New in: rippled 0.31.0][] |
 
 The following fields are deprecated and should not be provided: `ident`, `ledger`.
 
@@ -918,11 +918,11 @@ The response follows the [standard format](#response-formatting), with the resul
 | Field | Type | Description |
 |-------|------|-------------|
 | account_data | Object | The [AccountRoot ledger node](reference-ledger-format.html#accountroot) with this account's information, as stored in the ledger. |
-| signer\_lists | Array | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. _(New in [`rippled` 0.31.0][])_ |
+| signer\_lists | Array | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. [New in: rippled 0.31.0][] |
 | ledger\_current\_index | Integer | (Omitted if `ledger_index` is provided instead) The sequence number of the most-current ledger, which was used when retrieving this information. The information does not contain any changes from ledgers newer than this one.  |
 | ledger\_index | Integer | (Omitted if `ledger_current_index` is provided instead) The sequence number of the ledger used when retrieving this information. The information does not contain any changes from ledgers newer than this one. |
 | queue\_data | Object | (Omitted unless `queue` specified as `true`) Information about [queued transactions](concept-transaction-cost.html#queued-transactions) sent by this account. Some information is calculated "lazily" and may not be available. This information describes the state of the local `rippled` server, which may be different from other servers in the consensus network. |
-| validated | Boolean | True if this data is from a validated ledger version; if omitted or set to false, this data is not final. _(New in [`rippled` 0.26.0][])_ |
+| validated | Boolean | True if this data is from a validated ledger version; if omitted or set to false, this data is not final. [New in: rippled 0.26.0][] |
 
 The `queue_data` parameter, if present, contains the following fields:
 
@@ -1002,8 +1002,8 @@ The request accepts the following paramters:
 | ledger\_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | peer | String | (Optional) The [Address][] of a second account. If provided, show only lines of trust connecting the two accounts. |
-| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. _(New in [`rippled` 0.26.4][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Server-provided value to specify where to resume retrieving data from. _(New in [`rippled` 0.26.4][])_ |
+| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. [New in: rippled 0.26.4][] |
+| marker | [(Not Specified)](#markers-and-pagination) | (Optional) Server-provided value to specify where to resume retrieving data from. [New in: rippled 0.26.4][] |
 
 The following parameters are deprecated and may be removed without further notice: `ledger` and `peer_index`.
 
@@ -1110,10 +1110,10 @@ The response follows the [standard format](#response-formatting), with a success
 |-------|------|-------------|
 | account | String | Unique [Address][] of the account this request corresponds to. This is the "perspective account" for purpose of the trust lines. |
 | lines | Array | Array of trust-line objects, as described below. If the number of trust-lines is large, only returns up to the `limit` at a time. |
-| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
-| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
-| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. _(New in [`rippled` 0.26.4][])_ |
+| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
+| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
+| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
+| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. [New in: rippled 0.26.4][] |
 
 Each trust-line object has some combination of the following fields:
 
@@ -1195,8 +1195,8 @@ A request can include the following parameters:
 | ledger | Unsigned integer, or String | (Deprecated, Optional) A unique identifier for the ledger version to use, such as a ledger sequence number, a hash, or a shortcut such as "validated". |
 | ledger\_hash | String | (Optional) A 20-byte hex string identifying the ledger version to use. |
 | ledger\_index | (Optional) [Ledger Index][] | (Optional, defaults to `current`) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See [Specifying Ledgers](#specifying-ledgers)) |
-| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. _(New in [`rippled` 0.26.4][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. _(New in [`rippled` 0.26.4][])_ |
+| limit | Integer | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. [New in: rippled 0.26.4][] |
+| marker | [(Not Specified)](#markers-and-pagination) | Server-provided value to specify where to resume retrieving data from. [New in: rippled 0.26.4][] |
 
 The following parameter is deprecated and may be removed without further notice: `ledger`.
 
@@ -1305,10 +1305,10 @@ The response follows the [standard format](#response-formatting), with a success
 |-------|------|-------------|
 | account | String | Unique [Address][] identifying the account that made the offers |
 | offers | Array | Array of objects, where each object represents an offer made by this account that is outstanding as of the requested ledger version. If the number of offers is large, only returns up to `limit` at a time. |
-| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
-| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
-| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. _(New in [`rippled` 0.26.4-sp1][])_ |
-| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. _(New in [`rippled` 0.26.4][])_ |
+| ledger\_current\_index | Integer | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
+| ledger\_index | Integer | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
+| ledger\_hash | String | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
+| marker | [(Not Specified)](#markers-and-pagination) | Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. [New in: rippled 0.26.4][] |
 
 
 Each offer object contains the following fields:
@@ -1319,8 +1319,8 @@ Each offer object contains the following fields:
 | seq | Unsigned integer | Sequence number of the transaction that created this entry. (Transaction [sequence numbers](#account-sequence) are relative to accounts.) |
 | taker_gets | String or Object | The amount the account accepting the offer receives, as a String representing an amount in XRP, or a currency specification object. (See [Specifying Currency Amounts](#specifying-currency-amounts)) |
 | taker_pays | String or Object | The amount the account accepting the offer provides, as a String representing an amount in XRP, or a currency specification object. (See [Specifying Currency Amounts](#specifying-currency-amounts)) |
-| quality | Number | The exchange rate of the offer, as the ratio of the original `taker_pays` divided by the original `taker_gets`. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. _(New in [`rippled` 0.29.0][])_ |
-| expiration | Unsigned integer | (May be omitted) A time after which this offer is considered unfunded, as [the number of seconds since the Ripple Epoch](#specifying-time). See also: [Offer Expiration](reference-transaction-format.html#expiration). _(New in [`rippled` 0.30.1][])_ |
+| quality | Number | The exchange rate of the offer, as the ratio of the original `taker_pays` divided by the original `taker_gets`. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. [New in: rippled 0.29.0][] |
+| expiration | Unsigned integer | (May be omitted) A time after which this offer is considered unfunded, as [the number of seconds since the Ripple Epoch](#specifying-time). See also: [Offer Expiration](reference-transaction-format.html#expiration). [New in: rippled 0.30.1][] |
 
 #### Possible Errors ####
 
@@ -2725,7 +2725,7 @@ The response follows the [standard format](#response-formatting), with a success
 ## gateway_balances ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp "Source")
 
-The `gateway_balances` command calculates the total balances issued by a given account, optionally excluding amounts held by [operational addresses](concept-issuing-and-operational-addresses.html). _(New in [`rippled` 0.28.2][].)_
+The `gateway_balances` command calculates the total balances issued by a given account, optionally excluding amounts held by [operational addresses](concept-issuing-and-operational-addresses.html). [New in: rippled 0.28.2][]
 
 #### Request Format ####
 An example of the request format:
@@ -2949,7 +2949,7 @@ Use the `wallet_propose` method to generate a key pair and Ripple [address]. Thi
 
 *The `wallet_propose` request is an [admin command](#connecting-to-rippled) that cannot be run by unprivileged users!* (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)
 
-_(Updated in [`rippled` 0.31.0][])_
+[Updated in: rippled 0.31.0][New in: rippled 0.31.0]
 
 #### Request Format ####
 
@@ -3119,7 +3119,7 @@ The response follows the [standard format](#response-formatting), with a success
 | account\_id | String | The [Address][] of the account. |
 | public\_key | String | The public key of the account, in encoded string format. |
 | public\_key\_hex | String | The public key of the account, in hex format. |
-| warning | String | (May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. _(New in [`rippled` 0.32.0][])_ |
+| warning | String | (May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. [New in: rippled 0.32.0][] |
 
 The key generated by this method can also be used as a regular key for an account if you use the [SetRegularKey transaction type](reference-transaction-format.html#setregularkey) to do so.
 
@@ -3202,7 +3202,7 @@ The request can contain the following parameters:
 | transactions | Boolean | (Optional, defaults to false) If true, return information on transactions in the specified ledger version. Ignored if you did not specify a ledger. |
 | expand | Boolean | (Optional, defaults to false) Provide full JSON-formatted information for transaction/account information instead of only hashes. Ignored unless you requested transactions, accounts, or both. |
 | owner\_funds | Boolean | (Optional, defaults to false) Include `owner_funds` field in the metadata of OfferCreate transactions in the response. Ignored unless transactions are included and `expand` is true. |
-| binary | Boolean | (Optional, defaults to false) If `transactions` and `expand` are both true, and this option is also true, return transaction information in binary format instead of JSON format. _(New in [`rippled` 0.28.0][])_ |
+| binary | Boolean | (Optional, defaults to false) If `transactions` and `expand` are both true, and this option is also true, return transaction information in binary format instead of JSON format. [New in: rippled 0.28.0][] |
 
 The `ledger` field is deprecated and may be removed without further notice.
 
@@ -5527,8 +5527,8 @@ The request includes the following parameters:
 | subcommand | String | Use `"create"` to send the create subcommand |
 | source\_account | String | Unique address of the account to find a path from. (In other words, the account that would be sending a payment.) |
 | destination\_account | String | Unique address of the account to find a path to. (In other words, the account that would receive a payment.) |
-| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [`rippled` 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
-| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Not compatible with `source_currencies`. _(New in [`rippled` 0.30.0][])_ |
+| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** [New in: rippled 0.30.0][] You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
+| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Not compatible with `source_currencies`. [New in: rippled 0.30.0][] |
 | paths | Array | (Optional) Array of arrays of objects, representing [payment paths](concept-paths.html) to check. You can use this to keep updated on changes to particular paths you already know about, or to check the overall cost to make a payment along a certain path. |
 
 The server also recognizes the following fields, but the results of using them are not guaranteed: `source_currencies`, `bridges`. These fields should be considered reserved for future use.
@@ -5918,7 +5918,7 @@ The initial response follows the [standard format](#response-formatting), with a
 | destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination would receive in a transaction |
 | id | (Various) | (WebSocket only) The ID provided in the WebSocket request is included again at this level. |
 | source\_account | String | Unique address that would send a transaction |
-| full\_reply | Boolean | If `false`, this is the result of an incomplete search. A later reply may have a better path. If `true`, then this is the best path found. (It is still theoretically possible that a better path could exist, but `rippled` won't find it.) Until you close the pathfinding request, `rippled` continues to send updates each time a new ledger closes. _(New in [`rippled` 0.29.0][])_ |
+| full\_reply | Boolean | If `false`, this is the result of an incomplete search. A later reply may have a better path. If `true`, then this is the best path found. (It is still theoretically possible that a better path could exist, but `rippled` won't find it.) Until you close the pathfinding request, `rippled` continues to send updates each time a new ledger closes. [New in: rippled 0.29.0][] |
 
 Each element in the `alternatives` array is an object that represents a path from one possible source currency (held by the initiating account) to the destination account and currency. This object has the following fields:
 
@@ -6137,8 +6137,8 @@ The request includes the following parameters:
 |-------|------|-------------|
 | source\_account | String | Unique address of the account that would send funds in a transaction |
 | destination\_account | String | Unique address of the account that would receive funds in a transaction |
-| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** _(New in [`rippled` 0.30.0][])_ You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
-| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Cannot be used with `source_currencies`. _(New in [`rippled` 0.30.0][])_ |
+| destination\_amount | String or Object | [Currency amount](#specifying-currency-amounts) that the destination account would receive in a transaction. **Special case:** [New in: rippled 0.30.0][] You can specify `"-1"` (for XRP) or provide -1 as the contents of the `value` field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in `send_max` (if provided). |
+| send\_max | String or Object | (Optional) [Currency amount](#specifying-currency-amounts) that would be spent in the transaction. Cannot be used with `source_currencies`. [New in: rippled 0.30.0][] |
 | source\_currencies | Array | (Optional) Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory `currency` field and optional `issuer` field, like how [currency amounts](#specifying-currency-amounts) are specified. Cannot contain more than **18** source currencies. By default, uses all source currencies available up to a maximum of **88** different currency/issuer pairs. |
 | ledger\_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | ledger\_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
@@ -6488,7 +6488,7 @@ The request includes the following parameters:
 | offline | Boolean | (Optional, defaults to false) If true, when constructing the transaction, do not try to automatically fill in or validate values. |
 | build_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. **Caution:** The server looks for the presence or absence of this field, not its value. This behavior may change. |
 | fee\_mult\_max | Integer | (Optional, defaults to 10; recommended value 1000) Limits how high the [automatically-provided `Fee` field](reference-transaction-format.html#auto-fillable-fields) can be. Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). |
-| fee\_div\_max | Integer | (Optional, defaults to 1) Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). _(New in [`rippled` 0.30.1][])_ |
+| fee\_div\_max | Integer | (Optional, defaults to 1) Signing fails with the error `rpcHIGH_FEE` if the current [load multiplier on the transaction cost](concept-transaction-cost.html#local-load-cost) is greater than (`fee_mult_max` ÷ `fee_div_max`). Ignored if you specify the `Fee` field of the transaction ([transaction cost](concept-transaction-cost.html)). [New in: rippled 0.30.1][] |
 
 ### Auto-Fillable Fields ###
 
@@ -6623,7 +6623,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 The `sign_for` command provides one signature for a [multi-signed transaction](reference-transaction-format.html#multi-signing).
 
-This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. _(New in [`rippled` 0.31.0][])_
+This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. [New in: rippled 0.31.0][]
 
 #### Request Format ####
 An example of the request format:
@@ -6933,7 +6933,7 @@ The request includes the following parameters:
 | offline | Boolean | (Optional, defaults to false) If true, when constructing the transaction, do not try to automatically fill in or validate values. |
 | build\_path | Boolean | (Optional) If provided for a Payment-type transaction, automatically fill in the `Paths` field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. **Caution:** The server looks for the presence or absence of this field, not its value. This behavior may change. |
 | fee\_mult\_max | Integer | (Optional, defaults to 10, recommended value 1000) If the `Fee` parameter is omitted, this field limits the automatically-provided `Fee` value so that it is less than or equal to the long-term base transaction cost times this value. |
-| fee\_div\_max | Integer | (Optional, defaults to 1) Used with `fee_mult_max` to create a fractional multiplier for the limit. Specifically, the server multiplies its base [transaction cost](concept-transaction-cost.html) by `fee_mult_max`, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided `Fee` value would be over the limit, the submit command fails. _(New in [`rippled` 0.30.1][])_ |
+| fee\_div\_max | Integer | (Optional, defaults to 1) Used with `fee_mult_max` to create a fractional multiplier for the limit. Specifically, the server multiplies its base [transaction cost](concept-transaction-cost.html) by `fee_mult_max`, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided `Fee` value would be over the limit, the submit command fails. [New in: rippled 0.30.1][] |
 
 See the [sign command](#sign) for detailed information on how the server automatically fills in certain fields.
 
@@ -7139,7 +7139,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 The `submit_multisigned` command applies a [multi-signed](reference-transaction-format.html#multi-signing) transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the [`submit` command in submit-only mode](#submit-only-mode).)
 
-This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. _(New in [`rippled` 0.31.0][])_
+This command requires the [MultiSign amendment](concept-amendments.html#multisign) to be enabled. [New in: rippled 0.31.0][]
 
 #### Request Format ####
 An example of the request format:
@@ -7749,7 +7749,7 @@ The fields from a ledger stream message are as follows:
 
 ### Validations Stream ###
 
-_(New in [`rippled` 0.29.0][])_
+[New in: rippled 0.29.0][]
 
 The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:
 
@@ -7783,17 +7783,17 @@ The fields from a validations stream message are as follows:
 | Field | Type | Description |
 |-------|------|-------------|
 | `type` | String | The value `validationReceived` indicates this is from the validations stream. |
-| `amendments` | Array of Strings | (May be omitted) The [amendments](concept-amendments.html) this server wants to be added to the protocol. _(New in [`rippled` 0.32.0][])_ |
-| `base_fee` | Integer | (May be omitted) The unscaled transaction cost (`reference_fee` value) this server wants to set by [Fee Voting](concept-fee-voting.html). _(New in [`rippled` 0.32.0][])_ |
-| `flags` | Number | Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. _(New in [`rippled` 0.32.0][])_ |
-| `full` | Boolean | If `true`, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. _(New in [`rippled` 0.32.0][])_ |
+| `amendments` | Array of Strings | (May be omitted) The [amendments](concept-amendments.html) this server wants to be added to the protocol. [New in: rippled 0.32.0][] |
+| `base_fee` | Integer | (May be omitted) The unscaled transaction cost (`reference_fee` value) this server wants to set by [Fee Voting](concept-fee-voting.html). [New in: rippled 0.32.0][] |
+| `flags` | Number | Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. [New in: rippled 0.32.0][] |
+| `full` | Boolean | If `true`, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. [New in: rippled 0.32.0][] |
 | `ledger_hash` | String | The identifying hash of the proposed ledger is being validated. |
-| `ledger_index` | String - Integer | The [Ledger Index][] of the proposed ledger. _(New in [`rippled` 0.31.0][])_ |
-| `load_fee` | Integer | (May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. _(New in [`rippled` 0.32.0][])_ |
-| `reserve_base` | Integer | (May be omitted) The minimum reserve requirement (`account_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). _(New in [`rippled` 0.32.0][])_ |
-| `reserve_inc` | Integer | (May be omitted) The increment in the reserve requirement (`owner_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). _(New in [`rippled` 0.32.0][])_ |
+| `ledger_index` | String - Integer | The [Ledger Index][] of the proposed ledger. [New in: rippled 0.31.0][] |
+| `load_fee` | Integer | (May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. [New in: rippled 0.32.0][] |
+| `reserve_base` | Integer | (May be omitted) The minimum reserve requirement (`account_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). [New in: rippled 0.32.0][] |
+| `reserve_inc` | Integer | (May be omitted) The increment in the reserve requirement (`owner_reserve` value) this validator wants to set by [Fee Voting](concept-fee-voting.html). [New in: rippled 0.32.0][] |
 | `signature` | String | The signature that the validator used to sign its vote for this ledger. |
-| `signing_time` | Number | When this validation vote was signed, in seconds since the [Ripple Epoch](#specifying-time). _(New in [`rippled` 0.32.0][])_ |
+| `signing_time` | Number | When this validation vote was signed, in seconds since the [Ripple Epoch](#specifying-time). [New in: rippled 0.32.0][] |
 | `validation_public_key` | String | The base-58 encoded public key from the key-pair that the validator used to sign the message. This identifies the validator sending the message and can also be used to verify the `signature`. |
 
 
@@ -8478,16 +8478,16 @@ The `info` object may have some arrangement of the following fields:
 | load\_factor\_local | Number | (May be omitted) Current multiplier to the [transaction cost][] based on load to this server. |
 | load\_factor\_net | Number | (May be omitted) Current multiplier to the [transaction cost][] being used by the rest of the network (estimated from other servers' reported load values). |
 | load\_factor\_cluster | Number | (May be omitted) Current multiplier to the [transaction cost][] based on load to servers in [this cluster](tutorial-rippled-setup.html#clustering). |
-| load\_factor\_fee\_escalation | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the open ledger. _(New in [`rippled` 0.32.0][])_ |
-| load\_factor\_fee\_queue | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the queue, if the queue is full. _(New in [`rippled` 0.32.0][])_ |
+| load\_factor\_fee\_escalation | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the open ledger. [New in: rippled 0.32.0][] |
+| load\_factor\_fee\_queue | Number | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the queue, if the queue is full. [New in: rippled 0.32.0][] |
 | peers | Number | How many other `rippled` servers the node is currently connected to. |
 | pubkey_node | String | Public key used to verify this node for internal communications; this key is automatically generated by the server the first time it starts up. (If deleted, the node can create a new pair of keys.) |
 | pubkey\_validator | String | *Admin only* Public key used by this node to sign ledger validations. |
 | server\_state | String | A string indicating to what extent the server is participating in the network. See [Possible Server States](#possible-server-states) for more details. |
-| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. _(New in [`rippled` 0.30.1][])_ |
-| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) _(New in [`rippled` 0.30.1][])_ |
-| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. _(New in [`rippled` 0.30.1][])_ |
-| uptime | Number | Number of consecutive seconds that the server has been operational. _(New in [`rippled` 0.30.1][])_ |
+| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. [New in: rippled 0.30.1][] |
+| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) [New in: rippled 0.30.1][] |
+| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. [New in: rippled 0.30.1][] |
+| uptime | Number | Number of consecutive seconds that the server has been operational. [New in: rippled 0.30.1][] |
 | validated\_ledger | Object | Information about the fully-validated ledger with the highest [Ledger Index][] (the most recent) |
 | validated\_ledger.age | Number | The time since the ledger was closed, in seconds |
 | validated\_ledger.base\_fee\_xrp | Number | Base fee, in XRP. This may be represented in scientific notation such as 1e-05 for 0.00005 |
@@ -8763,17 +8763,17 @@ The `state` object may have some arrangement of the following fields:
 | load.threads | Number | *Admin only* The number of threads in the server's main job pool. |
 | load\_base | Integer | This is the baseline amount of server load used in [transaction cost](concept-transaction-cost.html) calculations. If the `load_factor` is equal to the `load_base` then only the base transaction cost is enforced. If the `load_factor` is higher than the `load_base`, then transaction costs are multiplied by the ratio between them. For example, if the `load_factor` is double the `load_base`, then transaction costs are doubled. |
 | load\_factor | Number | The load factor the server is currently enforcing. The ratio between this value and the `load_base` determines the multiplier for transaction costs. The load factor is determined by the highest of the individual server's load factor, cluster's load factor, and the overall network's load factor. |
-| load\_factor\_fee\_escalation | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the open ledger, in [fee levels][]. _(New in [`rippled` 0.32.0][])_ |
-| load\_factor\_fee\_queue | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the queue, if the queue is full, in [fee levels][]. _(New in [`rippled` 0.32.0][])_ |
-| load\_factor\_fee\_reference | Integer | (May be omitted) The [transaction cost][] with no load scaling, in [fee levels][]. _(New in [`rippled` 0.32.0][])_ |
+| load\_factor\_fee\_escalation | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the open ledger, in [fee levels][]. [New in: rippled 0.32.0][] |
+| load\_factor\_fee\_queue | Integer | (May be omitted) The current multiplier to the [transaction cost][] to get into the queue, if the queue is full, in [fee levels][]. [New in: rippled 0.32.0][] |
+| load\_factor\_fee\_reference | Integer | (May be omitted) The [transaction cost][] with no load scaling, in [fee levels][]. [New in: rippled 0.32.0][] |
 | peers | Number | How many other `rippled` servers the node is currently connected to. |
 | pubkey\_node | String | Public key used by this server (along with the corresponding private key) for secure communications between nodes. This key pair is automatically created and stored in `rippled`'s local database the first time it starts up; if lost or deleted, a new key pair can be generated with no ill effects. |
 | pubkey\_validator | String | *Admin only* Public key of the keypair used by this server to sign proposed ledgers for validation. |
 | server\_state | String | A string indicating to what extent the server is participating in the network. See [Possible Server States](#possible-server-states) for more details. |
-| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. _(New in [`rippled` 0.30.1][])_ |
-| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) _(New in [`rippled` 0.30.1][])_ |
-| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. _(New in [`rippled` 0.30.1][])_ |
-| uptime | Number | Number of consecutive seconds that the server has been operational. _(New in [`rippled` 0.30.1][])_ |
+| state\_accounting | Object | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. [New in: rippled 0.30.1][] |
+| state\_accounting.*.duration\_us | String | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) [New in: rippled 0.30.1][] |
+| state\_accounting.*.transitions | Number | The number of times the server has transitioned into this state. [New in: rippled 0.30.1][] |
+| uptime | Number | Number of consecutive seconds that the server has been operational. [New in: rippled 0.30.1][] |
 | validated\_ledger | Object | Information about the fully-validated ledger with the highest sequence number (the most recent) |
 | validated\_ledger.base\_fee | Unsigned Integer | Base fee, in drops of XRP, for propagating a transaction to the network.
 | validated\_ledger.close_time | Number | Time this ledger was closed, in seconds since the [Ripple Epoch](#specifying-time) |
@@ -9254,7 +9254,7 @@ The fields describing a fetch in progress are subject to change without notice. 
 ## feature ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Feature1.cpp "Source")
 
-The `feature` command returns information about [amendments](concept-amendments.html) this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the [amendment process](concept-amendments.html#amendment-process). _(New in [`rippled` 0.31.0][])_
+The `feature` command returns information about [amendments](concept-amendments.html) this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the [amendment process](concept-amendments.html#amendment-process). [New in: rippled 0.31.0][]
 
 You can use the `feature` command to temporarily configure the server to vote against or in favor of an amendment. This change does not persist if you restart the server. To make lasting changes in amendment voting, use the `rippled.cfg` file. See [Configuring Amendment Voting](concept-amendments.html#configuring-amendment-voting) for more information.
 
@@ -9445,7 +9445,7 @@ The response follows the [standard format](#response-formatting), with a success
 ## fee ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp "Source")
 
-The `fee` command reports the current state of the open-ledger requirements for the [transaction cost](concept-transaction-cost.html). This requires the [FeeEscalation amendment](concept-amendments.html#feeescalation) to be enabled. _(New in [`rippled` 0.31.0][])_
+The `fee` command reports the current state of the open-ledger requirements for the [transaction cost](concept-transaction-cost.html). This requires the [FeeEscalation amendment](concept-amendments.html#feeescalation) to be enabled. [New in: rippled 0.31.0][]
 
 _As of [`rippled` 0.32.0][], this is a public command available to unprivileged users._
 
@@ -10601,7 +10601,7 @@ The response follows the [standard format](#response-formatting), with a success
 
 | Field   | Type   | Description |
 |---------|--------|-------------|
-| cluster | Object | Summary of other `rippled` servers in the same cluster, if [configured as a cluster](tutorial-rippled-setup.html#clustering). _(New in [`rippled` 0.30.1][])_ |
+| cluster | Object | Summary of other `rippled` servers in the same cluster, if [configured as a cluster](tutorial-rippled-setup.html#clustering). [New in: rippled 0.30.1][] |
 | peers   | Array  | Array of peer objects. |
 
 Each field of the `cluster` object is the public key of that `rippled` server's identifying keypair. (This is the same value that that server returns as `pubkey_node` in the [`server_info` command](#server-info).) The contents of that field are an object with the following fields:
@@ -10628,7 +10628,7 @@ Each member of the `peers` array is a peer object with the following fields:
 | public\_key | String | (May be omitted) A public key that can be used to verify the integrity of the peer's messages. This is not the same key that is used for validations, but it follows the same format. |
 | sanity | String | (May be omitted) Whether this peer is following the same rules and ledger sequence as the current server. A value of `insane` probably indicates that the peer is part of a parallel network. The value `unknown` indicates that the current server is unsure whether the peer is compatible. <!-- STYLE_OVERRIDE: insane --> |
 | status | String | (May be omitted) The most recent status message from the peer. Could be `connecting`, `connected`, `monitoring`, `validating`, or `shutting`. |
-| uptime | Number | The number of seconds that your `rippled` server has been continuously connected to this peer. _(New in [`rippled` 0.30.1][])_ |
+| uptime | Number | The number of seconds that your `rippled` server has been continuously connected to this peer. [New in: rippled 0.30.1][] |
 | version | string | (May be omitted) The `rippled` version number of the peer server |
 
 #### Possible Errors ####

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -833,7 +833,6 @@ An example of a successful response:
             "lowest_sequence": 6,
             "max_spend_drops_total": "500",
             "transactions": [
-
                 {
                     "auth_change": false,
                     "fee": "100",
@@ -841,9 +840,7 @@ An example of a successful response:
                     "max_spend_drops": "100",
                     "seq": 6
                 },
-
                 ... (trimmed for length) ...
-
                 {
                     "LastLedgerSequence": 10,
                     "auth_change": true,
@@ -883,7 +880,6 @@ An example of a successful response:
             "lowest_sequence": 6,
             "max_spend_drops_total": "500",
             "transactions": [
-
                 {
                     "auth_change": false,
                     "fee": "100",
@@ -891,9 +887,7 @@ An example of a successful response:
                     "max_spend_drops": "100",
                     "seq": 6
                 },
-
                 ... (trimmed for length) ...
-
                 {
                     "LastLedgerSequence": 10,
                     "auth_change": true,
@@ -1239,9 +1233,7 @@ An example of a successful response:
           "value": "0.01886995237307572"
         }
       },
-
-      ...
-
+      ... trimmed for length ...
     ],
     "validated": false
   }
@@ -7775,7 +7767,6 @@ The validations stream sends messages whenever it receives validation messages, 
     "signing_time":515115322,
     "validation_public_key":"n94Gnc6svmaPPRHUAyyib1gQUov8sYbjLoEwUBYPH39qHZXuo8ZT"
 }
-
 ```
 
 The fields from a validations stream message are as follows:
@@ -8983,7 +8974,6 @@ An example of a successful response:
       "status" : "success"
    }
 }
-
 ```
 
 *Commandline*
@@ -9184,7 +9174,6 @@ An example of a successful response:
       "status" : "success"
    }
 }
-
 ```
 
 *Commandline*
@@ -9690,7 +9679,6 @@ An example of a successful response:
       "write_load" : 0
    }
 }
-
 ```
 
 *Commandline*
@@ -10487,7 +10475,6 @@ An example of a successful response:
       "status" : "success"
    }
 }
-
 ```
 
 *Commandline*
@@ -11149,7 +11136,6 @@ An example of a successful response:
       "status" : "success"
    }
 }
-
 ```
 
 *Commandline*

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -795,7 +795,7 @@ The request contains the following parameters:
 | account | String | A unique identifier for the account, most commonly the account's [Address][]. |
 | strict | Boolean | (Optional, defaults to False) If set to True, then the `account` field only accepts a public key or Ripple address. |
 | ledger_hash | String | (Optional) A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
-| ledger_index | String or Unsigned Integer| (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
+| ledger_index | String or Unsigned Integer | (Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers))|
 | queue | Boolean | (Optional) If `true`, and the [FeeEscalation amendment](concept-amendments.html#feeescalation) is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. _(New in [`rippled` 0.33.0][])_ |
 | signer\_lists | Boolean | (Optional) If `true`, and the [MultiSign amendment](concept-amendments.html#multisign) is enabled, also returns any [SignerList objects](reference-ledger-format.html#signerlist) associated with this account. _(New in [`rippled` 0.31.0][])_ |
 
@@ -942,7 +942,7 @@ Each object in the `transactions` array, if present, may contain any or all of t
 | auth\_change | Boolean | Whether this transaction changes this address's [ways of authorizing transactions](reference-transaction-format.html#authorizing-transactions). |
 | fee | String | The [Transaction Cost](concept-transaction-cost.html) of this transaction, in [drops of XRP](#specifying-currency-amounts). |
 | fee\_level | String | The transaction cost of this transaction, relative to the minimum cost for this type of transaction, in [fee levels][]. |
-| max\_spend\_drops | The maximum amount of XRP, [in drops](#specifying-currency-amounts), this transaction could send or destroy. |
+| max\_spend\_drops | String | The maximum amount of XRP, [in drops](#specifying-currency-amounts), this transaction could send or destroy. |
 | seq | Integer | The [Sequence Number][] of this transaction. |
 
 #### Possible Errors ####

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -242,6 +242,7 @@ Every transaction type has the same set of fundamental fields. Field names are c
 | [Flags][]              | Unsigned Integer | UInt32            | (Optional) Set of bit-flags for this transaction. |
 | [LastLedgerSequence][] | Number           | UInt32            | (Optional, but strongly recommended) Highest ledger sequence number that a transaction can appear in. |
 | [Memos][]              | Array of Objects | Array             | (Optional) Additional arbitrary information used to identify this transaction. |
+| PreviousTxnID | String | Hash256 | [Removed in: rippled 0.28.0][] Use `AccountTxnID` instead. |
 | [Sequence][]           | Unsigned Integer | UInt32            | (Required, but [auto-fillable](#auto-fillable-fields)) The sequence number, relative to the initiating account, of this transaction. A transaction is only valid if the `Sequence` number is exactly 1 greater than the last-valided transaction from the same account. |
 | SigningPubKey          | String           | PubKey            | (Automatically added when signing) Hex representation of the public key that corresponds to the private key used to sign this transaction. If an empty string, indicates a multi-signature is present in the `Signers` field instead. |
 | [Signers][]            | Array            | Array             | (Optional) Array of objects that represent a [multi-signature](#multi-signing) which authorizes this transaction. |
@@ -256,8 +257,6 @@ Every transaction type has the same set of fundamental fields. Field names are c
 [Memos]: #memos
 [Sequence]: #canceling-or-skipping-a-transaction
 [Signers]: #signers-field
-
-**Note:** The deprecated `PreviousTxnID` transaction parameter was removed entirely in [`rippled` 0.28.0][]. Use `AccountTxnID` instead.
 
 ### Auto-fillable Fields ###
 
@@ -544,9 +543,9 @@ The available AccountSet flags are:
 | asfAccountTxnID  | 5             | (None)                    | Track the ID of this account's most recent transaction. Required for [AccountTxnID](#accounttxnid) |
 | asfNoFreeze      | 6             | lsfNoFreeze               | Permanently give up the ability to [freeze individual trust lines or disable Global Freeze](concept-freeze.html). This flag can never be disabled after being enabled. |
 | asfGlobalFreeze  | 7             | lsfGlobalFreeze           | [Freeze](concept-freeze.html) all assets issued by this account. |
-| asfDefaultRipple | 8             | lsfDefaultRipple          | Enable [rippling](concept-noripple.html) on this account's trust lines by default. _(New in [`rippled` 0.27.3][])_ |
+| asfDefaultRipple | 8             | lsfDefaultRipple          | Enable [rippling](concept-noripple.html) on this account's trust lines by default. [New in: rippled 0.27.3][] |
 
-_New in [`rippled` 0.28.0][]:_ To enable the `asfDisableMaster` or `asfNoFreeze` flags, you must [authorize the transaction](#authorizing-transactions) by signing it with the master key. You cannot use a regular key or a multi-signature.
+To enable the `asfDisableMaster` or `asfNoFreeze` flags, you must [authorize the transaction](#authorizing-transactions) by signing it with the master key. You cannot use a regular key or a multi-signature. [New in: rippled 0.28.0][]
 
 The following [Transaction flags](#flags), specific to the AccountSet transaction type, serve the same purpose, but are discouraged:
 
@@ -812,7 +811,7 @@ Transactions of the TrustSet type support additional values in the [`Flags` fiel
 ## SignerListSet ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/ef511282709a6a0721b504c6b7703f9de3eecf38/src/ripple/app/tx/impl/SetSignerList.cpp "Source")
 
-The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to [multi-sign](#multi-signing) a transaction. This transaction type was introduced by the [MultiSign amendment](concept-amendments.html#multisign). _(New in [`rippled` 0.31.0][])_
+The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to [multi-sign](#multi-signing) a transaction. This transaction type was introduced by the [MultiSign amendment](concept-amendments.html#multisign). [New in: rippled 0.31.0][]
 
 Example SignerListSet:
 
@@ -1028,7 +1027,7 @@ Some fields that may appear in transaction metadata include:
 | DeliveredAmount                       | [Currency Amount][] | **DEPRECATED.** Replaced by `delivered_amount`. Omitted if not a partial payment. |
 | TransactionIndex                      | Unsigned Integer    | The transaction's position within the ledger that included it. (For example, the value `2` means it was the 2nd transaction in that ledger.) |
 | TransactionResult                     | String              | A [result code](#result-categories) indicating whether the transaction succeeded or how it failed. |
-| [delivered_amount](#delivered-amount) | [Currency Amount][] | The [Currency Amount][] actually received by the `Destination` account. Use this field to determine how much was delivered, regardless of whether the transaction is a [partial payment](#partial-payments). _(New in [`rippled` 0.27.0][])_ |
+| [delivered_amount](#delivered-amount) | [Currency Amount][] | The [Currency Amount][] actually received by the `Destination` account. Use this field to determine how much was delivered, regardless of whether the transaction is a [partial payment](#partial-payments). [New in: rippled 0.27.0][] |
 
 ### delivered_amount ###
 
@@ -1093,7 +1092,7 @@ These codes indicate that the transaction was malformed, and cannot succeed acco
 | temINVALID\_FLAG             | The transaction includes a [Flag](#flags) that does not exist, or includes a contradictory combination of flags. |
 | temMALFORMED                 | Unspecified problem with the format of the transaction. |
 | temREDUNDANT                 | The transaction would do nothing; for example, it is sending a payment directly to the sending account, or creating an offer to buy and sell the same currency from the same issuer. |
-| temREDUNDANT\_SEND\_MAX      | _(Removed in [`rippled` 0.28.0][])_             |
+| temREDUNDANT\_SEND\_MAX      | [Removed in: rippled 0.28.0][] |
 | temRIPPLE\_EMPTY             | The [Payment](#payment) transaction includes an empty `Paths` field, but paths are necessary to complete this payment. |
 | temBAD_WEIGHT                | The [SignerListSet](#signerlistset) transaction includes a `SignerWeight` that is invalid, for example a zero or negative value. |
 | temBAD_SIGNER                | The [SignerListSet](#signerlistset) transaction includes a signer who is invalid. For example, there may be duplicate entries, or the owner of the SignerList may also be a member. |
@@ -1161,15 +1160,15 @@ These codes indicate that the transaction failed, but it was applied to a ledger
 |:----------------------------|:------|:---------------------------------------|
 | tecCLAIM                    | 100   | Unspecified failure, with transaction cost destroyed. |
 | tecDIR\_FULL                | 121   | The address sending the transaction cannot own any more objects in the ledger. |
-| tecDST\_TAG\_NEEDED         | 143   | The [Payment](#payment) transaction omitted a destination tag, but the destination account has the `lsfRequireDestTag` flag enabled. _(New in [`rippled` 0.28.0][])_ |
+| tecDST\_TAG\_NEEDED         | 143   | The [Payment](#payment) transaction omitted a destination tag, but the destination account has the `lsfRequireDestTag` flag enabled. [New in: rippled 0.28.0][] |
 | tecFAILED\_PROCESSING       | 105   | An unspecified error occurred when processing the transaction. |
 | tecFROZEN                   | 137   | The [OfferCreate transaction](#offercreate) failed because one or both of the assets involved are subject to a [global freeze](concept-freeze.html). |
 | tecINSUF\_RESERVE\_LINE     | 122   | The transaction failed because the sending account does not have enough XRP to create a new trust line. (See: [Reserves](concept-reserves.html)) This error occurs when the counterparty already has a trust line in a non-default state to the sending account for the same currency. (See tecNO\_LINE\_INSUF\_RESERVE for the other case.) |
 | tecINSUF\_RESERVE\_OFFER    | 123   | The transaction failed because the sending account does not have enough XRP to create a new Offer. (See: [Reserves](concept-reserves.html)) |
 | tecINSUFFICIENT\_RESERVE    | 141   | The [SignerListSet](#signerlistset) or other transaction would increase the [reserve requirement](concept-reserves.html) higher than the sending account's balance. See [SignerLists and Reserves](reference-ledger-format.html#signerlists-and-reserves) for more information. |
 | tecINTERNAL                 | 144   | Unspecified internal error, with transaction cost applied. This error code should not normally be returned. |
-| tecNEED\_MASTER\_KEY        | 142   | This transaction tried to cause changes that require the master key, such as [disabling the master key or giving up the ability to freeze balances](#accountset-flags). _(New in [`rippled` 0.28.0][])_ |
-| tecNO\_ALTERNATIVE\_KEY     | 130   | The transaction tried to remove the only available method of [authorizing transactions](#authorizing-transactions). This could be a [SetRegularKey transaction](#setregularkey) to remove the regular key, a [SignerListSet transaction](#signerlistset) to delete a SignerList, or an [AccountSet transaction](#accountset) to disable the master key. (Prior to [`rippled` 0.30.0][], this was called `tecMASTER_DISABLED`.) |
+| tecNEED\_MASTER\_KEY        | 142   | This transaction tried to cause changes that require the master key, such as [disabling the master key or giving up the ability to freeze balances](#accountset-flags). [New in: rippled 0.28.0][] |
+| tecNO\_ALTERNATIVE\_KEY     | 130   | The transaction tried to remove the only available method of [authorizing transactions](#authorizing-transactions). This could be a [SetRegularKey transaction](#setregularkey) to remove the regular key, a [SignerListSet transaction](#signerlistset) to delete a SignerList, or an [AccountSet transaction](#accountset) to disable the master key. (Prior to `rippled` 0.30.0, this was called `tecMASTER_DISABLED`.) |
 | tecNO\_AUTH                 | 134   | The transaction failed because it needs to add a balance on a trust line to an account with the `lsfRequireAuth` flag enabled, and that trust line has not been authorized. If the trust line does not exist at all, tecNO\_LINE occurs instead. |
 | tecNO\_DST                  | 124   | The account on the receiving end of the transaction does not exist. This includes Payment and TrustSet transaction types. (It could be created if it received enough XRP.) |
 | tecNO\_DST\_INSUF_XRP       | 125   | The account on the receiving end of the transaction does not exist, and the transaction is not sending enough XRP to create it. |
@@ -1181,7 +1180,7 @@ These codes indicate that the transaction failed, but it was applied to a ledger
 | tecNO\_PERMISSION           | 139   | Reserved for future use.               |
 | tecNO\_REGULAR\_KEY         | 131   | The [AccountSet transaction](#accountset) tried to disable the master key, but the account does not have another way to [authorize transactions](#authorizing-transactions). If [multi-signing](#multi-signing) is enabled, this code is deprecated and `tecNO_ALTERNATIVE_KEY` is used instead. |
 | tecNO\_TARGET               | 138   | Reserved for future use.               |
-| tecOVERSIZE                 | 145   | This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. _(New in [`rippled` 0.29.0-hf1][] )_ |
+| tecOVERSIZE                 | 145   | This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. [New in: rippled 0.29.0-hf1][] |
 | tecOWNERS                   | 132   | The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the [`lsfRequireAuth`](#accountset-flags) flag if it has any trust lines or available offers. |
 | tecPATH\_DRY                | 128   | The transaction failed because the provided paths did not have enough liquidity to send anything at all. This could mean that the source and destination accounts are not linked by trust lines. |
 | tecPATH\_PARTIAL            | 101   | The transaction failed because the provided paths did not have enough liquidity to send the full amount. |

--- a/content/snippets/rippled_versions.md
+++ b/content/snippets/rippled_versions.md
@@ -1,4 +1,5 @@
-<!---- rippled release notes links ---->
+<!-- rippled release notes links -->
+
 [`rippled` 0.26.0]: https://github.com/ripple/rippled/releases/tag/0.26.0
 [`rippled` 0.26.1]: https://github.com/ripple/rippled/releases/tag/0.26.1
 [`rippled` 0.26.2]: https://github.com/ripple/rippled/releases/tag/0.26.2
@@ -20,3 +21,6 @@
 [`rippled` 0.30.1]: https://github.com/ripple/rippled/releases/tag/0.30.1
 [`rippled` 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0
 [`rippled` 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0
+[`rippled` 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0
+[`rippled` 0.32.1]: https://github.com/ripple/rippled/releases/tag/0.32.1
+[`rippled` 0.33.0]: https://github.com/ripple/rippled/releases/tag/0.33.0

--- a/content/snippets/rippled_versions.md
+++ b/content/snippets/rippled_versions.md
@@ -1,26 +1,27 @@
 <!-- rippled release notes links -->
 
-[`rippled` 0.26.0]: https://github.com/ripple/rippled/releases/tag/0.26.0
-[`rippled` 0.26.1]: https://github.com/ripple/rippled/releases/tag/0.26.1
-[`rippled` 0.26.2]: https://github.com/ripple/rippled/releases/tag/0.26.2
-[`rippled` 0.26.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.3-sp1
-[`rippled` 0.26.4]: https://github.com/ripple/rippled/releases/tag/0.26.4
-[`rippled` 0.26.4-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.4-sp1
-[`rippled` 0.27.0]: https://github.com/ripple/rippled/releases/tag/0.27.0
-[`rippled` 0.27.1]: https://github.com/ripple/rippled/releases/tag/0.27.1
-[`rippled` 0.27.2]: https://github.com/ripple/rippled/releases/tag/0.27.2
-[`rippled` 0.27.3]: https://github.com/ripple/rippled/releases/tag/0.27.3
-[`rippled` 0.27.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp1
-[`rippled` 0.27.3-sp2]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp2
-[`rippled` 0.27.4]: https://github.com/ripple/rippled/releases/tag/0.27.4
-[`rippled` 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0
-[`rippled` 0.28.2]: https://github.com/ripple/rippled/releases/tag/0.28.2
-[`rippled` 0.29.0]: https://github.com/ripple/rippled/releases/tag/0.29.0
-[`rippled` 0.29.0-hf1]: https://github.com/ripple/rippled/releases/tag/0.29.0-hf1
-[`rippled` 0.30.0]: https://github.com/ripple/rippled/releases/tag/0.30.0
-[`rippled` 0.30.1]: https://github.com/ripple/rippled/releases/tag/0.30.1
-[`rippled` 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0
-[`rippled` 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0
-[`rippled` 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0
-[`rippled` 0.32.1]: https://github.com/ripple/rippled/releases/tag/0.32.1
-[`rippled` 0.33.0]: https://github.com/ripple/rippled/releases/tag/0.33.0
+[New in: rippled 0.26.0]: https://github.com/ripple/rippled/releases/tag/0.26.0 "BADGE_BLUE"
+[New in: rippled 0.26.1]: https://github.com/ripple/rippled/releases/tag/0.26.1 "BADGE_BLUE"
+[New in: rippled 0.26.2]: https://github.com/ripple/rippled/releases/tag/0.26.2 "BADGE_BLUE"
+[New in: rippled 0.26.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.3-sp1 "BADGE_BLUE"
+[New in: rippled 0.26.4]: https://github.com/ripple/rippled/releases/tag/0.26.4 "BADGE_BLUE"
+[New in: rippled 0.26.4-sp1]: https://github.com/ripple/rippled/releases/tag/0.26.4-sp1 "BADGE_BLUE"
+[New in: rippled 0.27.0]: https://github.com/ripple/rippled/releases/tag/0.27.0 "BADGE_BLUE"
+[New in: rippled 0.27.1]: https://github.com/ripple/rippled/releases/tag/0.27.1 "BADGE_BLUE"
+[New in: rippled 0.27.2]: https://github.com/ripple/rippled/releases/tag/0.27.2 "BADGE_BLUE"
+[New in: rippled 0.27.3]: https://github.com/ripple/rippled/releases/tag/0.27.3 "BADGE_BLUE"
+[New in: rippled 0.27.3-sp1]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp1 "BADGE_BLUE"
+[New in: rippled 0.27.3-sp2]: https://github.com/ripple/rippled/releases/tag/0.27.3-sp2 "BADGE_BLUE"
+[New in: rippled 0.27.4]: https://github.com/ripple/rippled/releases/tag/0.27.4 "BADGE_BLUE"
+[New in: rippled 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0 "BADGE_BLUE"
+[Removed in: rippled 0.28.0]: https://github.com/ripple/rippled/releases/tag/0.28.0 "BADGE_RED"
+[New in: rippled 0.28.2]: https://github.com/ripple/rippled/releases/tag/0.28.2 "BADGE_BLUE"
+[New in: rippled 0.29.0]: https://github.com/ripple/rippled/releases/tag/0.29.0 "BADGE_BLUE"
+[New in: rippled 0.29.0-hf1]: https://github.com/ripple/rippled/releases/tag/0.29.0-hf1 "BADGE_BLUE"
+[New in: rippled 0.30.0]: https://github.com/ripple/rippled/releases/tag/0.30.0 "BADGE_BLUE"
+[New in: rippled 0.30.1]: https://github.com/ripple/rippled/releases/tag/0.30.1 "BADGE_BLUE"
+[New in: rippled 0.31.0]: https://github.com/ripple/rippled/releases/tag/0.31.0 "BADGE_BLUE"
+[New in: rippled 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0 "BADGE_BLUE"
+[New in: rippled 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0 "BADGE_BLUE"
+[New in: rippled 0.32.1]: https://github.com/ripple/rippled/releases/tag/0.32.1 "BADGE_BLUE"
+[New in: rippled 0.33.0]: https://github.com/ripple/rippled/releases/tag/0.33.0 "BADGE_BLUE"

--- a/reference-ledger-format.html
+++ b/reference-ledger-format.html
@@ -1023,7 +1023,7 @@
 </ul>
 <h2 id="signerlist">SignerList</h2>
 <p><a href="https://github.com/ripple/rippled/blob/6d2e3da30696bd10e3bb11a5ff6d45d2c4dae90f/src/ripple/protocol/impl/LedgerFormats.cpp#L127" title="Source">[Source]<br/></a></p>
-<p>The <code>SignerList</code> node type represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a SignerList using the <a href="reference-transaction-format.html#signerlistset">SignerListSet transaction type</a> This node type is introduced by the <a href="concept-amendments.html#multisign">MultiSign amendment</a>. <em>(New in <a href="https://github.com/ripple/rippled/releases/tag/0.31.0">version 0.31.0</a>)</em></p>
+<p>The <code>SignerList</code> node type represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a SignerList using the <a href="reference-transaction-format.html#signerlistset">SignerListSet transaction type</a> This node type is introduced by the <a href="concept-amendments.html#multisign">MultiSign amendment</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p>Example SignerList node:</p>
 <pre><code>{
     "Flags": 0,
@@ -1135,7 +1135,7 @@
 <p>When processing a multi-signed transaction, the server dereferences the <code>Account</code> values with respect to the ledger at the time of transaction execution. If the address <em>does not</em> correspond to a funded <a href="#accountroot">AccountRoot node</a>, then only the master secret associated with that address can be used to produce a valid signature. If the account <em>does</em> exist in the ledger, then it depends on the state of that account. If the account has a Regular Key configured, the Regular Key can be used. The account's master key can only be used if it is not disabled. A multi-signature cannot be used as part of another multi-signature.</p>
 <h3 id="signerlists-and-reserves">SignerLists and Reserves</h3>
 <p>A SignerList contributes to its owner's <a href="concept-reserves.html">reserve requirement</a>. The SignerList itself counts as two objects, and each member of the list counts as one. As a result, the total owner reserve associated with a SignerList is anywhere from 3 times to 10 times the reserve required by a single trust line (<a href="#ripplestate">RippleState</a>) or <a href="#offer">Offer</a> node in the ledger.</p>
-<!---- rippled release notes links ---->
+<!-- rippled release notes links -->
     </div>
       </main>
   </div>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -450,14 +450,19 @@
 <td>(WebSocket only) ID provided in the request that prompted this response</td>
 </tr>
 <tr>
-<td><code>status</code> (WebSocket) &lt;br&gt; <code>result.status</code> (JSON-RPC and Commandline)</td>
+<td><code>status</code></td>
 <td>String</td>
-<td><code>"success"</code> if the request was successful. In the WebSocket API responses, this is included at the top level; in JSON-RPC and Commandline responses, this is included as a sub-field of the <code>"result"</code> object.</td>
+<td>(WebSocket only) The value <code>success</code> indicates the request was successfully received and understood by the server.</td>
+</tr>
+<tr>
+<td><code>result.status</code></td>
+<td>String</td>
+<td>(JSON-RPC and Commandline) The value <code>success</code> indicates the request was successfully received and understood by the server.</td>
 </tr>
 <tr>
 <td><code>type</code></td>
 <td>String</td>
-<td>(WebSocket only) Typically <code>"response"</code>, which indicates a successful response to a command. Asynchronous notifications use a different value such as <code>"ledgerClosed"</code> or <code>"transaction"</code>.</td>
+<td>(WebSocket only) The value <code>response</code> indicates a successful response to a command. <a href="#subscriptions">Asynchronous notifications</a> use a different value such as <code>ledgerClosed</code> or <code>transaction</code>.</td>
 </tr>
 <tr>
 <td><code>result</code></td>
@@ -1107,7 +1112,8 @@ Null method
   "command": "account_info",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
   "strict": true,
-  "ledger_index": "validated"
+  "ledger_index": "current",
+  "queue": true
 }
 </code></pre></div>
 
@@ -1115,9 +1121,10 @@ Null method
     "method": "account_info",
     "params": [
         {
-            "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
             "strict": true,
-            "ledger_index": "validated"
+            "ledger_index": "current",
+            "queue": true
         }
     ]
 }
@@ -1159,6 +1166,11 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <td>(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
+<td>queue</td>
+<td>Boolean</td>
+<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. <em>(New in [<code>rippled</code> 0.33.0][])</em></td>
+</tr>
+<tr>
 <td>signer_lists</td>
 <td>Boolean</td>
 <td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
@@ -1168,26 +1180,103 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <p>The following fields are deprecated and should not be provided: <code>ident</code>, <code>ledger</code>.</p>
 <h4 id="response-format-1">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-6"><ul class="codetabs"><li><a href="#code-6-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-6"><ul class="codetabs"><li><a href="#code-6-0">WebSocket</a></li><li><a href="#code-6-1">JSON-RPC</a></li></ul>
 
 <div class="code_sample" id="code-6-0" style="position: static;"><pre><code>{
-  "id": 5,
-  "status": "success",
-  "type": "response",
-  "result": {
-    "account_data": {
-      "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-      "Balance": "27389517749",
-      "Flags": 0,
-      "LedgerEntryType": "AccountRoot",
-      "OwnerCount": 18,
-      "PreviousTxnID": "2F804E1A00DBCBDAFBDB7D001409F79FE196785EB68FBA463E5924002BE4DEE9",
-      "PreviousTxnLgrSeq": 6405716,
-      "Sequence": 1400,
-      "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05"
-    },
-    "ledger_current_index": 6507948
-  }
+    "id": 5,
+    "status": "success",
+    "type": "response",
+    "result": {
+        "account_data": {
+            "Account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+            "Balance": "999999999960",
+            "Flags": 8388608,
+            "LedgerEntryType": "AccountRoot",
+            "OwnerCount": 0,
+            "PreviousTxnID": "4294BEBE5B569A18C0A2702387C9B1E7146DC3A5850C1E87204951C6FDAA4C42",
+            "PreviousTxnLgrSeq": 3,
+            "Sequence": 6,
+            "index": "92FA6A9FC8EA6018D5D16532D7795C91BFB0831355BDFDA177E86C8BF997985F"
+        },
+        "ledger_current_index": 4,
+        "queue_data": {
+            "auth_change_queued": true,
+            "highest_sequence": 10,
+            "lowest_sequence": 6,
+            "max_spend_drops_total": "500",
+            "transactions": [
+
+                {
+                    "auth_change": false,
+                    "fee": "100",
+                    "fee_level": "2560",
+                    "max_spend_drops": "100",
+                    "seq": 6
+                },
+
+                ... (trimmed for length) ...
+
+                {
+                    "LastLedgerSequence": 10,
+                    "auth_change": true,
+                    "fee": "100",
+                    "fee_level": "2560",
+                    "max_spend_drops": "100",
+                    "seq": 10
+                }
+            ],
+            "txn_count": 5
+        },
+        "validated": false
+    }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-6-1" style="position: static;"><pre><code>{
+    "result": {
+        "account_data": {
+            "Account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+            "Balance": "999999999960",
+            "Flags": 8388608,
+            "LedgerEntryType": "AccountRoot",
+            "OwnerCount": 0,
+            "PreviousTxnID": "4294BEBE5B569A18C0A2702387C9B1E7146DC3A5850C1E87204951C6FDAA4C42",
+            "PreviousTxnLgrSeq": 3,
+            "Sequence": 6,
+            "index": "92FA6A9FC8EA6018D5D16532D7795C91BFB0831355BDFDA177E86C8BF997985F"
+        },
+        "ledger_current_index": 4,
+        "queue_data": {
+            "auth_change_queued": true,
+            "highest_sequence": 10,
+            "lowest_sequence": 6,
+            "max_spend_drops_total": "500",
+            "transactions": [
+
+                {
+                    "auth_change": false,
+                    "fee": "100",
+                    "fee_level": "2560",
+                    "max_spend_drops": "100",
+                    "seq": 6
+                },
+
+                ... (trimmed for length) ...
+
+                {
+                    "LastLedgerSequence": 10,
+                    "auth_change": true,
+                    "fee": "100",
+                    "fee_level": "2560",
+                    "max_spend_drops": "100",
+                    "seq": 10
+                }
+            ],
+            "txn_count": 5
+        },
+        "status": "success",
+        "validated": false
+    }
 }
 </code></pre></div>
 </div>
@@ -1222,16 +1311,100 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <td>(Omitted if <code>ledger_current_index</code> is provided instead) The sequence number of the ledger used when retrieving this information. The information does not contain any changes from ledgers newer than this one.</td>
 </tr>
 <tr>
+<td>queue_data</td>
+<td>Object</td>
+<td>(Omitted unless <code>queue</code> specified as <code>true</code>) Information about <a href="concept-transaction-cost.html#queued-transactions">queued transactions</a> sent by this account. Some information is calculated "lazily" and may not be available. This information describes the state of the local <code>rippled</code> server, which may be different from other servers in the consensus network.</td>
+</tr>
+<tr>
 <td>validated</td>
 <td>Boolean</td>
 <td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. <em>(New in [<code>rippled</code> 0.26.0][])</em></td>
 </tr>
 </tbody>
 </table>
+<p>The <code>queue_data</code> parameter, if present, contains the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>txn_count</td>
+<td>Integer</td>
+<td>Number of queued transactions from this address.</td>
+</tr>
+<tr>
+<td>auth_change_queued</td>
+<td>Boolean</td>
+<td>(May be omitted) Whether a transaction in the queue changes this address's <a href="reference-transaction-format.html#authorizing-transactions">ways of authorizing transactions</a>. If <code>true</code>, this address can queue no further transactions until that transaction has been executed or dropped from the queue.</td>
+</tr>
+<tr>
+<td>lowest_sequence</td>
+<td>Integer</td>
+<td>(May be omitted) The lowest <a href="#account-sequence">Sequence Number</a> among transactions queued by this address.</td>
+</tr>
+<tr>
+<td>highest_sequence</td>
+<td>Integer</td>
+<td>(May be omitted) The highest <a href="#account-sequence">Sequence Number</a> among transactions queued by this address.</td>
+</tr>
+<tr>
+<td>max_spend_drops_total</td>
+<td>String</td>
+<td>(May be omitted) Integer amount of <a href="#specifying-currency-amounts">drops of XRP</a> that could be debited from this address if every transaction in the queue consumes the maximum amount of XRP possible.</td>
+</tr>
+<tr>
+<td>transactions</td>
+<td>Array</td>
+<td>(May be omitted) Information about each queued transaction from this address.</td>
+</tr>
+</tbody>
+</table>
+<p>Each object in the <code>transactions</code> array, if present, may contain any or all of the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>auth_change</td>
+<td>Boolean</td>
+<td>Whether this transaction changes this address's <a href="reference-transaction-format.html#authorizing-transactions">ways of authorizing transactions</a>.</td>
+</tr>
+<tr>
+<td>fee</td>
+<td>String</td>
+<td>The <a href="concept-transaction-cost.html">Transaction Cost</a> of this transaction, in <a href="#specifying-currency-amounts">drops of XRP</a>.</td>
+</tr>
+<tr>
+<td>fee_level</td>
+<td>String</td>
+<td>The transaction cost of this transaction, relative to the minimum cost for this type of transaction, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>.</td>
+</tr>
+<tr>
+<td>max_spend_drops</td>
+<td>The maximum amount of XRP, <a href="#specifying-currency-amounts">in drops</a>, this transaction could send or destroy.</td>
+<td></td>
+</tr>
+<tr>
+<td>seq</td>
+<td>Integer</td>
+<td>The <a href="#account-sequence">Sequence Number</a> of this transaction.</td>
+</tr>
+</tbody>
+</table>
 <h4 id="possible-errors-1">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
-<li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
+<li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing. For example, the request specified <code>queue</code> as <code>true</code> but specified a <code>ledger_index</code> that is not the current open ledger.</li>
 <li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 </ul>
@@ -13048,7 +13221,7 @@ protocol = peer
 [peer_private]
 1
 </code></pre>
-<!---- rippled release notes links ---->
+<!-- rippled release notes links -->
     </div>
       </main>
   </div>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -5071,7 +5071,7 @@ Connecting to 127.0.0.1:5005
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing. This error can also occur if you specify a ledger index equal or higher than the current in-progress ledger.</li>
-<li><code>lgrNotFound</code> - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. <em>(<strong>Note:</strong> Prior to [<code>rippled</code> 0.30.1][], this error used the code <code>ledgerNotFound</code> instead.)</em></li>
+<li><code>lgrNotFound</code> - If the ledger is not yet available. This indicates that the server has started fetching the ledger, although it may fail if none of its connected peers have the requested ledger. (Previously, this error used the code <code>ledgerNotFound</code> instead.) <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="Updated in: rippled 0.30.1"><img alt="Updated in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/Updated%20in-rippled%200.30.1-blue.svg"/></a></li>
 </ul>
 <h2 id="ledger-accept">ledger_accept</h2>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp" title="Source">[Source]<br/></a></p>
@@ -8696,7 +8696,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td>taker</td>
 <td>String</td>
-<td>(Optional, defaults to [ACCOUNT_ONE][]) The <a href="#addresses">Address</a> of an account to use as a perspective. (This affects which unfunded offers are returned.)</td>
+<td>(Optional, defaults to <a href="#special-addresses">ACCOUNT_ONE</a>) The <a href="#addresses">Address</a> of an account to use as a perspective. (This affects which unfunded offers are returned.)</td>
 </tr>
 <tr>
 <td>taker_gets</td>
@@ -11187,7 +11187,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="fee">fee</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
-<p><em>As of [<code>rippled</code> 0.32.0][], this is a public command available to unprivileged users.</em></p>
+<p>This is a public command available to unprivileged users. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="Updated in: rippled 0.32.0"><img alt="Updated in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/Updated%20in-rippled%200.32.0-blue.svg"/></a></p>
 <h4 id="request-format-37">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-73"><ul class="codetabs"><li><a href="#code-73-0">WebSocket</a></li><li><a href="#code-73-1">JSON-RPC</a></li><li><a href="#code-73-2">Commandline</a></li></ul>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1292,7 +1292,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>signer_lists</td>
 <td>Array</td>
-<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
+<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most one SignerList, this array must have exactly one member if it is present. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>ledger_current_index</td>
@@ -1307,7 +1307,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>queue_data</td>
 <td>Object</td>
-<td>(Omitted unless <code>queue</code> specified as <code>true</code>) Information about <a href="concept-transaction-cost.html#queued-transactions">queued transactions</a> sent by this account. Some information is calculated "lazily" and may not be available. This information describes the state of the local <code>rippled</code> server, which may be different from other servers in the consensus network.</td>
+<td>(Omitted unless <code>queue</code> specified as <code>true</code> and querying the current open ledger.) Information about <a href="concept-transaction-cost.html#queued-transactions">queued transactions</a> sent by this account. This information describes the state of the local <code>rippled</code> server, which may be different from other servers in the consensus network. Some fields may be omitted because the values are calculated "lazily" by the queuing mechanism.</td>
 </tr>
 <tr>
 <td>validated</td>
@@ -1467,7 +1467,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>(Optional) Server-provided value to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td>(Optional) Value from a previous response to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1745,7 +1745,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-provided value to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td>Value from a previous response value to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -2001,7 +2001,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>(Optional) Server-provided value to specify where to resume retrieving data from.</td>
+<td>(Optional) Value from a previous response value to specify where to resume retrieving data from.</td>
 </tr>
 </tbody>
 </table>
@@ -2677,7 +2677,7 @@ rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-provided value to specify where to resume retrieving data from. This value is stable even if there is a change in the server's range of available ledgers.</td>
+<td>Value from a previous response value to specify where to resume retrieving data from. This value is stable even if there is a change in the server's range of available ledgers.</td>
 </tr>
 </tbody>
 </table>
@@ -4407,7 +4407,7 @@ rippled ledger_current
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-provided value to specify where to resume retrieving data from.</td>
+<td>Value from a previous response value to specify where to resume retrieving data from.</td>
 </tr>
 </tbody>
 </table>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1168,12 +1168,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>queue</td>
 <td>Boolean</td>
-<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. <em>(New in [<code>rippled</code> 0.33.0][])</em></td>
+<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>signer_lists</td>
 <td>Boolean</td>
-<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
+<td>(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1298,7 +1298,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>signer_lists</td>
 <td>Array</td>
-<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
+<td>(Omitted unless the request specified <code>signer_lists</code> and at least one SignerList is associated with the account.) Array of <a href="reference-ledger-format.html#signerlist">SignerList ledger nodes</a> associated with this account for <a href="reference-transaction-format.html#multi-signing">Multi-Signing</a>. Since an account can own at most 1 SignerList, this array should always have exactly 1 member if it is present. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>ledger_current_index</td>
@@ -1318,7 +1318,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>validated</td>
 <td>Boolean</td>
-<td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. <em>(New in [<code>rippled</code> 0.26.0][])</em></td>
+<td>True if this data is from a validated ledger version; if omitted or set to false, this data is not final. <a href="https://github.com/ripple/rippled/releases/tag/0.26.0" title="New in: rippled 0.26.0"><img alt="New in: rippled 0.26.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1468,12 +1468,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
+<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>(Optional) Server-provided value to specify where to resume retrieving data from. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
+<td>(Optional) Server-provided value to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1588,22 +1588,22 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td>ledger_current_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
+<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1" title="New in: rippled 0.26.4-sp1"><img alt="New in: rippled 0.26.4-sp1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4--sp1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
+<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1" title="New in: rippled 0.26.4-sp1"><img alt="New in: rippled 0.26.4-sp1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4--sp1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
+<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1" title="New in: rippled 0.26.4-sp1"><img alt="New in: rippled 0.26.4-sp1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4--sp1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
+<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1746,12 +1746,12 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>limit</td>
 <td>Integer</td>
-<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
+<td>(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-provided value to specify where to resume retrieving data from. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
+<td>Server-provided value to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1868,22 +1868,22 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>ledger_current_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
+<td>(Omitted if <code>ledger_hash</code> or <code>ledger_index</code> provided) Sequence number of the ledger version used when retrieving this data. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1" title="New in: rippled 0.26.4-sp1"><img alt="New in: rippled 0.26.4-sp1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4--sp1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>ledger_index</td>
 <td>Integer</td>
-<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
+<td>(Omitted if <code>ledger_current_index</code> provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1" title="New in: rippled 0.26.4-sp1"><img alt="New in: rippled 0.26.4-sp1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4--sp1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>ledger_hash</td>
 <td>String</td>
-<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <em>(New in [<code>rippled</code> 0.26.4-sp1][])</em></td>
+<td>(May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4-sp1" title="New in: rippled 0.26.4-sp1"><img alt="New in: rippled 0.26.4-sp1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4--sp1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>marker</td>
 <td><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. <em>(New in [<code>rippled</code> 0.26.4][])</em></td>
+<td>Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1920,12 +1920,12 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td>quality</td>
 <td>Number</td>
-<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. <em>(New in [<code>rippled</code> 0.29.0][])</em></td>
+<td>The exchange rate of the offer, as the ratio of the original <code>taker_pays</code> divided by the original <code>taker_gets</code>. When executing offers, the offer with the most favorable (lowest) quality is consumed first; offers with the same quality are executed from oldest to newest. <a href="https://github.com/ripple/rippled/releases/tag/0.29.0" title="New in: rippled 0.29.0"><img alt="New in: rippled 0.29.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.29.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>expiration</td>
 <td>Unsigned integer</td>
-<td>(May be omitted) A time after which this offer is considered unfunded, as <a href="#specifying-time">the number of seconds since the Ripple Epoch</a>. See also: <a href="reference-transaction-format.html#expiration">Offer Expiration</a>. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>(May be omitted) A time after which this offer is considered unfunded, as <a href="#specifying-time">the number of seconds since the Ripple Epoch</a>. See also: <a href="reference-transaction-format.html#expiration">Offer Expiration</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -3475,7 +3475,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </ul>
 <h2 id="gateway-balances">gateway_balances</h2>
 <p><a href="https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by <a href="concept-issuing-and-operational-addresses.html">operational addresses</a>. <em>(New in [<code>rippled</code> 0.28.2][].)</em></p>
+<p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by <a href="concept-issuing-and-operational-addresses.html">operational addresses</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.28.2" title="New in: rippled 0.28.2"><img alt="New in: rippled 0.28.2" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.28.2-blue.svg"/></a></p>
 <h4 id="request-format-7">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-17"><ul class="codetabs"><li><a href="#code-17-0">WebSocket</a></li><li><a href="#code-17-1">JSON-RPC</a></li></ul>
@@ -3731,7 +3731,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp" title="Source">[Source]<br/></a></p>
 <p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded address stored in the ledger, the address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
 <p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em> (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)</p>
-<p><em>(Updated in [<code>rippled</code> 0.31.0][])</em></p>
+<p><a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="Updated in: rippled 0.31.0"><img alt="Updated in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/Updated%20in-rippled%200.31.0-blue.svg"/></a></p>
 <h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-19"><ul class="codetabs"><li><a href="#code-19-0">WebSocket (with key type)</a></li><li><a href="#code-19-1">WebSocket (no key type)</a></li><li><a href="#code-19-2">JSON-RPC (with key type)</a></li><li><a href="#code-19-3">JSON-RPC (no key type)</a></li><li><a href="#code-19-4">Commandline</a></li></ul>
@@ -3916,7 +3916,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>warning</td>
 <td>String</td>
-<td>(May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) If the request specified a seed value, this field provides a warning that it may be insecure. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -4018,7 +4018,7 @@ rippled ledger current
 <tr>
 <td>binary</td>
 <td>Boolean</td>
-<td>(Optional, defaults to false) If <code>transactions</code> and <code>expand</code> are both true, and this option is also true, return transaction information in binary format instead of JSON format. <em>(New in [<code>rippled</code> 0.28.0][])</em></td>
+<td>(Optional, defaults to false) If <code>transactions</code> and <code>expand</code> are both true, and this option is also true, return transaction information in binary format instead of JSON format. <a href="https://github.com/ripple/rippled/releases/tag/0.28.0" title="New in: rippled 0.28.0"><img alt="New in: rippled 0.28.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.28.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -6551,12 +6551,12 @@ rippled tx_history 0
 <tr>
 <td>destination_amount</td>
 <td>String or Object</td>
-<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in [<code>rippled</code> 0.30.0][])</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
+<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
 </tr>
 <tr>
 <td>send_max</td>
 <td>String or Object</td>
-<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <em>(New in [<code>rippled</code> 0.30.0][])</em></td>
+<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>paths</td>
@@ -6973,7 +6973,7 @@ rippled tx_history 0
 <tr>
 <td>full_reply</td>
 <td>Boolean</td>
-<td>If <code>false</code>, this is the result of an incomplete search. A later reply may have a better path. If <code>true</code>, then this is the best path found. (It is still theoretically possible that a better path could exist, but <code>rippled</code> won't find it.) Until you close the pathfinding request, <code>rippled</code> continues to send updates each time a new ledger closes. <em>(New in [<code>rippled</code> 0.29.0][])</em></td>
+<td>If <code>false</code>, this is the result of an incomplete search. A later reply may have a better path. If <code>true</code>, then this is the best path found. (It is still theoretically possible that a better path could exist, but <code>rippled</code> won't find it.) Until you close the pathfinding request, <code>rippled</code> continues to send updates each time a new ledger closes. <a href="https://github.com/ripple/rippled/releases/tag/0.29.0" title="New in: rippled 0.29.0"><img alt="New in: rippled 0.29.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.29.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -7223,12 +7223,12 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <tr>
 <td>destination_amount</td>
 <td>String or Object</td>
-<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <em>(New in [<code>rippled</code> 0.30.0][])</em> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
+<td><a href="#specifying-currency-amounts">Currency amount</a> that the destination account would receive in a transaction. <strong>Special case:</strong> <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a> You can specify <code>"-1"</code> (for XRP) or provide -1 as the contents of the <code>value</code> field (for non-XRP currencies). This requests a path to deliver as much as possible, while spending no more than the amount specified in <code>send_max</code> (if provided).</td>
 </tr>
 <tr>
 <td>send_max</td>
 <td>String or Object</td>
-<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <em>(New in [<code>rippled</code> 0.30.0][])</em></td>
+<td>(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>source_currencies</td>
@@ -7641,7 +7641,7 @@ rippled sign s██████████████████████
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional, defaults to 1) Signing fails with the error <code>rpcHIGH_FEE</code> if the current <a href="concept-transaction-cost.html#local-load-cost">load multiplier on the transaction cost</a> is greater than (<code>fee_mult_max</code> ÷ <code>fee_div_max</code>). Ignored if you specify the <code>Fee</code> field of the transaction (<a href="concept-transaction-cost.html">transaction cost</a>). <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>(Optional, defaults to 1) Signing fails with the error <code>rpcHIGH_FEE</code> if the current <a href="concept-transaction-cost.html#local-load-cost">load multiplier on the transaction cost</a> is greater than (<code>fee_mult_max</code> ÷ <code>fee_div_max</code>). Ignored if you specify the <code>Fee</code> field of the transaction (<a href="concept-transaction-cost.html">transaction cost</a>). <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -7780,7 +7780,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="sign-for">sign_for</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SignFor.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>sign_for</code> command provides one signature for a <a href="reference-transaction-format.html#multi-signing">multi-signed transaction</a>.</p>
-<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
+<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <h4 id="request-format-24">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-49"><ul class="codetabs"><li><a href="#code-49-0">WebSocket</a></li><li><a href="#code-49-1">JSON-RPC</a></li><li><a href="#code-49-2">Commandline</a></li></ul>
@@ -8155,7 +8155,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td>fee_div_max</td>
 <td>Integer</td>
-<td>(Optional, defaults to 1) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>(Optional, defaults to 1) Used with <code>fee_mult_max</code> to create a fractional multiplier for the limit. Specifically, the server multiplies its base <a href="concept-transaction-cost.html">transaction cost</a> by <code>fee_mult_max</code>, then divides by this value (rounding down to an integer) to get a limit. If the automatically-provided <code>Fee</code> value would be over the limit, the submit command fails. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -8358,7 +8358,7 @@ Connecting to 127.0.0.1:5005
 <h2 id="submit-multisigned">submit_multisigned</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SubmitMultiSigned.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>submit_multisigned</code> command applies a <a href="reference-transaction-format.html#multi-signing">multi-signed</a> transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the <a href="#submit-only-mode"><code>submit</code> command in submit-only mode</a>.)</p>
-<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
+<p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <h4 id="request-format-27">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-54"><ul class="codetabs"><li><a href="#code-54-0">WebSocket</a></li><li><a href="#code-54-1">JSON-RPC</a></li><li><a href="#code-54-2">Commandline</a></li></ul>
@@ -9105,7 +9105,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tbody>
 </table>
 <h3 id="validations-stream">Validations Stream</h3>
-<p><em>(New in [<code>rippled</code> 0.29.0][])</em></p>
+<p><a href="https://github.com/ripple/rippled/releases/tag/0.29.0" title="New in: rippled 0.29.0"><img alt="New in: rippled 0.29.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.29.0-blue.svg"/></a></p>
 <p>The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:</p>
 <pre><code>{
     "type": "validationReceived",
@@ -9148,22 +9148,22 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td><code>amendments</code></td>
 <td>Array of Strings</td>
-<td>(May be omitted) The <a href="concept-amendments.html">amendments</a> this server wants to be added to the protocol. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The <a href="concept-amendments.html">amendments</a> this server wants to be added to the protocol. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>base_fee</code></td>
 <td>Integer</td>
-<td>(May be omitted) The unscaled transaction cost (<code>reference_fee</code> value) this server wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The unscaled transaction cost (<code>reference_fee</code> value) this server wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>flags</code></td>
 <td>Number</td>
-<td>Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>Bit-mask of flags added to this validation message. The flag 0x80000000 indicates that the validation signature is fully-canonical. The flag 0x00000001 indicates that this is a full validation; otherwise it's a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>full</code></td>
 <td>Boolean</td>
-<td>If <code>true</code>, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>If <code>true</code>, this is a full validation. Otherwise, this is a partial validation. Partial validations are not meant to vote for any particular ledger. A partial validation indicates that the validator is still online but not keeping up with consensus. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>ledger_hash</code></td>
@@ -9173,22 +9173,22 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td><code>ledger_index</code></td>
 <td>String - Integer</td>
-<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <em>(New in [<code>rippled</code> 0.31.0][])</em></td>
+<td>The <a href="#ledger-index">Ledger Index</a> of the proposed ledger. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>load_fee</code></td>
 <td>Integer</td>
-<td>(May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The local load-scaled transaction cost this validator is currently enforcing, in fee units. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>reserve_base</code></td>
 <td>Integer</td>
-<td>(May be omitted) The minimum reserve requirement (<code>account_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The minimum reserve requirement (<code>account_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>reserve_inc</code></td>
 <td>Integer</td>
-<td>(May be omitted) The increment in the reserve requirement (<code>owner_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The increment in the reserve requirement (<code>owner_reserve</code> value) this validator wants to set by <a href="concept-fee-voting.html">Fee Voting</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>signature</code></td>
@@ -9198,7 +9198,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td><code>signing_time</code></td>
 <td>Number</td>
-<td>When this validation vote was signed, in seconds since the <a href="#specifying-time">Ripple Epoch</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>When this validation vote was signed, in seconds since the <a href="#specifying-time">Ripple Epoch</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td><code>validation_public_key</code></td>
@@ -10028,12 +10028,12 @@ rippled server_info
 <tr>
 <td>load_factor_fee_escalation</td>
 <td>Number</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the open ledger. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the open ledger. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>load_factor_fee_queue</td>
 <td>Number</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the queue, if the queue is full. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> that a transaction must pay to get into the queue, if the queue is full. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -10058,22 +10058,22 @@ rippled server_info
 <tr>
 <td>state_accounting</td>
 <td>Object</td>
-<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>state_accounting.*.duration_us</td>
 <td>String</td>
-<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>state_accounting.*.transitions</td>
 <td>Number</td>
-<td>The number of times the server has transitioned into this state. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>The number of times the server has transitioned into this state. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>Number of consecutive seconds that the server has been operational. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>Number of consecutive seconds that the server has been operational. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -10393,17 +10393,17 @@ rippled server_state
 <tr>
 <td>load_factor_fee_escalation</td>
 <td>Integer</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the open ledger, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the open ledger, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>load_factor_fee_queue</td>
 <td>Integer</td>
-<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the queue, if the queue is full, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The current multiplier to the <a href="concept-transaction-cost.html">transaction cost</a> to get into the queue, if the queue is full, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>load_factor_fee_reference</td>
 <td>Integer</td>
-<td>(May be omitted) The <a href="concept-transaction-cost.html">transaction cost</a> with no load scaling, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <em>(New in [<code>rippled</code> 0.32.0][])</em></td>
+<td>(May be omitted) The <a href="concept-transaction-cost.html">transaction cost</a> with no load scaling, in <a href="concept-transaction-cost.html#fee-levels">fee levels</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="New in: rippled 0.32.0"><img alt="New in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.32.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -10428,22 +10428,22 @@ rippled server_state
 <tr>
 <td>state_accounting</td>
 <td>Object</td>
-<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>A map of various <a href="#possible-server-states">server states</a> with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>state_accounting.*.duration_us</td>
 <td>String</td>
-<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>state_accounting.*.transitions</td>
 <td>Number</td>
-<td>The number of times the server has transitioned into this state. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>The number of times the server has transitioned into this state. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>Number of consecutive seconds that the server has been operational. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>Number of consecutive seconds that the server has been operational. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>validated_ledger</td>
@@ -10996,7 +10996,7 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="feature">feature</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Feature1.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
+<p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p>You can use the <code>feature</code> command to temporarily configure the server to vote against or in favor of an amendment. This change does not persist if you restart the server. To make lasting changes in amendment voting, use the <code>rippled.cfg</code> file. See <a href="concept-amendments.html#configuring-amendment-voting">Configuring Amendment Voting</a> for more information.</p>
 <p><em>The <code>feature</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
 <h4 id="request-format-36">Request Format</h4>
@@ -11186,7 +11186,7 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="fee">fee</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
+<p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p><em>As of [<code>rippled</code> 0.32.0][], this is a public command available to unprivileged users.</em></p>
 <h4 id="request-format-37">Request Format</h4>
 <p>An example of the request format:</p>
@@ -12389,7 +12389,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>cluster</td>
 <td>Object</td>
-<td>Summary of other <code>rippled</code> servers in the same cluster, if <a href="tutorial-rippled-setup.html#clustering">configured as a cluster</a>. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>Summary of other <code>rippled</code> servers in the same cluster, if <a href="tutorial-rippled-setup.html#clustering">configured as a cluster</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>peers</td>
@@ -12498,7 +12498,7 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td>uptime</td>
 <td>Number</td>
-<td>The number of seconds that your <code>rippled</code> server has been continuously connected to this peer. <em>(New in [<code>rippled</code> 0.30.1][])</em></td>
+<td>The number of seconds that your <code>rippled</code> server has been continuously connected to this peer. <a href="https://github.com/ripple/rippled/releases/tag/0.30.1" title="New in: rippled 0.30.1"><img alt="New in: rippled 0.30.1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td>version</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1391,8 +1391,8 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tr>
 <tr>
 <td>max_spend_drops</td>
+<td>String</td>
 <td>The maximum amount of XRP, <a href="#specifying-currency-amounts">in drops</a>, this transaction could send or destroy.</td>
-<td></td>
 </tr>
 <tr>
 <td>seq</td>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1205,7 +1205,6 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
             "lowest_sequence": 6,
             "max_spend_drops_total": "500",
             "transactions": [
-
                 {
                     "auth_change": false,
                     "fee": "100",
@@ -1213,9 +1212,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
                     "max_spend_drops": "100",
                     "seq": 6
                 },
-
                 ... (trimmed for length) ...
-
                 {
                     "LastLedgerSequence": 10,
                     "auth_change": true,
@@ -1252,7 +1249,6 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
             "lowest_sequence": 6,
             "max_spend_drops_total": "500",
             "transactions": [
-
                 {
                     "auth_change": false,
                     "fee": "100",
@@ -1260,9 +1256,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
                     "max_spend_drops": "100",
                     "seq": 6
                 },
-
                 ... (trimmed for length) ...
-
                 {
                     "LastLedgerSequence": 10,
                     "auth_change": true,
@@ -1790,9 +1784,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
           "value": "0.01886995237307572"
         }
       },
-
-      ...
-
+      ... trimmed for length ...
     ],
     "validated": false
   }
@@ -9128,7 +9120,6 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
     "signing_time":515115322,
     "validation_public_key":"n94Gnc6svmaPPRHUAyyib1gQUov8sYbjLoEwUBYPH39qHZXuo8ZT"
 }
-
 </code></pre>
 <p>The fields from a validations stream message are as follows:</p>
 <table>
@@ -10666,7 +10657,6 @@ rippled consensus_info
       "status" : "success"
    }
 }
-
 </code></pre></div>
 
 <div class="code_sample" id="code-68-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
@@ -10891,7 +10881,6 @@ rippled fetch_info
       "status" : "success"
    }
 }
-
 </code></pre></div>
 
 <div class="code_sample" id="code-70-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
@@ -11455,7 +11444,6 @@ rippled get_counts 100
       "write_load" : 0
    }
 }
-
 </code></pre></div>
 
 <div class="code_sample" id="code-76-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
@@ -12271,7 +12259,6 @@ Connecting to 127.0.0.1:5005
       "status" : "success"
    }
 }
-
 </code></pre></div>
 
 <div class="code_sample" id="code-88-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
@@ -12933,7 +12920,6 @@ rippled connect 192.170.145.88 51235
       "status" : "success"
    }
 }
-
 </code></pre></div>
 
 <div class="code_sample" id="code-98-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -2209,7 +2209,7 @@
 </tr>
 </tbody>
 </table>
-<!---- rippled release notes links ---->
+<!-- rippled release notes links -->
     </div>
       </main>
   </div>

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -459,6 +459,12 @@
 <td align="left">(Optional) Additional arbitrary information used to identify this transaction.</td>
 </tr>
 <tr>
+<td align="left">PreviousTxnID</td>
+<td align="left">String</td>
+<td align="left">Hash256</td>
+<td align="left"><a href="https://github.com/ripple/rippled/releases/tag/0.28.0" title="Removed in: rippled 0.28.0"><img alt="Removed in: rippled 0.28.0" class="dactyl_badge" src="https://img.shields.io/badge/Removed%20in-rippled%200.28.0-red.svg"/></a> Use <code>AccountTxnID</code> instead.</td>
+</tr>
+<tr>
 <td align="left"><a href="#canceling-or-skipping-a-transaction">Sequence</a></td>
 <td align="left">Unsigned Integer</td>
 <td align="left">UInt32</td>
@@ -496,7 +502,6 @@
 </tr>
 </tbody>
 </table>
-<p class="devportal-callout note"><strong>Note:</strong> The deprecated <code>PreviousTxnID</code> transaction parameter was removed entirely in [<code>rippled</code> 0.28.0][]. Use <code>AccountTxnID</code> instead.</p>
 <h3 id="auto-fillable-fields">Auto-fillable Fields</h3>
 <p>Some fields can be automatically filled in before the transaction is signed, either by a <code>rippled</code> server or by the library used for offline signing. Both <a href="https://github.com/ripple/ripple-lib">ripple-lib</a> and <code>rippled</code> can automatically provide the following values:</p>
 <ul>
@@ -914,11 +919,11 @@
 <td align="left">asfDefaultRipple</td>
 <td align="left">8</td>
 <td align="left">lsfDefaultRipple</td>
-<td align="left">Enable <a href="concept-noripple.html">rippling</a> on this account's trust lines by default. <em>(New in [<code>rippled</code> 0.27.3][])</em></td>
+<td align="left">Enable <a href="concept-noripple.html">rippling</a> on this account's trust lines by default. <a href="https://github.com/ripple/rippled/releases/tag/0.27.3" title="New in: rippled 0.27.3"><img alt="New in: rippled 0.27.3" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.27.3-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
-<p><em>New in [<code>rippled</code> 0.28.0][]:</em> To enable the <code>asfDisableMaster</code> or <code>asfNoFreeze</code> flags, you must <a href="#authorizing-transactions">authorize the transaction</a> by signing it with the master key. You cannot use a regular key or a multi-signature.</p>
+<p>To enable the <code>asfDisableMaster</code> or <code>asfNoFreeze</code> flags, you must <a href="#authorizing-transactions">authorize the transaction</a> by signing it with the master key. You cannot use a regular key or a multi-signature. <a href="https://github.com/ripple/rippled/releases/tag/0.28.0" title="New in: rippled 0.28.0"><img alt="New in: rippled 0.28.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.28.0-blue.svg"/></a></p>
 <p>The following <a href="#flags">Transaction flags</a>, specific to the AccountSet transaction type, serve the same purpose, but are discouraged:</p>
 <table>
 <thead>
@@ -1299,7 +1304,7 @@
 </table>
 <h2 id="signerlistset">SignerListSet</h2>
 <p><a href="https://github.com/ripple/rippled/blob/ef511282709a6a0721b504c6b7703f9de3eecf38/src/ripple/app/tx/impl/SetSignerList.cpp" title="Source">[Source]<br/></a></p>
-<p>The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to <a href="#multi-signing">multi-sign</a> a transaction. This transaction type was introduced by the <a href="concept-amendments.html#multisign">MultiSign amendment</a>. <em>(New in [<code>rippled</code> 0.31.0][])</em></p>
+<p>The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to <a href="#multi-signing">multi-sign</a> a transaction. This transaction type was introduced by the <a href="concept-amendments.html#multisign">MultiSign amendment</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p>Example SignerListSet:</p>
 <pre><code>{
     "Flags": 0,
@@ -1692,7 +1697,7 @@
 <tr>
 <td align="left"><a href="#delivered-amount">delivered_amount</a></td>
 <td align="left"><a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a></td>
-<td align="left">The <a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a> actually received by the <code>Destination</code> account. Use this field to determine how much was delivered, regardless of whether the transaction is a <a href="#partial-payments">partial payment</a>. <em>(New in [<code>rippled</code> 0.27.0][])</em></td>
+<td align="left">The <a href="reference-rippled.html#specifying-currency-amounts">Currency Amount</a> actually received by the <code>Destination</code> account. Use this field to determine how much was delivered, regardless of whether the transaction is a <a href="#partial-payments">partial payment</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.27.0" title="New in: rippled 0.27.0"><img alt="New in: rippled 0.27.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.27.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1862,7 +1867,7 @@
 </tr>
 <tr>
 <td align="left">temREDUNDANT_SEND_MAX</td>
-<td align="left"><em>(Removed in [<code>rippled</code> 0.28.0][])</em></td>
+<td align="left"><a href="https://github.com/ripple/rippled/releases/tag/0.28.0" title="Removed in: rippled 0.28.0"><img alt="Removed in: rippled 0.28.0" class="dactyl_badge" src="https://img.shields.io/badge/Removed%20in-rippled%200.28.0-red.svg"/></a></td>
 </tr>
 <tr>
 <td align="left">temRIPPLE_EMPTY</td>
@@ -2070,7 +2075,7 @@
 <tr>
 <td align="left">tecDST_TAG_NEEDED</td>
 <td align="left">143</td>
-<td align="left">The <a href="#payment">Payment</a> transaction omitted a destination tag, but the destination account has the <code>lsfRequireDestTag</code> flag enabled. <em>(New in [<code>rippled</code> 0.28.0][])</em></td>
+<td align="left">The <a href="#payment">Payment</a> transaction omitted a destination tag, but the destination account has the <code>lsfRequireDestTag</code> flag enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.28.0" title="New in: rippled 0.28.0"><img alt="New in: rippled 0.28.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.28.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left">tecFAILED_PROCESSING</td>
@@ -2105,12 +2110,12 @@
 <tr>
 <td align="left">tecNEED_MASTER_KEY</td>
 <td align="left">142</td>
-<td align="left">This transaction tried to cause changes that require the master key, such as <a href="#accountset-flags">disabling the master key or giving up the ability to freeze balances</a>. <em>(New in [<code>rippled</code> 0.28.0][])</em></td>
+<td align="left">This transaction tried to cause changes that require the master key, such as <a href="#accountset-flags">disabling the master key or giving up the ability to freeze balances</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.28.0" title="New in: rippled 0.28.0"><img alt="New in: rippled 0.28.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.28.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left">tecNO_ALTERNATIVE_KEY</td>
 <td align="left">130</td>
-<td align="left">The transaction tried to remove the only available method of <a href="#authorizing-transactions">authorizing transactions</a>. This could be a <a href="#setregularkey">SetRegularKey transaction</a> to remove the regular key, a <a href="#signerlistset">SignerListSet transaction</a> to delete a SignerList, or an <a href="#accountset">AccountSet transaction</a> to disable the master key. (Prior to [<code>rippled</code> 0.30.0][], this was called <code>tecMASTER_DISABLED</code>.)</td>
+<td align="left">The transaction tried to remove the only available method of <a href="#authorizing-transactions">authorizing transactions</a>. This could be a <a href="#setregularkey">SetRegularKey transaction</a> to remove the regular key, a <a href="#signerlistset">SignerListSet transaction</a> to delete a SignerList, or an <a href="#accountset">AccountSet transaction</a> to disable the master key. (Prior to <code>rippled</code> 0.30.0, this was called <code>tecMASTER_DISABLED</code>.)</td>
 </tr>
 <tr>
 <td align="left">tecNO_AUTH</td>
@@ -2170,7 +2175,7 @@
 <tr>
 <td align="left">tecOVERSIZE</td>
 <td align="left">145</td>
-<td align="left">This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. <em>(New in [<code>rippled</code> 0.29.0-hf1][] )</em></td>
+<td align="left">This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. <a href="https://github.com/ripple/rippled/releases/tag/0.29.0-hf1" title="New in: rippled 0.29.0-hf1"><img alt="New in: rippled 0.29.0-hf1" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.29.0--hf1-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left">tecOWNERS</td>

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -344,6 +344,9 @@ known_broken_links:
     # Strangely, Python doesn't like the cert here. Firefox is OK with it.
     - https://validators.ripple.com
 
+    # rippled 0.33.0 is not released yet:
+    - https://github.com/ripple/rippled/releases/tag/0.33.0
+
 # Style Checker Config ------------------------------------------------------ #
 
 word_substitutions_file: word_substitutions.yaml

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -31,6 +31,7 @@ targets:
             - standardize_header_ids
             - buttonize
             - callouts
+            - badges
 
     -   name: ripple.com
         display_name: Ripple Developer Center
@@ -39,6 +40,7 @@ targets:
             - standardize_header_ids
             - buttonize
             - callouts
+            - badges
         template: template-contentwithtoc.html
         image_subs:
             "img/funds_flow_diagram.png": https://ripple.com/wp-content/uploads/2016/03/funds_flow_diagram.png
@@ -61,7 +63,7 @@ targets:
 
     -   name: rippled-setup
         filters:
-        - standardize_header_ids
+            - standardize_header_ids
 
 pages:
 # Intro pages is not directly replicated on ripple.com at this time

--- a/tool/filter_badges.py
+++ b/tool/filter_badges.py
@@ -40,3 +40,5 @@ def filter_soup(soup, target=None, page=None):
         b.clear()
         b.append(img)
         b["title"] = badge_label
+        if not b["href"]:
+            del b["href"]

--- a/tool/filter_badges.py
+++ b/tool/filter_badges.py
@@ -1,0 +1,42 @@
+################################################################################
+## Badges filter                                                              ##
+## Author: Rome Reginelli                                                     ##
+## Copyright: Ripple Labs, Inc. 2016                                          ##
+##                                                                            ##
+## Looks for links with the title text "BADGE" and makes them into badges.    ##
+## The alt text must be in the form of <badgelefthalf>:<badgerighthalf> and   ##
+## the left half can't contain a colon.                                       ##
+################################################################################
+import re
+import logging
+from urllib.parse import quote as urlescape
+
+BADGE_REGEX = re.compile("BADGE_(BRIGHTGREEN|GREEN|YELLOWGREEN|YELLOW|ORANGE|RED|LIGHTGREY|BLUE|[0-9A-Fa-f]{6})")
+
+def filter_soup(soup, target=None, page=None):
+    """replace underscores with dashes in h1,h2,etc. for backwards compatibility"""
+
+    badge_links = soup.find_all(name="a", title=BADGE_REGEX)
+
+    for b in badge_links:
+        badge_label = b.string
+        if not badge_label:
+            badge_label = "".join(b.strings)
+        if not badge_label:
+            logging.warning("Badge link with no string: %s" % b)
+            continue
+        if ":" not in badge_label:
+            logging.warning("Badge link specified with no ':' in link: %s" % b.string)
+            continue
+
+        badge_color = BADGE_REGEX.match(b["title"]).group(1).lower()
+        badge_left, badge_right = [urlescape(s.strip()).replace("-","--")
+                                   for s in badge_label.split(":", 1)]
+        badge_url = "https://img.shields.io/badge/%s-%s-%s.svg" % (
+                    badge_left, badge_right, badge_color)
+
+        img = soup.new_tag("img", src=badge_url, alt=badge_label)
+        img["class"]="dactyl_badge"
+        b.clear()
+        b.append(img)
+        b["title"] = badge_label


### PR DESCRIPTION
Normally I wouldn't batch these two mostly unrelated changes, but I discovered that I needed to link to rippled versions, which were broken recently. (Reference links whose text contains `backticks` don't work in the Python markdown parser.) So that basically presented an opportunity, where I had to change the exact thing anyway, so I changed it to how we wanted it - to use badges.

Also, I did a find/replace to turn tabs into 4 spaces throughout the code samples, and I slightly cleaned up the formatting of the "Response Formatting" section in a non-substantive way.

Basically, sorry this is a slightly messy pull request. The part that really needs reviews is the **account_info** section of the file `content/reference-ledger-format.md` -- everything else should be fine.
