### PR TITLE
fee rpc - ledger_current_index (doc717)

### DIFF
--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -9531,6 +9531,7 @@ An example of a successful response:
       "open_ledger_fee": "10"
     },
     "expected_ledger_size": "24",
+    "ledger_current_index": 26575101,
     "levels": {
       "median_level": "281600",
       "minimum_level": "256",
@@ -9557,6 +9558,7 @@ An example of a successful response:
             "open_ledger_fee": "2653937"
         },
         "expected_ledger_size": "55",
+        "ledger_current_index": 26575101,
         "levels": {
             "median_level": "256000",
             "minimum_level": "256",
@@ -9585,6 +9587,7 @@ Connecting to 127.0.0.1:5005
          "open_ledger_fee" : "3203982"
       },
       "expected_ledger_size" : "15",
+      "ledger_current_index": 26575101,
       "levels" : {
          "median_level" : "281600",
          "minimum_level" : "256",
@@ -9611,6 +9614,7 @@ The response follows the [standard format](#response-formatting), with a success
 | `drops.minimum_fee`        | String (Integer) | The minimum transaction cost for a [reference transaction](concept-transaction-cost.html#reference-transaction-cost) to be queued for a later ledger, represented in drops of XRP. If greater than `base_fee`, the transaction queue is full. |
 | `drops.open_ledger_fee`    | String (Integer) | The minimum transaction cost that a [reference transaction](concept-transaction-cost.html#reference-transaction-cost) must pay to be included in the current open ledger, represented in drops of XRP. |
 | `expected_ledger_size`     | String (Integer) | The approximate number of transactions expected to be included in the current ledger. This is based on the number of transactions in the previous ledger. |
+| `ledger_current_index`     | Number           | The [Ledger Index][] of the current open ledger these stats describe. [New in: rippled 0.50.0][] |
 | `levels`                   | Object           | Various information about the transaction cost, in [fee levels][]. The ratio in fee levels applies to any transaction relative to the minimum cost of that particular transaction. |
 | `levels.median_level`      | String (Integer) | The median transaction cost among transactions in the previous validated ledger, represented in [fee levels][]. |
 | `levels.minimum_level`     | String (Integer) | The minimum transaction cost required to be queued for a future ledger, represented in [fee levels][]. |

--- a/content/snippets/rippled_versions.md
+++ b/content/snippets/rippled_versions.md
@@ -25,3 +25,4 @@
 [New in: rippled 0.32.0]: https://github.com/ripple/rippled/releases/tag/0.32.0 "BADGE_BLUE"
 [New in: rippled 0.32.1]: https://github.com/ripple/rippled/releases/tag/0.32.1 "BADGE_BLUE"
 [New in: rippled 0.33.0]: https://github.com/ripple/rippled/releases/tag/0.33.0 "BADGE_BLUE"
+[New in: rippled 0.50.0]: https://github.com/ripple/rippled/releases/tag/0.50.0 "BADGE_BLUE"

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -11264,6 +11264,7 @@ rippled fee
       "open_ledger_fee": "10"
     },
     "expected_ledger_size": "24",
+    "ledger_current_index": 26575101,
     "levels": {
       "median_level": "281600",
       "minimum_level": "256",
@@ -11287,6 +11288,7 @@ rippled fee
             "open_ledger_fee": "2653937"
         },
         "expected_ledger_size": "55",
+        "ledger_current_index": 26575101,
         "levels": {
             "median_level": "256000",
             "minimum_level": "256",
@@ -11312,6 +11314,7 @@ Connecting to 127.0.0.1:5005
          "open_ledger_fee" : "3203982"
       },
       "expected_ledger_size" : "15",
+      "ledger_current_index": 26575101,
       "levels" : {
          "median_level" : "281600",
          "minimum_level" : "256",
@@ -11373,6 +11376,11 @@ Connecting to 127.0.0.1:5005
 <td align="left"><code>expected_ledger_size</code></td>
 <td align="left">String (Integer)</td>
 <td align="left">The approximate number of transactions expected to be included in the current ledger. This is based on the number of transactions in the previous ledger.</td>
+</tr>
+<tr>
+<td align="left"><code>ledger_current_index</code></td>
+<td align="left">Number</td>
+<td align="left">The <a href="#ledger-index">Ledger Index</a> of the current open ledger these stats describe. <a href="https://github.com/ripple/rippled/releases/tag/0.50.0" title="New in: rippled 0.50.0"><img alt="New in: rippled 0.50.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.50.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><code>levels</code></td>


### PR DESCRIPTION
(almost trivial)

Updates the `fee` RPC command description to mention the new `ledger_current_index` field.