### PR TITLE
Dactyl v0.4.0 compatibility

### DIFF
--- a/reference-data-api.html
+++ b/reference-data-api.html
@@ -320,7 +320,7 @@
 <div class="code_sample" id="code-0-0" style="position: static;"><pre><code>GET /v2/ledgers/{:identifier}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-ledger">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-ledger">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -419,7 +419,7 @@
 <div class="code_sample" id="code-1-0" style="position: static;"><pre><code>GET /v2/ledgers/{:ledger_hash}/validations
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-ledger-validations">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-ledger-validations">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -545,7 +545,7 @@
 <div class="code_sample" id="code-2-0" style="position: static;"><pre><code>GET /v2/ledgers/{:ledger_hash}/validations/{:pubkey}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-ledger-validation">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-ledger-validation">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -613,7 +613,7 @@
 <div class="code_sample" id="code-3-0" style="position: static;"><pre><code>GET /v2/transactions/{:hash}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-transaction">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-transaction">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -737,7 +737,7 @@
 <div class="code_sample" id="code-4-0" style="position: static;"><pre><code>GET /v2/transactions/
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-transactions">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-transactions">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -942,7 +942,7 @@
 <div class="code_sample" id="code-5-1" style="position: static;"><pre><code>GET /v2/payments/{:currency}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-payments">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-payments">Try it!</a></p>
 <p>This method uses the following URL parameters:</p>
 <table>
 <thead>
@@ -1163,7 +1163,7 @@
 <div class="code_sample" id="code-6-0" style="position: static;"><pre><code>GET /v2/exchanges/{:base}/{:counter}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-exchanges">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-exchanges">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -1358,7 +1358,7 @@
 <div class="code_sample" id="code-7-0" style="position: static;"><pre><code>GET /v2/exchange_rates/{:base}/{:counter}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-exchange-rates">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-exchange-rates">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -1448,7 +1448,7 @@
 <div class="code_sample" id="code-8-0" style="position: static;"><pre><code>GET /v2/normalize
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#normalize">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#normalize">Try it!</a></p>
 <p>You must provide at least some of the following query parameters:</p>
 <table>
 <thead>
@@ -1552,7 +1552,7 @@
 <div class="code_sample" id="code-9-0" style="position: static;"><pre><code>GET /v2/reports/{:date}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-daily-reports">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-daily-reports">Try it!</a></p>
 <p>This method uses the following URL parameter:</p>
 <table>
 <thead>
@@ -1761,7 +1761,7 @@
 <div class="code_sample" id="code-10-0" style="position: static;"><pre><code>GET /v2/stats
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-stats">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-stats">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -1960,7 +1960,7 @@
 <div class="code_sample" id="code-11-0" style="position: static;"><pre><code>GET /v2/capitaliztion/{:currency}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-capitalization">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-capitalization">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -2160,7 +2160,7 @@
 <div class="code_sample" id="code-12-0" style="position: static;"><pre><code>GET /v2/active_accounts/{:base}/{:counter}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-active-accounts">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-active-accounts">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -2411,7 +2411,7 @@
 <div class="code_sample" id="code-13-0" style="position: static;"><pre><code>GET /v2/network/exchange_volume
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-exchange-volume">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-exchange-volume">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -2632,7 +2632,7 @@
 <div class="code_sample" id="code-14-0" style="position: static;"><pre><code>GET /v2/network/payment_volume
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-payment-volume">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-payment-volume">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -2837,7 +2837,7 @@
 <div class="code_sample" id="code-15-0" style="position: static;"><pre><code>GET /v2/network/issued_value
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-issued-value">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-issued-value">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -3007,7 +3007,7 @@
 <div class="code_sample" id="code-16-0" style="position: static;"><pre><code>GET /v2/network/xrp_distribution
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-xrp-distribution">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-xrp-distribution">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -3142,7 +3142,7 @@
 <div class="code_sample" id="code-17-1" style="position: static;"><pre><code>GET /v2/network/top_currencies/{:date}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-top-currencies">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-top-currencies">Try it!</a></p>
 <p>This method uses the following URL parameter:</p>
 <table>
 <thead>
