### PR TITLE
rippled: paychan API methods

### DIFF
--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -1277,18 +1277,18 @@ An example of a successful response:
 
 <!-- MULTICODE_BLOCK_END -->
 
-The response follows the [standard format](#response-formatting), with a successful result containing the address of the account and an array of trust-line objects. Specifically, the result object contains the following fields:
+The response follows the [standard format](#response-formatting), with a successful result containing the address of the account and an array of trust line objects. Specifically, the result object contains the following fields:
 
 | `Field`                | Type                                       | Description |
 |:-----------------------|:-------------------------------------------|:-------|
 | `account`              | String                                     | Unique [Address][] of the account this request corresponds to. This is the "perspective account" for purpose of the trust lines. |
-| `lines`                | Array                                      | Array of trust-line objects, as described below. If the number of trust-lines is large, only returns up to the `limit` at a time. |
+| `lines`                | Array                                      | Array of trust line objects, as described below. If the number of trust lines is large, only returns up to the `limit` at a time. |
 | `ledger_current_index` | Integer                                    | (Omitted if `ledger_hash` or `ledger_index` provided) Sequence number of the ledger version used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
 | `ledger_index`         | Integer                                    | (Omitted if `ledger_current_index` provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
 | `ledger_hash`          | String                                     | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. [New in: rippled 0.26.4-sp1][] |
 | `marker`               | [(Not Specified)](#markers-and-pagination) | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. [New in: rippled 0.26.4][] |
 
-Each trust-line object has some combination of the following fields:
+Each trust line object has some combination of the following fields:
 
 | `Field`          | Type             | Description                            |
 |:-----------------|:-----------------|:---------------------------------------|

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -7926,7 +7926,7 @@ The request includes the following parameters:
 | `amount` | String | The amount of [XRP, in drops][], the provided `signature` authorizes. |
 | `channel_id` | String | The Channel ID of the channel that provides the XRP. This is a 64-character hexadecimal string. |
 | `public_key` | String | The public key of the channel and the key pair that was used to create the signature, in base58 format. (One way to get the public key in base58 format is from the [`wallet_propose` command](#wallet-propose).) |
-| `signature` |
+| `signature` | String | The signature to verify, in hexadecimal. |
 
 #### Response Format ####
 

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -7985,9 +7985,9 @@ The response follows the [standard format](#response-formatting), with a success
 
 * Any of the [universal error types](#universal-errors).
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
-* `publicMalformed` - The value specified in the `public_key` field of the request was not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58. The base58 representation of account public keys starts with the letter `a`.
-* `channelMalformed` - The value specified in the `channel_id` field of the reqeuest was not a valid Channel ID. The Channel ID should be a 256-bit (64-character) hexadecimal string.
-* `channelAmtMalformed` - The value specified in the `amount` field was not a valid XRP amount. See [Specifying Currency Amounts](#specifying-currency-amounts) for details.
+* `publicMalformed` - The `public_key` field of the request is not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58. The base58 representation of account public keys starts with the letter `a`.
+* `channelMalformed` - The `channel_id` field of the request is not a valid Channel ID. The Channel ID must be a 256-bit (64-character) hexadecimal string.
+* `channelAmtMalformed` - The value specified in the `amount` field was not a valid [XRP amount](#specifying-currency-amounts).
 
 
 
@@ -8119,8 +8119,8 @@ The response follows the [standard format](#response-formatting). The fields con
 * Any of the [universal error types](#universal-errors).
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
 * `noPermission` - The request included the `url` field, but you are not connected as an admin.
-* `unknownStream` - One or more the members of the `streams` field in the request was not recognized as a valid stream name.
-* `malformedStream` - The `streams` field of the request was not formatted properly.
+* `unknownStream` - One or more the members of the `streams` field of the request is not a valid stream name.
+* `malformedStream` - The `streams` field of the request is not formatted properly.
 * `malformedAccount` - One of the addresses in the `accounts` or `accounts_proposed` fields of the request is not a properly-formatted Ripple address. (**Note:**: You _can_ subscribe to the stream of an address that does not yet have an entry in the global ledger to get a message when that address becomes funded.)
 * `srcCurMalformed` - One or more `taker_pays` sub-fields of the `books` field in the request is not formatted properly.
 * `dstAmtMalformed` - One or more `taker_gets` sub-fields of the `books` field in the request is not formatted properly.
@@ -8616,7 +8616,7 @@ The response follows the [standard format](#response-formatting), with a success
 * Any of the [universal error types](#universal-errors).
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
 * `noPermission` - The request included the `url` field, but you are not connected as an admin.
-* `malformedStream` - The `streams` field of the request was not formatted properly.
+* `malformedStream` - The `streams` field of the request is not formatted properly.
 * `malformedAccount` - One of the addresses in the `accounts` or `accounts_proposed` fields of the request is not a properly-formatted Ripple address.
     * **Note:**: You _can_ subscribe to the stream of an address that does not yet have an entry in the global ledger to get a message when that address becomes funded.
 * `srcCurMalformed` - One or more `taker_pays` sub-fields of the `books` field in the request is not formatted properly.
@@ -10207,7 +10207,7 @@ For most other entries, the value indicates the number of objects of that type c
 ## ledger_cleaner ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/df54b47cd0957a31837493cd69e4d9aade0b5055/src/ripple/rpc/handlers/LedgerCleaner.cpp "Source")
 
-The `ledger_cleaner` command controls the [Ledger Cleaner](https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner), an asynchronous maintenance process that can find and repair corruption in rippled's database of ledgers.
+The `ledger_cleaner` command controls the [Ledger Cleaner](https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner), an asynchronous maintenance process that can find and repair corruption in `rippled`'s database of ledgers.
 
 _The `ledger_cleaner` method is an [admin command](#connecting-to-rippled) that cannot be run by unprivileged users._
 
@@ -10271,7 +10271,7 @@ The response follows the [standard format](#response-formatting), with a success
 #### Possible Errors ####
 
 * Any of the [universal error types](#universal-errors).
-* `internal` if one the parameters was specified in a way that the server couldn't interpret. (This is a bug, and it should return `invalidParams` instead.)
+* `internal` if one the parameters is specified incorrectly. (This is a bug; the intended error code is `invalidParams`.)
 
 
 ## log_level ##

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -1775,7 +1775,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 </div>
-<p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing the address of the account and an array of trust-line objects. Specifically, the result object contains the following fields:</p>
+<p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing the address of the account and an array of trust line objects. Specifically, the result object contains the following fields:</p>
 <table>
 <thead>
 <tr>
@@ -1793,7 +1793,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td align="left"><code>lines</code></td>
 <td align="left">Array</td>
-<td align="left">Array of trust-line objects, as described below. If the number of trust-lines is large, only returns up to the <code>limit</code> at a time.</td>
+<td align="left">Array of trust line objects, as described below. If the number of trust lines is large, only returns up to the <code>limit</code> at a time.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_current_index</code></td>
@@ -1817,7 +1817,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tr>
 </tbody>
 </table>
-<p>Each trust-line object has some combination of the following fields:</p>
+<p>Each trust line object has some combination of the following fields:</p>
 <table>
 <thead>
 <tr>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -819,7 +819,7 @@ Null method
 <h2 id="list-of-public-commands">List of Public Commands</h2>
 <ul>
 <li><a href="#account-currencies"><code>account_currencies</code> - Get a list of currencies an account can send or receive</a></li>
-<li><a href="#account-channels"><code>account_channels</code> - Get a list of payment channels where the account is the source</a></li>
+<li><a href="#account-channels"><code>account_channels</code> - Get a list of payment channels where the account is the source of the channel</a></li>
 <li><a href="#account-info"><code>account_info</code> - Get basic data about an account</a></li>
 <li><a href="#account-lines"><code>account_lines</code> - Get info about an account's trust lines</a></li>
 <li><a href="#account-objects"><code>account_objects</code> - Get all ledger objects owned by an account</a></li>
@@ -934,17 +934,17 @@ Null method
 <tr>
 <td align="left"><code>strict</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If true, only accept an address or public key for the account parameter. Defaults to false.</td>
+<td align="left"><em>(Optional)</em> If true, only accept an address or public key for the account parameter. Defaults to false.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -1065,7 +1065,7 @@ Null method
 <h2 id="account-channels">account_channels</h2>
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/AccountChannels.cpp" title="Source">[Source]<br/></a></p>
 <p><em>(Requires the <a href="concept-amendments.html#paychan">PayChan amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a>)</em></p>
-<p>The <code>account_channels</code> method returns information about an account's Payment Channels. This includes only channels where the specified account is the source, not the destination. All information retrieved is relative to a particular version of the ledger.</p>
+<p>The <code>account_channels</code> method returns information about an account's Payment Channels. This includes only channels where the specified account is the channel's source, not the destination. (A channel's "source" and "owner" are the same.) All information retrieved is relative to a particular version of the ledger.</p>
 <h4 id="request-format-1">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-5"><ul class="codetabs"><li><a href="#code-5-0">WebSocket</a></li><li><a href="#code-5-1">JSON-RPC</a></li><li><a href="#code-5-2">Commandline</a></li></ul>
@@ -1106,12 +1106,12 @@ rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFY
 <tr>
 <td align="left"><code>account</code></td>
 <td align="left">String</td>
-<td align="left">A unique identifier for the account whose channels to retrieve. Typically this is the account's <a href="#addresses">Address</a>.</td>
+<td align="left">The unique identifier of an account, typically the account's <a href="#addresses">Address</a>. The request returns channels where this account is the channel's owner/source.</td>
 </tr>
 <tr>
 <td align="left"><code>destination_account</code></td>
 <td align="left">String</td>
-<td align="left"><em>(Optional)</em> If provided, filter results to payment channels where the destination of the channel. Typically this is an <a href="#addresses">Address</a>.</td>
+<td align="left"><em>(Optional)</em> The unique identifier of an account, typically the account's <a href="#addresses">Address</a>. If provided, filter results to payment channels whose destination is this account.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_hash</code></td>
@@ -1126,12 +1126,12 @@ rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFY
 <tr>
 <td align="left"><code>limit</code></td>
 <td align="left">Integer</td>
-<td align="left"><em>(Optional)</em> Limit the number of transactions to retrieve. The server is not required to honor this value. The default is 200. Cannot be smaller than 10 or larger than 400.</td>
+<td align="left"><em>(Optional)</em> Limit the number of transactions to retrieve. The server is not required to honor this value. Must be within the inclusive range 10 to 400. Defaults to 200.</td>
 </tr>
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left"><em>(Optional)</em> Value from a previous response to specify where to resume retrieving data from.</td>
+<td align="left"><em>(Optional)</em> Value from a previous paginated response. Resume retrieving data where that response left off.</td>
 </tr>
 </tbody>
 </table>
@@ -1218,7 +1218,7 @@ rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFY
 <tr>
 <td align="left"><code>account</code></td>
 <td align="left">String</td>
-<td align="left">The address of the account from the request; the owner of the payment channels.</td>
+<td align="left">The address of the source/owner of the payment channels. This corresponds to the <code>account</code> field of the request.</td>
 </tr>
 <tr>
 <td align="left"><code>channels</code></td>
@@ -1255,12 +1255,12 @@ rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFY
 <tr>
 <td><code>amount</code></td>
 <td>String</td>
-<td>The amount of <a href="#specifying-currency-amounts">XRP, in drops</a> allocated to this channel in total.</td>
+<td>The total amount of <a href="#specifying-currency-amounts">XRP, in drops</a> allocated to this channel.</td>
 </tr>
 <tr>
 <td><code>balance</code></td>
 <td>String</td>
-<td>The total amount of XRP, in drops, paid out from this channel so far. (You can calculate the amount of XRP remaining in the channel by subtracting <code>balance</code> from <code>amount</code>.)</td>
+<td>The total amount of XRP, in drops, paid out from this channel, as of the ledger version used. (You can calculate the amount of XRP remaining in the channel by subtracting <code>balance</code> from <code>amount</code>.)</td>
 </tr>
 <tr>
 <td><code>channel_id</code></td>
@@ -1270,12 +1270,12 @@ rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFY
 <tr>
 <td><code>destination_account</code></td>
 <td>String</td>
-<td>The destination of the channel, as an <a href="#addresses">Address</a>. Only this account can receive the XRP in the channel while it remains open.</td>
+<td>the destination account of the channel, as an <a href="#addresses">Address</a>. Only this account can receive the XRP in the channel while it remains open.</td>
 </tr>
 <tr>
 <td><code>public_key</code></td>
 <td>String</td>
-<td><em>(May be omitted)</em> The public key for the payment channel in base58 format, if one was specified at channel creation. Signed claims against this channel must be redeemed with the matching key pair.</td>
+<td><em>(May be omitted)</em> The public key for the payment channel in base58 format. Signed claims against this channel must be redeemed with the matching key pair.</td>
 </tr>
 <tr>
 <td><code>public_key_hex</code></td>
@@ -1300,7 +1300,7 @@ rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFY
 <tr>
 <td><code>source_tag</code></td>
 <td>Unsigned Integer</td>
-<td><em>(May be omitted)</em> A 32-bit unsigned integer to use as a <a href="tutorial-gateway-guide.html#source-and-destination-tags">source tag</a> for payments through this payment channel, if one was specified at channel creation. This indicates the payment channel's originator or other purpose at the source account. Conventionally, if you bounce payments from this channel, you should specify this value as the destination of the return payment.</td>
+<td><em>(May be omitted)</em> A 32-bit unsigned integer to use as a <a href="tutorial-gateway-guide.html#source-and-destination-tags">source tag</a> for payments through this payment channel, if one was specified at channel creation. This indicates the payment channel's originator or other purpose at the source account. Conventionally, if you bounce payments from this channel, you should specify this value in the <code>DestinationTag</code> of the return payment.</td>
 </tr>
 <tr>
 <td><code>destination_tag</code></td>
@@ -1374,22 +1374,22 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>queue</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If <code>true</code>, and the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a></td>
+<td align="left"><em>(Optional)</em> If <code>true</code>, and the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><code>signer_lists</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
+<td align="left"><em>(Optional)</em> If <code>true</code>, and the <a href="concept-amendments.html#multisign">MultiSign amendment</a> is enabled, also returns any <a href="reference-ledger-format.html#signerlist">SignerList objects</a> associated with this account. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1663,27 +1663,27 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>peer</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) The <a href="#addresses">Address</a> of a second account. If provided, show only lines of trust connecting the two accounts.</td>
+<td align="left"><em>(Optional)</em> The <a href="#addresses">Address</a> of a second account. If provided, show only lines of trust connecting the two accounts.</td>
 </tr>
 <tr>
 <td align="left"><code>limit</code></td>
 <td align="left">Integer</td>
-<td align="left">(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be smaller than 10 or larger than 400. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td align="left">(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Must be within the inclusive range 10 to 400. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">(Optional) Value from a previous response to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td align="left"><em>(Optional)</em> Value from a previous paginated response. Resume retrieving data where that response left off. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1813,7 +1813,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td align="left">Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -1946,22 +1946,22 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string identifying the ledger version to use.</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string identifying the ledger version to use.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
-<td align="left">(Optional) <a href="#ledger-index">Ledger Index</a></td>
+<td align="left"><em>(Optional)</em> <a href="#ledger-index">Ledger Index</a></td>
 <td align="left">(Optional, defaults to <code>current</code>) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See <a href="#specifying-ledgers">Specifying Ledgers</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>limit</code></td>
 <td align="left">Integer</td>
-<td align="left">(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Cannot be lower than 10 or higher than 400. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td align="left">(Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Must be within the inclusive range 10 to 400. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Value from a previous response value to specify where to resume retrieving data from. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td align="left">Value from a previous paginated response. Resume retrieving data where that response left off. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -2091,7 +2091,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
+<td align="left">Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. <a href="https://github.com/ripple/rippled/releases/tag/0.26.4" title="New in: rippled 0.26.4"><img alt="New in: rippled 0.26.4" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.26.4-blue.svg"/></a></td>
 </tr>
 </tbody>
 </table>
@@ -2205,27 +2205,27 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <tr>
 <td align="left"><code>type</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) If included, filter results to include only this type of ledger node. Valid types include <code>state</code> (trust lines), <code>offer</code> (offers), and <code>ticket</code> (part of the forthcoming signing process).</td>
+<td align="left"><em>(Optional)</em> If included, filter results to include only this type of ledger node. Valid types include <code>state</code> (trust lines), <code>offer</code> (offers), and <code>ticket</code> (part of the forthcoming signing process).</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>limit</code></td>
 <td align="left">Unsigned Integer</td>
-<td align="left">(Optional) The maximum number of objects to include in the results. Cannot be less than 10 or higher than 400 on non-admin connections. Defaults to 200.</td>
+<td align="left"><em>(Optional)</em> The maximum number of objects to include in the results. Must be within the inclusive range 10 to 400 on non-admin connections. Defaults to 200.</td>
 </tr>
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">(Optional) Value from a previous response value to specify where to resume retrieving data from.</td>
+<td align="left"><em>(Optional)</em> Value from a previous paginated response. Resume retrieving data where that response left off.</td>
 </tr>
 </tbody>
 </table>
@@ -2789,7 +2789,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Server-defined value. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one.</td>
+<td align="left">Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one.</td>
 </tr>
 <tr>
 <td align="left"><code>validated</code></td>
@@ -2876,12 +2876,12 @@ rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> Use instead of ledger_index_min and ledger_index_max to look for transactions from a single ledger only. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>binary</code></td>
@@ -2901,7 +2901,7 @@ rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Value from a previous response value to specify where to resume retrieving data from. This value is stable even if there is a change in the server's range of available ledgers.</td>
+<td align="left">Value from a previous paginated response. Resume retrieving data where that response left off. This value is stable even if there is a change in the server's range of available ledgers.</td>
 </tr>
 </tbody>
 </table>
@@ -3414,7 +3414,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Server-defined value. Pass this to the next call to resume where this call left off.</td>
+<td align="left">Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off.</td>
 </tr>
 <tr>
 <td align="left"><code>offset</code></td>
@@ -3535,22 +3535,22 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td align="left"><code>transactions</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If <code>true</code>, include an array of suggested <a href="reference-transaction-format.html">transactions</a>, as JSON objects, that you can sign and submit to fix the problems. Defaults to false.</td>
+<td align="left"><em>(Optional)</em> If <code>true</code>, include an array of suggested <a href="reference-transaction-format.html">transactions</a>, as JSON objects, that you can sign and submit to fix the problems. Defaults to false.</td>
 </tr>
 <tr>
 <td align="left"><code>limit</code></td>
 <td align="left">Unsigned Integer</td>
-<td align="left">(Optional) The maximum number of trust line problems to include in the results. Defaults to 300.</td>
+<td align="left"><em>(Optional)</em> The maximum number of trust line problems to include in the results. Defaults to 300.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -3740,7 +3740,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td align="left"><code>strict</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If true, only accept an address or public key for the account parameter. Defaults to false.</td>
+<td align="left"><em>(Optional)</em> If true, only accept an address or public key for the account parameter. Defaults to false.</td>
 </tr>
 <tr>
 <td align="left"><code>hotwallet</code></td>
@@ -3750,12 +3750,12 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger version to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger version to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -4008,17 +4008,17 @@ rippled wallet_propose masterpassphrase
 <tr>
 <td align="left"><code>passphrase</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Generate a key pair and address from this seed value. This value can be formatted in <a href="https://en.wikipedia.org/wiki/Hexadecimal">hexadecimal</a>, <a href="https://en.wikipedia.org/wiki/Base58">base58</a>, <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a>, or as an arbitrary string. Cannot be used with <code>seed</code> or <code>seed_hex</code>.</td>
+<td align="left"><em>(Optional)</em> Generate a key pair and address from this seed value. This value can be formatted in <a href="https://en.wikipedia.org/wiki/Hexadecimal">hexadecimal</a>, <a href="https://en.wikipedia.org/wiki/Base58">base58</a>, <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a>, or as an arbitrary string. Cannot be used with <code>seed</code> or <code>seed_hex</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>seed</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Generate the key pair and address from this <a href="https://en.wikipedia.org/wiki/Base58">base58</a>-encoded seed value. Cannot be used with <code>passphrase</code> or <code>seed_hex</code>.</td>
+<td align="left"><em>(Optional)</em> Generate the key pair and address from this <a href="https://en.wikipedia.org/wiki/Base58">base58</a>-encoded seed value. Cannot be used with <code>passphrase</code> or <code>seed_hex</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>seed_hex</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Generate the key pair and address from this seed value in <a href="https://en.wikipedia.org/wiki/Hexadecimal">hexadecimal</a> format. Cannot be used with <code>passphrase</code> or <code>seed</code>.</td>
+<td align="left"><em>(Optional)</em> Generate the key pair and address from this seed value in <a href="https://en.wikipedia.org/wiki/Hexadecimal">hexadecimal</a> format. Cannot be used with <code>passphrase</code> or <code>seed</code>.</td>
 </tr>
 </tbody>
 </table>
@@ -4198,12 +4198,12 @@ rippled ledger current
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>).</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>).</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>full</code></td>
@@ -4610,12 +4610,12 @@ rippled ledger_current
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>binary</code></td>
@@ -4630,7 +4630,7 @@ rippled ledger_current
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Value from a previous response value to specify where to resume retrieving data from.</td>
+<td align="left">Value from a previous paginated response. Resume retrieving data where that response left off.</td>
 </tr>
 </tbody>
 </table>
@@ -4830,7 +4830,7 @@ rippled ledger_current
 <tr>
 <td align="left"><code>marker</code></td>
 <td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
-<td align="left">Server-defined value. Pass this to the next call to resume where this call left off.</td>
+<td align="left">Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off.</td>
 </tr>
 </tbody>
 </table>
@@ -4924,22 +4924,22 @@ rippled ledger_current
 <tr>
 <td align="left"><code>index</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Specify the unique identifier of a single ledger entry to retrieve.</td>
+<td align="left"><em>(Optional)</em> Specify the unique identifier of a single ledger entry to retrieve.</td>
 </tr>
 <tr>
 <td align="left"><code>account_root</code></td>
 <td align="left">String - <a href="#addresses">Address</a></td>
-<td align="left">(Optional) Specify an <a href="reference-ledger-format.html#accountroot">AccountRoot node</a> to retrieve.</td>
+<td align="left"><em>(Optional)</em> Specify an <a href="reference-ledger-format.html#accountroot">AccountRoot node</a> to retrieve.</td>
 </tr>
 <tr>
 <td align="left"><code>directory</code></td>
 <td align="left">Object or String</td>
-<td align="left">(Optional) Specify a <a href="reference-ledger-format.html#directorynode">DirectoryNode</a>. (Directory nodes each contain a list of IDs for things contained in them.) If a string, interpret as the <a href="reference-ledger-format.html#tree-format">unique index</a> to the directory, in hex. If an object, requires either <code>dir_root</code> or <code>owner</code> as a sub-field, plus optionally a <code>sub_index</code> sub-field.</td>
+<td align="left"><em>(Optional)</em> Specify a <a href="reference-ledger-format.html#directorynode">DirectoryNode</a>. (Directory nodes each contain a list of IDs for things contained in them.) If a string, interpret as the <a href="reference-ledger-format.html#tree-format">unique index</a> to the directory, in hex. If an object, requires either <code>dir_root</code> or <code>owner</code> as a sub-field, plus optionally a <code>sub_index</code> sub-field.</td>
 </tr>
 <tr>
 <td align="left"><code>directory.sub_index</code></td>
 <td align="left">Unsigned Integer</td>
-<td align="left">(Optional) If provided, jumps to a further sub-node in the <a href="reference-ledger-format.html#directorynode">DirectoryNode</a>.</td>
+<td align="left"><em>(Optional)</em> If provided, jumps to a further sub-node in the <a href="reference-ledger-format.html#directorynode">DirectoryNode</a>.</td>
 </tr>
 <tr>
 <td align="left"><code>directory.dir_root</code></td>
@@ -4954,7 +4954,7 @@ rippled ledger_current
 <tr>
 <td align="left"><code>offer</code></td>
 <td align="left">Object or String</td>
-<td align="left">(Optional) Specify an <a href="reference-ledger-format.html#offer">Offer node</a> to retrieve. If a string, interpret as the <a href="reference-ledger-format.html#tree-format">unique index</a> to the Offer. If an object, requires the sub-fields <code>account</code> and <code>seq</code> to uniquely identify the offer.</td>
+<td align="left"><em>(Optional)</em> Specify an <a href="reference-ledger-format.html#offer">Offer node</a> to retrieve. If a string, interpret as the <a href="reference-ledger-format.html#tree-format">unique index</a> to the Offer. If an object, requires the sub-fields <code>account</code> and <code>seq</code> to uniquely identify the offer.</td>
 </tr>
 <tr>
 <td align="left"><code>offer.account</code></td>
@@ -4969,7 +4969,7 @@ rippled ledger_current
 <tr>
 <td align="left"><code>ripple_state</code></td>
 <td align="left">Object</td>
-<td align="left">(Optional) Object specifying the RippleState (trust line) node to retrieve. The <code>accounts</code> and <code>currency</code> sub-fields are required to uniquely specify the RippleState entry to retrieve.</td>
+<td align="left"><em>(Optional)</em> Object specifying the RippleState (trust line) node to retrieve. The <code>accounts</code> and <code>currency</code> sub-fields are required to uniquely specify the RippleState entry to retrieve.</td>
 </tr>
 <tr>
 <td align="left"><code>ripple_state.accounts</code></td>
@@ -4989,12 +4989,12 @@ rippled ledger_current
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -5115,12 +5115,12 @@ rippled ledger_current
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">Number</td>
-<td align="left">(Optional) Retrieve the specified ledger by its <a href="#ledger-index">Ledger Index</a>.</td>
+<td align="left"><em>(Optional)</em> Retrieve the specified ledger by its <a href="#ledger-index">Ledger Index</a>.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Retrieve the specified ledger by its identifying <a href="#hashes">Hash</a>.</td>
+<td align="left"><em>(Optional)</em> Retrieve the specified ledger by its identifying <a href="#hashes">Hash</a>.</td>
 </tr>
 </tbody>
 </table>
@@ -5618,12 +5618,12 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>tx_hash</code></td>
@@ -6771,12 +6771,12 @@ rippled tx_history 0
 <tr>
 <td align="left"><code>send_max</code></td>
 <td align="left">String or Object</td>
-<td align="left">(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a></td>
+<td align="left"><em>(Optional)</em> <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Not compatible with <code>source_currencies</code>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><code>paths</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of arrays of objects, representing <a href="concept-paths.html">payment paths</a> to check. You can use this to keep updated on changes to particular paths you already know about, or to check the overall cost to make a payment along a certain path.</td>
+<td align="left"><em>(Optional)</em> Array of arrays of objects, representing <a href="concept-paths.html">payment paths</a> to check. You can use this to keep updated on changes to particular paths you already know about, or to check the overall cost to make a payment along a certain path.</td>
 </tr>
 </tbody>
 </table>
@@ -7443,22 +7443,22 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <tr>
 <td align="left"><code>send_max</code></td>
 <td align="left">String or Object</td>
-<td align="left">(Optional) <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a></td>
+<td align="left"><em>(Optional)</em> <a href="#specifying-currency-amounts">Currency amount</a> that would be spent in the transaction. Cannot be used with <code>source_currencies</code>. <a href="https://github.com/ripple/rippled/releases/tag/0.30.0" title="New in: rippled 0.30.0"><img alt="New in: rippled 0.30.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.30.0-blue.svg"/></a></td>
 </tr>
 <tr>
 <td align="left"><code>source_currencies</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory <code>currency</code> field and optional <code>issuer</code> field, like how <a href="#specifying-currency-amounts">currency amounts</a> are specified. Cannot contain more than <strong>18</strong> source currencies. By default, uses all source currencies available up to a maximum of <strong>88</strong> different currency/issuer pairs.</td>
+<td align="left"><em>(Optional)</em> Array of currencies that the source account might want to spend. Each entry in the array should be a JSON object with a mandatory <code>currency</code> field and optional <code>issuer</code> field, like how <a href="#specifying-currency-amounts">currency amounts</a> are specified. Cannot contain more than <strong>18</strong> source currencies. By default, uses all source currencies available up to a maximum of <strong>88</strong> different currency/issuer pairs.</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 </tbody>
 </table>
@@ -7816,27 +7816,27 @@ rippled sign s██████████████████████
 <tr>
 <td align="left"><code>secret</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections. Cannot be used with <code>key_type</code>, <code>seed</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections. Cannot be used with <code>key_type</code>, <code>seed</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>seed</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in <a href="https://en.wikipedia.org/wiki/Base58">base58</a> format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it. Must be in <a href="https://en.wikipedia.org/wiki/Base58">base58</a> format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>seed_hex</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in hexadecimal format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>passphrase</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it. Must be in hexadecimal format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>passphrase</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>passphrase</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>seed_hex</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>seed_hex</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>key_type</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Type of cryptographic key provided in this request. Valid types are <code>secp256k1</code> or <code>ed25519</code>. Defaults to <code>secp256k1</code>. Cannot be used with <code>secret</code>. <strong>Caution:</strong> Ed25519 support is experimental.</td>
+<td align="left"><em>(Optional)</em> Type of cryptographic key provided in this request. Valid types are <code>secp256k1</code> or <code>ed25519</code>. Defaults to <code>secp256k1</code>. Cannot be used with <code>secret</code>. <strong>Caution:</strong> Ed25519 support is experimental.</td>
 </tr>
 <tr>
 <td align="left"><code>offline</code></td>
@@ -7846,7 +7846,7 @@ rippled sign s██████████████████████
 <tr>
 <td align="left"><code>build_path</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. <strong>Caution:</strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
+<td align="left"><em>(Optional)</em> If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. <strong>Caution:</strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
 </tr>
 <tr>
 <td align="left"><code>fee_mult_max</code></td>
@@ -8085,27 +8085,27 @@ rippled sign_for rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW s█████████
 <tr>
 <td align="left"><code>secret</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) The secret key to sign with. (Cannot be used with <code>key_type</code>.)</td>
+<td align="left"><em>(Optional)</em> The secret key to sign with. (Cannot be used with <code>key_type</code>.)</td>
 </tr>
 <tr>
 <td align="left"><code>passphrase</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A passphrase to use as the secret key to sign with.</td>
+<td align="left"><em>(Optional)</em> A passphrase to use as the secret key to sign with.</td>
 </tr>
 <tr>
 <td align="left"><code>seed</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A <a href="https://en.wikipedia.org/wiki/Base58">base58</a>-encoded secret key to sign with.</td>
+<td align="left"><em>(Optional)</em> A <a href="https://en.wikipedia.org/wiki/Base58">base58</a>-encoded secret key to sign with.</td>
 </tr>
 <tr>
 <td align="left"><code>seed_hex</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A hexadecimal secret key to sign with.</td>
+<td align="left"><em>(Optional)</em> A hexadecimal secret key to sign with.</td>
 </tr>
 <tr>
 <td align="left"><code>key_type</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) The type of key to use for signing. This can be <code>secp256k1</code> or <code>ed25519</code>. (Ed25519 support is experimental.)</td>
+<td align="left"><em>(Optional)</em> The type of key to use for signing. This can be <code>secp256k1</code> or <code>ed25519</code>. (Ed25519 support is experimental.)</td>
 </tr>
 </tbody>
 </table>
@@ -8325,27 +8325,27 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td align="left"><code>secret</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections. Cannot be used with <code>key_type</code>, <code>seed</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it. Do not send your secret to untrusted servers or through unsecured network connections. Cannot be used with <code>key_type</code>, <code>seed</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>seed</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in <a href="https://en.wikipedia.org/wiki/Base58">base58</a> format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it. Must be in <a href="https://en.wikipedia.org/wiki/Base58">base58</a> format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed_hex</code>, or <code>passphrase</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>seed_hex</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it. Must be in hexadecimal format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>passphrase</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it. Must be in hexadecimal format. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>passphrase</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>passphrase</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>seed_hex</code>.</td>
+<td align="left"><em>(Optional)</em> Secret key of the account supplying the transaction, used to sign it, as a string passphrase. If provided, you must also specify the <code>key_type</code>. Cannot be used with <code>secret</code>, <code>seed</code>, or <code>seed_hex</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>key_type</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Type of cryptographic key provided in this request. Valid types are <code>secp256k1</code> or <code>ed25519</code>. Defaults to <code>secp256k1</code>. Cannot be used with <code>secret</code>. <strong>Caution:</strong> Ed25519 support is experimental.</td>
+<td align="left"><em>(Optional)</em> Type of cryptographic key provided in this request. Valid types are <code>secp256k1</code> or <code>ed25519</code>. Defaults to <code>secp256k1</code>. Cannot be used with <code>secret</code>. <strong>Caution:</strong> Ed25519 support is experimental.</td>
 </tr>
 <tr>
 <td align="left"><code>fail_hard</code></td>
@@ -8360,7 +8360,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 <tr>
 <td align="left"><code>build_path</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. <strong>Caution:</strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
+<td align="left"><em>(Optional)</em> If provided for a Payment-type transaction, automatically fill in the <code>Paths</code> field before signing. You must omit this field if the transaction is a direct XRP-to-XRP transfer. <strong>Caution:</strong> The server looks for the presence or absence of this field, not its value. This behavior may change.</td>
 </tr>
 <tr>
 <td align="left"><code>fee_mult_max</code></td>
@@ -8896,22 +8896,22 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <tr>
 <td align="left"><code>ledger_hash</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>ledger_index</code></td>
 <td align="left">String or Unsigned Integer</td>
-<td align="left">(Optional) The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
 </tr>
 <tr>
 <td align="left"><code>limit</code></td>
 <td align="left">Unsigned Integer</td>
-<td align="left">(Optional) If provided, the server does not provide more than this many offers in the results. The total number of results returned may be fewer than the limit, because the server omits unfunded offers.</td>
+<td align="left"><em>(Optional)</em> If provided, the server does not provide more than this many offers in the results. The total number of results returned may be fewer than the limit, because the server omits unfunded offers.</td>
 </tr>
 <tr>
 <td align="left"><code>taker</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) The <a href="#addresses">Address</a> of an account to use as a perspective. <a href="reference-transaction-format.html#lifecycle-of-an-offer">Unfunded offers</a> placed by this account are always included in the response. (You can use this to look up your own orders to cancel them.)</td>
+<td align="left"><em>(Optional)</em> The <a href="#addresses">Address</a> of an account to use as a perspective. <a href="reference-transaction-format.html#lifecycle-of-an-offer">Unfunded offers</a> placed by this account are always included in the response. (You can use this to look up your own orders to cancel them.)</td>
 </tr>
 <tr>
 <td align="left"><code>taker_gets</code></td>
@@ -9071,7 +9071,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <h2 id="channel-authorize">channel_authorize</h2>
 <p><a href="https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L41" title="Source">[Source]<br/></a></p>
 <p><em>(Requires the <a href="concept-amendments.html#paychan">PayChan amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a>)</em></p>
-<p>The <code>account_channels</code> method creates a signature that can be used to redeem a specific amount of XRP from a payment channel.</p>
+<p>The <code>channel_authorize</code> method creates a signature that can be used to redeem a specific amount of XRP from a payment channel.</p>
 <h4 id="request-format-30">Request Format</h4>
 <p>An example of the request format:</p>
 <div class="multicode" id="code-60"><ul class="codetabs"><li><a href="#code-60-0">WebSocket</a></li><li><a href="#code-60-1">JSON-RPC</a></li><li><a href="#code-60-2">Commandline</a></li></ul>
@@ -9174,7 +9174,7 @@ rippled channel_authorize s█████████████████�
 <tr>
 <td><code>signature</code></td>
 <td>String</td>
-<td>The signature for this claim, as a hexadecimal value. To verify this signature or process the claim, the destination of the payment channel must send a <a href="reference-transaction-format.html#paymentchannelclaim">PaymentChannelClaim transaction</a> with this signature, the exact Channel ID, XRP amount, and public key of the channel.</td>
+<td>The signature for this claim, as a hexadecimal value. To verify this signature or process the claim, the destination account of the payment channel must send a <a href="reference-transaction-format.html#paymentchannelclaim">PaymentChannelClaim transaction</a> with this signature, the exact Channel ID, XRP amount, and public key of the channel.</td>
 </tr>
 </tbody>
 </table>
@@ -9244,7 +9244,7 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <tr>
 <td><code>public_key</code></td>
 <td>String</td>
-<td>The public key of the channel and the key pair that was used to create the signature, in base58 format. (One way to get the public key in base58 format is from the <a href="#wallet-propose"><code>wallet_propose</code> command</a>.)</td>
+<td>The public key of the channel and the key pair that was used to create the signature, in base58 format. (One way to get the public key in base58 format is to use the <a href="#wallet-propose"><code>wallet_propose</code> command</a>.)</td>
 </tr>
 <tr>
 <td><code>signature</code></td>
@@ -9307,7 +9307,7 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>publicMalformed</code> - The value specified in the <code>public_key</code> field of the request was not a valid public key in the correct format. Public keys should be 33 bytes, represented in base58. The base58 representation should start with letter <code>a</code>.</li>
+<li><code>publicMalformed</code> - The value specified in the <code>public_key</code> field of the request was not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58. The base58 representation of account public keys starts with the letter <code>a</code>.</li>
 <li><code>channelMalformed</code> - The value specified in the <code>channel_id</code> field of the reqeuest was not a valid Channel ID. The Channel ID should be a 256-bit (64-character) hexadecimal string.</li>
 <li><code>channelAmtMalformed</code> - The value specified in the <code>amount</code> field was not a valid XRP amount. See <a href="#specifying-currency-amounts">Specifying Currency Amounts</a> for details.</li>
 </ul>
@@ -9367,22 +9367,22 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <tr>
 <td align="left"><code>streams</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of string names of generic streams to subscribe to, as explained below</td>
+<td align="left"><em>(Optional)</em> Array of string names of generic streams to subscribe to, as explained below</td>
 </tr>
 <tr>
 <td align="left"><code>accounts</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array with the unique <a href="https://en.wikipedia.org/wiki/Base58">base58</a> addresses of accounts to monitor for validated transactions. The server sends a notification for any transaction that affects at least one of these accounts.</td>
+<td align="left"><em>(Optional)</em> Array with the unique <a href="https://en.wikipedia.org/wiki/Base58">base58</a> addresses of accounts to monitor for validated transactions. The server sends a notification for any transaction that affects at least one of these accounts.</td>
 </tr>
 <tr>
 <td align="left"><code>accounts_proposed</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Like <code>accounts</code>, but include transactions that are not yet finalized.</td>
+<td align="left"><em>(Optional)</em> Like <code>accounts</code>, but include transactions that are not yet finalized.</td>
 </tr>
 <tr>
 <td align="left"><code>books</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of objects defining <a href="http://www.investopedia.com/terms/o/order-book.asp">order books</a> to monitor for updates, as detailed below.</td>
+<td align="left"><em>(Optional)</em> Array of objects defining <a href="http://www.investopedia.com/terms/o/order-book.asp">order books</a> to monitor for updates, as detailed below.</td>
 </tr>
 <tr>
 <td align="left"><code>url</code></td>
@@ -9392,12 +9392,12 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <tr>
 <td align="left"><code>url_username</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Username to provide for basic authentication at the callback URL.</td>
+<td align="left"><em>(Optional)</em> Username to provide for basic authentication at the callback URL.</td>
 </tr>
 <tr>
 <td align="left"><code>url_password</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Password to provide for basic authentication at the callback URL.</td>
+<td align="left"><em>(Optional)</em> Password to provide for basic authentication at the callback URL.</td>
 </tr>
 </tbody>
 </table>
@@ -10114,22 +10114,22 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <tr>
 <td align="left"><code>streams</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of string names of generic streams to unsubscribe from, including <code>ledger</code>, <code>server</code>, <code>transactions</code>, and <code>transactions_proposed</code>.</td>
+<td align="left"><em>(Optional)</em> Array of string names of generic streams to unsubscribe from, including <code>ledger</code>, <code>server</code>, <code>transactions</code>, and <code>transactions_proposed</code>.</td>
 </tr>
 <tr>
 <td align="left"><code>accounts</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of unique <a href="https://en.wikipedia.org/wiki/Base58">base58</a> account addresses to stop receiving updates for. (This only stops those messages if you previously subscribed to those accounts specifically. You cannot use this to filter accounts out of the general transactions stream.)</td>
+<td align="left"><em>(Optional)</em> Array of unique <a href="https://en.wikipedia.org/wiki/Base58">base58</a> account addresses to stop receiving updates for. (This only stops those messages if you previously subscribed to those accounts specifically. You cannot use this to filter accounts out of the general transactions stream.)</td>
 </tr>
 <tr>
 <td align="left"><code>accounts_proposed</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Like <code>accounts</code>, but for <code>accounts_proposed</code> subscriptions that included not-yet-validated transactions.</td>
+<td align="left"><em>(Optional)</em> Like <code>accounts</code>, but for <code>accounts_proposed</code> subscriptions that included not-yet-validated transactions.</td>
 </tr>
 <tr>
 <td align="left"><code>books</code></td>
 <td align="left">Array</td>
-<td align="left">(Optional) Array of objects defining order books to unsubscribe from, as explained below.</td>
+<td align="left"><em>(Optional)</em> Array of objects defining order books to unsubscribe from, as explained below.</td>
 </tr>
 </tbody>
 </table>
@@ -11550,7 +11550,7 @@ rippled feature 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373
 <tr>
 <td align="left"><code>feature</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) The unique ID of an amendment, as hexadecimal; or the short name of the amendment. If provided, limits the response to one amendment. Otherwise, the response lists all amendments.</td>
+<td align="left"><em>(Optional)</em> The unique ID of an amendment, as hexadecimal; or the short name of the amendment. If provided, limits the response to one amendment. Otherwise, the response lists all amendments.</td>
 </tr>
 <tr>
 <td align="left"><code>vetoed</code></td>
@@ -12068,37 +12068,37 @@ Connecting to 127.0.0.1:5005
 <tr>
 <td align="left"><code>ledger</code></td>
 <td align="left">Number (Ledger Sequence Number)</td>
-<td align="left">(Optional) If provided, check and correct this specific ledger only.</td>
+<td align="left"><em>(Optional)</em> If provided, check and correct this specific ledger only.</td>
 </tr>
 <tr>
 <td align="left"><code>max_ledger</code></td>
 <td align="left">Number (Ledger Sequence Number)</td>
-<td align="left">(Optional) Configure the ledger cleaner to check ledgers with sequence numbers equal or lower than this.</td>
+<td align="left"><em>(Optional)</em> Configure the ledger cleaner to check ledgers with sequence numbers equal or lower than this.</td>
 </tr>
 <tr>
 <td align="left"><code>min_ledger</code></td>
 <td align="left">Number (Ledger Sequence Number)</td>
-<td align="left">(Optional) Configure the ledger cleaner to check ledgers with sequence numbers equal or higher than this.</td>
+<td align="left"><em>(Optional)</em> Configure the ledger cleaner to check ledgers with sequence numbers equal or higher than this.</td>
 </tr>
 <tr>
 <td align="left"><code>full</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If true, fix ledger state nodes and transations in the specified ledger(s). Defaults to false. Automatically set to <code>true</code> if <code>ledger</code> is provided.</td>
+<td align="left"><em>(Optional)</em> If true, fix ledger state nodes and transations in the specified ledger(s). Defaults to false. Automatically set to <code>true</code> if <code>ledger</code> is provided.</td>
 </tr>
 <tr>
 <td align="left"><code>fix_txns</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If true, correct transaction in the specified ledger(s). Overrides <code>full</code> if provided.</td>
+<td align="left"><em>(Optional)</em> If true, correct transaction in the specified ledger(s). Overrides <code>full</code> if provided.</td>
 </tr>
 <tr>
 <td align="left"><code>check_nodes</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If true, correct ledger state nodes in the specified ledger(s). Overrides <code>full</code> if provided.</td>
+<td align="left"><em>(Optional)</em> If true, correct ledger state nodes in the specified ledger(s). Overrides <code>full</code> if provided.</td>
 </tr>
 <tr>
 <td align="left"><code>stop</code></td>
 <td align="left">Boolean</td>
-<td align="left">(Optional) If true, disable the ledger cleaner.</td>
+<td align="left"><em>(Optional)</em> If true, disable the ledger cleaner.</td>
 </tr>
 </tbody>
 </table>
@@ -12171,12 +12171,12 @@ rippled log_level PathRequest debug
 <tr>
 <td align="left"><code>severity</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) What level of verbosity to set logging at. Valid values are, in order from least to most verbose: <code>fatal</code>, <code>error</code>, <code>warn</code>, <code>info</code>, <code>debug</code>, and <code>trace</code>. If omitted, return current log verbosity for all categories.</td>
+<td align="left"><em>(Optional)</em> What level of verbosity to set logging at. Valid values are, in order from least to most verbose: <code>fatal</code>, <code>error</code>, <code>warn</code>, <code>info</code>, <code>debug</code>, and <code>trace</code>. If omitted, return current log verbosity for all categories.</td>
 </tr>
 <tr>
 <td align="left"><code>partition</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Ignored unless <code>severity</code> is provided. Which logging category to modify. If omitted, or if provided with the value <code>base</code>, set logging level for all categories.</td>
+<td align="left"><em>(Optional)</em> Ignored unless <code>severity</code> is provided. Which logging category to modify. If omitted, or if provided with the value <code>base</code>, set logging level for all categories.</td>
 </tr>
 </tbody>
 </table>
@@ -12383,7 +12383,7 @@ rippled validation_create "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIR
 <tr>
 <td align="left"><code>secret</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) Use this value as a seed to generate the credentials. The same secret always generates the same credentials. You can provide the seed in <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a> format or Ripple's <a href="https://en.wikipedia.org/wiki/Base58">base58</a> format. If omitted, generate a random seed.</td>
+<td align="left"><em>(Optional)</em> Use this value as a seed to generate the credentials. The same secret always generates the same credentials. You can provide the seed in <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a> format or Ripple's <a href="https://en.wikipedia.org/wiki/Base58">base58</a> format. If omitted, generate a random seed.</td>
 </tr>
 </tbody>
 </table>
@@ -12478,7 +12478,7 @@ rippled validation_seed 'BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE'
 <tr>
 <td align="left"><code>secret</code></td>
 <td align="left">String</td>
-<td align="left">(Optional) If present, use this value as the secret value for the validating key pair. Valid formats include <a href="https://en.wikipedia.org/wiki/Base58">base58</a>, <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a>, or as a passphrase. If omitted, disables proposing validations to the network.</td>
+<td align="left"><em>(Optional)</em> If present, use this value as the secret value for the validating key pair. Valid formats include <a href="https://en.wikipedia.org/wiki/Base58">base58</a>, <a href="https://tools.ietf.org/html/rfc1751">RFC-1751</a>, or as a passphrase. If omitted, disables proposing validations to the network.</td>
 </tr>
 </tbody>
 </table>
@@ -13430,7 +13430,7 @@ rippled connect 192.170.145.88 51235
 <tr>
 <td align="left"><code>port</code></td>
 <td align="left">Number</td>
-<td align="left">(Optional) Port number to use when connecting. Defaults to 6561.</td>
+<td align="left"><em>(Optional)</em> Port number to use when connecting. Defaults to 6561.</td>
 </tr>
 </tbody>
 </table>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -9307,9 +9307,9 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
-<li><code>publicMalformed</code> - The value specified in the <code>public_key</code> field of the request was not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58. The base58 representation of account public keys starts with the letter <code>a</code>.</li>
-<li><code>channelMalformed</code> - The value specified in the <code>channel_id</code> field of the reqeuest was not a valid Channel ID. The Channel ID should be a 256-bit (64-character) hexadecimal string.</li>
-<li><code>channelAmtMalformed</code> - The value specified in the <code>amount</code> field was not a valid XRP amount. See <a href="#specifying-currency-amounts">Specifying Currency Amounts</a> for details.</li>
+<li><code>publicMalformed</code> - The <code>public_key</code> field of the request is not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58. The base58 representation of account public keys starts with the letter <code>a</code>.</li>
+<li><code>channelMalformed</code> - The <code>channel_id</code> field of the request is not a valid Channel ID. The Channel ID must be a 256-bit (64-character) hexadecimal string.</li>
+<li><code>channelAmtMalformed</code> - The value specified in the <code>amount</code> field was not a valid <a href="#specifying-currency-amounts">XRP amount</a>.</li>
 </ul>
 <h1 id="subscriptions">Subscriptions</h1>
 <p>Using subscriptions, you can have the server push updates to your client when various events happen, so that you can know and react right away. Subscriptions are only supported in the WebSocket API, where you can receive additional responses in the same channel.</p>
@@ -9474,8 +9474,8 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
 <li><code>noPermission</code> - The request included the <code>url</code> field, but you are not connected as an admin.</li>
-<li><code>unknownStream</code> - One or more the members of the <code>streams</code> field in the request was not recognized as a valid stream name.</li>
-<li><code>malformedStream</code> - The <code>streams</code> field of the request was not formatted properly.</li>
+<li><code>unknownStream</code> - One or more the members of the <code>streams</code> field of the request is not a valid stream name.</li>
+<li><code>malformedStream</code> - The <code>streams</code> field of the request is not formatted properly.</li>
 <li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address. (<strong>Note:</strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger to get a message when that address becomes funded.)</li>
 <li><code>srcCurMalformed</code> - One or more <code>taker_pays</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
 <li><code>dstAmtMalformed</code> - One or more <code>taker_gets</code> sub-fields of the <code>books</code> field in the request is not formatted properly.</li>
@@ -10179,7 +10179,7 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
 <li><code>noPermission</code> - The request included the <code>url</code> field, but you are not connected as an admin.</li>
-<li><code>malformedStream</code> - The <code>streams</code> field of the request was not formatted properly.</li>
+<li><code>malformedStream</code> - The <code>streams</code> field of the request is not formatted properly.</li>
 <li><code>malformedAccount</code> - One of the addresses in the <code>accounts</code> or <code>accounts_proposed</code> fields of the request is not a properly-formatted Ripple address.<ul>
 <li class="devportal-callout note"><strong>Note:</strong>: You <em>can</em> subscribe to the stream of an address that does not yet have an entry in the global ledger to get a message when that address becomes funded.</li>
 </ul>
@@ -12041,7 +12041,7 @@ Connecting to 127.0.0.1:5005
 </ul>
 <h2 id="ledger-cleaner">ledger_cleaner</h2>
 <p><a href="https://github.com/ripple/rippled/blob/df54b47cd0957a31837493cd69e4d9aade0b5055/src/ripple/rpc/handlers/LedgerCleaner.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>ledger_cleaner</code> command controls the <a href="https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner">Ledger Cleaner</a>, an asynchronous maintenance process that can find and repair corruption in rippled's database of ledgers.</p>
+<p>The <code>ledger_cleaner</code> command controls the <a href="https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner">Ledger Cleaner</a>, an asynchronous maintenance process that can find and repair corruption in <code>rippled</code>'s database of ledgers.</p>
 <p><em>The <code>ledger_cleaner</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
 <h4 id="request-format-42">Request Format</h4>
 <p>An example of the request format:</p>
@@ -12136,7 +12136,7 @@ Connecting to 127.0.0.1:5005
 <h4 id="possible-errors-41">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
-<li><code>internal</code> if one the parameters was specified in a way that the server couldn't interpret. (This is a bug, and it should return <code>invalidParams</code> instead.)</li>
+<li><code>internal</code> if one the parameters is specified incorrectly. (This is a bug; the intended error code is <code>invalidParams</code>.)</li>
 </ul>
 <h2 id="log-level">log_level</h2>
 <p><a href="https://github.com/ripple/rippled/blob/155fcdbcd0b4927152892c8c8be01d9cf62bed68/src/ripple/rpc/handlers/LogLevel.cpp" title="Source">[Source]<br/></a></p>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -9248,8 +9248,8 @@ rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB0
 </tr>
 <tr>
 <td><code>signature</code></td>
-<td></td>
-<td></td>
+<td>String</td>
+<td>The signature to verify, in hexadecimal.</td>
 </tr>
 </tbody>
 </table>

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -168,6 +168,7 @@
 <li class="level-2"><a href="#commandline-access">Commandline Access</a></li>
 <li class="level-1"><a href="#account-information">Account Information</a></li>
 <li class="level-2"><a href="#account-currencies">account_currencies</a></li>
+<li class="level-2"><a href="#account-channels">account_channels</a></li>
 <li class="level-2"><a href="#account-info">account_info</a></li>
 <li class="level-2"><a href="#account-lines">account_lines</a></li>
 <li class="level-2"><a href="#account-offers">account_offers</a></li>
@@ -201,6 +202,8 @@
 <li class="level-3"><a href="#sign-and-submit-mode">Sign-and-Submit Mode</a></li>
 <li class="level-2"><a href="#submit-multisigned">submit_multisigned</a></li>
 <li class="level-2"><a href="#book-offers">book_offers</a></li>
+<li class="level-2"><a href="#channel-authorize">channel_authorize</a></li>
+<li class="level-2"><a href="#channel-verify">channel_verify</a></li>
 <li class="level-1"><a href="#subscriptions">Subscriptions</a></li>
 <li class="level-2"><a href="#subscribe">subscribe</a></li>
 <li class="level-3"><a href="#ledger-stream">Ledger Stream</a></li>
@@ -816,12 +819,15 @@ Null method
 <h2 id="list-of-public-commands">List of Public Commands</h2>
 <ul>
 <li><a href="#account-currencies"><code>account_currencies</code> - Get a list of currencies an account can send or receive</a></li>
+<li><a href="#account-channels"><code>account_channels</code> - Get a list of payment channels where the account is the source</a></li>
 <li><a href="#account-info"><code>account_info</code> - Get basic data about an account</a></li>
 <li><a href="#account-lines"><code>account_lines</code> - Get info about an account's trust lines</a></li>
 <li><a href="#account-objects"><code>account_objects</code> - Get all ledger objects owned by an account</a></li>
 <li><a href="#account-offers"><code>account_offers</code> - Get info about an account's currency exchange offers</a></li>
 <li><a href="#account-tx"><code>account_tx</code> - Get info about an account's transactions</a></li>
 <li><a href="#book-offers"><code>book_offers</code> - Get info about offers to exchange two currencies</a></li>
+<li><a href="#channel-authorize"><code>channel_authorize</code> - Sign a claim for money from a payment channel</a></li>
+<li><a href="#channel-verify"><code>channel_verify</code> - Check a payment channel claim's signature</a></li>
 <li><a href="#fee"><code>fee</code> - Get information about transaction cost</a></li>
 <li><a href="#gateway-balances"><code>gateway_balances</code> - Calculate total amounts issued by an account</a></li>
 <li><a href="#ledger"><code>ledger</code> - Get info about a ledger version</a></li>
@@ -1056,14 +1062,268 @@ Null method
 <li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
 <li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
 </ul>
+<h2 id="account-channels">account_channels</h2>
+<p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/AccountChannels.cpp" title="Source">[Source]<br/></a></p>
+<p><em>(Requires the <a href="concept-amendments.html#paychan">PayChan amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a>)</em></p>
+<p>The <code>account_channels</code> method returns information about an account's Payment Channels. This includes only channels where the specified account is the source, not the destination. All information retrieved is relative to a particular version of the ledger.</p>
+<h4 id="request-format-1">Request Format</h4>
+<p>An example of the request format:</p>
+<div class="multicode" id="code-5"><ul class="codetabs"><li><a href="#code-5-0">WebSocket</a></li><li><a href="#code-5-1">JSON-RPC</a></li><li><a href="#code-5-2">Commandline</a></li></ul>
+
+<div class="code_sample" id="code-5-0" style="position: static;"><pre><code class="json">{
+  "id": 1,
+  "command": "account_channels",
+  "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+  "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+  "ledger_index": "validated"
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-5-1" style="position: static;"><pre><code class="json">{
+    "method": "account_channels",
+    "params": [{
+        "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+        "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "ledger_index": "validated"
+    }]
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-5-2" style="position: static;"><pre><code class="bash">#Syntax: account_channels &lt;account&gt; [&lt;destination_account&gt;] [&lt;ledger&gt;]
+rippled account_channels rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn validated
+</code></pre></div>
+</div>
+<p>The request includes the following parameters:</p>
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left"><code>account</code></td>
+<td align="left">String</td>
+<td align="left">A unique identifier for the account whose channels to retrieve. Typically this is the account's <a href="#addresses">Address</a>.</td>
+</tr>
+<tr>
+<td align="left"><code>destination_account</code></td>
+<td align="left">String</td>
+<td align="left"><em>(Optional)</em> If provided, filter results to payment channels where the destination of the channel. Typically this is an <a href="#addresses">Address</a>.</td>
+</tr>
+<tr>
+<td align="left"><code>ledger_hash</code></td>
+<td align="left">String</td>
+<td align="left"><em>(Optional)</em> A 20-byte hex string for the ledger version to use. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+</tr>
+<tr>
+<td align="left"><code>ledger_index</code></td>
+<td align="left">String or Unsigned Integer</td>
+<td align="left"><em>(Optional)</em> The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See <a href="#specifying-ledgers">Specifying a Ledger</a>)</td>
+</tr>
+<tr>
+<td align="left"><code>limit</code></td>
+<td align="left">Integer</td>
+<td align="left"><em>(Optional)</em> Limit the number of transactions to retrieve. The server is not required to honor this value. The default is 200. Cannot be smaller than 10 or larger than 400.</td>
+</tr>
+<tr>
+<td align="left"><code>marker</code></td>
+<td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
+<td align="left"><em>(Optional)</em> Value from a previous response to specify where to resume retrieving data from.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="response-format-1">Response Format</h4>
+<p>An example of a successful response:</p>
+<div class="multicode" id="code-6"><ul class="codetabs"><li><a href="#code-6-0">WebSocket</a></li><li><a href="#code-6-1">JSON-RPC</a></li><li><a href="#code-6-2">Commandline</a></li></ul>
+
+<div class="code_sample" id="code-6-0" style="position: static;"><pre><code class="json">{
+  "id": 2,
+  "status": "success",
+  "type": "response",
+  "result": {
+    "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+    "channels": [
+      {
+        "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+        "amount": "100000000",
+        "balance": "1000000",
+        "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+        "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "destination_tag": 20170428,
+        "expiration": 547073182,
+        "public_key": "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3",
+        "public_key_hex": "023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6",
+        "settle_delay": 86400
+      }
+    ]
+  }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-6-1" style="position: static;"><pre><code class="json">200 OK
+
+{
+    "result": {
+        "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+        "channels": [{
+            "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+            "amount": "100000000",
+            "balance": "0",
+            "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+            "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "destination_tag": 20170428,
+            "public_key": "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3",
+            "public_key_hex": "023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6",
+            "settle_delay": 86400
+        }],
+        "status": "success"
+    }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-6-2" style="position: static;"><pre><code class="json">200 OK
+
+{
+    "result": {
+        "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+        "channels": [{
+            "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+            "amount": "100000000",
+            "balance": "0",
+            "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+            "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "destination_tag": 20170428,
+            "public_key": "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3",
+            "public_key_hex": "023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6",
+            "settle_delay": 86400
+        }],
+        "status": "success"
+    }
+}
+</code></pre></div>
+</div>
+<p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing the following fields:</p>
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left"><code>account</code></td>
+<td align="left">String</td>
+<td align="left">The address of the account from the request; the owner of the payment channels.</td>
+</tr>
+<tr>
+<td align="left"><code>channels</code></td>
+<td align="left">Array of Channel Objects</td>
+<td align="left">Payment channels owned by this <code>account</code>.</td>
+</tr>
+<tr>
+<td align="left"><code>limit</code></td>
+<td align="left">Number</td>
+<td align="left"><em>(May be omitted)</em> The limit to how many channel objects were actually returned by this request.</td>
+</tr>
+<tr>
+<td align="left"><code>marker</code></td>
+<td align="left"><a href="#markers-and-pagination">(Not Specified)</a></td>
+<td align="left"><em>(May be omitted)</em> Server-defined value for pagination. Pass this to the next call to resume getting results where this call left off. Omitted when there are no additional pages after this one.</td>
+</tr>
+</tbody>
+</table>
+<p>Each Channel Object has the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>account</code></td>
+<td>String</td>
+<td>The owner of the channel, as an <a href="#addresses">Address</a>.</td>
+</tr>
+<tr>
+<td><code>amount</code></td>
+<td>String</td>
+<td>The amount of <a href="#specifying-currency-amounts">XRP, in drops</a> allocated to this channel in total.</td>
+</tr>
+<tr>
+<td><code>balance</code></td>
+<td>String</td>
+<td>The total amount of XRP, in drops, paid out from this channel so far. (You can calculate the amount of XRP remaining in the channel by subtracting <code>balance</code> from <code>amount</code>.)</td>
+</tr>
+<tr>
+<td><code>channel_id</code></td>
+<td>String</td>
+<td>A unique ID for this channel, as a 64-character hexadecimal string. This is also the <a href="reference-ledger-format.html#paychannel-index-format">index of the channel</a> in the ledger's state data.</td>
+</tr>
+<tr>
+<td><code>destination_account</code></td>
+<td>String</td>
+<td>The destination of the channel, as an <a href="#addresses">Address</a>. Only this account can receive the XRP in the channel while it remains open.</td>
+</tr>
+<tr>
+<td><code>public_key</code></td>
+<td>String</td>
+<td><em>(May be omitted)</em> The public key for the payment channel in base58 format, if one was specified at channel creation. Signed claims against this channel must be redeemed with the matching key pair.</td>
+</tr>
+<tr>
+<td><code>public_key_hex</code></td>
+<td>String</td>
+<td><em>(May be omitted)</em> The public key for the payment channel in hexadecimal format, if one was specified at channel creation. Signed claims against this channel must be redeemed with the matching key pair.</td>
+</tr>
+<tr>
+<td><code>settle_delay</code></td>
+<td>Unsigned Integer</td>
+<td>The number of seconds the payment channel must remain open after the owner of the channel requests to close it.</td>
+</tr>
+<tr>
+<td><code>expiration</code></td>
+<td>Unsigned Integer</td>
+<td><em>(May be omitted)</em> Time, in seconds since the <a href="#specifying-time">Ripple Epoch</a>, when this channel is set to expire. This expiration date is mutable. If this is before the close time of the most recent validated ledger, the channel is expired.</td>
+</tr>
+<tr>
+<td><code>cancel_after</code></td>
+<td>Unsigned Integer</td>
+<td><em>(May be omitted)</em> Time, in seconds since the <a href="#specifying-time">Ripple Epoch</a>, of this channel's immutable expiration, if one was specified at channel creation. If this is before the close time of the most recent validated ledger, the channel is expired.</td>
+</tr>
+<tr>
+<td><code>source_tag</code></td>
+<td>Unsigned Integer</td>
+<td><em>(May be omitted)</em> A 32-bit unsigned integer to use as a <a href="tutorial-gateway-guide.html#source-and-destination-tags">source tag</a> for payments through this payment channel, if one was specified at channel creation. This indicates the payment channel's originator or other purpose at the source account. Conventionally, if you bounce payments from this channel, you should specify this value as the destination of the return payment.</td>
+</tr>
+<tr>
+<td><code>destination_tag</code></td>
+<td>Unsigned Integer</td>
+<td><em>(May be omitted)</em> A 32-bit unsigned integer to use as a <a href="tutorial-gateway-guide.html#source-and-destination-tags">destination tag</a> for payments through this channel, if one was specified at channel creation. This indicates the payment channel's beneficiary or other purpose at the destination account.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="possible-errors-1">Possible Errors</h4>
+<ul>
+<li>Any of the <a href="#universal-errors">universal error types</a>.</li>
+<li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
+<li><code>actNotFound</code> - The address specified in the <code>account</code> field of the request does not correspond to an account in the ledger.</li>
+<li><code>lgrNotFound</code> - The ledger specified by the <code>ledger_hash</code> or <code>ledger_index</code> does not exist, or it does exist but the server does not have it.</li>
+</ul>
 <h2 id="account-info">account_info</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountInfo.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>account_info</code> command retrieves information about an account, its activity, and its XRP balance. All information retrieved is relative to a particular version of the ledger.</p>
-<h4 id="request-format-1">Request Format</h4>
+<h4 id="request-format-2">Request Format</h4>
 <p>An example of an account_info request:</p>
-<div class="multicode" id="code-5"><ul class="codetabs"><li><a href="#code-5-0">WebSocket</a></li><li><a href="#code-5-1">JSON-RPC</a></li><li><a href="#code-5-2">Commandline</a></li></ul>
+<div class="multicode" id="code-7"><ul class="codetabs"><li><a href="#code-7-0">WebSocket</a></li><li><a href="#code-7-1">JSON-RPC</a></li><li><a href="#code-7-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-5-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-7-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "account_info",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -1073,7 +1333,7 @@ Null method
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-5-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-7-1" style="position: static;"><pre><code>{
     "method": "account_info",
     "params": [
         {
@@ -1086,7 +1346,7 @@ Null method
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-5-2" style="position: static;"><pre><code>#Syntax: account_info account [ledger_index|ledger_hash] [strict]
+<div class="code_sample" id="code-7-2" style="position: static;"><pre><code>#Syntax: account_info account [ledger_index|ledger_hash] [strict]
 rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </code></pre></div>
 </div>
@@ -1134,11 +1394,11 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tbody>
 </table>
 <p>The following fields are deprecated and should not be provided: <code>ident</code>, <code>ledger</code>.</p>
-<h4 id="response-format-1">Response Format</h4>
+<h4 id="response-format-2">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-6"><ul class="codetabs"><li><a href="#code-6-0">WebSocket</a></li><li><a href="#code-6-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-8"><ul class="codetabs"><li><a href="#code-8-0">WebSocket</a></li><li><a href="#code-8-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-6-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-8-0" style="position: static;"><pre><code>{
     "id": 5,
     "status": "success",
     "type": "response",
@@ -1185,7 +1445,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-6-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-8-1" style="position: static;"><pre><code>{
     "result": {
         "account_data": {
             "Account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
@@ -1351,7 +1611,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-1">Possible Errors</h4>
+<h4 id="possible-errors-2">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing. For example, the request specified <code>queue</code> as <code>true</code> but specified a <code>ledger_index</code> that is not the current open ledger.</li>
@@ -1360,12 +1620,12 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </ul>
 <h2 id="account-lines">account_lines</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountLines.cpp" title="Source">[Source]<br/></a></p>
-<p>The <code>account_lines</code> method returns information about the account's lines of trust, including balances in all non-XRP currencies and assets. All information retrieved is relative to a particular version of the ledger.</p>
-<h4 id="request-format-2">Request Format</h4>
+<p>The <code>account_lines</code> method returns information about an account's trust lines, including balances in all non-XRP currencies and assets. All information retrieved is relative to a particular version of the ledger.</p>
+<h4 id="request-format-3">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-7"><ul class="codetabs"><li><a href="#code-7-0">WebSocket</a></li><li><a href="#code-7-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-9"><ul class="codetabs"><li><a href="#code-9-0">WebSocket</a></li><li><a href="#code-9-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-7-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-9-0" style="position: static;"><pre><code>{
   "id": 1,
   "command": "account_lines",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -1373,7 +1633,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-7-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-9-1" style="position: static;"><pre><code>{
     "method": "account_lines",
     "params": [
         {
@@ -1428,11 +1688,11 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tbody>
 </table>
 <p>The following parameters are deprecated and may be removed without further notice: <code>ledger</code> and <code>peer_index</code>.</p>
-<h4 id="response-format-2">Response Format</h4>
+<h4 id="response-format-3">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-8"><ul class="codetabs"><li><a href="#code-8-0">WebSocket</a></li><li><a href="#code-8-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-10"><ul class="codetabs"><li><a href="#code-10-0">WebSocket</a></li><li><a href="#code-10-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-8-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-10-0" style="position: static;"><pre><code>{
     "id": 1,
     "status": "success",
     "type": "response",
@@ -1474,7 +1734,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-8-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-10-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -1624,7 +1884,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-2">Possible Errors</h4>
+<h4 id="possible-errors-3">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -1635,11 +1895,11 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 <h2 id="account-offers">account_offers</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountOffers.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>account_offers</code> method retrieves a list of offers made by a given account that are outstanding as of a particular ledger version.</p>
-<h4 id="request-format-3">Request Format</h4>
+<h4 id="request-format-4">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-9"><ul class="codetabs"><li><a href="#code-9-0">WebSocket</a></li><li><a href="#code-9-1">JSON-RPC</a></li><li><a href="#code-9-2">Commandline</a></li></ul>
+<div class="multicode" id="code-11"><ul class="codetabs"><li><a href="#code-11-0">WebSocket</a></li><li><a href="#code-11-1">JSON-RPC</a></li><li><a href="#code-11-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-9-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-11-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "account_offers",
   "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
@@ -1647,7 +1907,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-9-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-11-1" style="position: static;"><pre><code>{
     "method": "account_offers",
     "params": [
         {
@@ -1658,7 +1918,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-9-2" style="position: static;"><pre><code>#Syntax: account_offers account [ledger_index]
+<div class="code_sample" id="code-11-2" style="position: static;"><pre><code>#Syntax: account_offers account [ledger_index]
 rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 </code></pre></div>
 </div>
@@ -1706,11 +1966,11 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 </tbody>
 </table>
 <p>The following parameter is deprecated and may be removed without further notice: <code>ledger</code>.</p>
-<h4 id="response-format-3">Response Format</h4>
+<h4 id="response-format-4">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-10"><ul class="codetabs"><li><a href="#code-10-0">WebSocket</a></li><li><a href="#code-10-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-12"><ul class="codetabs"><li><a href="#code-12-0">WebSocket</a></li><li><a href="#code-12-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-10-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-12-0" style="position: static;"><pre><code>{
   "id": 9,
   "status": "success",
   "type": "response",
@@ -1747,7 +2007,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-10-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-12-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
@@ -1877,7 +2137,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-3">Possible Errors</h4>
+<h4 id="possible-errors-4">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -1896,11 +2156,11 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 <li><a href="reference-ledger-format.html#escrow">Escrow nodes</a> for held payments that have not yet been executed or canceled.</li>
 <li><a href="reference-ledger-format.html#paychannel">PayChannel nodes</a> for open payment channels.</li>
 </ul>
-<h4 id="request-format-4">Request Format</h4>
+<h4 id="request-format-5">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-11"><ul class="codetabs"><li><a href="#code-11-0">WebSocket</a></li><li><a href="#code-11-1">JSON-RPC</a></li><li><a href="#code-11-2">Commandline</a></li></ul>
+<div class="multicode" id="code-13"><ul class="codetabs"><li><a href="#code-13-0">WebSocket</a></li><li><a href="#code-13-1">JSON-RPC</a></li><li><a href="#code-13-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-11-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-13-0" style="position: static;"><pre><code>{
   "id": 1,
   "command": "account_objects",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -1910,7 +2170,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-11-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-13-1" style="position: static;"><pre><code>{
     "method": "account_objects",
     "params": [
         {
@@ -1923,7 +2183,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-11-2" style="position: static;"><pre><code>#Syntax: account_objects &lt;account&gt; [&lt;ledger&gt;]
+<div class="code_sample" id="code-13-2" style="position: static;"><pre><code>#Syntax: account_objects &lt;account&gt; [&lt;ledger&gt;]
 rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 </code></pre></div>
 </div>
@@ -1969,11 +2229,11 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-4">Response Format</h4>
+<h4 id="response-format-5">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-12"><ul class="codetabs"><li><a href="#code-12-0">WebSocket</a></li><li><a href="#code-12-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-14"><ul class="codetabs"><li><a href="#code-14-0">WebSocket</a></li><li><a href="#code-14-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-12-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-14-0" style="position: static;"><pre><code>{
     "id": 8,
     "status": "success",
     "type": "response",
@@ -2230,7 +2490,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-12-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-14-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -2538,7 +2798,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-4">Possible Errors</h4>
+<h4 id="possible-errors-5">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -2548,11 +2808,11 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 <h2 id="account-tx">account_tx</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTx.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>account_tx</code> method retrieves a list of transactions that involved the specified account.</p>
-<h4 id="request-format-5">Request Format</h4>
+<h4 id="request-format-6">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-13"><ul class="codetabs"><li><a href="#code-13-0">WebSocket</a></li><li><a href="#code-13-1">JSON-RPC</a></li><li><a href="#code-13-2">Commandline</a></li></ul>
+<div class="multicode" id="code-15"><ul class="codetabs"><li><a href="#code-15-0">WebSocket</a></li><li><a href="#code-15-1">JSON-RPC</a></li><li><a href="#code-15-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-13-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-15-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "account_tx",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -2565,7 +2825,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-13-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-15-1" style="position: static;"><pre><code>{
     "method": "account_tx",
     "params": [
         {
@@ -2583,7 +2843,7 @@ rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-13-2" style="position: static;"><pre><code>#Syntax account_tx account [ledger_index_min [ledger_index_max [limit]]] [binary] [count] [forward]
+<div class="code_sample" id="code-15-2" style="position: static;"><pre><code>#Syntax account_tx account [ledger_index_min [ledger_index_max [limit]]] [binary] [count] [forward]
 rippled account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 false false false
 </code></pre></div>
 </div>
@@ -2650,11 +2910,11 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <h5 id="iterating-over-queried-data"><strong>Iterating over queried data</strong></h5>
 <p>As with other paginated methods, you can use the <code>marker</code> field to return multiple pages of data.</p>
 <p>In the time between requests, <code>"ledger_index_min": -1</code> and <code>"ledger_index_max": -1</code> may change to refer to different ledger versions than they did before. The <code>marker</code> field can safely paginate even if there are changes in the ledger range from the request, so long as the marker does not indicate a point outside the range of ledgers specified in the request.</p>
-<h4 id="response-format-5">Response Format</h4>
+<h4 id="response-format-6">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-14"><ul class="codetabs"><li><a href="#code-14-0">WebSocket</a></li><li><a href="#code-14-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-16"><ul class="codetabs"><li><a href="#code-16-0">WebSocket</a></li><li><a href="#code-16-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-14-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-16-0" style="position: static;"><pre><code>{
     "id": 2,
     "status": "success",
     "type": "response",
@@ -2888,7 +3148,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-14-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-16-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -3211,7 +3471,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-5">Possible Errors</h4>
+<h4 id="possible-errors-6">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -3222,11 +3482,11 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <h2 id="noripple-check">noripple_check</h2>
 <p><a href="https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/NoRippleCheck.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>noripple_check</code> command provides a quick way to check the status of <a href="concept-noripple.html">the DefaultRipple field for an account and the NoRipple flag of its trust lines</a>, compared with the recommended settings.</p>
-<h4 id="request-format-6">Request Format</h4>
+<h4 id="request-format-7">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-15"><ul class="codetabs"><li><a href="#code-15-0">WebSocket</a></li><li><a href="#code-15-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-17"><ul class="codetabs"><li><a href="#code-17-0">WebSocket</a></li><li><a href="#code-17-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-15-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-17-0" style="position: static;"><pre><code>{
     "id": 0,
     "command": "noripple_check",
     "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -3237,7 +3497,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-15-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-17-1" style="position: static;"><pre><code>{
     "method": "noripple_check",
     "params": [
         {
@@ -3294,11 +3554,11 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-6">Response Format</h4>
+<h4 id="response-format-7">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-16"><ul class="codetabs"><li><a href="#code-16-0">WebSocket</a></li><li><a href="#code-16-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-18"><ul class="codetabs"><li><a href="#code-18-0">WebSocket</a></li><li><a href="#code-18-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-16-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-18-0" style="position: static;"><pre><code>{
   "id": 0,
   "status": "success",
   "type": "response",
@@ -3347,7 +3607,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-16-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-18-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "ledger_current_index": 14380381,
@@ -3422,7 +3682,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-6">Possible Errors</h4>
+<h4 id="possible-errors-7">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -3432,11 +3692,11 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <h2 id="gateway-balances">gateway_balances</h2>
 <p><a href="https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>gateway_balances</code> command calculates the total balances issued by a given account, optionally excluding amounts held by <a href="concept-issuing-and-operational-addresses.html">operational addresses</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.28.2" title="New in: rippled 0.28.2"><img alt="New in: rippled 0.28.2" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.28.2-blue.svg"/></a></p>
-<h4 id="request-format-7">Request Format</h4>
+<h4 id="request-format-8">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-17"><ul class="codetabs"><li><a href="#code-17-0">WebSocket</a></li><li><a href="#code-17-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-19"><ul class="codetabs"><li><a href="#code-19-0">WebSocket</a></li><li><a href="#code-19-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-17-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-19-0" style="position: static;"><pre><code>{
     "id": "example_gateway_balances_1",
     "command": "gateway_balances",
     "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -3446,7 +3706,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-17-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-19-1" style="position: static;"><pre><code>{
     "method": "gateway_balances",
     "params": [
         {
@@ -3499,11 +3759,11 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-7">Response Format</h4>
+<h4 id="response-format-8">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-18"><ul class="codetabs"><li><a href="#code-18-0">WebSocket</a></li><li><a href="#code-18-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-20"><ul class="codetabs"><li><a href="#code-20-0">WebSocket</a></li><li><a href="#code-20-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-18-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-20-0" style="position: static;"><pre><code>{
   "id": 3,
   "status": "success",
   "type": "response",
@@ -3568,7 +3828,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-18-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-20-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
@@ -3675,7 +3935,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-7">Possible Errors</h4>
+<h4 id="possible-errors-8">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -3688,24 +3948,24 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 <p>Use the <code>wallet_propose</code> method to generate a key pair and Ripple <a href="#addresses">address</a>. This command only generates keys, and does not affect the Ripple Consensus Ledger itself in any way. To become a funded address stored in the ledger, the address must <a href="reference-transaction-format.html#creating-accounts">receive a Payment transaction</a> that provides enough XRP to meet the <a href="concept-reserves.html">reserve requirement</a>.</p>
 <p><em>The <code>wallet_propose</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em> (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)</p>
 <p><a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="Updated in: rippled 0.31.0"><img alt="Updated in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/Updated%20in-rippled%200.31.0-blue.svg"/></a></p>
-<h4 id="request-format-8">Request Format</h4>
+<h4 id="request-format-9">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-19"><ul class="codetabs"><li><a href="#code-19-0">WebSocket (with key type)</a></li><li><a href="#code-19-1">WebSocket (no key type)</a></li><li><a href="#code-19-2">JSON-RPC (with key type)</a></li><li><a href="#code-19-3">JSON-RPC (no key type)</a></li><li><a href="#code-19-4">Commandline</a></li></ul>
+<div class="multicode" id="code-21"><ul class="codetabs"><li><a href="#code-21-0">WebSocket (with key type)</a></li><li><a href="#code-21-1">WebSocket (no key type)</a></li><li><a href="#code-21-2">JSON-RPC (with key type)</a></li><li><a href="#code-21-3">JSON-RPC (no key type)</a></li><li><a href="#code-21-4">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-19-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-21-0" style="position: static;"><pre><code>{
     "command": "wallet_propose",
     "seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
     "key_type": "secp256k1"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-19-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-21-1" style="position: static;"><pre><code>{
     "command": "wallet_propose",
     "passphrase": "masterpassphrase"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-19-2" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-21-2" style="position: static;"><pre><code>{
     "method": "wallet_propose",
     "params": [
         {
@@ -3716,7 +3976,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-19-3" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-21-3" style="position: static;"><pre><code>{
     "method": "wallet_propose",
     "params": [
         {
@@ -3726,7 +3986,7 @@ There is also a deprecated legacy variation of the <code>account_tx</code> metho
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-19-4" style="position: static;"><pre><code>#Syntax: wallet_propose [passphrase]
+<div class="code_sample" id="code-21-4" style="position: static;"><pre><code>#Syntax: wallet_propose [passphrase]
 rippled wallet_propose masterpassphrase
 </code></pre></div>
 </div>
@@ -3778,11 +4038,11 @@ rippled wallet_propose masterpassphrase
 <li>As a 128-bit <a href="https://en.wikipedia.org/wiki/Hexadecimal">hexadecimal</a> string. Example: <code>DEDCE9CE67B451D852FD4E846FCDE31C</code>.</li>
 <li>An arbitrary string to use as a seed value. For example: <code>masterpassphrase</code>.</li>
 </ul>
-<h4 id="response-format-8">Response Format</h4>
+<h4 id="response-format-9">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-20"><ul class="codetabs"><li><a href="#code-20-0">WebSocket</a></li><li><a href="#code-20-1">JSON-RPC</a></li><li><a href="#code-20-2">Commandline</a></li></ul>
+<div class="multicode" id="code-22"><ul class="codetabs"><li><a href="#code-22-0">WebSocket</a></li><li><a href="#code-22-1">JSON-RPC</a></li><li><a href="#code-22-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-20-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-22-0" style="position: static;"><pre><code>{
   "id": 2,
   "status": "success",
   "type": "response",
@@ -3798,7 +4058,7 @@ rippled wallet_propose masterpassphrase
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-20-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-22-1" style="position: static;"><pre><code>{
     "result": {
         "account_id": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "key_type": "secp256k1",
@@ -3812,7 +4072,7 @@ rippled wallet_propose masterpassphrase
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-20-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-22-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -3876,7 +4136,7 @@ Connecting to 127.0.0.1:5005
 </tbody>
 </table>
 <p>The key generated by this method can also be used as a regular key for an account if you use the <a href="reference-transaction-format.html#setregularkey">SetRegularKey transaction type</a> to do so.</p>
-<h4 id="possible-errors-8">Possible Errors</h4>
+<h4 id="possible-errors-9">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly.</li>
@@ -3887,11 +4147,11 @@ Connecting to 127.0.0.1:5005
 <h2 id="ledger">ledger</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerHandler.cpp" title="Source">[Source]<br/></a></p>
 <p>Retrieve information about the public ledger.</p>
-<h4 id="request-format-9">Request Format</h4>
+<h4 id="request-format-10">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-21"><ul class="codetabs"><li><a href="#code-21-0">WebSocket</a></li><li><a href="#code-21-1">JSON-RPC</a></li><li><a href="#code-21-2">Commandline</a></li></ul>
+<div class="multicode" id="code-23"><ul class="codetabs"><li><a href="#code-23-0">WebSocket</a></li><li><a href="#code-23-1">JSON-RPC</a></li><li><a href="#code-23-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-21-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-23-0" style="position: static;"><pre><code>{
     "id": 14,
     "command": "ledger",
     "ledger_index": "validated",
@@ -3903,7 +4163,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-21-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-23-1" style="position: static;"><pre><code>{
     "method": "ledger",
     "params": [
         {
@@ -3918,7 +4178,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-21-2" style="position: static;"><pre><code>#Syntax: ledger ledger_index|ledger_hash [full|tx]
+<div class="code_sample" id="code-23-2" style="position: static;"><pre><code>#Syntax: ledger ledger_index|ledger_hash [full|tx]
 # "full" is equivalent to "full": true
 # "tx" is equivalent to "transactions": true
 rippled ledger current
@@ -3978,11 +4238,11 @@ rippled ledger current
 </tbody>
 </table>
 <p>The <code>ledger</code> field is deprecated and may be removed without further notice.</p>
-<h4 id="response-format-9">Response Format</h4>
+<h4 id="response-format-10">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-22"><ul class="codetabs"><li><a href="#code-22-0">WebSocket</a></li><li><a href="#code-22-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-24"><ul class="codetabs"><li><a href="#code-24-0">WebSocket</a></li><li><a href="#code-24-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-22-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-24-0" style="position: static;"><pre><code>{
   "id": 4,
   "status": "success",
   "type": "response",
@@ -4012,7 +4272,7 @@ rippled ledger current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-22-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-24-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "ledger": {
@@ -4146,7 +4406,7 @@ rippled ledger current
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-9">Possible Errors</h4>
+<h4 id="possible-errors-10">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -4156,17 +4416,17 @@ rippled ledger current
 <h2 id="ledger-closed">ledger_closed</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerClosed.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_closed</code> method returns the unique identifiers of the most recently closed ledger. (This ledger is not necessarily validated and immutable yet.)</p>
-<h4 id="request-format-10">Request Format</h4>
+<h4 id="request-format-11">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-23"><ul class="codetabs"><li><a href="#code-23-0">WebSocket</a></li><li><a href="#code-23-1">JSON-RPC</a></li><li><a href="#code-23-2">Commandline</a></li></ul>
+<div class="multicode" id="code-25"><ul class="codetabs"><li><a href="#code-25-0">WebSocket</a></li><li><a href="#code-25-1">JSON-RPC</a></li><li><a href="#code-25-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-23-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-25-0" style="position: static;"><pre><code>{
    "id": 2,
    "command": "ledger_closed"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-23-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-25-1" style="position: static;"><pre><code>{
     "method": "ledger_closed",
     "params": [
         {}
@@ -4174,17 +4434,17 @@ rippled ledger current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-23-2" style="position: static;"><pre><code>#Syntax: ledger_closed
+<div class="code_sample" id="code-25-2" style="position: static;"><pre><code>#Syntax: ledger_closed
 rippled ledger_closed
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#ledger_closed">Try it!</a></p>
 <p>This method accepts no parameters.</p>
-<h4 id="response-format-10">Response Format</h4>
+<h4 id="response-format-11">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-24"><ul class="codetabs"><li><a href="#code-24-0">WebSocket</a></li><li><a href="#code-24-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-26"><ul class="codetabs"><li><a href="#code-26-0">WebSocket</a></li><li><a href="#code-26-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-24-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-26-0" style="position: static;"><pre><code>{
   "id": 1,
   "status": "success",
   "type": "response",
@@ -4195,7 +4455,7 @@ rippled ledger_closed
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-24-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-26-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "ledger_hash": "8B5A0C5F6B198254A6E411AF55C29EE40AA86251D2E78DD0BB17647047FA9C24",
@@ -4227,24 +4487,24 @@ rippled ledger_closed
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-10">Possible Errors</h4>
+<h4 id="possible-errors-11">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
 <h2 id="ledger-current">ledger_current</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerCurrent.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_current</code> method returns the unique identifiers of the current in-progress ledger. This command is mostly useful for testing, because the ledger returned is still in flux.</p>
-<h4 id="request-format-11">Request Format</h4>
+<h4 id="request-format-12">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-25"><ul class="codetabs"><li><a href="#code-25-0">WebSocket</a></li><li><a href="#code-25-1">JSON-RPC</a></li><li><a href="#code-25-2">Commandline</a></li></ul>
+<div class="multicode" id="code-27"><ul class="codetabs"><li><a href="#code-27-0">WebSocket</a></li><li><a href="#code-27-1">JSON-RPC</a></li><li><a href="#code-27-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-25-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-27-0" style="position: static;"><pre><code>{
    "id": 2,
    "command": "ledger_current"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-25-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-27-1" style="position: static;"><pre><code>{
     "method": "ledger_current",
     "params": [
         {}
@@ -4252,17 +4512,17 @@ rippled ledger_closed
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-25-2" style="position: static;"><pre><code>#Syntax: ledger_current
+<div class="code_sample" id="code-27-2" style="position: static;"><pre><code>#Syntax: ledger_current
 rippled ledger_current
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#ledger_current">Try it!</a></p>
 <p>The request contains no parameters.</p>
-<h4 id="response-format-11">Response Format</h4>
+<h4 id="response-format-12">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-26"><ul class="codetabs"><li><a href="#code-26-0">WebSocket</a></li><li><a href="#code-26-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-28"><ul class="codetabs"><li><a href="#code-28-0">WebSocket</a></li><li><a href="#code-28-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-26-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-28-0" style="position: static;"><pre><code>{
   "id": 2,
   "status": "success",
   "type": "response",
@@ -4272,7 +4532,7 @@ rippled ledger_current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-26-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-28-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "ledger_current_index": 8696233,
@@ -4299,18 +4559,18 @@ rippled ledger_current
 </tbody>
 </table>
 <p>A <code>ledger_hash</code> field is not provided, because the hash of the current ledger is constantly changing along with its contents.</p>
-<h4 id="possible-errors-11">Possible Errors</h4>
+<h4 id="possible-errors-12">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
 <h2 id="ledger-data">ledger_data</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerData.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_data</code> method retrieves contents of the specified ledger. You can iterate through several calls to retrieve the entire contents of a single ledger version.</p>
-<h4 id="request-format-12">Request Format</h4>
+<h4 id="request-format-13">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-27"><ul class="codetabs"><li><a href="#code-27-0">WebSocket</a></li><li><a href="#code-27-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-29"><ul class="codetabs"><li><a href="#code-29-0">WebSocket</a></li><li><a href="#code-29-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-27-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-29-0" style="position: static;"><pre><code>{
    "id": 2,
    "ledger_hash": "842B57C1CC0613299A686D3E9F310EC0422C84D3911E5056389AA7E5808A93C8",
    "command": "ledger_data",
@@ -4319,7 +4579,7 @@ rippled ledger_current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-27-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-29-1" style="position: static;"><pre><code>{
     "method": "ledger_data",
     "params": [
         {
@@ -4375,11 +4635,11 @@ rippled ledger_current
 </tbody>
 </table>
 <p>The <code>ledger</code> field is deprecated and may be removed without further notice.</p>
-<h4 id="response-format-12">Response Format</h4>
+<h4 id="response-format-13">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-28"><ul class="codetabs"><li><a href="#code-28-0">WebSocket (binary:true)</a></li><li><a href="#code-28-1">WebSocket (binary:false)</a></li><li><a href="#code-28-2">JSON-RPC (binary:true)</a></li></ul>
+<div class="multicode" id="code-30"><ul class="codetabs"><li><a href="#code-30-0">WebSocket (binary:true)</a></li><li><a href="#code-30-1">WebSocket (binary:false)</a></li><li><a href="#code-30-2">JSON-RPC (binary:true)</a></li></ul>
 
-<div class="code_sample" id="code-28-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-30-0" style="position: static;"><pre><code>{
     "id": 2,
     "result": {
         "ledger_hash": "842B57C1CC0613299A686D3E9F310EC0422C84D3911E5056389AA7E5808A93C8",
@@ -4413,7 +4673,7 @@ rippled ledger_current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-28-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-30-1" style="position: static;"><pre><code>{
     "id": 2,
     "result": {
         "ledger_hash": "842B57C1CC0613299A686D3E9F310EC0422C84D3911E5056389AA7E5808A93C8",
@@ -4509,7 +4769,7 @@ rippled ledger_current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-28-2" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-30-2" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "ledger_hash": "842B57C1CC0613299A686D3E9F310EC0422C84D3911E5056389AA7E5808A93C8",
@@ -4606,7 +4866,7 @@ rippled ledger_current
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-12">Possible Errors</h4>
+<h4 id="possible-errors-13">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a></li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -4616,11 +4876,11 @@ rippled ledger_current
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerEntry.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_entry</code> method returns a single ledger node from the Ripple Consensus Ledger in its raw format. See <a href="reference-ledger-format.html">ledger format</a> for information on the different types of objects you can retrieve.</p>
 <p class="devportal-callout note"><strong>Note:</strong> There is no commandline version of this method. You can use the <a href="#json"><code>json</code> command</a> to access this method from the commandline instead.</p>
-<h4 id="request-format-13">Request Format</h4>
+<h4 id="request-format-14">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-29"><ul class="codetabs"><li><a href="#code-29-0">WebSocket</a></li><li><a href="#code-29-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-31"><ul class="codetabs"><li><a href="#code-31-0">WebSocket</a></li><li><a href="#code-31-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-29-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-31-0" style="position: static;"><pre><code>{
   "id": 3,
   "command": "ledger_entry",
   "type": "account_root",
@@ -4629,7 +4889,7 @@ rippled ledger_current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-29-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-31-1" style="position: static;"><pre><code>{
     "method": "ledger_entry",
     "params": [
         {
@@ -4739,11 +4999,11 @@ rippled ledger_current
 </tbody>
 </table>
 <p>The <code>generator</code> and <code>ledger</code> parameters are deprecated and may be removed without further notice.</p>
-<h4 id="response-format-13">Response Format</h4>
+<h4 id="response-format-14">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-30"><ul class="codetabs"><li><a href="#code-30-0">WebSocket</a></li><li><a href="#code-30-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-32"><ul class="codetabs"><li><a href="#code-32-0">WebSocket</a></li><li><a href="#code-32-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-30-0" style="position: static;"><pre><code>    "id": 3,
+<div class="code_sample" id="code-32-0" style="position: static;"><pre><code>    "id": 3,
     "result": {
         "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
         "ledger_index": 6889347,
@@ -4764,7 +5024,7 @@ rippled ledger_current
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-30-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-32-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
@@ -4818,7 +5078,7 @@ rippled ledger_current
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-13">Possible Errors</h4>
+<h4 id="possible-errors-14">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -4828,18 +5088,18 @@ rippled ledger_current
 <p><a href="https://github.com/ripple/rippled/blob/e980e69eca9ea843d200773eb1f43abe3848f1a0/src/ripple/rpc/handlers/LedgerRequest.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_request</code> command tells server to fetch a specific ledger version from its connected peers. This only works if one of the server's immediately-connected peers has that ledger. You may need to run the command several times to completely fetch a ledger.</p>
 <p><em>The <code>ledger_request</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-14">Request Format</h4>
+<h4 id="request-format-15">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-31"><ul class="codetabs"><li><a href="#code-31-0">WebSocket</a></li><li><a href="#code-31-1">Commandline</a></li></ul>
+<div class="multicode" id="code-33"><ul class="codetabs"><li><a href="#code-33-0">WebSocket</a></li><li><a href="#code-33-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-31-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-33-0" style="position: static;"><pre><code>{
     "id": 102,
     "command": "ledger_request",
     "ledger_index": 13800000
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-31-1" style="position: static;"><pre><code>rippled ledger_request 13800000
+<div class="code_sample" id="code-33-1" style="position: static;"><pre><code>rippled ledger_request 13800000
 </code></pre></div>
 </div>
 <p>The request includes the following parameters:</p>
@@ -4865,13 +5125,13 @@ rippled ledger_current
 </tbody>
 </table>
 <p>You must provide either <code>ledger_index</code> or <code>ledger_hash</code> but not both.</p>
-<h4 id="response-format-14">Response Format</h4>
+<h4 id="response-format-15">Response Format</h4>
 <p>The response follows the <a href="#response-formatting">standard format</a>. However, the request returns a failure response if it does not have the specified ledger <em>even if it successfully instructed the <code>rippled</code> server to start retrieving the ledger</em>.</p>
 <p class="devportal-callout note"><strong>Note:</strong> To retrieve a ledger, the rippled server must have a direct peer with that ledger in its history. If none of the peers have the requested ledger, you can use the <a href="#connect"><code>connect</code> command</a> or the <code>fixed_ips</code> section of the config file to add Ripple's full-history server at <code>s2.ripple.com</code> and then make the <code>ledger_request</code> request again.</p>
 <p>A failure response indicates the status of fetching the ledger. A successful response contains the information for the ledger in a similar format to the <a href="#ledger"><code>ledger</code> command</a>.</p>
-<div class="multicode" id="code-32"><ul class="codetabs"><li><a href="#code-32-0">Commandline (failure)</a></li><li><a href="#code-32-1">Commandline (in-progress)</a></li><li><a href="#code-32-2">Commandline (success)</a></li></ul>
+<div class="multicode" id="code-34"><ul class="codetabs"><li><a href="#code-34-0">Commandline (failure)</a></li><li><a href="#code-34-1">Commandline (in-progress)</a></li><li><a href="#code-34-2">Commandline (success)</a></li></ul>
 
-<div class="code_sample" id="code-32-0" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-34-0" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -4893,7 +5153,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-32-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-34-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -4936,7 +5196,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-32-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-34-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -5022,7 +5282,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-14">Possible Errors</h4>
+<h4 id="possible-errors-15">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing. This error can also occur if you specify a ledger index equal or higher than the current in-progress ledger.</li>
@@ -5032,22 +5292,22 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_accept</code> method forces the server to close the current-working ledger and move to the next ledger number. This method is intended for testing purposes only, and is only available when the <code>rippled</code> server is running stand-alone mode.</p>
 <p><em>The <code>ledger_accept</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-15">Request Format</h4>
+<h4 id="request-format-16">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-33"><ul class="codetabs"><li><a href="#code-33-0">WebSocket</a></li><li><a href="#code-33-1">Commandline</a></li></ul>
+<div class="multicode" id="code-35"><ul class="codetabs"><li><a href="#code-35-0">WebSocket</a></li><li><a href="#code-35-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-33-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-35-0" style="position: static;"><pre><code>{
    "id": "Accept my ledger!",
    "command": "ledger_accept"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-33-1" style="position: static;"><pre><code>#Syntax: ledger_accept
+<div class="code_sample" id="code-35-1" style="position: static;"><pre><code>#Syntax: ledger_accept
 rippled ledger_accept
 </code></pre></div>
 </div>
 <p>The request accepts no parameters.</p>
-<h4 id="response-format-15">Response Format</h4>
+<h4 id="response-format-16">Response Format</h4>
 <p>An example of a successful response:</p>
 <pre><code class="js">{
   "id": "Accept my ledger!",
@@ -5076,7 +5336,7 @@ rippled ledger_accept
 </tbody>
 </table>
 <p class="devportal-callout note"><strong>Note:</strong> When you close a ledger, <code>rippled</code> determines the canonical order of transactions in that ledger and replays them. This can change the outcome of transactions that were provisionally applied to the current ledger.</p>
-<h4 id="possible-errors-15">Possible Errors</h4>
+<h4 id="possible-errors-16">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>notStandAlone</code> - If the <code>rippled</code> server is not currently running in stand-alone mode.</li>
@@ -5087,11 +5347,11 @@ rippled ledger_accept
 <h2 id="tx">tx</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Tx.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>tx</code> method retrieves information on a single transaction.</p>
-<h4 id="request-format-16">Request Format</h4>
+<h4 id="request-format-17">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-34"><ul class="codetabs"><li><a href="#code-34-0">WebSocket</a></li><li><a href="#code-34-1">JSON-RPC</a></li><li><a href="#code-34-2">Commandline</a></li></ul>
+<div class="multicode" id="code-36"><ul class="codetabs"><li><a href="#code-36-0">WebSocket</a></li><li><a href="#code-36-1">JSON-RPC</a></li><li><a href="#code-36-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-34-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-36-0" style="position: static;"><pre><code>{
   "id": 1,
   "command": "tx",
   "transaction": "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7",
@@ -5099,7 +5359,7 @@ rippled ledger_accept
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-34-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-36-1" style="position: static;"><pre><code>{
     "method": "tx",
     "params": [
         {
@@ -5110,7 +5370,7 @@ rippled ledger_accept
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-34-2" style="position: static;"><pre><code>#Syntax: tx transaction [binary]
+<div class="code_sample" id="code-36-2" style="position: static;"><pre><code>#Syntax: tx transaction [binary]
 rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 false
 </code></pre></div>
 </div>
@@ -5137,11 +5397,11 @@ rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 fals
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-16">Response Format</h4>
+<h4 id="response-format-17">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-35"><ul class="codetabs"><li><a href="#code-35-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-37"><ul class="codetabs"><li><a href="#code-37-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-35-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-37-0" style="position: static;"><pre><code>{
     "id": 1,
     "result": {
         "Account": "r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH",
@@ -5308,7 +5568,7 @@ rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 fals
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-16">Possible Errors</h4>
+<h4 id="possible-errors-17">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -5317,11 +5577,11 @@ rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 fals
 <h2 id="transaction-entry">transaction_entry</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TransactionEntry.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>transaction_entry</code> method retrieves information on a single transaction from a specific ledger version. (The <a href="#tx"><code>tx</code></a> command, by contrast, searches all ledgers for the specified transaction. We recommend using that method instead.)</p>
-<h4 id="request-format-17">Request Format</h4>
+<h4 id="request-format-18">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-36"><ul class="codetabs"><li><a href="#code-36-0">WebSocket</a></li><li><a href="#code-36-1">JSON-RPC</a></li><li><a href="#code-36-2">Commandline</a></li></ul>
+<div class="multicode" id="code-38"><ul class="codetabs"><li><a href="#code-38-0">WebSocket</a></li><li><a href="#code-38-1">JSON-RPC</a></li><li><a href="#code-38-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-36-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-38-0" style="position: static;"><pre><code>{
   "id": 4,
   "command": "transaction_entry",
   "tx_hash": "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7",
@@ -5329,7 +5589,7 @@ rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 fals
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-36-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-38-1" style="position: static;"><pre><code>{
     "method": "transaction_entry",
     "params": [
         {
@@ -5340,7 +5600,7 @@ rippled tx E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 fals
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-36-2" style="position: static;"><pre><code>#Syntax: transaction_entry transaction_hash ledger_index|ledger_hash
+<div class="code_sample" id="code-38-2" style="position: static;"><pre><code>#Syntax: transaction_entry transaction_hash ledger_index|ledger_hash
 rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7 348734
 </code></pre></div>
 </div>
@@ -5373,11 +5633,11 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 </tbody>
 </table>
 <p class="devportal-callout note"><strong>Note:</strong> This method does not support retrieving information from the current in-progress ledger. You must specify a ledger version in either <code>ledger_index</code> or <code>ledger_hash</code>.</p>
-<h4 id="response-format-17">Response Format</h4>
+<h4 id="response-format-18">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-37"><ul class="codetabs"><li><a href="#code-37-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-39"><ul class="codetabs"><li><a href="#code-39-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-37-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-39-0" style="position: static;"><pre><code>{
     "id": 4,
     "result": {
         "ledger_index": 348734,
@@ -5542,7 +5802,7 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 <li>The transaction exists, but not in the specified ledger version</li>
 <li>The server does not have the specified ledger version available. Another server that has the correct version on hand may have a different response.</li>
 </ul>
-<h4 id="possible-errors-17">Possible Errors</h4>
+<h4 id="possible-errors-18">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>fieldNotFoundTransaction</code> - The <code>tx_hash</code> field was omitted from the request</li>
@@ -5555,18 +5815,18 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TxHistory.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>tx_history</code> method retrieves some of the most recent transactions made.</p>
 <p class="devportal-callout caution"><strong>Caution:</strong> This method is deprecated, and may be removed without further notice.</p>
-<h4 id="request-format-18">Request Format</h4>
+<h4 id="request-format-19">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-38"><ul class="codetabs"><li><a href="#code-38-0">WebSocket</a></li><li><a href="#code-38-1">JSON-RPC</a></li><li><a href="#code-38-2">Commandline</a></li></ul>
+<div class="multicode" id="code-40"><ul class="codetabs"><li><a href="#code-40-0">WebSocket</a></li><li><a href="#code-40-1">JSON-RPC</a></li><li><a href="#code-40-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-38-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-40-0" style="position: static;"><pre><code>{
   "id": 5,
   "command": "tx_history",
   "start": 0
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-38-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-40-1" style="position: static;"><pre><code>{
     "method": "tx_history",
     "params": [
         {
@@ -5576,7 +5836,7 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-38-2" style="position: static;"><pre><code>#Syntax: tx_history [start]
+<div class="code_sample" id="code-40-2" style="position: static;"><pre><code>#Syntax: tx_history [start]
 rippled tx_history 0
 </code></pre></div>
 </div>
@@ -5598,11 +5858,11 @@ rippled tx_history 0
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-18">Response Format</h4>
+<h4 id="response-format-19">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-39"><ul class="codetabs"><li><a href="#code-39-0">WebSocket</a></li><li><a href="#code-39-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-41"><ul class="codetabs"><li><a href="#code-41-0">WebSocket</a></li><li><a href="#code-41-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-39-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-41-0" style="position: static;"><pre><code>{
   "id": 2,
   "status": "success",
   "type": "response",
@@ -6052,7 +6312,7 @@ rippled tx_history 0
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-39-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-41-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "index": 0,
@@ -6439,7 +6699,7 @@ rippled tx_history 0
 </tbody>
 </table>
 <p>The fields included in each transaction object vary slightly depending on the type of transaction. See <a href="reference-transaction-format.html">Transaction Format</a> for details.</p>
-<h4 id="possible-errors-18">Possible Errors</h4>
+<h4 id="possible-errors-19">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -6459,11 +6719,11 @@ rippled tx_history 0
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L38" title="Source">[Source]<br/></a></p>
 <p>The <code>create</code> subcommand of <code>path_find</code> creates an ongoing request to find possible paths along which a payment transaction could be made from one specified account such that another account receives a desired amount of some currency. The initial response contains a suggested path between the two addresses that would result in the desired amount being received. After that, the server sends additional messages, with <code>"type": "path_find"</code>, with updates to the potential paths. The frequency of updates is left to the discretion of the server, but it usually means once every few seconds when there is a new ledger version.</p>
 <p>A client can only have one pathfinding request open at a time. If another pathfinding request is already open on the same connection, the old request is automatically closed and replaced with the new request.</p>
-<h4 id="request-format-19">Request Format</h4>
+<h4 id="request-format-20">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-40"><ul class="codetabs"><li><a href="#code-40-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-42"><ul class="codetabs"><li><a href="#code-42-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-40-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-42-0" style="position: static;"><pre><code>{
     "id": 8,
     "command": "path_find",
     "subcommand": "create",
@@ -6521,11 +6781,11 @@ rippled tx_history 0
 </tbody>
 </table>
 <p>The server also recognizes the following fields, but the results of using them are not guaranteed: <code>source_currencies</code>, <code>bridges</code>. These fields should be considered reserved for future use.</p>
-<h4 id="response-format-19">Response Format</h4>
+<h4 id="response-format-20">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-41"><ul class="codetabs"><li><a href="#code-41-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-43"><ul class="codetabs"><li><a href="#code-43-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-41-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-43-0" style="position: static;"><pre><code>{
   "id": 1,
   "status": "success",
   "type": "response",
@@ -6954,7 +7214,7 @@ rippled tx_history 0
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-19">Possible Errors</h4>
+<h4 id="possible-errors-20">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -6964,9 +7224,9 @@ rippled tx_history 0
 <p>In addition to the initial response, the server sends more messages in a similar format to update on the status of <a href="concept-paths.html">payment paths</a> over time. These messages include the <code>id</code> of the original WebSocket request so you can tell which request prompted them, and the field <code>"type": "path_find"</code> at the top level to indicate that they are additional responses. The other fields are defined in the same way as the initial response.</p>
 <p>If the follow-up includes <code>"full_reply": true</code>, then this is the best path that rippled can find as of the current ledger.</p>
 <p>Here is an example of an asychronous follow-up from a path_find create request:</p>
-<div class="multicode" id="code-42"><ul class="codetabs"><li><a href="#code-42-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-44"><ul class="codetabs"><li><a href="#code-44-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-42-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-44-0" style="position: static;"><pre><code>{
     "id": 1,
     "type": "path_find",
     "alternatives": [
@@ -6985,11 +7245,11 @@ rippled tx_history 0
 <h3 id="path-find-close">path_find close</h3>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L46" title="Source">[Source]<br/></a></p>
 <p>The <code>close</code> subcommand of <code>path_find</code> instructs the server to stop sending information about the current open pathfinding request.</p>
-<h4 id="request-format-20">Request Format</h4>
+<h4 id="request-format-21">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-43"><ul class="codetabs"><li><a href="#code-43-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-45"><ul class="codetabs"><li><a href="#code-45-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-43-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-45-0" style="position: static;"><pre><code>{
   "id": 57,
   "command": "path_find",
   "subcommand": "close"
@@ -7013,7 +7273,7 @@ rippled tx_history 0
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-20">Response Format</h4>
+<h4 id="response-format-21">Response Format</h4>
 <p>If a pathfinding request was successfully closed, the response follows the same format as the initial response to <a href="#path-find-create"><code>path_find create</code></a>, plus the following field:</p>
 <table>
 <thead>
@@ -7032,7 +7292,7 @@ rippled tx_history 0
 </tbody>
 </table>
 <p>If there was no outstanding pathfinding request, an error is returned instead.</p>
-<h4 id="possible-errors-20">Possible Errors</h4>
+<h4 id="possible-errors-21">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - If any fields are specified incorrectly, or any required fields are missing.</li>
@@ -7042,11 +7302,11 @@ rippled tx_history 0
 <h3 id="path-find-status">path_find status</h3>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L57" title="Source">[Source]<br/></a></p>
 <p>The <code>status</code> subcommand of <code>path_find</code> requests an immediate update about the client's currently-open pathfinding request.</p>
-<h4 id="request-format-21">Request Format</h4>
+<h4 id="request-format-22">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-44"><ul class="codetabs"><li><a href="#code-44-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-46"><ul class="codetabs"><li><a href="#code-46-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-44-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-46-0" style="position: static;"><pre><code>{
   "id": 58,
   "command": "path_find",
   "subcommand": "status"
@@ -7070,7 +7330,7 @@ rippled tx_history 0
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-21">Response Format</h4>
+<h4 id="response-format-22">Response Format</h4>
 <p>If a pathfinding request is open, the response follows the same format as the initial response to <a href="#path-find-create"><code>path_find create</code></a>, plus the following field:</p>
 <table>
 <thead>
@@ -7089,7 +7349,7 @@ rippled tx_history 0
 </tbody>
 </table>
 <p>If there was no outstanding pathfinding request, an error is returned instead.</p>
-<h4 id="possible-errors-21">Possible Errors</h4>
+<h4 id="possible-errors-22">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -7101,11 +7361,11 @@ rippled tx_history 0
 <p>The <code>ripple_path_find</code> method is a simplified version of <a href="#path-find"><code>path_find</code></a> that provides a single response with a <a href="concept-paths.html">payment path</a> you can use right away. It is available in both the WebSocket and JSON-RPC APIs. However, the results tend to become outdated as time passes. Instead of making multiple calls to stay updated, you should use <a href="#path-find"><code>path_find</code></a> instead where possible.</p>
 <p>Although the <code>rippled</code> server tries to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths.</p>
 <p class="devportal-callout caution"><strong>Caution:</strong> Be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths to earn money for its operators. A server may also return poor results when under heavy load. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers run by different parties, to minimize the risk of a single server returning poor results.</p>
-<h4 id="request-format-22">Request Format</h4>
+<h4 id="request-format-23">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-45"><ul class="codetabs"><li><a href="#code-45-0">WebSocket</a></li><li><a href="#code-45-1">JSON-RPC</a></li><li><a href="#code-45-2">Commandline</a></li></ul>
+<div class="multicode" id="code-47"><ul class="codetabs"><li><a href="#code-47-0">WebSocket</a></li><li><a href="#code-47-1">JSON-RPC</a></li><li><a href="#code-47-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-45-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-47-0" style="position: static;"><pre><code>{
     "id": 8,
     "command": "ripple_path_find",
     "source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -7126,7 +7386,7 @@ rippled tx_history 0
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-45-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-47-1" style="position: static;"><pre><code>{
     "method": "ripple_path_find",
     "params": [
         {
@@ -7150,7 +7410,7 @@ rippled tx_history 0
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-45-2" style="position: static;"><pre><code>#Syntax ripple_path_find json ledger_index|ledger_hash
+<div class="code_sample" id="code-47-2" style="position: static;"><pre><code>#Syntax ripple_path_find json ledger_index|ledger_hash
 rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59", "source_currencies": [ { "currency": "XRP" }, { "currency": "USD" } ], "destination_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59", "destination_amount": { "value": "0.001", "currency": "USD", "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B" } }'
 </code></pre></div>
 </div>
@@ -7202,11 +7462,11 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-22">Response Format</h4>
+<h4 id="response-format-23">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-46"><ul class="codetabs"><li><a href="#code-46-0">WebSocket</a></li><li><a href="#code-46-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-48"><ul class="codetabs"><li><a href="#code-48-0">WebSocket</a></li><li><a href="#code-48-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-46-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-48-0" style="position: static;"><pre><code>{
     "id": 8,
     "status": "success",
     "type": "response",
@@ -7312,7 +7572,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-46-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-48-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "alternatives": [
@@ -7467,7 +7727,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 </tbody>
 </table>
 <p>The following fields are deprecated, and may be omitted: <code>paths_canonical</code>, and <code>paths_expanded</code>. If they appear, you should disregard them.</p>
-<h4 id="possible-errors-22">Possible Errors</h4>
+<h4 id="possible-errors-23">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>tooBusy</code> - The server is under too much load to calculate paths. Not returned if you are connected as an admin.</li>
@@ -7483,11 +7743,11 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/SignHandler.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>sign</code> method takes a <a href="reference-transaction-format.html">transaction in JSON format</a> and a secret key, and returns a signed binary representation of the transaction. The result is always different, even when you provide the same transaction JSON and secret key. To contribute one signature to a multi-signed transaction, use the <a href="#sign-for"><code>sign_for</code> command</a> instead.</p>
 <p class="devportal-callout caution"><strong>Caution:</strong> Unless you run the <code>rippled</code> server yourself, you should do <a href="reference-rippleapi.html#sign">local signing with RippleAPI</a> instead of using this command. An untrustworthy server could change the transaction before signing it, or use your secret key to sign additional arbitrary transactions as if they came from you.</p>
-<h4 id="request-format-23">Request Format</h4>
+<h4 id="request-format-24">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-47"><ul class="codetabs"><li><a href="#code-47-0">WebSocket</a></li><li><a href="#code-47-1">JSON-RPC</a></li><li><a href="#code-47-2">Commandline</a></li></ul>
+<div class="multicode" id="code-49"><ul class="codetabs"><li><a href="#code-49-0">WebSocket</a></li><li><a href="#code-49-1">JSON-RPC</a></li><li><a href="#code-49-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-47-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-49-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "sign",
   "tx_json" : {
@@ -7506,7 +7766,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-47-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-49-1" style="position: static;"><pre><code>{
     "method": "sign",
     "params": [
         {
@@ -7528,7 +7788,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-47-2" style="position: static;"><pre><code>#Syntax: sign secret tx_json [offline]
+<div class="code_sample" id="code-49-2" style="position: static;"><pre><code>#Syntax: sign secret tx_json [offline]
 rippled sign s████████████████████████████ '{"TransactionType": "Payment", "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "Amount": { "currency": "USD", "value": "1", "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn" }, "Sequence": 360, "Fee": "10000"}' offline
 </code></pre></div>
 </div>
@@ -7615,11 +7875,11 @@ rippled sign s██████████████████████
 </li>
 <li><code>Paths</code> - For Payment-type transactions (excluding XRP-to-XRP transfers), the Paths field can be automatically filled, as if you did a <a href="#ripple-path-find">ripple_path_find</a>. Only filled if <code>build_path</code> is provided.</li>
 </ul>
-<h4 id="response-format-23">Response Format</h4>
+<h4 id="response-format-24">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-48"><ul class="codetabs"><li><a href="#code-48-0">WebSocket</a></li><li><a href="#code-48-1">JSON-RPC</a></li><li><a href="#code-48-2">Commandline</a></li></ul>
+<div class="multicode" id="code-50"><ul class="codetabs"><li><a href="#code-50-0">WebSocket</a></li><li><a href="#code-50-1">JSON-RPC</a></li><li><a href="#code-50-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-48-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-50-0" style="position: static;"><pre><code>{
   "id": 2,
   "status": "success",
   "type": "response",
@@ -7645,7 +7905,7 @@ rippled sign s██████████████████████
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-48-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-50-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "status": "success",
@@ -7670,7 +7930,7 @@ rippled sign s██████████████████████
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-48-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-50-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -7724,7 +7984,7 @@ Connecting to 127.0.0.1:5005
 <li>Do not paste this error to a public place for debugging.</li>
 <li>Do not display the error message on a website, even by accident.</li>
 </ul>
-<h4 id="possible-errors-23">Possible Errors</h4>
+<h4 id="possible-errors-24">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -7736,11 +7996,11 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SignFor.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>sign_for</code> command provides one signature for a <a href="reference-transaction-format.html#multi-signing">multi-signed transaction</a>.</p>
 <p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
-<h4 id="request-format-24">Request Format</h4>
+<h4 id="request-format-25">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-49"><ul class="codetabs"><li><a href="#code-49-0">WebSocket</a></li><li><a href="#code-49-1">JSON-RPC</a></li><li><a href="#code-49-2">Commandline</a></li></ul>
+<div class="multicode" id="code-51"><ul class="codetabs"><li><a href="#code-51-0">WebSocket</a></li><li><a href="#code-51-1">JSON-RPC</a></li><li><a href="#code-51-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-49-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-51-0" style="position: static;"><pre><code>{
     "id": "sign_for_example",
     "command": "sign_for",
     "account": "rLFd1FzHMScFhLsXeaxStzv3UC97QHGAbM",
@@ -7762,7 +8022,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-49-1" style="position: static;"><pre><code>POST http://localhost:5005/
+<div class="code_sample" id="code-51-1" style="position: static;"><pre><code>POST http://localhost:5005/
 {
     "method": "sign_for",
     "params": [{
@@ -7786,7 +8046,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-49-2" style="position: static;"><pre><code>#Syntax: rippled sign_for &lt;signer_address&gt; &lt;signer_secret&gt; [offline]
+<div class="code_sample" id="code-51-2" style="position: static;"><pre><code>#Syntax: rippled sign_for &lt;signer_address&gt; &lt;signer_secret&gt; [offline]
 rippled sign_for rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW s████████████████████████████ '{
     "TransactionType": "TrustSet",
     "Account": "rEuLyBCvcw4CFmzv8RepSiAoNgF8tTGJQC",
@@ -7850,11 +8110,11 @@ rippled sign_for rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW s█████████
 </tbody>
 </table>
 <p>You must provide exactly 1 field with the secret key. You can use any of the following fields: <code>secret</code>, <code>passphrase</code>, <code>seed</code>, or <code>seed_hex</code>.</p>
-<h4 id="response-format-24">Response Format</h4>
+<h4 id="response-format-25">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-50"><ul class="codetabs"><li><a href="#code-50-0">WebSocket</a></li><li><a href="#code-50-1">JSON-RPC</a></li><li><a href="#code-50-2">Commandline</a></li></ul>
+<div class="multicode" id="code-52"><ul class="codetabs"><li><a href="#code-52-0">WebSocket</a></li><li><a href="#code-52-1">JSON-RPC</a></li><li><a href="#code-52-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-50-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-52-0" style="position: static;"><pre><code>{
   "id": "sign_for_example",
   "status": "success",
   "type": "response",
@@ -7887,7 +8147,7 @@ rippled sign_for rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW s█████████
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-50-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-52-1" style="position: static;"><pre><code>200 OK
 {
    "result" : {
       "status" : "success",
@@ -7919,7 +8179,7 @@ rippled sign_for rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW s█████████
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-50-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-52-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -7974,7 +8234,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-24">Possible Errors</h4>
+<h4 id="possible-errors-25">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -8015,17 +8275,17 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="request-format-25">Request Format</h4>
-<div class="multicode" id="code-51"><ul class="codetabs"><li><a href="#code-51-0">WebSocket</a></li><li><a href="#code-51-1">JSON-RPC</a></li><li><a href="#code-51-2">Commandline</a></li></ul>
+<h4 id="request-format-26">Request Format</h4>
+<div class="multicode" id="code-53"><ul class="codetabs"><li><a href="#code-53-0">WebSocket</a></li><li><a href="#code-53-1">JSON-RPC</a></li><li><a href="#code-53-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-51-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-53-0" style="position: static;"><pre><code>{
     "id": 3,
     "command": "submit",
     "tx_blob": "1200002280000000240000001E61D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000B732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7447304502210095D23D8AF107DF50651F266259CC7139D0CD0C64ABBA3A958156352A0D95A21E02207FCF9B77D7510380E49FF250C21B57169E14E9B4ACFD314CEDC79DDD0A38B8A681144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-51-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-53-1" style="position: static;"><pre><code>{
     "method": "submit",
     "params": [
         {
@@ -8035,7 +8295,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-51-2" style="position: static;"><pre><code>#Syntax: submit tx_blob
+<div class="code_sample" id="code-53-2" style="position: static;"><pre><code>#Syntax: submit tx_blob
 submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100D184EB4AE5956FF600E7536EE459345C7BBCF097A84CC61A93B9AF7197EDB98702201CEA8009B7BEEBAA2AACC0359B41C427C1C5B550A4CA4B80CF2174AF2D6D5DCE81144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754
 </code></pre></div>
 </div>
@@ -8115,11 +8375,11 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 </tbody>
 </table>
 <p>See the <a href="#sign">sign command</a> for detailed information on how the server automatically fills in certain fields.</p>
-<h4 id="request-format-26">Request Format</h4>
+<h4 id="request-format-27">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-52"><ul class="codetabs"><li><a href="#code-52-0">WebSocket</a></li><li><a href="#code-52-1">JSON-RPC</a></li><li><a href="#code-52-2">Commandline</a></li></ul>
+<div class="multicode" id="code-54"><ul class="codetabs"><li><a href="#code-54-0">WebSocket</a></li><li><a href="#code-54-1">JSON-RPC</a></li><li><a href="#code-54-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-52-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-54-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "submit",
   "tx_json" : {
@@ -8138,7 +8398,7 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-52-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-54-1" style="position: static;"><pre><code>{
     "method": "submit",
     "params": [
         {
@@ -8160,16 +8420,16 @@ submit 1200002280000000240000000361D4838D7EA4C6800000000000000000000000000055534
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-52-2" style="position: static;"><pre><code>#Syntax: submit secret json [offline]
+<div class="code_sample" id="code-54-2" style="position: static;"><pre><code>#Syntax: submit secret json [offline]
 rippled submit s████████████████████████████ '{"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "Amount": { "currency": "USD", "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "value": "1" }, "Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX", "TransactionType": "Payment", "Fee": "10000"}'
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#submit">Try it!</a></p>
-<h4 id="response-format-25">Response Format</h4>
+<h4 id="response-format-26">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-53"><ul class="codetabs"><li><a href="#code-53-0">WebSocket</a></li><li><a href="#code-53-1">JSON-RPC</a></li><li><a href="#code-53-2">Commandline</a></li></ul>
+<div class="multicode" id="code-55"><ul class="codetabs"><li><a href="#code-55-0">WebSocket</a></li><li><a href="#code-55-1">JSON-RPC</a></li><li><a href="#code-55-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-53-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-55-0" style="position: static;"><pre><code>{
   "id": 1,
   "status": "success",
   "type": "response",
@@ -8198,7 +8458,7 @@ rippled submit s█████████████████████�
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-53-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-55-1" style="position: static;"><pre><code>{
     "result": {
         "engine_result": "tesSUCCESS",
         "engine_result_code": 0,
@@ -8225,7 +8485,7 @@ rippled submit s█████████████████████�
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-53-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-55-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -8298,7 +8558,7 @@ Connecting to 127.0.0.1:5005
 <li>Do not paste an error including your secret key to a public place for debugging.</li>
 <li>Do not display an error message including your secret key on a website, even by accident.</li>
 </ul>
-<h4 id="possible-errors-25">Possible Errors</h4>
+<h4 id="possible-errors-26">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidTransaction</code> - The transaction is malformed or otherwise invalid.</li>
@@ -8314,11 +8574,11 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SubmitMultiSigned.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>submit_multisigned</code> command applies a <a href="reference-transaction-format.html#multi-signing">multi-signed</a> transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the <a href="#submit-only-mode"><code>submit</code> command in submit-only mode</a>.)</p>
 <p>This command requires the <a href="concept-amendments.html#multisign">MultiSign amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
-<h4 id="request-format-27">Request Format</h4>
+<h4 id="request-format-28">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-54"><ul class="codetabs"><li><a href="#code-54-0">WebSocket</a></li><li><a href="#code-54-1">JSON-RPC</a></li><li><a href="#code-54-2">Commandline</a></li></ul>
+<div class="multicode" id="code-56"><ul class="codetabs"><li><a href="#code-56-0">WebSocket</a></li><li><a href="#code-56-1">JSON-RPC</a></li><li><a href="#code-56-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-54-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-56-0" style="position: static;"><pre><code>{
     "id": "submit_multisigned_example"
     "command": "submit_multisigned",
     "tx_json": {
@@ -8351,7 +8611,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-54-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-56-1" style="position: static;"><pre><code>{
     "method": "submit_multisigned",
     "params": [
         {
@@ -8390,7 +8650,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-54-2" style="position: static;"><pre><code>#Syntax: submit_multisigned &lt;tx_json&gt;
+<div class="code_sample" id="code-56-2" style="position: static;"><pre><code>#Syntax: submit_multisigned &lt;tx_json&gt;
 rippled submit_multisigned '{
     "Account": "rEuLyBCvcw4CFmzv8RepSiAoNgF8tTGJQC",
     "Fee": "30000",
@@ -8445,11 +8705,11 @@ rippled submit_multisigned '{
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-26">Response Format</h4>
+<h4 id="response-format-27">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-55"><ul class="codetabs"><li><a href="#code-55-0">WebSocket</a></li><li><a href="#code-55-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-57"><ul class="codetabs"><li><a href="#code-57-0">WebSocket</a></li><li><a href="#code-57-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-55-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-57-0" style="position: static;"><pre><code>{
   "id": "submit_multisigned_example",
   "status": "success",
   "type": "response",
@@ -8492,7 +8752,7 @@ rippled submit_multisigned '{
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-55-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-57-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "engine_result": "tesSUCCESS",
@@ -8571,7 +8831,7 @@ rippled submit_multisigned '{
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-26">Possible Errors</h4>
+<h4 id="possible-errors-27">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -8581,11 +8841,11 @@ rippled submit_multisigned '{
 <h2 id="book-offers">book_offers</h2>
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/BookOffers.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>book_offers</code> method retrieves a list of offers, also known as the <a href="http://www.investopedia.com/terms/o/order-book.asp">order book</a>, between two currencies. If the results are very large, a partial result is returned with a marker so that later requests can resume from where the previous one left off.</p>
-<h4 id="request-format-28">Request Format</h4>
+<h4 id="request-format-29">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-56"><ul class="codetabs"><li><a href="#code-56-0">WebSocket</a></li><li><a href="#code-56-1">JSON-RPC</a></li><li><a href="#code-56-2">Commandline</a></li></ul>
+<div class="multicode" id="code-58"><ul class="codetabs"><li><a href="#code-58-0">WebSocket</a></li><li><a href="#code-58-1">JSON-RPC</a></li><li><a href="#code-58-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-56-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-58-0" style="position: static;"><pre><code>{
   "id": 4,
   "command": "book_offers",
   "taker": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -8600,7 +8860,7 @@ rippled submit_multisigned '{
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-56-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-58-1" style="position: static;"><pre><code>{
     "method": "book_offers",
     "params": [
         {
@@ -8618,7 +8878,7 @@ rippled submit_multisigned '{
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-56-2" style="position: static;"><pre><code>#Syntax: book_offers taker_pays taker_gets [taker [ledger [limit] ] ]
+<div class="code_sample" id="code-58-2" style="position: static;"><pre><code>#Syntax: book_offers taker_pays taker_gets [taker [ledger [limit] ] ]
 rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
 </code></pre></div>
 </div>
@@ -8665,11 +8925,11 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-27">Response Format</h4>
+<h4 id="response-format-28">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-57"><ul class="codetabs"><li><a href="#code-57-0">WebSocket</a></li><li><a href="#code-57-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-59"><ul class="codetabs"><li><a href="#code-59-0">WebSocket</a></li><li><a href="#code-59-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-57-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-59-0" style="position: static;"><pre><code>{
   "id": 11,
   "status": "success",
   "type": "response",
@@ -8727,7 +8987,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-57-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-59-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "ledger_current_index": 8696243,
@@ -8797,7 +9057,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-27">Possible Errors</h4>
+<h4 id="possible-errors-28">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -8808,24 +9068,267 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li><code>dstIsrMalformed</code> - The <code>issuer</code> field of the <code>taker_gets</code> field in the request is not valid.</li>
 <li><code>badMarket</code> - The desired order book does not exist; for example, offers to exchange a currency for itself.</li>
 </ul>
+<h2 id="channel-authorize">channel_authorize</h2>
+<p><a href="https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L41" title="Source">[Source]<br/></a></p>
+<p><em>(Requires the <a href="concept-amendments.html#paychan">PayChan amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a>)</em></p>
+<p>The <code>account_channels</code> method creates a signature that can be used to redeem a specific amount of XRP from a payment channel.</p>
+<h4 id="request-format-30">Request Format</h4>
+<p>An example of the request format:</p>
+<div class="multicode" id="code-60"><ul class="codetabs"><li><a href="#code-60-0">WebSocket</a></li><li><a href="#code-60-1">JSON-RPC</a></li><li><a href="#code-60-2">Commandline</a></li></ul>
+
+<div class="code_sample" id="code-60-0" style="position: static;"><pre><code>{
+    "id": "channel_authorize_example_id1",
+    "command": "channel_authorize",
+    "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+    "secret": "s████████████████████████████",
+    "amount": "1000000"
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-60-1" style="position: static;"><pre><code class="json">POST http://localhost:5005/
+Content-Type: application/json
+
+{
+    "method": "channel_authorize",
+    "params": [{
+        "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+        "secret": "s████████████████████████████",
+        "amount": "1000000"
+    }]
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-60-2" style="position: static;"><pre><code>#Syntax: channel_authorize &lt;private_key&gt; &lt;channel_id&gt; &lt;drops&gt;
+rippled channel_authorize s████████████████████████████ 5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3 1000000
+</code></pre></div>
+</div>
+<p>The request includes the following parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>channel_id</code></td>
+<td>String</td>
+<td>The unique ID of the payment channel to use.</td>
+</tr>
+<tr>
+<td><code>secret</code></td>
+<td>String</td>
+<td>The secret key to use to sign the claim. This must be the same key pair as the public key specified in the channel.</td>
+</tr>
+<tr>
+<td><code>amount</code></td>
+<td>String</td>
+<td>Cumulative amount of XRP, in drops, to authorize. If the destination has already received a lesser amount of XRP from this channel, the signature created by this method can be redeemed for the difference.</td>
+</tr>
+</tbody>
+</table>
+<p class="devportal-callout note"><strong>Note:</strong> You cannot use Ed25519 keys to sign claims with this method. This is a known bug.</p>
+<h4 id="response-format-29">Response Format</h4>
+<p>An example of a successful response:</p>
+<div class="multicode" id="code-61"><ul class="codetabs"><li><a href="#code-61-0">WebSocket</a></li><li><a href="#code-61-1">JSON-RPC</a></li><li><a href="#code-61-2">Commandline</a></li></ul>
+
+<div class="code_sample" id="code-61-0" style="position: static;"><pre><code>{
+    "id": "channel_authorize_example_id1",
+    "status": "success"
+    "result": {
+        "signature": "304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064",
+    }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-61-1" style="position: static;"><pre><code class="json">200 OK
+
+{
+    "result": {
+        "signature": "304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064",
+        "status": "success"
+    }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-61-2" style="position: static;"><pre><code>{
+    "result": {
+        "signature": "304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064",
+        "status": "success"
+    }
+}
+</code></pre></div>
+</div>
+<p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>signature</code></td>
+<td>String</td>
+<td>The signature for this claim, as a hexadecimal value. To verify this signature or process the claim, the destination of the payment channel must send a <a href="reference-transaction-format.html#paymentchannelclaim">PaymentChannelClaim transaction</a> with this signature, the exact Channel ID, XRP amount, and public key of the channel.</td>
+</tr>
+</tbody>
+</table>
+<h4 id="possible-errors-29">Possible Errors</h4>
+<ul>
+<li>Any of the <a href="#universal-errors">universal error types</a>.</li>
+<li><code>badSeed</code> - The value specified in the <code>secret</code> field was not a valid secret key.</li>
+<li><code>channelAmtMalformed</code> - The value specified in the <code>amount</code> field was not a valid XRP amount. See <a href="#specifying-currency-amounts">Specifying Currency Amounts</a> for details.</li>
+<li><code>channelMalformed</code> - The value specified in the <code>channel_id</code> field of the reqeuest was not a valid Channel ID. The Channel ID should be a 256-bit (64-character) hexadecimal string.</li>
+</ul>
+<h2 id="channel-verify">channel_verify</h2>
+<p><a href="https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L89" title="Source">[Source]<br/></a></p>
+<p><em>(Requires the <a href="concept-amendments.html#paychan">PayChan amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.33.0" title="New in: rippled 0.33.0"><img alt="New in: rippled 0.33.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.33.0-blue.svg"/></a>)</em></p>
+<p>The <code>channel_verify</code> method checks the validity of a signature that can be used to redeem a specific amount of XRP from a payment channel.</p>
+<h4 id="request-format-31">Request Format</h4>
+<p>An example of the request format:</p>
+<div class="multicode" id="code-62"><ul class="codetabs"><li><a href="#code-62-0">WebSocket</a></li><li><a href="#code-62-1">JSON-RPC</a></li><li><a href="#code-62-2">Commandline</a></li></ul>
+
+<div class="code_sample" id="code-62-0" style="position: static;"><pre><code>{
+    "id": 1,
+    "command": "channel_verify",
+    "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+    "signature": "304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064",
+    "public_key": "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3",
+    "amount": "1000000"
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-62-1" style="position: static;"><pre><code>POST http://localhost:5005/
+Content-Type: application/json
+
+{
+    "method": "channel_verify",
+    "params": [{
+        "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+        "signature": "304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064",
+        "public_key": "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3",
+        "amount": "1000000"
+    }]
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-62-2" style="position: static;"><pre><code>#Syntax: channel_verify &lt;public_key&gt; &lt;channel_id&gt; &lt;amount&gt; &lt;signature&gt;
+rippled channel_verify aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3 5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3 1000000 304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064
+</code></pre></div>
+</div>
+<p>The request includes the following parameters:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>amount</code></td>
+<td>String</td>
+<td>The amount of <a href="#xrp">XRP, in drops</a>, the provided <code>signature</code> authorizes.</td>
+</tr>
+<tr>
+<td><code>channel_id</code></td>
+<td>String</td>
+<td>The Channel ID of the channel that provides the XRP. This is a 64-character hexadecimal string.</td>
+</tr>
+<tr>
+<td><code>public_key</code></td>
+<td>String</td>
+<td>The public key of the channel and the key pair that was used to create the signature, in base58 format. (One way to get the public key in base58 format is from the <a href="#wallet-propose"><code>wallet_propose</code> command</a>.)</td>
+</tr>
+<tr>
+<td><code>signature</code></td>
+<td></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<h4 id="response-format-30">Response Format</h4>
+<p>An example of a successful response:</p>
+<div class="multicode" id="code-63"><ul class="codetabs"><li><a href="#code-63-0">WebSocket</a></li><li><a href="#code-63-1">JSON-RPC</a></li><li><a href="#code-63-2">Commandline</a></li></ul>
+
+<div class="code_sample" id="code-63-0" style="position: static;"><pre><code>{
+    "id": 1,
+    "status": "success",
+    "type": "response",
+    "result": {
+        "signature_verified":true
+    }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-63-1" style="position: static;"><pre><code>200 OK
+
+{
+    "result": {
+        "signature_verified":true,
+        "status":"success"
+    }
+}
+</code></pre></div>
+
+<div class="code_sample" id="code-63-2" style="position: static;"><pre><code>{
+    "result": {
+        "signature_verified":true,
+        "status":"success"
+    }
+}
+</code></pre></div>
+</div>
+<p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing the following fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>signature_verified</code></td>
+<td>Boolean</td>
+<td>If <code>true</code>, the signature is valid for the stated amount, channel, and public key.</td>
+</tr>
+</tbody>
+</table>
+<p class="devportal-callout caution"><strong>Caution:</strong> This does not indicate check that the channel has sufficient XRP allocated to it. Before considering a claim valid, you should look up the channel in the latest validated ledger and confirm that the channel is open and its <code>amount</code> value is equal or greater than the <code>amount</code> of the claim. To do so, use the <a href="#account-channels"><code>account_channels</code> method</a>.</p>
+<h4 id="possible-errors-30">Possible Errors</h4>
+<ul>
+<li>Any of the <a href="#universal-errors">universal error types</a>.</li>
+<li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
+<li><code>publicMalformed</code> - The value specified in the <code>public_key</code> field of the request was not a valid public key in the correct format. Public keys should be 33 bytes, represented in base58. The base58 representation should start with letter <code>a</code>.</li>
+<li><code>channelMalformed</code> - The value specified in the <code>channel_id</code> field of the reqeuest was not a valid Channel ID. The Channel ID should be a 256-bit (64-character) hexadecimal string.</li>
+<li><code>channelAmtMalformed</code> - The value specified in the <code>amount</code> field was not a valid XRP amount. See <a href="#specifying-currency-amounts">Specifying Currency Amounts</a> for details.</li>
+</ul>
 <h1 id="subscriptions">Subscriptions</h1>
 <p>Using subscriptions, you can have the server push updates to your client when various events happen, so that you can know and react right away. Subscriptions are only supported in the WebSocket API, where you can receive additional responses in the same channel.</p>
 <p>JSON-RPC support for subscription callbacks is deprecated and may not work as expected.</p>
 <h2 id="subscribe">subscribe</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Subscribe.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>subscribe</code> method requests periodic notifications from the server when certain events happen.</p>
-<h4 id="request-format-29">Request Format</h4>
+<h4 id="request-format-32">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-58"><ul class="codetabs"><li><a href="#code-58-0">Subscribe to accounts</a></li><li><a href="#code-58-1">Subscribe to order book</a></li><li><a href="#code-58-2">Subscribe to ledger stream</a></li></ul>
+<div class="multicode" id="code-64"><ul class="codetabs"><li><a href="#code-64-0">Subscribe to accounts</a></li><li><a href="#code-64-1">Subscribe to order book</a></li><li><a href="#code-64-2">Subscribe to ledger stream</a></li></ul>
 
-<div class="code_sample" id="code-58-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-64-0" style="position: static;"><pre><code>{
   "id": "Example watch Bitstamp's hot wallet",
   "command": "subscribe",
   "accounts": ["rrpNnNLKrartuEqfJGpqyDwPj1AFPg9vn1"]
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-58-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-64-1" style="position: static;"><pre><code>{
     "id": "Example subscribe to XRP/GateHub USD order book",
     "command": "subscribe",
     "books": [
@@ -8843,7 +9346,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-58-2" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-64-2" style="position: static;"><pre><code>{
   "id": "Example watch for new validated ledgers",
   "command": "subscribe",
   "streams": ["ledger"]
@@ -8946,11 +9449,11 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-28">Response Format</h4>
+<h4 id="response-format-31">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-59"><ul class="codetabs"><li><a href="#code-59-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-65"><ul class="codetabs"><li><a href="#code-65-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-59-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-65-0" style="position: static;"><pre><code>{
   "id": "Example watch Bitstamp's hot wallet",
   "status": "success",
   "type": "response",
@@ -8966,7 +9469,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <li><em>Stream: ledger</em> - Information about the ledgers on hand and current fee schedule, such as <code>fee_base</code> (current base fee for transactions in XRP), <code>fee_ref</code> (current base fee for transactions in fee units), <code>ledger_hash</code> (hash of the latest validated ledger), <code>reserve_base</code> (minimum reserve for accounts), and more.</li>
 <li><code>books</code> - No fields returned by default. If <code>"snapshot": true</code> is set in the request, returns <code>offers</code> (an array of offer definition objects defining the order book)</li>
 </ul>
-<h4 id="possible-errors-28">Possible Errors</h4>
+<h4 id="possible-errors-31">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -9572,11 +10075,11 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <h2 id="unsubscribe">unsubscribe</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Unsubscribe.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>unsubscribe</code> command tells the server to stop sending messages for a particular subscription or set of subscriptions.</p>
-<h4 id="request-format-30">Request Format</h4>
+<h4 id="request-format-33">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-60"><ul class="codetabs"><li><a href="#code-60-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-66"><ul class="codetabs"><li><a href="#code-66-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-60-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-66-0" style="position: static;"><pre><code>{
     "id": "Unsubscribe a lot of stuff",
     "command": "unsubscribe",
     "streams": ["ledger","server","transactions","transactions_proposed"],
@@ -9658,11 +10161,11 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-29">Response Format</h4>
+<h4 id="response-format-32">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-61"><ul class="codetabs"><li><a href="#code-61-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-67"><ul class="codetabs"><li><a href="#code-67-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-61-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-67-0" style="position: static;"><pre><code>{
     "id": "Unsubscribe a lot of stuff",
     "result": {},
     "status": "success",
@@ -9671,7 +10174,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 </code></pre></div>
 </div>
 <p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing no fields.</p>
-<h4 id="possible-errors-29">Possible Errors</h4>
+<h4 id="possible-errors-32">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -9692,17 +10195,17 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 <h2 id="server-info">server_info</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ServerInfo.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>server_info</code> command asks the server for a human-readable version of various information about the <code>rippled</code> server being queried.</p>
-<h4 id="request-format-31">Request Format</h4>
+<h4 id="request-format-34">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-62"><ul class="codetabs"><li><a href="#code-62-0">WebSocket</a></li><li><a href="#code-62-1">JSON-RPC</a></li><li><a href="#code-62-2">Commandline</a></li></ul>
+<div class="multicode" id="code-68"><ul class="codetabs"><li><a href="#code-68-0">WebSocket</a></li><li><a href="#code-68-1">JSON-RPC</a></li><li><a href="#code-68-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-62-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-68-0" style="position: static;"><pre><code>{
   "id": 1,
   "command": "server_info"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-62-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-68-1" style="position: static;"><pre><code>{
     "method": "server_info",
     "params": [
         {}
@@ -9710,17 +10213,17 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-62-2" style="position: static;"><pre><code>#Syntax: server_info
+<div class="code_sample" id="code-68-2" style="position: static;"><pre><code>#Syntax: server_info
 rippled server_info
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#server_info">Try it!</a></p>
 <p>The request does not takes any parameters.</p>
-<h4 id="response-format-30">Response Format</h4>
+<h4 id="response-format-33">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-63"><ul class="codetabs"><li><a href="#code-63-0">WebSocket</a></li><li><a href="#code-63-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-69"><ul class="codetabs"><li><a href="#code-69-0">WebSocket</a></li><li><a href="#code-69-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-63-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-69-0" style="position: static;"><pre><code>{
   "id": 1,
   "status": "success",
   "type": "response",
@@ -9822,7 +10325,7 @@ rippled server_info
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-63-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-69-1" style="position: static;"><pre><code>200 OK
 {
    "result" : {
       "info" : {
@@ -10111,24 +10614,24 @@ rippled server_info
 </tbody>
 </table>
 <p class="devportal-callout note"><strong>Note:</strong> If the <code>closed_ledger</code> field is present and has a small <code>seq</code> value (less than 8 digits), that indicates <code>rippled</code> does not currently have a copy of the validated ledger from the peer-to-peer network. This could mean your server is still syncing. Typically, it takes about 5 minutes to sync with the network, depending on your connection speed and hardware specs.</p>
-<h4 id="possible-errors-30">Possible Errors</h4>
+<h4 id="possible-errors-33">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
 <h2 id="server-state">server_state</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ServerState.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>server_state</code> command asks the server for various machine-readable information about the <code>rippled</code> server's current state. The results are almost the same as <a href="#server-info"><code>server_info</code></a>, but using units that are easier to process instead of easier to read. (For example, XRP values are given in integer drops instead of scientific notation or decimal values, and time is given in milliseconds instead of seconds.)</p>
-<h4 id="request-format-32">Request Format</h4>
+<h4 id="request-format-35">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-64"><ul class="codetabs"><li><a href="#code-64-0">WebSocket</a></li><li><a href="#code-64-1">JSON-RPC</a></li><li><a href="#code-64-2">Commandline</a></li></ul>
+<div class="multicode" id="code-70"><ul class="codetabs"><li><a href="#code-70-0">WebSocket</a></li><li><a href="#code-70-1">JSON-RPC</a></li><li><a href="#code-70-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-64-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-70-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "server_state"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-64-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-70-1" style="position: static;"><pre><code>{
     "method": "server_state",
     "params": [
         {}
@@ -10136,17 +10639,17 @@ rippled server_info
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-64-2" style="position: static;"><pre><code>#Syntax: server_state
+<div class="code_sample" id="code-70-2" style="position: static;"><pre><code>#Syntax: server_state
 rippled server_state
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#server_state">Try it!</a></p>
 <p>The request does not takes any parameters.</p>
-<h4 id="response-format-31">Response Format</h4>
+<h4 id="response-format-34">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-65"><ul class="codetabs"><li><a href="#code-65-0">WebSocket</a></li><li><a href="#code-65-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-71"><ul class="codetabs"><li><a href="#code-71-0">WebSocket</a></li><li><a href="#code-71-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-65-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-71-0" style="position: static;"><pre><code>{
   "id": 2,
   "status": "success",
   "type": "response",
@@ -10239,7 +10742,7 @@ rippled server_state
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-65-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-71-1" style="position: static;"><pre><code>200 OK
 {
    "result" : {
       "state" : {
@@ -10491,7 +10994,7 @@ rippled server_state
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-31">Possible Errors</h4>
+<h4 id="possible-errors-34">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -10499,18 +11002,18 @@ rippled server_state
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/CanDelete.cpp" title="Source">[Source]<br/></a></p>
 <p>With <code>online_delete</code> and <code>advisory_delete</code> configuration options enabled, the <code>can_delete</code> method informs the rippled server of the latest ledger which may be deleted.</p>
 <p><em>The <code>can_delete</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-33">Request Format</h4>
+<h4 id="request-format-36">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-66"><ul class="codetabs"><li><a href="#code-66-0">WebSocket</a></li><li><a href="#code-66-1">JSON-RPC</a></li><li><a href="#code-66-2">Commandline</a></li></ul>
+<div class="multicode" id="code-72"><ul class="codetabs"><li><a href="#code-72-0">WebSocket</a></li><li><a href="#code-72-1">JSON-RPC</a></li><li><a href="#code-72-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-66-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-72-0" style="position: static;"><pre><code>{
   "id": 2,
   "command": "can_delete",
   "can_delete": 11320417
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-66-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-72-1" style="position: static;"><pre><code>{
     "method": "can_delete",
     "params": [
         {
@@ -10520,7 +11023,7 @@ rippled server_state
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-66-2" style="position: static;"><pre><code>#Syntax can_delete [&lt;ledger_index&gt;|&lt;ledger_hash&gt;|now|always|never]
+<div class="code_sample" id="code-72-2" style="position: static;"><pre><code>#Syntax can_delete [&lt;ledger_index&gt;|&lt;ledger_hash&gt;|now|always|never]
 rippled can_delete 11320417
 </code></pre></div>
 </div>
@@ -10561,7 +11064,7 @@ a successful result containing the following fields:</p>
 </tbody>
 </table>
 <p>Use this command with no parameter to query the existing <code>can_delete</code> setting.</p>
-<h4 id="possible-errors-32">Possible Errors</h4>
+<h4 id="possible-errors-35">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>notEnabled</code> - Not enabled in configuration.</li>
@@ -10573,17 +11076,17 @@ a successful result containing the following fields:</p>
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ConsensusInfo.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>consensus_info</code> command provides information about the consensus process for debugging purposes.</p>
 <p><em>The <code>consensus_info</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-34">Request Format</h4>
+<h4 id="request-format-37">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-67"><ul class="codetabs"><li><a href="#code-67-0">WebSocket</a></li><li><a href="#code-67-1">JSON-RPC</a></li><li><a href="#code-67-2">Commandline</a></li></ul>
+<div class="multicode" id="code-73"><ul class="codetabs"><li><a href="#code-73-0">WebSocket</a></li><li><a href="#code-73-1">JSON-RPC</a></li><li><a href="#code-73-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-67-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-73-0" style="position: static;"><pre><code>{
     "id": 99,
     "command": "consensus_info"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-67-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-73-1" style="position: static;"><pre><code>{
     "method": "consensus_info",
     "params": [
         {}
@@ -10591,16 +11094,16 @@ a successful result containing the following fields:</p>
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-67-2" style="position: static;"><pre><code>#Syntax: consensus_info
+<div class="code_sample" id="code-73-2" style="position: static;"><pre><code>#Syntax: consensus_info
 rippled consensus_info
 </code></pre></div>
 </div>
 <p>The request has no parameters.</p>
-<h4 id="response-format-32">Response Format</h4>
+<h4 id="response-format-35">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-68"><ul class="codetabs"><li><a href="#code-68-0">JSON-RPC</a></li><li><a href="#code-68-1">Commandline</a></li></ul>
+<div class="multicode" id="code-74"><ul class="codetabs"><li><a href="#code-74-0">JSON-RPC</a></li><li><a href="#code-74-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-68-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-74-0" style="position: static;"><pre><code>{
    "result" : {
       "info" : {
          "acquired" : {
@@ -10672,7 +11175,7 @@ rippled consensus_info
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-68-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-74-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -10807,7 +11310,7 @@ Connecting to 127.0.0.1:5005
 </table>
 <p>It is also normal to get a minimal result where the only field in <code>info</code> is <code>"consensus": "none"</code>. This indicates that the server is in between consensus rounds.</p>
 <p>The results of the <code>consensus_info</code> command can vary dramatically if you run it several times, even in short succession.</p>
-<h4 id="possible-errors-33">Possible Errors</h4>
+<h4 id="possible-errors-36">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -10815,18 +11318,18 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/FetchInfo.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>fetch_info</code> command returns information about objects that this server is currently fetching from the network, and how many peers have that information. It can also be used to reset current fetches.</p>
 <p><em>The <code>fetch_info</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-35">Request Format</h4>
+<h4 id="request-format-38">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-69"><ul class="codetabs"><li><a href="#code-69-0">WebSocket</a></li><li><a href="#code-69-1">JSON-RPC</a></li><li><a href="#code-69-2">Commandline</a></li></ul>
+<div class="multicode" id="code-75"><ul class="codetabs"><li><a href="#code-75-0">WebSocket</a></li><li><a href="#code-75-1">JSON-RPC</a></li><li><a href="#code-75-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-69-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-75-0" style="position: static;"><pre><code>{
     "id": 91,
     "command": "fetch_info",
     "clear": false
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-69-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-75-1" style="position: static;"><pre><code>{
     "method": "fetch_info",
     "params": [
         {
@@ -10836,7 +11339,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-69-2" style="position: static;"><pre><code>#Syntax: fetch_info [clear]
+<div class="code_sample" id="code-75-2" style="position: static;"><pre><code>#Syntax: fetch_info [clear]
 rippled fetch_info
 </code></pre></div>
 </div>
@@ -10857,11 +11360,11 @@ rippled fetch_info
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-33">Response Format</h4>
+<h4 id="response-format-36">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-70"><ul class="codetabs"><li><a href="#code-70-0">JSON-RPC</a></li><li><a href="#code-70-1">Commandline</a></li></ul>
+<div class="multicode" id="code-76"><ul class="codetabs"><li><a href="#code-76-0">JSON-RPC</a></li><li><a href="#code-76-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-70-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-76-0" style="position: static;"><pre><code>{
    "result" : {
       "info" : {
          "348928" : {
@@ -10896,7 +11399,7 @@ rippled fetch_info
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-70-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-76-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -10992,7 +11495,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-34">Possible Errors</h4>
+<h4 id="possible-errors-37">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -11001,17 +11504,17 @@ Connecting to 127.0.0.1:5005
 <p>The <code>feature</code> command returns information about <a href="concept-amendments.html">amendments</a> this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the <a href="concept-amendments.html#amendment-process">amendment process</a>. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p>You can use the <code>feature</code> command to temporarily configure the server to vote against or in favor of an amendment. This change does not persist if you restart the server. To make lasting changes in amendment voting, use the <code>rippled.cfg</code> file. See <a href="concept-amendments.html#configuring-amendment-voting">Configuring Amendment Voting</a> for more information.</p>
 <p><em>The <code>feature</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-36">Request Format</h4>
+<h4 id="request-format-39">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-71"><ul class="codetabs"><li><a href="#code-71-0">WebSocket - list all</a></li><li><a href="#code-71-1">WebSocket - reject</a></li><li><a href="#code-71-2">JSON-RPC</a></li><li><a href="#code-71-3">Commandline</a></li></ul>
+<div class="multicode" id="code-77"><ul class="codetabs"><li><a href="#code-77-0">WebSocket - list all</a></li><li><a href="#code-77-1">WebSocket - reject</a></li><li><a href="#code-77-2">JSON-RPC</a></li><li><a href="#code-77-3">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-71-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-77-0" style="position: static;"><pre><code>{
   "id": "list_all_features",
   "command": "feature"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-71-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-77-1" style="position: static;"><pre><code>{
   "id": "reject_multi_sign",
   "command": "feature",
   "feature": "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373",
@@ -11019,7 +11522,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-71-2" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-77-2" style="position: static;"><pre><code>{
     "method": "feature",
     "params": [
         {
@@ -11030,7 +11533,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-71-3" style="position: static;"><pre><code>#Syntax: feature [&lt;feature_id&gt; [accept|reject]]
+<div class="code_sample" id="code-77-3" style="position: static;"><pre><code>#Syntax: feature [&lt;feature_id&gt; [accept|reject]]
 rippled feature 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 accept
 </code></pre></div>
 </div>
@@ -11057,11 +11560,11 @@ rippled feature 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373
 </tbody>
 </table>
 <p class="devportal-callout note"><strong>Note:</strong> You can configure your server to vote in favor of a new amendment, even if the server does not currently know how to apply that amendment, by specifying the amendment ID in the <code>feature</code> field. For example, you might want to do this if you plan to upgrade soon to a new <code>rippled</code> version that <em>does</em> support the amendment.</p>
-<h4 id="response-format-34">Response Format</h4>
+<h4 id="response-format-37">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-72"><ul class="codetabs"><li><a href="#code-72-0">WebSocket - list all</a></li><li><a href="#code-72-1">WebSocket - reject</a></li><li><a href="#code-72-2">JSON-RPC</a></li><li><a href="#code-72-3">Commandline</a></li></ul>
+<div class="multicode" id="code-78"><ul class="codetabs"><li><a href="#code-78-0">WebSocket - list all</a></li><li><a href="#code-78-1">WebSocket - reject</a></li><li><a href="#code-78-2">JSON-RPC</a></li><li><a href="#code-78-3">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-72-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-78-0" style="position: static;"><pre><code>{
   "id": "list_all_features",
   "status": "success",
   "type": "response",
@@ -11102,7 +11605,7 @@ rippled feature 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-72-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-78-1" style="position: static;"><pre><code>{
     "id": "reject_multi_sign",
     "status": "success",
     "type": "response",
@@ -11119,7 +11622,7 @@ rippled feature 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-72-2" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-78-2" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373": {
@@ -11133,7 +11636,7 @@ rippled feature 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-72-3" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-78-3" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
     "result": {
@@ -11181,7 +11684,7 @@ Connecting to 127.0.0.1:5005
 </tbody>
 </table>
 <p class="devportal-callout caution"><strong>Caution:</strong> The <code>name</code> for an amendment does not strictly indicate what that amendment does. The name is not guaranteed to be unique or consistent across servers.</p>
-<h4 id="possible-errors-35">Possible Errors</h4>
+<h4 id="possible-errors-38">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>badFeature</code> - The <code>feature</code> specified was invalidly formatted, or the server does not know an amendment with that name.</li>
@@ -11190,32 +11693,32 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>fee</code> command reports the current state of the open-ledger requirements for the <a href="concept-transaction-cost.html">transaction cost</a>. This requires the <a href="concept-amendments.html#feeescalation">FeeEscalation amendment</a> to be enabled. <a href="https://github.com/ripple/rippled/releases/tag/0.31.0" title="New in: rippled 0.31.0"><img alt="New in: rippled 0.31.0" class="dactyl_badge" src="https://img.shields.io/badge/New%20in-rippled%200.31.0-blue.svg"/></a></p>
 <p>This is a public command available to unprivileged users. <a href="https://github.com/ripple/rippled/releases/tag/0.32.0" title="Updated in: rippled 0.32.0"><img alt="Updated in: rippled 0.32.0" class="dactyl_badge" src="https://img.shields.io/badge/Updated%20in-rippled%200.32.0-blue.svg"/></a></p>
-<h4 id="request-format-37">Request Format</h4>
+<h4 id="request-format-40">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-73"><ul class="codetabs"><li><a href="#code-73-0">WebSocket</a></li><li><a href="#code-73-1">JSON-RPC</a></li><li><a href="#code-73-2">Commandline</a></li></ul>
+<div class="multicode" id="code-79"><ul class="codetabs"><li><a href="#code-79-0">WebSocket</a></li><li><a href="#code-79-1">JSON-RPC</a></li><li><a href="#code-79-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-73-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-79-0" style="position: static;"><pre><code>{
   "id": "fee_websocket_example",
   "command": "fee"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-73-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-79-1" style="position: static;"><pre><code>{
     "method": "fee",
     "params": [{}]
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-73-2" style="position: static;"><pre><code>#Syntax: fee
+<div class="code_sample" id="code-79-2" style="position: static;"><pre><code>#Syntax: fee
 rippled fee
 </code></pre></div>
 </div>
 <p>The request does not include any parameters.</p>
-<h4 id="response-format-35">Response Format</h4>
+<h4 id="response-format-38">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-74"><ul class="codetabs"><li><a href="#code-74-0">WebSocket</a></li><li><a href="#code-74-1">JSON-RPC</a></li><li><a href="#code-74-2">Commandline</a></li></ul>
+<div class="multicode" id="code-80"><ul class="codetabs"><li><a href="#code-80-0">WebSocket</a></li><li><a href="#code-80-1">JSON-RPC</a></li><li><a href="#code-80-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-74-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-80-0" style="position: static;"><pre><code>{
   "id": "fee_websocket_example",
   "status": "success",
   "type": "response",
@@ -11241,7 +11744,7 @@ rippled fee
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-74-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-80-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "current_ledger_size": "56",
@@ -11266,7 +11769,7 @@ rippled fee
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-74-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-80-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -11379,7 +11882,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-36">Possible Errors</h4>
+<h4 id="possible-errors-39">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -11387,18 +11890,18 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/c7118a183a660648aa88a3546a6b2c5bce858440/src/ripple/rpc/handlers/GetCounts.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>get_counts</code> command provides various stats about the health of the server, mostly the number of objects of different types that it currently holds in memory.</p>
 <p><em>The <code>get_counts</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-38">Request Format</h4>
+<h4 id="request-format-41">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-75"><ul class="codetabs"><li><a href="#code-75-0">WebSocket</a></li><li><a href="#code-75-1">JSON-RPC</a></li><li><a href="#code-75-2">Commandline</a></li></ul>
+<div class="multicode" id="code-81"><ul class="codetabs"><li><a href="#code-81-0">WebSocket</a></li><li><a href="#code-81-1">JSON-RPC</a></li><li><a href="#code-81-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-75-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-81-0" style="position: static;"><pre><code>{
     "id": 90,
     "command": "get_counts",
     "min_count": 100
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-75-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-81-1" style="position: static;"><pre><code>{
     "method": "get_counts",
     "params": [
         {
@@ -11408,7 +11911,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-75-2" style="position: static;"><pre><code>#Syntax: get_counts [min_count]
+<div class="code_sample" id="code-81-2" style="position: static;"><pre><code>#Syntax: get_counts [min_count]
 rippled get_counts 100
 </code></pre></div>
 </div>
@@ -11429,11 +11932,11 @@ rippled get_counts 100
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-36">Response Format</h4>
+<h4 id="response-format-39">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-76"><ul class="codetabs"><li><a href="#code-76-0">JSON-RPC</a></li><li><a href="#code-76-1">Commandline</a></li></ul>
+<div class="multicode" id="code-82"><ul class="codetabs"><li><a href="#code-82-0">JSON-RPC</a></li><li><a href="#code-82-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-76-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-82-0" style="position: static;"><pre><code>{
    "result" : {
       "AL_hit_rate" : 48.36725616455078,
       "HashRouterEntry" : 3048,
@@ -11467,7 +11970,7 @@ rippled get_counts 100
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-76-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-82-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -11531,7 +12034,7 @@ Connecting to 127.0.0.1:5005
 </tbody>
 </table>
 <p>For most other entries, the value indicates the number of objects of that type currently in memory.</p>
-<h4 id="possible-errors-37">Possible Errors</h4>
+<h4 id="possible-errors-40">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -11540,11 +12043,11 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/df54b47cd0957a31837493cd69e4d9aade0b5055/src/ripple/rpc/handlers/LedgerCleaner.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ledger_cleaner</code> command controls the <a href="https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner">Ledger Cleaner</a>, an asynchronous maintenance process that can find and repair corruption in rippled's database of ledgers.</p>
 <p><em>The <code>ledger_cleaner</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-39">Request Format</h4>
+<h4 id="request-format-42">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-77"><ul class="codetabs"><li><a href="#code-77-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-83"><ul class="codetabs"><li><a href="#code-83-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-77-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-83-0" style="position: static;"><pre><code>{
     "command": "ledger_cleaner",
     "max_ledger": 13818756,
     "min_ledger": 13818000,
@@ -11599,11 +12102,11 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-37">Response Format</h4>
+<h4 id="response-format-40">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-78"><ul class="codetabs"><li><a href="#code-78-0">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-84"><ul class="codetabs"><li><a href="#code-84-0">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-78-0" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-84-0" style="position: static;"><pre><code>200 OK
 {
    "result" : {
       "message" : "Cleaner configured",
@@ -11630,7 +12133,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-38">Possible Errors</h4>
+<h4 id="possible-errors-41">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>internal</code> if one the parameters was specified in a way that the server couldn't interpret. (This is a bug, and it should return <code>invalidParams</code> instead.)</li>
@@ -11639,11 +12142,11 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/155fcdbcd0b4927152892c8c8be01d9cf62bed68/src/ripple/rpc/handlers/LogLevel.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>log_level</code> command changes the <code>rippled</code> server's logging verbosity, or returns the current logging level for each category (called a <em>partition</em>) of log messages.</p>
 <p><em>The <code>log_level</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-40">Request Format</h4>
+<h4 id="request-format-43">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-79"><ul class="codetabs"><li><a href="#code-79-0">WebSocket</a></li><li><a href="#code-79-1">Commandline</a></li></ul>
+<div class="multicode" id="code-85"><ul class="codetabs"><li><a href="#code-85-0">WebSocket</a></li><li><a href="#code-85-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-79-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-85-0" style="position: static;"><pre><code>{
     "id": "ll1",
     "command": "log_level",
     "severity": "debug",
@@ -11651,7 +12154,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-79-1" style="position: static;"><pre><code>#Syntax: log_level [[partition] severity]
+<div class="code_sample" id="code-85-1" style="position: static;"><pre><code>#Syntax: log_level [[partition] severity]
 rippled log_level PathRequest debug
 </code></pre></div>
 </div>
@@ -11677,11 +12180,11 @@ rippled log_level PathRequest debug
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-38">Response Format</h4>
+<h4 id="response-format-41">Response Format</h4>
 <p>Examples of successful responses:</p>
-<div class="multicode" id="code-80"><ul class="codetabs"><li><a href="#code-80-0">Commandline (set log level)</a></li><li><a href="#code-80-1">Commandline (check log levels)</a></li></ul>
+<div class="multicode" id="code-86"><ul class="codetabs"><li><a href="#code-86-0">Commandline (set log level)</a></li><li><a href="#code-86-1">Commandline (check log levels)</a></li></ul>
 
-<div class="code_sample" id="code-80-0" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-86-0" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -11690,7 +12193,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-80-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-86-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -11769,7 +12272,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-39">Possible Errors</h4>
+<h4 id="possible-errors-42">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -11778,25 +12281,25 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/743bd6c9175c472814448ea889413be79dfd1c07/src/ripple/rpc/handlers/LogRotate.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>logrotate</code> command closes and reopens the log file. This is intended to help with log rotation on Linux file systems.</p>
 <p><em>The <code>logrotate</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-41">Request Format</h4>
+<h4 id="request-format-44">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-81"><ul class="codetabs"><li><a href="#code-81-0">WebSocket</a></li><li><a href="#code-81-1">Commandline</a></li></ul>
+<div class="multicode" id="code-87"><ul class="codetabs"><li><a href="#code-87-0">WebSocket</a></li><li><a href="#code-87-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-81-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-87-0" style="position: static;"><pre><code>{
     "id": "lr1",
     "command": "logrotate"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-81-1" style="position: static;"><pre><code>rippled logrotate
+<div class="code_sample" id="code-87-1" style="position: static;"><pre><code>rippled logrotate
 </code></pre></div>
 </div>
 <p>The request includes no parameters.</p>
-<h4 id="response-format-39">Response Format</h4>
+<h4 id="response-format-42">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-82"><ul class="codetabs"><li><a href="#code-82-0">JSON-RPC</a></li><li><a href="#code-82-1">Commandline</a></li></ul>
+<div class="multicode" id="code-88"><ul class="codetabs"><li><a href="#code-88-0">JSON-RPC</a></li><li><a href="#code-88-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-82-0" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-88-0" style="position: static;"><pre><code>200 OK
 {
    "result" : {
       "message" : "The log file was closed and reopened.",
@@ -11806,7 +12309,7 @@ Connecting to 127.0.0.1:5005
 
 </code></pre></div>
 
-<div class="code_sample" id="code-82-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-88-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -11834,7 +12337,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-40">Possible Errors</h4>
+<h4 id="possible-errors-43">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -11842,18 +12345,18 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/ValidationCreate.cpp" title="Source">[Source]<br/></a></p>
 <p>Use the <code>validation_create</code> command to generate the keys for a rippled <a href="tutorial-rippled-setup.html#validator-setup">validating node</a>. Similar to the <a href="#wallet-propose">wallet_propose</a> command, this command makes no real changes, but only generates a set of keys in the proper format.</p>
 <p><em>The <code>validation_create</code> method is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users.</em></p>
-<h4 id="request-format-42">Request Format</h4>
+<h4 id="request-format-45">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-83"><ul class="codetabs"><li><a href="#code-83-0">WebSocket</a></li><li><a href="#code-83-1">JSON-RPC</a></li><li><a href="#code-83-2">Commandline</a></li></ul>
+<div class="multicode" id="code-89"><ul class="codetabs"><li><a href="#code-89-0">WebSocket</a></li><li><a href="#code-89-1">JSON-RPC</a></li><li><a href="#code-89-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-83-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-89-0" style="position: static;"><pre><code>{
     "id": 0,
     "command": "validation_create",
     "secret": "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-83-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-89-1" style="position: static;"><pre><code>{
     "method": "validation_create",
     "params": [
         {
@@ -11863,7 +12366,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-83-2" style="position: static;"><pre><code>#Syntax: validation_create [secret]
+<div class="code_sample" id="code-89-2" style="position: static;"><pre><code>#Syntax: validation_create [secret]
 rippled validation_create "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE"
 </code></pre></div>
 </div>
@@ -11885,11 +12388,11 @@ rippled validation_create "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIR
 </tbody>
 </table>
 <p class="devportal-callout note"><strong>Note:</strong> The security of your validator depends on the entropy of your seed. Do not use a secret value that is not sufficiently randomized for real business purposes. We recommend omitting the <code>secret</code> when generating new credentials for the first time.</p>
-<h4 id="response-format-40">Response Format</h4>
+<h4 id="response-format-43">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-84"><ul class="codetabs"><li><a href="#code-84-0">JSON-RPC</a></li><li><a href="#code-84-1">Commandline</a></li></ul>
+<div class="multicode" id="code-90"><ul class="codetabs"><li><a href="#code-90-0">JSON-RPC</a></li><li><a href="#code-90-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-84-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-90-0" style="position: static;"><pre><code>{
    "result" : {
       "status" : "success",
       "validation_key" : "FAWN JAVA JADE HEAL VARY HER REEL SHAW GAIL ARCH BEN IRMA",
@@ -11899,7 +12402,7 @@ rippled validation_create "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIR
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-84-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-90-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -11938,7 +12441,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-41">Possible Errors</h4>
+<h4 id="possible-errors-44">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>badSeed</code> - The request provided an invalid seed value. This usually means that the seed value appears to be a valid string of a different format, such as an account address or validation public key.</li>
@@ -11947,18 +12450,18 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ValidationSeed.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>validation_seed</code> command temporarily sets the secret value that rippled uses to sign validations. This value resets based on the config file when you restart the server.</p>
 <p><em>The <code>validation_seed</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-43">Request Format</h4>
+<h4 id="request-format-46">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-85"><ul class="codetabs"><li><a href="#code-85-0">WebSocket</a></li><li><a href="#code-85-1">Commandline</a></li></ul>
+<div class="multicode" id="code-91"><ul class="codetabs"><li><a href="#code-91-0">WebSocket</a></li><li><a href="#code-91-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-85-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-91-0" style="position: static;"><pre><code>{
     "id": "set_seed_1",
     "command": "validation_seed",
     "secret": "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-85-1" style="position: static;"><pre><code>#Syntax: validation_seed [secret]
+<div class="code_sample" id="code-91-1" style="position: static;"><pre><code>#Syntax: validation_seed [secret]
 rippled validation_seed 'BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE'
 </code></pre></div>
 </div>
@@ -11979,11 +12482,11 @@ rippled validation_seed 'BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE'
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-41">Response Format</h4>
+<h4 id="response-format-44">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-86"><ul class="codetabs"><li><a href="#code-86-0">JSON-RPC</a></li><li><a href="#code-86-1">Commandline</a></li></ul>
+<div class="multicode" id="code-92"><ul class="codetabs"><li><a href="#code-92-0">JSON-RPC</a></li><li><a href="#code-92-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-86-0" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-92-0" style="position: static;"><pre><code>200 OK
 {
    "result" : {
       "status" : "success",
@@ -11994,7 +12497,7 @@ rippled validation_seed 'BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE'
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-86-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-92-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -12033,7 +12536,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-42">Possible Errors</h4>
+<h4 id="possible-errors-45">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>badSeed</code> - The request provided an invalid secret value. This usually means that the secret value appears to be a valid string of a different format, such as an account address or validation public key.</li>
@@ -12042,25 +12545,25 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/52f298f150fc1530d201d3140c80d3eaf781cb5f/src/ripple/rpc/handlers/Peers.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>peers</code> command returns a list of all other <code>rippled</code> servers currently connected to this one, including information on their connection and sync status.</p>
 <p><em>The <code>peers</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-44">Request Format</h4>
+<h4 id="request-format-47">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-87"><ul class="codetabs"><li><a href="#code-87-0">WebSocket</a></li><li><a href="#code-87-1">Commandline</a></li></ul>
+<div class="multicode" id="code-93"><ul class="codetabs"><li><a href="#code-93-0">WebSocket</a></li><li><a href="#code-93-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-87-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-93-0" style="position: static;"><pre><code>{
     "id": 2,
     "command": "peers"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-87-1" style="position: static;"><pre><code>rippled peers
+<div class="code_sample" id="code-93-1" style="position: static;"><pre><code>rippled peers
 </code></pre></div>
 </div>
 <p>The request includes no additional parameters.</p>
-<h4 id="response-format-42">Response Format</h4>
+<h4 id="response-format-45">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-88"><ul class="codetabs"><li><a href="#code-88-0">WebSocket</a></li><li><a href="#code-88-1">JSON-RPC</a></li><li><a href="#code-88-2">Commandline</a></li></ul>
+<div class="multicode" id="code-94"><ul class="codetabs"><li><a href="#code-94-0">WebSocket</a></li><li><a href="#code-94-1">JSON-RPC</a></li><li><a href="#code-94-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-88-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-94-0" style="position: static;"><pre><code>{
   "id": 2,
   "status": "success",
   "type": "response",
@@ -12172,7 +12675,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-88-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-94-1" style="position: static;"><pre><code>{
    "result" : {
       "cluster" : {},
       "peers" : [
@@ -12282,7 +12785,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-88-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-94-2" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -12515,7 +13018,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-43">Possible Errors</h4>
+<h4 id="possible-errors-46">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -12523,25 +13026,25 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/Print.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>print</code> command returns the current status of various internal subsystems, including peers, the ledger cleaner, and the resource manager.</p>
 <p><em>The <code>print</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-45">Request Format</h4>
+<h4 id="request-format-48">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-89"><ul class="codetabs"><li><a href="#code-89-0">WebSocket</a></li><li><a href="#code-89-1">Commandline</a></li></ul>
+<div class="multicode" id="code-95"><ul class="codetabs"><li><a href="#code-95-0">WebSocket</a></li><li><a href="#code-95-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-89-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-95-0" style="position: static;"><pre><code>{
     "id": "print_req_1",
     "command": "print"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-89-1" style="position: static;"><pre><code>rippled print
+<div class="code_sample" id="code-95-1" style="position: static;"><pre><code>rippled print
 </code></pre></div>
 </div>
 <p>The request includes no parameters.</p>
-<h4 id="response-format-43">Response Format</h4>
+<h4 id="response-format-46">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-90"><ul class="codetabs"><li><a href="#code-90-0">Commandline</a></li></ul>
+<div class="multicode" id="code-96"><ul class="codetabs"><li><a href="#code-96-0">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-90-0" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-96-0" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -12726,7 +13229,7 @@ Connecting to 127.0.0.1:5005
 </code></pre></div>
 </div>
 <p>The response follows the <a href="#response-formatting">standard format</a>. Additional fields in the result depend on the internal state of the <code>rippled</code> server. The results of this command are subject to change without notice.</p>
-<h4 id="possible-errors-44">Possible Errors</h4>
+<h4 id="possible-errors-47">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -12735,17 +13238,17 @@ Connecting to 127.0.0.1:5005
 <h2 id="ping">ping</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Ping.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>ping</code> command returns an acknowledgement, so that clients can test the connection status and latency.</p>
-<h4 id="request-format-46">Request Format</h4>
+<h4 id="request-format-49">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-91"><ul class="codetabs"><li><a href="#code-91-0">WebSocket</a></li><li><a href="#code-91-1">JSON-RPC</a></li><li><a href="#code-91-2">Commandline</a></li></ul>
+<div class="multicode" id="code-97"><ul class="codetabs"><li><a href="#code-97-0">WebSocket</a></li><li><a href="#code-97-1">JSON-RPC</a></li><li><a href="#code-97-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-91-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-97-0" style="position: static;"><pre><code>{
     "id": 1,
     "command": "ping"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-91-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-97-1" style="position: static;"><pre><code>{
     "method": "ping",
     "params": [
         {}
@@ -12753,17 +13256,17 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-91-2" style="position: static;"><pre><code>#Syntax: ping
+<div class="code_sample" id="code-97-2" style="position: static;"><pre><code>#Syntax: ping
 rippled ping
 </code></pre></div>
 </div>
 <p><a class="button" href="ripple-api-tool.html#ping">Try it!</a></p>
 <p>The request includes no parameters.</p>
-<h4 id="response-format-44">Response Format</h4>
+<h4 id="response-format-47">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-92"><ul class="codetabs"><li><a href="#code-92-0">WebSocket</a></li><li><a href="#code-92-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-98"><ul class="codetabs"><li><a href="#code-98-0">WebSocket</a></li><li><a href="#code-98-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-92-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-98-0" style="position: static;"><pre><code>{
     "id": 1,
     "result": {},
     "status": "success",
@@ -12771,7 +13274,7 @@ rippled ping
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-92-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-98-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "status": "success"
@@ -12780,24 +13283,24 @@ rippled ping
 </code></pre></div>
 </div>
 <p>The response follows the <a href="#response-formatting">standard format</a>, with a successful result containing no fields. The client can measure the round-trip time from request to response as latency.</p>
-<h4 id="possible-errors-45">Possible Errors</h4>
+<h4 id="possible-errors-48">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
 <h2 id="random">random</h2>
 <p><a href="https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Random.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>random</code> command provides a random number to be used as a source of entropy for random number generation by clients.</p>
-<h4 id="request-format-47">Request Format</h4>
+<h4 id="request-format-50">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-93"><ul class="codetabs"><li><a href="#code-93-0">WebSocket</a></li><li><a href="#code-93-1">JSON-RPC</a></li><li><a href="#code-93-2">Commandline</a></li></ul>
+<div class="multicode" id="code-99"><ul class="codetabs"><li><a href="#code-99-0">WebSocket</a></li><li><a href="#code-99-1">JSON-RPC</a></li><li><a href="#code-99-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-93-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-99-0" style="position: static;"><pre><code>{
     "id": 1,
     "command": "random"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-93-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-99-1" style="position: static;"><pre><code>{
     "method": "random",
     "params": [
         {}
@@ -12805,16 +13308,16 @@ rippled ping
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-93-2" style="position: static;"><pre><code>#Syntax: random
+<div class="code_sample" id="code-99-2" style="position: static;"><pre><code>#Syntax: random
 rippled random
 </code></pre></div>
 </div>
 <p>The request includes no parameters.</p>
-<h4 id="response-format-45">Response Format</h4>
+<h4 id="response-format-48">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-94"><ul class="codetabs"><li><a href="#code-94-0">WebSocket</a></li><li><a href="#code-94-1">JSON-RPC</a></li></ul>
+<div class="multicode" id="code-100"><ul class="codetabs"><li><a href="#code-100-0">WebSocket</a></li><li><a href="#code-100-1">JSON-RPC</a></li></ul>
 
-<div class="code_sample" id="code-94-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-100-0" style="position: static;"><pre><code>{
     "id": 1,
     "result": {
         "random": "8ED765AEBBD6767603C2C9375B2679AEC76E6A8133EF59F04F9FC1AAA70E41AF"
@@ -12824,7 +13327,7 @@ rippled random
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-94-1" style="position: static;"><pre><code>200 OK
+<div class="code_sample" id="code-100-1" style="position: static;"><pre><code>200 OK
 {
     "result": {
         "random": "4E57146AA47BC6E88FDFE8BAA235B900126C916B6CC521550996F590487B837A",
@@ -12850,26 +13353,26 @@ rippled random
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-46">Possible Errors</h4>
+<h4 id="possible-errors-49">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>internal</code> - Some internal error occurred, possibly relating to the random number generator.</li>
 </ul>
 <h2 id="json">json</h2>
 <p>The <code>json</code> method is a proxy to running other commands, and accepts the parameters for the command as a JSON value. It is <em>exclusive to the Commandline client</em>, and intended for cases where the commandline syntax for specifying parameters is inadequate or undesirable.</p>
-<h4 id="request-format-48">Request Format</h4>
+<h4 id="request-format-51">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-95"><ul class="codetabs"><li><a href="#code-95-0">Commandline</a></li></ul>
+<div class="multicode" id="code-101"><ul class="codetabs"><li><a href="#code-101-0">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-95-0" style="position: static;"><pre><code># Syntax: json method json_stanza
+<div class="code_sample" id="code-101-0" style="position: static;"><pre><code># Syntax: json method json_stanza
 rippled -q json ledger_closed '{}'
 </code></pre></div>
 </div>
-<h4 id="response-format-46">Response Format</h4>
+<h4 id="response-format-49">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-96"><ul class="codetabs"><li><a href="#code-96-0">WebSocket</a></li></ul>
+<div class="multicode" id="code-102"><ul class="codetabs"><li><a href="#code-102-0">WebSocket</a></li></ul>
 
-<div class="code_sample" id="code-96-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-102-0" style="position: static;"><pre><code>{
    "result" : {
       "ledger_hash" : "8047C3ECF1FA66326C1E57694F6814A1C32867C04D3D68A851367EE2F89BBEF3",
       "ledger_index" : 390308,
@@ -12883,18 +13386,18 @@ rippled -q json ledger_closed '{}'
 <p><a href="https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/Connect.cpp" title="Source">[Source]<br/></a></p>
 <p>The <code>connect</code> command forces the rippled server to connect to a specific peer rippled server.</p>
 <p><em>The <code>connect</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-49">Request Format</h4>
+<h4 id="request-format-52">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-97"><ul class="codetabs"><li><a href="#code-97-0">WebSocket</a></li><li><a href="#code-97-1">JSON-RPC</a></li><li><a href="#code-97-2">Commandline</a></li></ul>
+<div class="multicode" id="code-103"><ul class="codetabs"><li><a href="#code-103-0">WebSocket</a></li><li><a href="#code-103-1">JSON-RPC</a></li><li><a href="#code-103-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-97-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-103-0" style="position: static;"><pre><code>{
     "command": "connect",
     "ip": "192.170.145.88",
     "port": 51235
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-97-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-103-1" style="position: static;"><pre><code>{
     "method": "connect",
     "params": [
         {
@@ -12905,7 +13408,7 @@ rippled -q json ledger_closed '{}'
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-97-2" style="position: static;"><pre><code>#Syntax: connect ip [port]
+<div class="code_sample" id="code-103-2" style="position: static;"><pre><code>#Syntax: connect ip [port]
 rippled connect 192.170.145.88 51235
 </code></pre></div>
 </div>
@@ -12931,11 +13434,11 @@ rippled connect 192.170.145.88 51235
 </tr>
 </tbody>
 </table>
-<h4 id="response-format-47">Response Format</h4>
+<h4 id="response-format-50">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-98"><ul class="codetabs"><li><a href="#code-98-0">JSON-RPC</a></li><li><a href="#code-98-1">Commandline</a></li></ul>
+<div class="multicode" id="code-104"><ul class="codetabs"><li><a href="#code-104-0">JSON-RPC</a></li><li><a href="#code-104-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-98-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-104-0" style="position: static;"><pre><code>{
    "result" : {
       "message" : "connecting",
       "status" : "success"
@@ -12943,7 +13446,7 @@ rippled connect 192.170.145.88 51235
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-98-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-104-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -12970,7 +13473,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-47">Possible Errors</h4>
+<h4 id="possible-errors-50">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 <li><code>invalidParams</code> - One or more fields are specified incorrectly, or one or more required fields are missing.</li>
@@ -12980,17 +13483,17 @@ Connecting to 127.0.0.1:5005
 <p><a href="https://github.com/ripple/rippled/blob/develop/src/ripple/rpc/handlers/Stop.cpp" title="Source">[Source]<br/></a></p>
 <p>Gracefully shuts down the server.</p>
 <p><em>The <code>stop</code> request is an <a href="#connecting-to-rippled">admin command</a> that cannot be run by unprivileged users!</em></p>
-<h4 id="request-format-50">Request Format</h4>
+<h4 id="request-format-53">Request Format</h4>
 <p>An example of the request format:</p>
-<div class="multicode" id="code-99"><ul class="codetabs"><li><a href="#code-99-0">WebSocket</a></li><li><a href="#code-99-1">JSON-RPC</a></li><li><a href="#code-99-2">Commandline</a></li></ul>
+<div class="multicode" id="code-105"><ul class="codetabs"><li><a href="#code-105-0">WebSocket</a></li><li><a href="#code-105-1">JSON-RPC</a></li><li><a href="#code-105-2">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-99-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-105-0" style="position: static;"><pre><code>{
     "id": 0,
     "command": "stop"
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-99-1" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-105-1" style="position: static;"><pre><code>{
     "method": "stop",
     "params": [
         {}
@@ -12998,15 +13501,15 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-99-2" style="position: static;"><pre><code>rippled stop
+<div class="code_sample" id="code-105-2" style="position: static;"><pre><code>rippled stop
 </code></pre></div>
 </div>
 <p>The request includes no parameters.</p>
-<h4 id="response-format-48">Response Format</h4>
+<h4 id="response-format-51">Response Format</h4>
 <p>An example of a successful response:</p>
-<div class="multicode" id="code-100"><ul class="codetabs"><li><a href="#code-100-0">JSON-RPC</a></li><li><a href="#code-100-1">Commandline</a></li></ul>
+<div class="multicode" id="code-106"><ul class="codetabs"><li><a href="#code-106-0">JSON-RPC</a></li><li><a href="#code-106-1">Commandline</a></li></ul>
 
-<div class="code_sample" id="code-100-0" style="position: static;"><pre><code>{
+<div class="code_sample" id="code-106-0" style="position: static;"><pre><code>{
    "result" : {
       "message" : "ripple server stopping",
       "status" : "success"
@@ -13014,7 +13517,7 @@ Connecting to 127.0.0.1:5005
 }
 </code></pre></div>
 
-<div class="code_sample" id="code-100-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
+<div class="code_sample" id="code-106-1" style="position: static;"><pre><code>Loading: "/etc/rippled.cfg"
 Connecting to 127.0.0.1:5005
 {
    "result" : {
@@ -13041,7 +13544,7 @@ Connecting to 127.0.0.1:5005
 </tr>
 </tbody>
 </table>
-<h4 id="possible-errors-48">Possible Errors</h4>
+<h4 id="possible-errors-51">Possible Errors</h4>
 <ul>
 <li>Any of the <a href="#universal-errors">universal error types</a>.</li>
 </ul>
@@ -13058,7 +13561,7 @@ protocol = peer
 </code></pre>
 <h2 id="peer-crawler">Peer Crawler</h2>
 <p>The Peer Crawler asks a <code>rippled</code> server to report information about the other <code>rippled</code> servers it is connected to as peers. The <a href="#peers"><code>peers</code> command</a> in the <a href="#websocket-and-json-rpc-apis">WebSocket and JSON-RPC APIs</a> also returns a similar, more comprehensive set of information, but requires <a href="#connecting-to-rippled">administrative access</a> to the server. The Peer Crawler response is available to other servers on a non-privileged basis through the Peer Protocol (RTXP) port.</p>
-<h4 id="request-format-51">Request Format</h4>
+<h4 id="request-format-54">Request Format</h4>
 <p>To request the Peer Crawler information, make the following HTTP request:</p>
 <ul>
 <li><strong>Protocol:</strong> https</li>
@@ -13068,7 +13571,7 @@ protocol = peer
 <li><strong>Path:</strong> <code>/crawl</code></li>
 <li><strong>Notes:</strong> Most <code>rippled</code> servers use a self-signed certificate to respond to the request. By default, most tools (including web browsers) flag or block such responses for being untrusted. You must ignore the certificate checking (for example, if using cURL, add the <code>--insecure</code> flag) to display a response from those servers.</li>
 </ul>
-<h4 id="response-format-49">Response Format</h4>
+<h4 id="response-format-52">Response Format</h4>
 <p>The response has the status code <strong>200 OK</strong> and a JSON object in the message body.</p>
 <p>The JSON object has the following fields:</p>
 <table>
@@ -13131,12 +13634,12 @@ protocol = peer
 </table>
 <h4 id="example">Example</h4>
 <p>Request:</p>
-<div class="multicode" id="code-101"><ul class="codetabs"><li><a href="#code-101-0">HTTP</a></li><li><a href="#code-101-1">cURL</a></li></ul>
+<div class="multicode" id="code-107"><ul class="codetabs"><li><a href="#code-107-0">HTTP</a></li><li><a href="#code-107-1">cURL</a></li></ul>
 
-<div class="code_sample" id="code-101-0" style="position: static;"><pre><code>GET https://s1.ripple.com:51235/crawl
+<div class="code_sample" id="code-107-0" style="position: static;"><pre><code>GET https://s1.ripple.com:51235/crawl
 </code></pre></div>
 
-<div class="code_sample" id="code-101-1" style="position: static;"><pre><code>curl -k https://s1.ripple.com:51235/crawl
+<div class="code_sample" id="code-107-1" style="position: static;"><pre><code>curl -k https://s1.ripple.com:51235/crawl
 </code></pre></div>
 </div>
 <p>Response:</p>


### PR DESCRIPTION
Adds documentation for three new rippled RPC API methods related to payment channels.

As usual, the HTML files are generated from the MD files so you can ignore those.