### PR TITLE
EscrowFinish transaction cost

### DIFF
--- a/concept-transaction-cost.html
+++ b/concept-transaction-cost.html
@@ -195,7 +195,7 @@
 </tr>
 <tr>
 <td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish Transaction with Fulfillment</a></td>
-<td>42 drops + (Fulfillment size in bytes divided by 16)</td>
+<td>10 drops + (32 drops × (Fulfillment size in bytes ÷ 16))</td>
 </tr>
 </tbody>
 </table>
@@ -281,9 +281,9 @@
 </tr>
 <tr>
 <td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish transaction</a> with 32-byte preimage.</td>
-<td>44</td>
+<td>74</td>
 <td>245</td>
-<td>88</td>
+<td>148</td>
 <td>512</td>
 </tr>
 </tbody>

--- a/concept-transaction-cost.html
+++ b/concept-transaction-cost.html
@@ -195,7 +195,7 @@
 </tr>
 <tr>
 <td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish Transaction with Fulfillment</a></td>
-<td>10 drops + (32 drops × (Fulfillment size in bytes ÷ 16))</td>
+<td>10 drops × (32 + (Fulfillment size in bytes ÷ 16))</td>
 </tr>
 </tbody>
 </table>
@@ -281,9 +281,9 @@
 </tr>
 <tr>
 <td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish transaction</a> with 32-byte preimage.</td>
-<td>74</td>
+<td>340</td>
 <td>245</td>
-<td>148</td>
+<td>680</td>
 <td>512</td>
 </tr>
 </tbody>

--- a/concept-transaction-cost.html
+++ b/concept-transaction-cost.html
@@ -190,8 +190,12 @@
 <td>0</td>
 </tr>
 <tr>
-<td><a href="reference-transaction-format.html#multi-signing">Multi-signed transaction</a></td>
+<td><a href="reference-transaction-format.html#multi-signing">Multi-signed Transaction</a></td>
 <td>10 drops × (1 + Number of Signatures Provided)</td>
+</tr>
+<tr>
+<td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish Transaction with Fulfillment</a></td>
+<td>42 drops + (Fulfillment size in bytes divided by 16)</td>
 </tr>
 </tbody>
 </table>
@@ -274,6 +278,13 @@
 <td>(Effectively infinite)</td>
 <td>N/A</td>
 <td>(Effectively infinite)</td>
+</tr>
+<tr>
+<td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish transaction</a> with 32-byte preimage.</td>
+<td>44</td>
+<td>245</td>
+<td>88</td>
+<td>512</td>
 </tr>
 </tbody>
 </table>

--- a/concept-transaction-cost.html
+++ b/concept-transaction-cost.html
@@ -195,7 +195,7 @@
 </tr>
 <tr>
 <td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish Transaction with Fulfillment</a></td>
-<td>10 drops × (32 + (Fulfillment size in bytes ÷ 16))</td>
+<td>10 drops × (33 + (Fulfillment size in bytes ÷ 16))</td>
 </tr>
 </tbody>
 </table>
@@ -281,9 +281,9 @@
 </tr>
 <tr>
 <td><a href="reference-transaction-format.html#escrowfinish">EscrowFinish transaction</a> with 32-byte preimage.</td>
-<td>340</td>
-<td>245</td>
-<td>680</td>
+<td>350</td>
+<td>256</td>
+<td>700</td>
 <td>512</td>
 </tr>
 </tbody>