@@ -3306,7 +3306,7 @@
 <div class="code_sample" id="code-18-1" style="position: static;"><pre><code>GET /v2/network/top_markets/{:date}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-top-markets">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-top-markets">Try it!</a></p>
 <p>This method uses the following URL parameter:</p>
 <table>
 <thead>
@@ -3473,7 +3473,7 @@
 <div class="code_sample" id="code-19-0" style="position: static;"><pre><code>GET /v2/network/fees
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-transaction-costs">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-transaction-costs">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -3648,7 +3648,7 @@
 <div class="code_sample" id="code-20-0" style="position: static;"><pre><code>GET /v2/network/topology
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-topology">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-topology">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -3779,7 +3779,7 @@
 <div class="code_sample" id="code-21-0" style="position: static;"><pre><code>GET /v2/network/topology/nodes
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-topology-nodes">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-topology-nodes">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -3893,7 +3893,7 @@
 <div class="code_sample" id="code-22-0" style="position: static;"><pre><code>GET /v2/network/topology/nodes/{:pubkey}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-topology-node">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-topology-node">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -3967,7 +3967,7 @@
 <div class="code_sample" id="code-23-0" style="position: static;"><pre><code>GET /v2/network/topology/links
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-topology-links">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-topology-links">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -4146,7 +4146,7 @@
 <div class="code_sample" id="code-25-0" style="position: static;"><pre><code>GET /v2/network/validators
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-validators">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-validators">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -4214,7 +4214,7 @@
 <div class="code_sample" id="code-26-0" style="position: static;"><pre><code>GET /v2/network/validators/{:pubkey}/validations
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-validator-validations">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-validator-validations">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -4353,7 +4353,7 @@
 <div class="code_sample" id="code-27-0" style="position: static;"><pre><code>GET /v2/network/validations
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-validations">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-validations">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -4479,7 +4479,7 @@
 <div class="code_sample" id="code-28-0" style="position: static;"><pre><code>GET /v2/network/validators/{:pubkey}/reports
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-single-validator-reports">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-single-validator-reports">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -4641,7 +4641,7 @@
 <div class="code_sample" id="code-29-0" style="position: static;"><pre><code>GET /v2/network/validator_reports
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-daily-validator-reports">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-daily-validator-reports">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -4809,7 +4809,7 @@
 <div class="code_sample" id="code-30-0" style="position: static;"><pre><code>GET /v2/network/rippled_versions
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-rippled-versions">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-rippled-versions">Try it!</a></p>
 <h4 id="response-format-30">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body with the following:</p>
 <table>
@@ -4902,7 +4902,7 @@
 <div class="code_sample" id="code-31-0" style="position: static;"><pre><code>GET /v2/gateways/
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-all-gateways">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-all-gateways">Try it!</a></p>
 <p>This method takes no query parameters.</p>
 <h4 id="response-format-31">Response Format</h4>
 <p>A successful response uses the HTTP code <strong>200 OK</strong> and has a JSON body.</p>
@@ -5005,7 +5005,7 @@
 <div class="code_sample" id="code-32-0" style="position: static;"><pre><code>GET /v2/gateways/{:gateway}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-gateway">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-gateway">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -5190,7 +5190,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-34-0" style="position: static;"><pre><code>GET /v2/accounts
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-accounts">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-accounts">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -5350,7 +5350,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-35-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -5417,7 +5417,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-36-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/balances
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-balances">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-balances">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -5564,7 +5564,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-37-0" style="position: static;"><pre><code>GET /v2/account/{:address}/orders
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-orders">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-orders">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -5774,7 +5774,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-38-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/transactions
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-transaction-history">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-transaction-history">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -5968,7 +5968,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-39-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/transactions/{:sequence}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-transaction-by-account-and-sequence">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-transaction-by-account-and-sequence">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -6057,7 +6057,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-40-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/payments
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-payments">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-payments">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -6230,7 +6230,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-41-1" style="position: static;"><pre><code>GET /v2/accounts/{:address}/exchanges/{:base}/{:counter}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-exchanges-all">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-exchanges-all">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -6394,7 +6394,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-42-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/balance_changes/
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-balance-changes">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-balance-changes">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -6553,7 +6553,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-43-1" style="position: static;"><pre><code>GET /v2/accounts/{:address}/reports/{:date}
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-reports-by-day">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-reports-by-day">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -6706,7 +6706,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-44-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/stats/transactions
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-transaction-stats">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-transaction-stats">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -6870,7 +6870,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-45-0" style="position: static;"><pre><code>GET /v2/accounts/{:address}/stats/value
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#get-account-value-stats">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#get-account-value-stats">Try it!</a></p>
 <p>This method requires the following URL parameters:</p>
 <table>
 <thead>
@@ -7017,7 +7017,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-46-0" style="position: static;"><pre><code>GET /v2/health/api
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#api-health-check">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#api-health-check">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -7108,7 +7108,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-47-0" style="position: static;"><pre><code>GET /v2/health/importer
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#importer-health-check">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#importer-health-check">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -7226,7 +7226,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-48-0" style="position: static;"><pre><code>GET /v2/health/nodes_etl
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#nodes-etl-health-check">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#nodes-etl-health-check">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>
@@ -7322,7 +7322,7 @@ Content-Type: image/svg+xml
 <div class="code_sample" id="code-49-0" style="position: static;"><pre><code>GET /v2/health/validations_etl
 </code></pre></div>
 </div>
-<p><a class="button" href="data-api-v2-tool.html#validations-etl-health-check">Try it! &gt;</a></p>
+<p><a class="button" href="data-api-v2-tool.html#validations-etl-health-check">Try it!</a></p>
 <p>Optionally, you can provide the following query parameters:</p>
 <table>
 <thead>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -950,7 +950,7 @@ Null method
 }
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#account_currencies">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#account_currencies">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -1131,7 +1131,7 @@ Null method
 rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#account_info">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#account_info">Try it!</a></p>
 <p>The request contains the following parameters:</p>
 <table>
 <thead>
@@ -1425,7 +1425,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#account_lines">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#account_lines">Try it!</a></p>
 <p>The request accepts the following paramters:</p>
 <table>
 <thead>
@@ -1703,7 +1703,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#account_offers">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#account_offers">Try it!</a></p>
 <p>A request can include the following parameters:</p>
 <table>
 <thead>
@@ -2620,7 +2620,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#account_tx">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#account_tx">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -3958,7 +3958,7 @@ Connecting to 127.0.0.1:5005
 rippled ledger current
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#ledger">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#ledger">Try it!</a></p>
 <p>The request can contain the following parameters:</p>
 <table>
 <thead>
@@ -4212,7 +4212,7 @@ rippled ledger current
 rippled ledger_closed
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#ledger_closed">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#ledger_closed">Try it!</a></p>
 <p>This method accepts no parameters.</p>
 <h4 id="response-format-10">Response Format</h4>
 <p>An example of a successful response:</p>
@@ -4290,7 +4290,7 @@ rippled ledger_closed
 rippled ledger_current
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#ledger_current">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#ledger_current">Try it!</a></p>
 <p>The request contains no parameters.</p>
 <h4 id="response-format-11">Response Format</h4>
 <p>An example of a successful response:</p>
@@ -4675,7 +4675,7 @@ rippled ledger_current
 }
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#ledger_entry">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#ledger_entry">Try it!</a></p>
 <p>This method can retrieve several different types of data. You can select which type of item to retrieve by passing the appropriate parameters. Specifically, you should provide exactly one of the following fields:</p>
 <ol>
 <li><code>index</code> - Retrieve any type of ledger node by its unique index</li>