--- a/content/concept-transaction-cost.md
+++ b/content/concept-transaction-cost.md
@@ -20,7 +20,7 @@ Some transactions have different transaction costs:
 | [Reference Transaction](#reference-transaction-cost) (Most transactions) | 10 drops |
 | [Key Reset Transaction](#key-reset-transaction) | 0 |
 | [Multi-signed Transaction](reference-transaction-format.html#multi-signing) | 10 drops × (1 + Number of Signatures Provided) |
-| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 10 drops × (32 + (Fulfillment size in bytes ÷ 16)) |
+| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 10 drops × (33 + (Fulfillment size in bytes ÷ 16)) |
 
 
 ## Beneficiaries of the Transaction Cost ##
@@ -102,7 +102,7 @@ _Fee levels_ represent the proportional difference between the minimum cost and 
 | Reference transaction (most transactions) | 10 | 256 | 20 | 512 |
 | [Multi-signed transaction](reference-transaction-format.html#multi-signing) with 4 signatures | 50 | 256 | 100 | 512 |
 | [Key reset transaction](concept-transaction-cost.html#key-reset-transaction) | 0 | (Effectively infinite) | N/A | (Effectively infinite) |
-| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 340 | 245 | 680 | 512 |
+| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 350 | 256 | 700 | 512 |
 
 
 ## Querying the Transaction Cost ##

--- a/content/concept-transaction-cost.md
+++ b/content/concept-transaction-cost.md
@@ -20,7 +20,7 @@ Some transactions have different transaction costs:
 | [Reference Transaction](#reference-transaction-cost) (Most transactions) | 10 drops |
 | [Key Reset Transaction](#key-reset-transaction) | 0 |
 | [Multi-signed Transaction](reference-transaction-format.html#multi-signing) | 10 drops × (1 + Number of Signatures Provided) |
-| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 42 drops + (Fulfillment size in bytes divided by 16) |
+| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 10 drops + (32 drops × (Fulfillment size in bytes ÷ 16)) |
 
 
 ## Beneficiaries of the Transaction Cost ##
@@ -102,7 +102,7 @@ _Fee levels_ represent the proportional difference between the minimum cost and 
 | Reference transaction (most transactions) | 10 | 256 | 20 | 512 |
 | [Multi-signed transaction](reference-transaction-format.html#multi-signing) with 4 signatures | 50 | 256 | 100 | 512 |
 | [Key reset transaction](concept-transaction-cost.html#key-reset-transaction) | 0 | (Effectively infinite) | N/A | (Effectively infinite) |
-| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 44 | 245 | 88 | 512 |
+| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 74 | 245 | 148 | 512 |
 
 
 ## Querying the Transaction Cost ##

--- a/content/concept-transaction-cost.md
+++ b/content/concept-transaction-cost.md
@@ -20,7 +20,7 @@ Some transactions have different transaction costs:
 | [Reference Transaction](#reference-transaction-cost) (Most transactions) | 10 drops |
 | [Key Reset Transaction](#key-reset-transaction) | 0 |
 | [Multi-signed Transaction](reference-transaction-format.html#multi-signing) | 10 drops × (1 + Number of Signatures Provided) |
-| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 10 drops + (32 drops × (Fulfillment size in bytes ÷ 16)) |
+| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 10 drops × (32 + (Fulfillment size in bytes ÷ 16)) |
 
 
 ## Beneficiaries of the Transaction Cost ##
@@ -102,7 +102,7 @@ _Fee levels_ represent the proportional difference between the minimum cost and 
 | Reference transaction (most transactions) | 10 | 256 | 20 | 512 |
 | [Multi-signed transaction](reference-transaction-format.html#multi-signing) with 4 signatures | 50 | 256 | 100 | 512 |
 | [Key reset transaction](concept-transaction-cost.html#key-reset-transaction) | 0 | (Effectively infinite) | N/A | (Effectively infinite) |
-| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 74 | 245 | 148 | 512 |
+| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 340 | 245 | 680 | 512 |
 
 
 ## Querying the Transaction Cost ##

--- a/content/concept-transaction-cost.md
+++ b/content/concept-transaction-cost.md
@@ -19,7 +19,8 @@ Some transactions have different transaction costs:
 |-----------------------|--------------------------|
 | [Reference Transaction](#reference-transaction-cost) (Most transactions) | 10 drops |
 | [Key Reset Transaction](#key-reset-transaction) | 0 |
-| [Multi-signed transaction](reference-transaction-format.html#multi-signing) | 10 drops × (1 + Number of Signatures Provided) |
+| [Multi-signed Transaction](reference-transaction-format.html#multi-signing) | 10 drops × (1 + Number of Signatures Provided) |
+| [EscrowFinish Transaction with Fulfillment](reference-transaction-format.html#escrowfinish) | 42 drops + (Fulfillment size in bytes divided by 16) |
 
 
 ## Beneficiaries of the Transaction Cost ##
@@ -101,6 +102,7 @@ _Fee levels_ represent the proportional difference between the minimum cost and 
 | Reference transaction (most transactions) | 10 | 256 | 20 | 512 |
 | [Multi-signed transaction](reference-transaction-format.html#multi-signing) with 4 signatures | 50 | 256 | 100 | 512 |
 | [Key reset transaction](concept-transaction-cost.html#key-reset-transaction) | 0 | (Effectively infinite) | N/A | (Effectively infinite) |
+| [EscrowFinish transaction](reference-transaction-format.html#escrowfinish) with 32-byte preimage. | 44 | 245 | 88 | 512 |
 
 
 ## Querying the Transaction Cost ##

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -581,7 +581,7 @@ Any account may submit an EscrowFinish transaction.
 * If the corresponding [EscrowCreate transaction][] specified a `FinishAfter` time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 * If the corresponding [EscrowCreate transaction][] specified a `CancelAfter` time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 
-**Note:** The [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction is higher if it contains a fulfillment. Instead of the usual base cost of 10 [drops of XRP](reference-rippled.html#specifying-currency-amounts), an EscrowFinish transaction costs 42 drops plus another 1 drop for every 16 bytes in size of the preimage. (For example, a fulfillment with a 32-byte preimage would cost 44 drops of XRP.)
+**Note:** The [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 10 [drops of XRP](reference-rippled.html#specifying-currency-amounts), plus an additional 32 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 + (32 drops × (32 bytes / 16)) = 74 drops of XRP.
 
 
 

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -581,7 +581,7 @@ Any account may submit an EscrowFinish transaction.
 * If the corresponding [EscrowCreate transaction][] specified a `FinishAfter` time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 * If the corresponding [EscrowCreate transaction][] specified a `CancelAfter` time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 
-**Note:** The [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 10 [drops of XRP](reference-rippled.html#specifying-currency-amounts), plus an additional 32 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 + (32 drops × (32 bytes / 16)) = 74 drops of XRP.
+**Note:** The [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 320 [drops of XRP](reference-rippled.html#specifying-currency-amounts), plus an additional 10 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 × (32 drops + (32 bytes ÷ 16)) = 340 drops of XRP.
 
 
 

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -581,6 +581,8 @@ Any account may submit an EscrowFinish transaction.
 * If the corresponding [EscrowCreate transaction][] specified a `FinishAfter` time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 * If the corresponding [EscrowCreate transaction][] specified a `CancelAfter` time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 
+**Note:** The [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction is higher if it contains a fulfillment. Instead of the usual base cost of 10 [drops of XRP](reference-rippled.html#specifying-currency-amounts), an EscrowFinish transaction costs 42 drops plus another 1 drop for every 16 bytes in size of the preimage. (For example, a fulfillment with a 32-byte preimage would cost 44 drops of XRP.)
+
 
 
 ## OfferCancel ##

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -554,7 +554,7 @@ Either `CancelAfter` or `FinishAfter` must be specified. If both are included, t
 
 _Requires the [Escrow Amendment](concept-amendments.html#escrow)._
 
-Deliver escrowed XRP the recipient.
+Deliver XRP from a held payment to the recipient.
 
 Example EscrowFinish:
 
@@ -578,10 +578,11 @@ Example EscrowFinish:
 
 Any account may submit an EscrowFinish transaction.
 
-* If the corresponding [EscrowCreate transaction][] specified a `FinishAfter` time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
-* If the corresponding [EscrowCreate transaction][] specified a `CancelAfter` time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
+- If the held payment has a `FinishAfter` time, you cannot execute it before this time. Specifically, if the corresponding [EscrowCreate transaction][] specified a `FinishAfter` time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
+- If the held payment has a `Condition`, you cannot execute it unless you provide a matching `Fulfillment` for the condition.
+- You cannot execute a held payment after it has expired. Specifically, if the corresponding [EscrowCreate transaction][] specified a `CancelAfter` time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.
 
-**Note:** The [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 320 [drops of XRP](reference-rippled.html#specifying-currency-amounts), plus an additional 10 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 × (32 drops + (32 bytes ÷ 16)) = 340 drops of XRP.
+**Note:** The minimum [transaction cost](concept-transaction-cost.html) to submit an EscrowFinish transaction increases if it contains a fulfillment. If the transaction has no fulfillment, the transaction cost is the standard 10 drops. If the transaction contains a fulfillment, the transaction cost is 330 [drops of XRP](reference-rippled.html#specifying-currency-amounts) plus another 10 drops for every 16 bytes in size of the preimage.
 
 
 

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -1028,6 +1028,7 @@
 <li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>FinishAfter</code> time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 <li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>CancelAfter</code> time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 </ul>
+<p class="devportal-callout note"><strong>Note:</strong> The <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction is higher if it contains a fulfillment. Instead of the usual base cost of 10 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a>, an EscrowFinish transaction costs 42 drops plus another 1 drop for every 16 bytes in size of the preimage. (For example, a fulfillment with a 32-byte preimage would cost 44 drops of XRP.)</p>
 <h2 id="offercancel">OfferCancel</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp" title="Source">[Source]<br/></a></p>
 <p>An OfferCancel transaction removes an Offer node from the Ripple Consensus Ledger.</p>

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -976,7 +976,7 @@
 <h2 id="escrowfinish">EscrowFinish</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/app/tx/impl/Escrow.cpp" title="Source">[Source]<br/></a></p>
 <p><em>Requires the <a href="concept-amendments.html#escrow">Escrow Amendment</a>.</em></p>
-<p>Deliver escrowed XRP the recipient.</p>
+<p>Deliver XRP from a held payment to the recipient.</p>
 <p>Example EscrowFinish:</p>
 <pre><code class="json">{
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -1025,10 +1025,11 @@
 </table>
 <p>Any account may submit an EscrowFinish transaction.</p>
 <ul>
-<li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>FinishAfter</code> time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
-<li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>CancelAfter</code> time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
+<li>If the held payment has a <code>FinishAfter</code> time, you cannot execute it before this time. Specifically, if the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>FinishAfter</code> time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
+<li>If the held payment has a <code>Condition</code>, you cannot execute it unless you provide a matching <code>Fulfillment</code> for the condition.</li>
+<li>You cannot execute a held payment after it has expired. Specifically, if the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>CancelAfter</code> time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 </ul>
-<p class="devportal-callout note"><strong>Note:</strong> The <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 320 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a>, plus an additional 10 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 × (32 drops + (32 bytes ÷ 16)) = 340 drops of XRP.</p>
+<p class="devportal-callout note"><strong>Note:</strong> The minimum <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction increases if it contains a fulfillment. If the transaction has no fulfillment, the transaction cost is the standard 10 drops. If the transaction contains a fulfillment, the transaction cost is 330 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a> plus another 10 drops for every 16 bytes in size of the preimage.</p>
 <h2 id="offercancel">OfferCancel</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp" title="Source">[Source]<br/></a></p>
 <p>An OfferCancel transaction removes an Offer node from the Ripple Consensus Ledger.</p>

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -1028,7 +1028,7 @@
 <li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>FinishAfter</code> time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 <li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>CancelAfter</code> time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 </ul>
-<p class="devportal-callout note"><strong>Note:</strong> The <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 10 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a>, plus an additional 32 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 + (32 drops × (32 bytes / 16)) = 74 drops of XRP.</p>
+<p class="devportal-callout note"><strong>Note:</strong> The <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 320 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a>, plus an additional 10 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 × (32 drops + (32 bytes ÷ 16)) = 340 drops of XRP.</p>
 <h2 id="offercancel">OfferCancel</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp" title="Source">[Source]<br/></a></p>
 <p>An OfferCancel transaction removes an Offer node from the Ripple Consensus Ledger.</p>

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -1028,7 +1028,7 @@
 <li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>FinishAfter</code> time that is after the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 <li>If the corresponding <a href="#escrowcreate">EscrowCreate transaction</a> specified a <code>CancelAfter</code> time that is before the close time of the most recently-closed ledger, the EscrowFinish transaction fails.</li>
 </ul>
-<p class="devportal-callout note"><strong>Note:</strong> The <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction is higher if it contains a fulfillment. Instead of the usual base cost of 10 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a>, an EscrowFinish transaction costs 42 drops plus another 1 drop for every 16 bytes in size of the preimage. (For example, a fulfillment with a 32-byte preimage would cost 44 drops of XRP.)</p>
+<p class="devportal-callout note"><strong>Note:</strong> The <a href="concept-transaction-cost.html">transaction cost</a> to submit an EscrowFinish transaction increases if it contains a fulfillment. An EscrowFinish transaction has a base cost of 10 <a href="reference-rippled.html#specifying-currency-amounts">drops of XRP</a>, plus an additional 32 drops for every 16 bytes in size of the preimage. For example, a fulfillment with a 32-byte preimage would cost 10 + (32 drops × (32 bytes / 16)) = 74 drops of XRP.</p>
 <h2 id="offercancel">OfferCancel</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp" title="Source">[Source]<br/></a></p>
 <p>An OfferCancel transaction removes an Offer node from the Ripple Consensus Ledger.</p>


### PR DESCRIPTION
The EscrowFinish transaction type has a higher than usual transaction cost if has a fulfillment. This update clarifies that.

Technically the formula is:

    base fee + 32 + (crypto-condition cost÷16) drops

However, since the base fee is fairly stable at 10 and the only currently-supported crypto-condition is PREIMAGE-SHA-256, whose cost is equal to the size of the preimage in bytes, I simplified the formula to:

    42 drops + (preimage size ÷ 16)