@@ -5148,7 +5148,7 @@ rippled ledger_accept
 rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 false
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#tx">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#tx">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -5378,7 +5378,7 @@ rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 fals
 rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 348734
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#transaction_entry">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#transaction_entry">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -5614,7 +5614,7 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 rippled tx_history 0
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#tx_history">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#tx_history">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -6511,7 +6511,7 @@ rippled tx_history 0
 }
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#path_find">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#path_find">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -7188,7 +7188,7 @@ rippled tx_history 0
 rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59", "source_currencies": [ { "currency": "XRP" }, { "currency": "USD" } ], "destination_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59", "destination_amount": { "value": "0.001", "currency": "USD", "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B" } }'
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#ripple_path_find">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#ripple_path_find">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -7566,7 +7566,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 rippled sign s████████████████████████████ '{"TransactionType": "Payment", "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "Amount": { "currency": "USD", "value": "1", "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn" }, "Sequence": 360, "Fee": "10000"}' offline
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#sign">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#sign">Try it!</a></p>
 <p>To sign a transaction, you must provide a secret key that can <a href="reference-transaction-format.html#authorizing-transactions">authorize the transaction</a>. You can do this in a few ways:</p>
 <ul>
 <li>Provide a <code>secret</code> value and omit the <code>key_type</code> field. This value can be formatted as base-58 seed, RFC-1751, hexadecimal, or as a string passphrase. (secp256k1 keys only)</li>
@@ -8073,7 +8073,7 @@ Connecting to 127.0.0.1:5005
 submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#submit">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#submit">Try it!</a></p>
 <h3 id="sign-and-submit-mode">Sign-and-Submit Mode</h3>
 <p>This mode signs a transaction and immediately submits it. This mode is intended to be used for testing. You cannot use this mode for <a href="reference-transaction-format.html#multi-signing">multi-signed transactions</a>.</p>
 <p>You can provide the secret key used to sign the transaction in the following ways:</p>
@@ -8198,7 +8198,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 rippled submit s████████████████████████████ '{"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Amount": { "currency": "USD", "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "value": "1" }, "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "TransactionType": "Payment", "Fee": "10000"}'
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#submit">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#submit">Try it!</a></p>
 <h4 id="response-format-25">Response Format</h4>
 <p>An example of a successful response:</p>
 <div class="multicode" id="code-53"><ul class="codetabs"><li><a href="#code-53-0">WebSocket</a></li><li><a href="#code-53-1">JSON-RPC</a></li><li><a href="#code-53-2">Commandline</a></li></ul>
@@ -8656,7 +8656,7 @@ rippled submit_multisigned '{
 rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#book_offers">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#book_offers">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -8885,7 +8885,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 }
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#subscribe">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#subscribe">Try it!</a></p>
 <p>The request includes the following parameters:</p>
 <table>
 <thead>
@@ -9632,7 +9632,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 }
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#unsubscribe">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#unsubscribe">Try it!</a></p>
 <p>The parameters in the request are specified almost exactly like the parameters to <a href="#subscribe"><code>subscribe</code></a>, except that they are used to define which subscriptions to end instead. The parameters are:</p>
 <table>
 <thead>
@@ -9749,7 +9749,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 rippled server_info
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#server_info">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#server_info">Try it!</a></p>
 <p>The request does not takes any parameters.</p>
 <h4 id="response-format-30">Response Format</h4>
 <p>An example of a successful response:</p>
@@ -10175,7 +10175,7 @@ rippled server_info
 rippled server_state
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#server_state">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#server_state">Try it!</a></p>
 <p>The request does not takes any parameters.</p>
 <h4 id="response-format-31">Response Format</h4>
 <p>An example of a successful response:</p>
@@ -12792,7 +12792,7 @@ Connecting to 127.0.0.1:5005
 rippled ping
 </code></pre></div>
 </div>
-<p><a class="button" href="ripple-api-tool.html#ping">Try it! &gt;</a></p>
+<p><a class="button" href="ripple-api-tool.html#ping">Try it!</a></p>
 <p>The request includes no parameters.</p>
 <h4 id="response-format-44">Response Format</h4>
 <p>An example of a successful response:</p>

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -43,6 +43,32 @@ targets:
     -   name: ripple.com
         display_name: Ripple Developer Center
         template: template-contentwithtoc.html
+        link_subs:
+            "reference-rippled.html": https://ripple.com/build/rippled-apis/
+            "reference-rippleapi.html": https://ripple.com/build/rippleapi/
+            "reference-transaction-format.html": https://ripple.com/build/transactions/
+            "reference-ledger-format.html": https://ripple.com/build/ledger-format/
+            "reference-data-api.html": https://ripple.com/build/data-api-v2/
+            "tutorial-multisign.html": https://ripple.com/build/how-to-multi-sign/
+            "concept-issuing-and-operational-addresses.html": https://ripple.com/build/issuing-operational-addresses/
+            "tutorial-reliable-transaction-submission.html": https://ripple.com/build/reliable-transaction-submission/
+            "tutorial-rippleapi-beginners-guide.html": https://ripple.com/build/rippleapi-beginners-guide/
+            "tutorial-rippled-setup.html": https://ripple.com/build/rippled-setup/
+            "tutorial-gateway-guide.html": https://ripple.com/build/gateway-guide/
+            "concept-amendments.html": https://ripple.com/build/amendments/
+            "concept-fee-voting.html": https://ripple.com/build/fee-voting/
+            "concept-fees.html": https://ripple.com/build/fees-disambiguation/
+            "concept-freeze.html": https://ripple.com/build/freeze/
+            "concept-paths.html": https://ripple.com/build/paths/
+            "concept-reserves.html": https://ripple.com/build/reserves/
+            "concept-stand-alone-mode.html": https://ripple.com/build/stand-alone-mode/
+            "concept-transaction-cost.html": https://ripple.com/build/transaction-cost/
+            "concept-transfer-fees.html": https://ripple.com/build/transfer-fees/
+            "concept-noripple.html": https://ripple.com/build/understanding-the-noripple-flag/
+            "gb-2015-06.html": https://ripple.com/build/gateway-guide/gb-2015-06-corrections-autobridging/
+            "gb-2015-05.html": https://ripple.com/build/gateway-guide/gb-2015-05-historical-ledger-query-migration/
+            "ripple-api-tool.html": https://ripple.com/build/websocket-tool/
+            "data-api-v2-tool.html": https://ripple.com/build/data-api-tool/
         image_subs:
             "img/funds_flow_diagram.png": https://ripple.com/wp-content/uploads/2016/03/funds_flow_diagram.png
             "img/e2g-01.png": https://ripple.com/wp-content/themes/ripple-beta/assets/img/e2g-01.png
@@ -72,7 +98,6 @@ pages:
         html: reference-rippleapi.html
         # Currently this is the only page that's fetched remotely.
         md: https://raw.githubusercontent.com/ripple/ripple-lib/0.17.2/docs/index.md
-        ripple.com: https://ripple.com/build/rippleapi/
         filters:
             - remove_doctoc
             - add_version
@@ -84,7 +109,6 @@ pages:
         category: References
         html: reference-rippled.html
         md: reference-rippled.md
-        ripple.com: https://ripple.com/build/rippled-apis/
         targets:
             - local
             - ripple.com
@@ -93,7 +117,6 @@ pages:
         category: References
         html: reference-transaction-format.html
         md: reference-transaction-format.md
-        ripple.com: https://ripple.com/build/transactions/
         targets:
             - local
             - ripple.com
@@ -102,7 +125,6 @@ pages:
         category: References
         html: reference-ledger-format.html
         md: reference-ledger-format.md
-        ripple.com: https://ripple.com/build/ledger-format/
         targets:
             - local
             - ripple.com
@@ -111,7 +133,6 @@ pages:
         category: References
         html: reference-data-api.html
         md: reference-data-api.md
-        ripple.com: https://ripple.com/build/data-api-v2/
         targets:
             - local
             - ripple.com
@@ -121,7 +142,6 @@ pages:
         category: Tutorials
         html: tutorial-multisign.html
         md: tutorial-multisign.md
-        ripple.com: https://ripple.com/build/how-to-multi-sign/
         targets:
             - local
             - ripple.com
@@ -131,7 +151,6 @@ pages:
         category: Tutorials
         html: concept-issuing-and-operational-addresses.html
         md: concept-issuing-and-operational-addresses.md
-        ripple.com: https://ripple.com/build/issuing-operational-addresses/
         targets:
             - local
             - ripple.com
@@ -140,7 +159,6 @@ pages:
         category: Tutorials
         html: tutorial-reliable-transaction-submission.html
         md: tutorial-reliable-transaction-submission.md
-        ripple.com: https://ripple.com/build/reliable-transaction-submission/
         targets:
             - local
             - ripple.com
@@ -149,7 +167,6 @@ pages:
         category: Tutorials
         html: tutorial-rippleapi-beginners-guide.html
         md: tutorial-rippleapi-beginners-guide.md
-        ripple.com: https://ripple.com/build/rippleapi-beginners-guide/
         targets:
             - local
             - ripple.com
@@ -158,7 +175,6 @@ pages:
         category: Tutorials
         html: tutorial-rippled-setup.html
         md: tutorial-rippled-setup.md
-        ripple.com: https://ripple.com/build/rippled-setup/
         targets:
             - local
             - ripple.com
@@ -169,7 +185,6 @@ pages:
         category: Tutorials
         html: tutorial-gateway-guide.html
         md: tutorial-gateway-guide.md
-        ripple.com: https://ripple.com/build/gateway-guide/
         targets:
             - local
             - ripple.com
@@ -179,7 +194,6 @@ pages:
         category: RCL Features
         html: concept-amendments.html
         md: concept-amendments.md
-        ripple.com: https://ripple.com/build/amendments/
         targets:
             - local
             - ripple.com
@@ -188,7 +202,6 @@ pages:
         category: RCL Features
         html: concept-fee-voting.html
         md: concept-fee-voting.md
-        ripple.com: https://ripple.com/build/fee-voting/
         targets:
             - local
             - ripple.com
@@ -197,7 +210,6 @@ pages:
         category: RCL Features
         html: concept-fees.html
         md: concept-fees.md
-        ripple.com: https://ripple.com/build/fees-disambiguation/
         targets:
             - local
             - ripple.com
@@ -206,7 +218,6 @@ pages:
         category: RCL Features
         html: concept-freeze.html
         md: concept-freeze.md
-        ripple.com: https://ripple.com/build/freeze/
         targets:
             - local
             - ripple.com
@@ -215,7 +226,6 @@ pages:
         category: RCL Features
         html: concept-paths.html
         md: concept-paths.md
-        ripple.com: https://ripple.com/build/paths/
         targets:
             - local
             - ripple.com
@@ -224,7 +234,6 @@ pages:
         category: RCL Features
         html: concept-reserves.html
         md: concept-reserves.md
-        ripple.com: https://ripple.com/build/reserves/
         targets:
             - local
             - ripple.com
@@ -233,7 +242,6 @@ pages:
         category: RCL Features
         html: concept-stand-alone-mode.html
         md: concept-stand-alone-mode.md
-        ripple.com: https://ripple.com/build/stand-alone-mode/
         targets:
             - local
             - ripple.com
@@ -242,7 +250,6 @@ pages:
         category: RCL Features
         html: concept-transaction-cost.html
         md: concept-transaction-cost.md
-        ripple.com: https://ripple.com/build/transaction-cost/
         targets:
             - local
             - ripple.com
@@ -251,7 +258,6 @@ pages:
         category: RCL Features
         html: concept-transfer-fees.html
         md: concept-transfer-fees.md
-        ripple.com: https://ripple.com/build/transfer-fees/
         targets:
             - local
             - ripple.com
@@ -260,7 +266,6 @@ pages:
         category: RCL Features
         html: concept-noripple.html
         md: concept-noripple.md
-        ripple.com: https://ripple.com/build/understanding-the-noripple-flag/
         targets:
             - local
             - ripple.com
@@ -269,7 +274,6 @@ pages:
         category: Gateway Bulletins
         html: gb-2015-06.html
         md: gb-2015-06.md
-        ripple.com: https://ripple.com/build/gateway-guide/gb-2015-06-corrections-autobridging/
         targets:
             - local
             - ripple.com
@@ -278,7 +282,6 @@ pages:
         category: Gateway Bulletins
         html: gb-2015-05.html
         md: gb-2015-05.md
-        ripple.com: https://ripple.com/build/gateway-guide/gb-2015-05-historical-ledger-query-migration/
         targets:
             - local
             - ripple.com
@@ -287,7 +290,6 @@ pages:
     -   name: WebSocket API Tool
         category: API Tools
         html: ripple-api-tool.html
-        ripple.com: https://ripple.com/build/websocket-tool/
         sidebar: custom
         targets:
             - local
@@ -297,7 +299,6 @@ pages:
     -   name: Data API v2 Tool
         category: API Tools
         html: data-api-v2-tool.html
-        ripple.com: https://ripple.com/build/data-api-tool/
         methods_js: js/apitool-methods-data_v2.js
         rest_host: https://data.ripple.com
         doc_page: reference-data-api.html

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -28,6 +28,7 @@ default_filters:
     - buttonize
     - callouts
     - badges
+    - link_replacement
 
 callout_class: "devportal-callout"
 

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -29,10 +29,12 @@ default_filters:
     - callouts
     - badges
 
+callout_class: "devportal-callout"
+
 cover_page:
     name: Overview
     html: index.html
-    sidebar: false
+    sidebar: "off"
     template: template-index.html
 
 targets:

--- a/tool/template-base.html
+++ b/tool/template-base.html
@@ -27,7 +27,7 @@
 
 </head>
 
-<body class="page page-template page-template-template-dev-portal page-template-template-dev-portal-php {% if currentpage.sidebar %}sidebar-primary{% endif %} wpb-js-composer js-comp-ver-3.6.2 vc_responsive">
+<body class="page page-template page-template-template-dev-portal page-template-template-dev-portal-php {% if currentpage.sidebar != 'off' %}sidebar-primary{% endif %} wpb-js-composer js-comp-ver-3.6.2 vc_responsive">
   <header role="banner" class="banner navbar navbar-default navbar-fixed-top initial_header">
     <div class="container">
       <div class="navbar-header">
@@ -63,7 +63,7 @@
 
 
   <div class="wrap container" role="document">
-      {% if currentpage.sidebar %}
+      {% if currentpage.sidebar != 'off' %}
       <aside class="sidebar" role="complementary">
           {% block sidebar %}{% endblock %}
       </aside>

--- a/tool/template-doc.html
+++ b/tool/template-doc.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block sidebar %}
-  {% if currentpage.sidebar %}
+  {% if currentpage.sidebar != 'off' %}
     <div class="dev_nav_wrapper">
         <div id="cont">
             <h5>In this category:</h5>
@@ -38,7 +38,7 @@
             <hr />
             <h5>In this page:</h5>
             <ul class="dev_nav_sidebar" id="dactyl_toc_sidebar">
-                {{ sidebar_content }}
+                {{ page_toc }}
             </ul>
         </div>
     </div>


### PR DESCRIPTION
This repo is affected by the breaking changes to link substitution in Dactyl v0.4.0. Link substitution won't work without these changes, but this config file won't work with earlier Dactyl versions because it uses the filter, so we need to update Dactyl at the same time this PR gets merged.

Other changes that are backwards compatible here:

- Add a `callout_class` field to the config to make the updated callouts filter compatible with the existing CSS (`devportal-callout` class instead of `dactyl-callout`.
- Changes to the buttonize filter mean "Try it! >" links become "Try it!" links in the HTML. (I consider this an upgrade.)
- Dactyl no longer fills in the `sidebar` page field automatically, so the templates and config file had to change a little to handle that more effectively.