### PR TITLE
Add Listing XRP as an Exchange Guide 

### DIFF
--- a/concept-accounts.html
+++ b/concept-accounts.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-amendments.html
+++ b/concept-amendments.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-fee-voting.html
+++ b/concept-fee-voting.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-fees.html
+++ b/concept-fees.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-freeze.html
+++ b/concept-freeze.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-issuing-and-operational-addresses.html
+++ b/concept-issuing-and-operational-addresses.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/concept-noripple.html
+++ b/concept-noripple.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-paths.html
+++ b/concept-paths.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-reserves.html
+++ b/concept-reserves.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-stand-alone-mode.html
+++ b/concept-stand-alone-mode.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-transaction-cost.html
+++ b/concept-transaction-cost.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/concept-transfer-fees.html
+++ b/concept-transfer-fees.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/content/exchange-guide.md
+++ b/content/exchange-guide.md
@@ -38,7 +38,7 @@ See also:
 
 * [Requirements for Sending to RCL](https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl)
 
-* [Requirements for Sending to RCL](https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl)
+* [Requirements for Receiving from RCL](https://ripple.com/build/gateway-guide/#requirements-for-receiving-from-rcl)
 
 * [Gateway Precautions](https://ripple.com/build/gateway-guide/#precautions)
 
@@ -390,7 +390,7 @@ For more information about trading _on_ the RCL, see [Lifecycle of an Offer](htt
 
 Exchanges can adjust the balances between their operational and issuing accounts at any time. Each balance adjustment consumes a [transaction fee](https://ripple.com/build/fees-disambiguation/), but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's [transaction fees](https://ripple.com/build/transaction-cost/).)
 
-The following table demonstrates balance adjustment of 80,000 XRP (via a [_payment_](https://ripple.com/build/transactions/#payment) on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was debited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.
+The following table demonstrates a balance adjustment of 80,000 XRP (via a [_payment_](https://ripple.com/build/transactions/#payment) on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was credited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.
 
 
 <table>

--- a/content/exchange-guide.md
+++ b/content/exchange-guide.md
@@ -32,15 +32,27 @@ To support XRP, Alpha Exchange must:
 
 * Create and maintain [balance sheets](#balance-sheets)
 
+See also:
+
+* [Gateway Compliance](https://ripple.com/build/gateway-guide/#gateway-compliance) — Gateways and exchanges are different, but exchanges should also ensure that they are complying with local regulations and reporting to the appropriate agencies.
+
+* [Requirements for Sending to RCL](https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl)
+
+* [Requirements for Sending to RCL](https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl)
+
+* [Gateway Precautions](https://ripple.com/build/gateway-guide/#precautions)
+
 ### Accounts
 
-Alpha Exchange must create at least two new [accounts](https://ripple.com/build/accounts/) (also referred to as "wallets") on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating [_issuing_, _operational_, and _standby_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The operational/standby/issuing model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:
+XRP is held in *accounts* (sometimes referred to as *wallets* ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, [OfferCreate](https://ripple.com/build/transactions/#offercreate) and others used for trading), RCL accounts require XRP [reserves](https://ripple.com/build/reserves/) to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, [account objects](https://ripple.com/build/ledger-format/#accountroot) describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the [Accounts](https://ripple.com/build/accounts/) article.
+
+To comply with Ripple's recommend best practices, Alpha Exchange should create at least two new [accounts](https://ripple.com/build/accounts/) on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating [_issuing_, _operational_, and _standby_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The operational/standby/issuing model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:
 
 * An [_issuing_ account](https://ripple.com/build/issuing-operational-addresses/#issuing-address) to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.
 
     For more information about the possible consequences of a compromised issuing account, see [Issuing Account Compromise](https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise).
 
-* One or more [_operational_ accounts](https://ripple.com/build/issuing-operational-addresses/#operational-addresses) to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. Operational accounts need to be online to service instant withdrawal requests.
+* One or more [_operational_ accounts](https://ripple.com/build/issuing-operational-addresses/#operational-addresses) to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with an opertaitional wallet, exchanges can securely support these types of automated XRP transfers. Operational accounts need to be online to service instant withdrawal requests.
 
     For more information about the possible consequences of a compromised operational account, see [Operational Account Compromise](https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise).
 
@@ -48,11 +60,16 @@ Alpha Exchange must create at least two new [accounts](https://ripple.com/build/
 
     For more information about the possible consequences of a compromised standby account, see [Standby Account Compromise](https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise).
 
-For more information, see:
+
+See also:
 
 * ["Suggested Business Practices" in the _Gateway Guide_](https://ripple.com/build/gateway-guide/#suggested-business-practices)
 
 * [Issuing and Operational Addresses](https://ripple.com/build/issuing-operational-addresses/)
+
+* [Creating Accounts](https://ripple.com/build/transactions/#creating-accounts)
+
+* [Reserves](https://ripple.com/build/reserves/)
 
 ### Balance Sheets
 
@@ -140,7 +157,15 @@ XRP Balances</i></b></td>
   </tr>
 </table>
 
-## On-Ledger and Off-Ledger
+#### XRP Amounts
+
+Amounts of XRP are represented on the RCL as an unsigned integer count of *drops*, where one XRP == 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.
+
+One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.
+
+For more informtion, see [Specifying Currency Amounts](https://ripple.com/build/rippled-apis/#specifying-currency-amounts).
+
+#### On-Ledger and Off-Ledger
 
 With exchanges like _Alpha Exchange_, XRP can be "on-ledger" or "off-ledger":
 
@@ -153,9 +178,9 @@ With exchanges like _Alpha Exchange_, XRP can be "on-ledger" or "off-ledger":
 
 ## Flow of Funds
 
-The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in a [previous section](#balance-sheets).
+The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in the ["Balance Sheets" section](#balance-sheets).
 
-There are three main steps involved in an exchange's typical flow of funds:
+There are four main steps involved in an exchange's typical flow of funds:
 
 1. [Deposit XRP into Exchange](#deposit-xrp-into-an-exchange)
 
@@ -166,9 +191,9 @@ There are three main steps involved in an exchange's typical flow of funds:
 4. [Trade XRP on the Exchange](#trade-xrp-on-the-exchange)
 
 
-This list does not include the [prerequisites](#prerequisites for Supporting XRP) required of an exchange.
+This list does not include the [prerequisites](#prerequisites-for-supporting-xrp) required of an exchange.
 
-At this point, _Alpha Exchange_ has created [operational, standby, and issuing accounts](#accounts) on the RCL and added them to its balance sheet, but has not funded the new accounts.
+At this point, _Alpha Exchange_ has created [operational, standby, and issuing accounts](#accounts) on the RCL and added them to its balance sheet, but has not accepted any deposits from its users.
 
 
 <table>
@@ -249,32 +274,40 @@ XRP Balances</i></b></td>
 </table>
 
 
+### Deposit XRP into Exchange
 
+To track [off-ledger XRP balances](#on-ledger-and-off-ledger) exchanges need to create new [balance sheets](#balance-sheets) (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.
 
-## Deposit XRP into Exchange
+A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:
 
-The exchange is required to create a new accounting system to track off ledger XRP balances. Figure 1 shows the initial condition of this new account system, where all user balances start with a value of zero.
+1. Charlie submits a payment of 50,000  XRP (by using [RippleAPI](https://ripple.com/build/rippleapi/) or similar software) to Alpha Exchange's [issuing account](#accounts).
 
-Example deposit : The user Charlie wishes to deposit 50,000 XRP to Alpha Exchange. Through the interface that Alpha Exchange provides, Charlie is instructed to submit a payment (via Ripple API or wallet software) for that amount to Alpha Exchange’s cold wallet address, and to associate a numerical identifier (say 789) with the payment.
+    a. Charlie adds an identifier (in this case, `789`) to the payment to associate it with his account at Alpha Exchange. This is called a [_destination tag_](https://ripple.com/build/gateway-guide/#source-and-destination-tags). (To use this, Alpha Exchange must have set the asfRequireDest flag on all of its accounts. This flag requires all incoming payments to have a destination tag like Charlie's. For more information, see [AccountSet Flags](https://ripple.com/build/transactions/#accountset-flags).
+
+2. The software at Alpha Exchange detects the incoming payment, and recognizes `789` as the destination tag for Charlie’s account.
+
+3. When it detects the incoming payment, Alpha Exchange's software updates its balance sheet to indicate that the 50,000 XRP it received is controlled by Charlie.
+
+    Charlie can now use up to 50,000 XRP on the exchange. For example, he can create offers to trade XRP with BTC or any of the other currencies Alpha Exchange supports.
 
 <table>
   <tr>
-    <td>XRP Balances
-on RCL</td>
+    <td><b><i>XRP Balances
+on RCL</i></b></td>
     <td></td>
     <td></td>
-    <td>Alpha Exchange
-XRP Balances</td>
+    <td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
-    <td>User</td>
-    <td>Balance</td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
     <td></td>
-    <td>Acct #</td>
-    <td>User</td>
-    <td>Balance</td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
   </tr>
   <tr>
     <td>Dave</td>
@@ -294,13 +327,13 @@ XRP Balances</td>
   </tr>
   <tr>
     <td>Charlie</td>
-    <td>100,000
-50,000</td>
+    <td><s>100,000</s>
+<br>50,000</td>
     <td></td>
     <td>789</td>
     <td>Charlie</td>
-    <td> 0
-50,000</td>
+    <td><s>0</s>
+<br>50,000</td>
   </tr>
   <tr>
     <td></td>
@@ -311,7 +344,7 @@ XRP Balances</td>
     <td></td>
   </tr>
   <tr>
-    <td>Alpha Hot</td>
+    <td>Alpha Operational</td>
     <td>0</td>
     <td></td>
     <td>...</td>
@@ -319,7 +352,7 @@ XRP Balances</td>
     <td></td>
   </tr>
   <tr>
-    <td>Alpha Warm</td>
+    <td>Alpha Standby</td>
     <td>0</td>
     <td></td>
     <td></td>
@@ -327,9 +360,9 @@ XRP Balances</td>
     <td></td>
   </tr>
   <tr>
-    <td>Alpha Cold</td>
-    <td> 0
-50,000</td>
+    <td>Alpha Issuing</td>
+    <td><s>0</s>
+<br>50,000</td>
     <td></td>
     <td></td>
     <td></td>
@@ -346,51 +379,53 @@ XRP Balances</td>
 </table>
 
 
-Figure 2 : Before and after a XRP deposit is made by Charlie to Alpha Exchange
+### Trade XRP on The Exchange
 
-The software at Alpha Exchange detects the incoming payment, and recognizes 789 as the identifier associated with Charlie’s account. The number 789 is a field known as a "Destination Tag" on the RCL. (Alpha Exchange has set a flag, called asfRequireDest, on its wallets to ensure that all incoming payment have a destination tag.)
+Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are _off-ledger_ and independent from the RCL, so the balance changes are not recorded there.
 
-[https://ripple.com/build/transactions/#accountset-flags](https://ripple.com/build/transactions/#accountset-flags)
+For more information about trading _on_ the RCL, see [Lifecycle of an Offer](https://ripple.com/build/transactions/#lifecycle-of-an-offer).
 
-Upon detecting the incoming payment, Alpha Exchange software updates the balance sheet to reflect the 50,000 XRP received is controlled by Charlie.  Charlie is now able to use up to 50,000 XRP on the exchange, for example to create orders trading XRP to other supported currencies on Alpha Exchange.
 
-## Rebalancing XRP Holdings
+### Rebalancing XRP Holdings
 
-In order to securely support automated transfers of XRP, the exchange will keep a portion of XRP holdings in one (or more) operational "hot" wallets. In most XRP integrations, an exchange will elect to have their middleware software make payments automatically from the hot wallet (a withdrawal payment, for example), while a cold wallet will require human intervention.
+Exchanges can adjust the balances between their operational and issuing accounts at any time. Each balance adjustment consumes a [transaction fee](https://ripple.com/build/fees-disambiguation/), but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's [transaction fees](https://ripple.com/build/transaction-cost/).)
+
+The following table demonstrates balance adjustment of 80,000 XRP (via a [_payment_](https://ripple.com/build/transactions/#payment) on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was debited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.
+
 
 <table>
   <tr>
-    <td>Alpha Exchange XRP
-Off Ledger Balances</td>
+    <td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</i></b></td>
     <td></td>
     <td></td>
     <td></td>
-    <td>Alpha Exchange XRP On Ledger Balances</td>
+    <td><b><i>Alpha Exchange XRP On-Ledger Balances</i></b></td>
     <td></td>
   </tr>
   <tr>
-    <td>Acct #</td>
-    <td>User</td>
-    <td>Balance</td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
     <td></td>
-    <td>Wallet</td>
-    <td>Balance</td>
+    <td><b>RCL Account</b></td>
+    <td><b>Balance</b></td>
   </tr>
   <tr>
     <td>123</td>
     <td>Alice</td>
     <td>80,000</td>
     <td></td>
-    <td>Hot</td>
-    <td>0
-80,000</td>
+    <td>Operational</td>
+    <td><s>0</s>
+<br>80,000</td>
   </tr>
   <tr>
     <td>456</td>
     <td>Bob</td>
     <td>50,000</td>
     <td></td>
-    <td>Warm</td>
+    <td>Standby</td>
     <td>0</td>
   </tr>
   <tr>
@@ -406,9 +441,9 @@ Off Ledger Balances</td>
     <td>Charlie</td>
     <td>50,000</td>
     <td></td>
-    <td>Cold</td>
-    <td>180,000
-100,000</td>
+    <td>Issuing</td>
+    <td><s>180,000</s>
+<br>100,000</td>
   </tr>
   <tr>
     <td></td>
@@ -429,41 +464,44 @@ Off Ledger Balances</td>
 </table>
 
 
-Figure 3 : Without fractional reserve, XRP moves to operational hot wallet
+### Withdraw XRP from Exchange
 
-The exchange can adjust balances between hot and cold wallets at any time.  While each such adjustment consumes a fee, it does not otherwise affect the overall balance, which is an aggregate of all the holding wallets.  This aggregate On Ledger balance should at all times exceed the total available for trade on the exchange.  (Where the excess is sufficient to cover ledger transaction fees.)
+Withdrawals allow an exchange's users to move XRP from the exchange's off-ledger balance sheet to an account on the RCL.
 
-Figure 3 shows a balance adjustment via a payment of 80,000 XRP from Cold wallet to Hot wallet.  A payment made in reverse (debit the hot wallet, credit the cold wallet; not shown) would decrease the hot wallet balance. These balance adjustments allow an exchange to limit the risk associated with holding XRP in an online Hot wallet, by holding a balance in an offline Cold wallet.
+In this example, Charlie withdraws 25,000 XRP from Alpha Exchange. This involves the following steps:
 
-## Withdraw XRP from Exchange
+1. Charlie initiates the process on Alpha Exchange’s website. He provides instructions to transfer 25,000 XRP to a specific account on the RCL (named "Charlie RCL" in the following table).
 
-The *withdraw* feature allows customers to move XRP from Alpha Exchange to a wallet on the Ripple Consensus Ledger.
+2. In response to Charlie’s instructions, Alpha Exchange does the following:
 
-In this example, Charlie initiates the process on the Alpha Exchange’s website.  He provides instructions to transfer 25,000 XRP to a specific Ripple wallet on RCL (named "Charlie" in figure 4).
+    a. Debits the amount (25,000 XRP) from Charlie’s account on its off-ledger balance sheet
+
+    b. Submits a payment on the RCL for the same amount (25,000 XRP), from Alpha Exchange's operational account to Charlie’s RCL account
+
 
 <table>
   <tr>
-    <td>RCL On Ledger XRP Balances</td>
+    <td><b><i>RCL On-Ledger XRP Balances</td>
     <td></td>
     <td></td>
-    <td>Alpha Exchange XRP
-Off Ledger Balances</td>
+    <td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</td>
     <td></td>
     <td></td>
     <td></td>
-    <td>Alpha Exchange XRP On Ledger Balances</td>
+    <td><b><i>Alpha Exchange XRP On-Ledger Balances</td>
     <td></td>
   </tr>
   <tr>
-    <td>User</td>
-    <td>Balance</td>
+    <td><b>User</td>
+    <td><b>Balance</td>
     <td></td>
-    <td>Acct #</td>
-    <td>User</td>
-    <td>Balance</td>
+    <td><b>Acct #</td>
+    <td><b>User</td>
+    <td><b>Balance</td>
     <td></td>
-    <td>Wallet</td>
-    <td>Balance</td>
+    <td><b>RCL Account</td>
+    <td><b>Balance</td>
   </tr>
   <tr>
     <td>Dave</td>
@@ -473,9 +511,9 @@ Off Ledger Balances</td>
     <td>Alice</td>
     <td>80,000</td>
     <td></td>
-    <td>Hot</td>
-    <td>80,000
-55,000</td>
+    <td>Operational</td>
+    <td><s>80,000</s>
+<br>55,000</td>
   </tr>
   <tr>
     <td>Edward</td>
@@ -485,7 +523,7 @@ Off Ledger Balances</td>
     <td>Bob</td>
     <td>50,000</td>
     <td></td>
-    <td>Warm</td>
+    <td>Standby</td>
     <td>0</td>
   </tr>
   <tr>
@@ -500,16 +538,16 @@ Off Ledger Balances</td>
     <td></td>
   </tr>
   <tr>
-    <td>Charlie</td>
-    <td>50,000
-75,000</td>
+    <td>Charlie RCL</td>
+    <td><s>50,000</s>
+<br>75,000</td>
     <td></td>
     <td>789</td>
     <td>Charlie</td>
-    <td>50,000
-25,000</td>
+    <td><s>50,000</s>
+<br>25,000</td>
     <td></td>
-    <td>Cold</td>
+    <td>Issuing</td>
     <td>100,000</td>
   </tr>
   <tr>
@@ -535,32 +573,3 @@ Off Ledger Balances</td>
     <td></td>
   </tr>
 </table>
-
-
-Figure 4 : Before and after a XRP withdrawal by Charlie
-
-In response to Charlie’s instruction to withdraw 25,000 XRP, Alpha Exchange performs the following tasks, shown in figure 4, in this order:
-
-* Debit the amount from Charlie’s row on the balance sheet
-
-* Submit a Ripple payment for the same amount, from Alpha Exchange hot wallet to Charlie’s RCL wallet
-
-## Trade XRP on The Exchange
-
-Users of Alpha Exchange can trade the credit based balances on Alpha Exchange, and Alpha should be expected to keep track of all users balances as the trades are made. These trades are independent of, and not reflected on, RCL.
-
-# About XRP Accounts
-
-XRP is held in Ripple Consensus Ledger *accounts* (sometimes referred to as *wallets* or *addresses*).  This document shows that an exchange is able to store all of the customers’ XRP in relatively few wallets.  (Technically, all the XRP could be managed in a single wallet.  It is for security reasons that an exchange should manage a set of hot, warm, and cold wallets.)
-
-An exchange should not create a Ripple wallet for each customer who holds XRP with the exchange.  The RCL differs from other blockchains such as Bitcoin where additional wallets incur essentially no overhead.  A Bitcoin balance is a collation of multiple UTXOs from prior blocks.  A Ripple account, in contrast, is represented in each iteration of the ledger, and can never be destroyed or removed (similar to Ethereum).  The Ripple account object includes an XRP balance as well as other properties.  Also, each Ripple account requires an XRP reserve, which adds a cost to creating a large number of wallets.
-
-See [https://ripple.com/build/transactions/#creating-accounts](https://ripple.com/build/transactions/#creating-accounts) and [https://ripple.com/build/reserves/](https://ripple.com/build/reserves/).
-
-# About XRP Balances
-
-Amounts of XRP are represented on the Ripple Consensus Ledger as an unsigned integer count of *drops*, where one XRP == 1,000,000 drops.  Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values.  However all user interfaces should present balances in units of XRP.
-
-One drop (or .000001 XRP) cannot be further subdivided.  Bear this in mind when calculating and displaying FX rates between XRP and other assets.
-
-See [https://ripple.com/build/rippled-apis/#specifying-currency-amounts](https://ripple.com/build/rippled-apis/#specifying-currency-amounts) for additional detail.

--- a/content/exchange-guide.md
+++ b/content/exchange-guide.md
@@ -1,0 +1,444 @@
+# Listing XRP as an Exchange
+
+This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of `rippled` and the Ripple Consensus Ledger (RCL), see [https://ripple.com/build](https://ripple.com/build).
+
+## Alpha Exchange
+
+For illustrative purposes, this document uses a fictitious change called _Alpha Exchange_ that has the following characteristics:
+
+* Currently specializes in listing BTC/USD
+* Wants to add BTC/XRP and XRP/USD trading pairs
+* Maintains balances for all of its customers
+* Maintains balances for each of its supported currencies
+
+### User Benefits
+
+By supporting the BTC/XRP and XRP/USD trading pairs, Alpha Exchange allows its users to:
+
+* Deposit XRP _to_ Alpha Exchange _from_ the RCL
+
+* Withdraw XRP _from_ Alpha Exchange _to_ the RCL
+
+* Trade XRP with other currencies, such as BTC, USD, amongst others
+
+### Prerequisites for Supporting XRP
+
+To support XRP, Alpha Exchange must create and maintain new accounts and balance sheets.
+
+#### Accounts
+
+Alpha Exchange must create at least two new [accounts](https://ripple.com/build/accounts/) (also referred to as "wallets") on the RCL. To minimize the risk associated with a compromised secret key, Ripple recommends creating [_issuing_ and _operational_ accounts](https://ripple.com/build/issuing-operational-addresses/):
+
+    * An _issuing_ account to securely hold the majority of XRP and customers' funds
+
+    * One or more _operational_ (and, perhaps, _standby_) accounts to conduct the day-to-day business of accepting customers' XRP withdrawals and deposits
+
+#### Balance Sheets
+
+* An additional balance sheet to track each customer’s XRP held at Alpha Exchange
+
+The new RCL wallets are represented on the left-hand side of Figure 1. A  model of hot, cold and warm wallets is intended to balance security and convenience for users deposits and withdrawals. Cold wallets are understood to be offline, warm may be online using the [Ripple Multisign](https://ripple.com/build/how-to-multi-sign/) technology, and hot wallets are developed to service instant withdrawal requests.  For more information about secure wallets and  additional best practices, see the Ripple Developer Portal :
+
+[https://ripple.com/build/gateway-guide/#suggested-business-practices](https://ripple.com/build/gateway-guide/#suggested-business-practices)
+
+The additional balance sheet is represented on the right-hand side of Figure 1.  Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.  The remainder of this document describes the flow of funds as Alpha Exchange allows users to deposit, trade, and redeem XRP balances.
+
+<table>
+  <tr>
+    <td>XRP Balances
+on RCL</td>
+    <td></td>
+    <td></td>
+    <td>Alpha Exchange
+XRP Balances</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>User</td>
+    <td>Balance</td>
+    <td></td>
+    <td>Acct #</td>
+    <td>User</td>
+    <td>Balance</td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Alpha Hot</td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Warm</td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Cold</td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+
+Figure 1 : Initial requirements for listing XRP, denoted by green table cells
+
+## Key Definitions
+
+**On Ledger XRP**: XRP that is visible by querying the public RCL blockchain via the public address of the XRP holder. The counterparty to these balances is the global, decentralized and distributed, RCL.
+
+**Off Ledger XRP**: XRP that is held by the accounting system of an exchange that is visible by querying the exchange interface. These balances are credit based, and have a counterparty as the exchange. While these XRP balances are traded between participants in an exchange, the exchange is obligated to hold a balance of On Ledger XRP equal to the aggregate amount of Off Ledger XRP available for trade.
+
+## Deposit XRP into Exchange
+
+The exchange is required to create a new accounting system to track off ledger XRP balances. Figure 1 shows the initial condition of this new account system, where all user balances start with a value of zero.
+
+Example deposit : The user Charlie wishes to deposit 50,000 XRP to Alpha Exchange. Through the interface that Alpha Exchange provides, Charlie is instructed to submit a payment (via Ripple API or wallet software) for that amount to Alpha Exchange’s cold wallet address, and to associate a numerical identifier (say 789) with the payment.
+
+<table>
+  <tr>
+    <td>XRP Balances
+on RCL</td>
+    <td></td>
+    <td></td>
+    <td>Alpha Exchange
+XRP Balances</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>User</td>
+    <td>Balance</td>
+    <td></td>
+    <td>Acct #</td>
+    <td>User</td>
+    <td>Balance</td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>100,000
+50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td> 0
+50,000</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Hot</td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Warm</td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Cold</td>
+    <td> 0
+50,000</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+
+Figure 2 : Before and after a XRP deposit is made by Charlie to Alpha Exchange
+
+The software at Alpha Exchange detects the incoming payment, and recognizes 789 as the identifier associated with Charlie’s account. The number 789 is a field known as a "Destination Tag" on the RCL. (Alpha Exchange has set a flag, called asfRequireDest, on its wallets to ensure that all incoming payment have a destination tag.)
+
+[https://ripple.com/build/transactions/#accountset-flags](https://ripple.com/build/transactions/#accountset-flags)
+
+Upon detecting the incoming payment, Alpha Exchange software updates the balance sheet to reflect the 50,000 XRP received is controlled by Charlie.  Charlie is now able to use up to 50,000 XRP on the exchange, for example to create orders trading XRP to other supported currencies on Alpha Exchange.
+
+## Rebalancing XRP Holdings
+
+In order to securely support automated transfers of XRP, the exchange will keep a portion of XRP holdings in one (or more) operational "hot" wallets. In most XRP integrations, an exchange will elect to have their middleware software make payments automatically from the hot wallet (a withdrawal payment, for example), while a cold wallet will require human intervention.
+
+<table>
+  <tr>
+    <td>Alpha Exchange XRP
+Off Ledger Balances</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>Alpha Exchange XRP On Ledger Balances</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Acct #</td>
+    <td>User</td>
+    <td>Balance</td>
+    <td></td>
+    <td>Wallet</td>
+    <td>Balance</td>
+  </tr>
+  <tr>
+    <td>123</td>
+    <td>Alice</td>
+    <td>80,000</td>
+    <td></td>
+    <td>Hot</td>
+    <td>0
+80,000</td>
+  </tr>
+  <tr>
+    <td>456</td>
+    <td>Bob</td>
+    <td>50,000</td>
+    <td></td>
+    <td>Warm</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>….</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>….</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>Cold</td>
+    <td>180,000
+100,000</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+  </tr>
+</table>
+
+
+Figure 3 : Without fractional reserve, XRP moves to operational hot wallet
+
+The exchange can adjust balances between hot and cold wallets at any time.  While each such adjustment consumes a fee, it does not otherwise affect the overall balance, which is an aggregate of all the holding wallets.  This aggregate On Ledger balance should at all times exceed the total available for trade on the exchange.  (Where the excess is sufficient to cover ledger transaction fees.)
+
+Figure 3 shows a balance adjustment via a payment of 80,000 XRP from Cold wallet to Hot wallet.  A payment made in reverse (debit the hot wallet, credit the cold wallet; not shown) would decrease the hot wallet balance. These balance adjustments allow an exchange to limit the risk associated with holding XRP in an online Hot wallet, by holding a balance in an offline Cold wallet.
+
+## Withdraw XRP from Exchange
+
+The *withdraw* feature allows customers to move XRP from Alpha Exchange to a wallet on the Ripple Consensus Ledger.
+
+In this example, Charlie initiates the process on the Alpha Exchange’s website.  He provides instructions to transfer 25,000 XRP to a specific Ripple wallet on RCL (named "Charlie" in figure 4).
+
+<table>
+  <tr>
+    <td>RCL On Ledger XRP Balances</td>
+    <td></td>
+    <td></td>
+    <td>Alpha Exchange XRP
+Off Ledger Balances</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>Alpha Exchange XRP On Ledger Balances</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>User</td>
+    <td>Balance</td>
+    <td></td>
+    <td>Acct #</td>
+    <td>User</td>
+    <td>Balance</td>
+    <td></td>
+    <td>Wallet</td>
+    <td>Balance</td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>80,000</td>
+    <td></td>
+    <td>Hot</td>
+    <td>80,000
+55,000</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>50,000</td>
+    <td></td>
+    <td>Warm</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>….</td>
+    <td></td>
+    <td></td>
+    <td>….</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>….</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>50,000
+75,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>50,000
+25,000</td>
+    <td></td>
+    <td>Cold</td>
+    <td>100,000</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+  </tr>
+</table>
+
+
+Figure 4 : Before and after a XRP withdrawal by Charlie
+
+In response to Charlie’s instruction to withdraw 25,000 XRP, Alpha Exchange performs the following tasks, shown in figure 4, in this order:
+
+* Debit the amount from Charlie’s row on the balance sheet
+
+* Submit a Ripple payment for the same amount, from Alpha Exchange hot wallet to Charlie’s RCL wallet
+
+## Trade XRP on The Exchange
+
+Users of Alpha Exchange can trade the credit based balances on Alpha Exchange, and Alpha should be expected to keep track of all users balances as the trades are made. These trades are independent of, and not reflected on, RCL.
+
+# About XRP Accounts
+
+XRP is held in Ripple Consensus Ledger *accounts* (sometimes referred to as *wallets* or *addresses*).  This document shows that an exchange is able to store all of the customers’ XRP in relatively few wallets.  (Technically, all the XRP could be managed in a single wallet.  It is for security reasons that an exchange should manage a set of hot, warm, and cold wallets.)
+
+An exchange should not create a Ripple wallet for each customer who holds XRP with the exchange.  The RCL differs from other blockchains such as Bitcoin where additional wallets incur essentially no overhead.  A Bitcoin balance is a collation of multiple UTXOs from prior blocks.  A Ripple account, in contrast, is represented in each iteration of the ledger, and can never be destroyed or removed (similar to Ethereum).  The Ripple account object includes an XRP balance as well as other properties.  Also, each Ripple account requires an XRP reserve, which adds a cost to creating a large number of wallets.
+
+See [https://ripple.com/build/transactions/#creating-accounts](https://ripple.com/build/transactions/#creating-accounts) and [https://ripple.com/build/reserves/](https://ripple.com/build/reserves/).
+
+# About XRP Balances
+
+Amounts of XRP are represented on the Ripple Consensus Ledger as an unsigned integer count of *drops*, where one XRP == 1,000,000 drops.  Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values.  However all user interfaces should present balances in units of XRP.
+
+One drop (or .000001 XRP) cannot be further subdivided.  Bear this in mind when calculating and displaying FX rates between XRP and other assets.
+
+See [https://ripple.com/build/rippled-apis/#specifying-currency-amounts](https://ripple.com/build/rippled-apis/#specifying-currency-amounts) for additional detail.

--- a/content/exchange-guide.md
+++ b/content/exchange-guide.md
@@ -182,7 +182,7 @@ The remaining sections describe how funds flow through the accounts managed by A
 
 There are four main steps involved in an exchange's typical flow of funds:
 
-1. [Deposit XRP into Exchange](#deposit-xrp-into-an-exchange)
+1. [Deposit XRP into Exchange](#deposit-xrp-into-exchange)
 
 2. [Rebalance XRP Holdings](#rebalance-xrp-holdings)
 
@@ -386,7 +386,7 @@ Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exc
 For more information about trading _on_ the RCL, see [Lifecycle of an Offer](https://ripple.com/build/transactions/#lifecycle-of-an-offer).
 
 
-### Rebalancing XRP Holdings
+### Rebalance XRP Holdings
 
 Exchanges can adjust the balances between their operational and issuing accounts at any time. Each balance adjustment consumes a [transaction fee](https://ripple.com/build/fees-disambiguation/), but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's [transaction fees](https://ripple.com/build/transaction-cost/).)
 

--- a/content/exchange-guide.md
+++ b/content/exchange-guide.md
@@ -4,16 +4,19 @@ This document describes the steps that an exchange needs to take to list XRP. Fo
 
 ## Alpha Exchange
 
-For illustrative purposes, this document uses a fictitious change called _Alpha Exchange_ that has the following characteristics:
+For illustrative purposes, this document uses a fictitious business called _Alpha Exchange_ that has the following characteristics:
 
 * Currently specializes in listing BTC/USD
+
 * Wants to add BTC/XRP and XRP/USD trading pairs
+
 * Maintains balances for all of its customers
+
 * Maintains balances for each of its supported currencies
 
 ### User Benefits
 
-By supporting the BTC/XRP and XRP/USD trading pairs, Alpha Exchange allows its users to:
+Alpha Exchange wants to list BTC/XRP and XRP/USD trading pairs partially because listing these pairs will benefit its users. Specifically, this support will allow its users to:
 
 * Deposit XRP _to_ Alpha Exchange _from_ the RCL
 
@@ -21,27 +24,117 @@ By supporting the BTC/XRP and XRP/USD trading pairs, Alpha Exchange allows its u
 
 * Trade XRP with other currencies, such as BTC, USD, amongst others
 
-### Prerequisites for Supporting XRP
+## Prerequisites for Supporting XRP
 
-To support XRP, Alpha Exchange must create and maintain new accounts and balance sheets.
+To support XRP, Alpha Exchange must:
 
-#### Accounts
+* Create and maintain new [accounts](#accounts)
 
-Alpha Exchange must create at least two new [accounts](https://ripple.com/build/accounts/) (also referred to as "wallets") on the RCL. To minimize the risk associated with a compromised secret key, Ripple recommends creating [_issuing_ and _operational_ accounts](https://ripple.com/build/issuing-operational-addresses/):
+* Create and maintain [balance sheets](#balance-sheets)
 
-    * An _issuing_ account to securely hold the majority of XRP and customers' funds
+### Accounts
 
-    * One or more _operational_ (and, perhaps, _standby_) accounts to conduct the day-to-day business of accepting customers' XRP withdrawals and deposits
+Alpha Exchange must create at least two new [accounts](https://ripple.com/build/accounts/) (also referred to as "wallets") on the RCL. To minimize the risk associated with a compromised secret key, Ripple recommends creating [_issuing_, _operational_, and _standby_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). This model is intended to balance security and convenience.
 
-#### Balance Sheets
+    * An _issuing_ account to securely hold the majority of XRP and customers' funds. This account should be offline.
 
-* An additional balance sheet to track each customer’s XRP held at Alpha Exchange
+    * One or more _operational_ (and, perhaps, _standby_) accounts to conduct the day-to-day business of accepting customers' XRP withdrawals and deposits. Standby accounts can be online if you use the [Multisign](https://ripple.com/build/how-to-multi-sign/) feature. Operational accounts need to be online to service instant withdrawal requests.
 
-The new RCL wallets are represented on the left-hand side of Figure 1. A  model of hot, cold and warm wallets is intended to balance security and convenience for users deposits and withdrawals. Cold wallets are understood to be offline, warm may be online using the [Ripple Multisign](https://ripple.com/build/how-to-multi-sign/) technology, and hot wallets are developed to service instant withdrawal requests.  For more information about secure wallets and  additional best practices, see the Ripple Developer Portal :
+For more information, see:
 
-[https://ripple.com/build/gateway-guide/#suggested-business-practices](https://ripple.com/build/gateway-guide/#suggested-business-practices)
+* ["Suggested Business Practices" in the _Gateway Guide_](https://ripple.com/build/gateway-guide/#suggested-business-practices)
 
-The additional balance sheet is represented on the right-hand side of Figure 1.  Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.  The remainder of this document describes the flow of funds as Alpha Exchange allows users to deposit, trade, and redeem XRP balances.
+* [Issuing and Operational Addresses](https://ripple.com/build/issuing-operational-addresses/)
+
+### Balance Sheets
+
+Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance. To do this, Alpha Exchange must create and maintain an additional balance sheet. The following table illustrates what this balance sheet might look like.
+
+<table>
+  <tr>
+    <td><b>XRP Balances
+on RCL</b></td>
+    <td></td>
+    <td></td>
+    <td><b>Alpha Exchange
+XRP Balances</b></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+    <td></td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td><i>Alpha Operational</i></td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Standby</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Issuing</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+
+The new RCL accounts (_Alpha Operational_, _Alpha Standby_, _Alpha Issuing_) are in the *User* column of the *XRP Balances on RCL* table.
+
+The *Alpha Exchange XRP Balances* table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.
+
+## Flow of Funds
+
+The remainder of this document describes the flow of funds as Alpha Exchange allows users to deposit, trade, and redeem XRP balances.
 
 <table>
   <tr>

--- a/content/exchange-guide.md
+++ b/content/exchange-guide.md
@@ -1,10 +1,10 @@
 # Listing XRP as an Exchange
 
-This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of `rippled` and the Ripple Consensus Ledger (RCL), see [https://ripple.com/build](https://ripple.com/build).
+This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of `rippled` and the Ripple Consensus Ledger (RCL), see the  [Ripple Developer Center](https://ripple.com/build).
 
 ## Alpha Exchange
 
-For illustrative purposes, this document uses a fictitious business called _Alpha Exchange_ that has the following characteristics:
+For illustrative purposes, this document uses a fictitious business called _Alpha Exchange_ to explain the high-level steps required to list XRP. For the purposes of this document, Alpha Exchange:
 
 * Currently specializes in listing BTC/USD
 
@@ -34,11 +34,19 @@ To support XRP, Alpha Exchange must:
 
 ### Accounts
 
-Alpha Exchange must create at least two new [accounts](https://ripple.com/build/accounts/) (also referred to as "wallets") on the RCL. To minimize the risk associated with a compromised secret key, Ripple recommends creating [_issuing_, _operational_, and _standby_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). This model is intended to balance security and convenience.
+Alpha Exchange must create at least two new [accounts](https://ripple.com/build/accounts/) (also referred to as "wallets") on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating [_issuing_, _operational_, and _standby_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The operational/standby/issuing model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:
 
-    * An _issuing_ account to securely hold the majority of XRP and customers' funds. This account should be offline.
+* An [_issuing_ account](https://ripple.com/build/issuing-operational-addresses/#issuing-address) to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.
 
-    * One or more _operational_ (and, perhaps, _standby_) accounts to conduct the day-to-day business of accepting customers' XRP withdrawals and deposits. Standby accounts can be online if you use the [Multisign](https://ripple.com/build/how-to-multi-sign/) feature. Operational accounts need to be online to service instant withdrawal requests.
+    For more information about the possible consequences of a compromised issuing account, see [Issuing Account Compromise](https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise).
+
+* One or more [_operational_ accounts](https://ripple.com/build/issuing-operational-addresses/#operational-addresses) to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. Operational accounts need to be online to service instant withdrawal requests.
+
+    For more information about the possible consequences of a compromised operational account, see [Operational Account Compromise](https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise).
+
+* Optionally, one or more standby accounts to provide an additional layer of security between the issuing and operational accounts. Unlike an operational account, the secret key of a standby account does not need to be online. Additionally, you can distribute the secret keys for the standby account to several different people and implement  [multisigning](https://ripple.com/build/how-to-multi-sign/) to increase security.
+
+    For more information about the possible consequences of a compromised standby account, see [Standby Account Compromise](https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise).
 
 For more information, see:
 
@@ -48,16 +56,129 @@ For more information, see:
 
 ### Balance Sheets
 
-Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance. To do this, Alpha Exchange must create and maintain an additional balance sheet. The following table illustrates what this balance sheet might look like.
+Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance(s). To do this, Alpha Exchange must create and maintain an additional balance sheet. The following table illustrates what this balance sheet might look like.
+
+The new RCL accounts (_Alpha Operational_, _Alpha Standby_, _Alpha Issuing_) are in the *User* column of the *XRP Balances on RCL* table.
+
+The *Alpha Exchange XRP Balances* table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.
+
 
 <table>
   <tr>
-    <td><b>XRP Balances
-on RCL</b></td>
+    <td><b><i>XRP Balances
+on RCL</i></b></td>
     <td></td>
     <td></td>
-    <td><b>Alpha Exchange
-XRP Balances</b></td>
+    <td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+    <td></td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td><i>Alpha Operational</i></td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Standby</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Issuing</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+## On-Ledger and Off-Ledger
+
+With exchanges like _Alpha Exchange_, XRP can be "on-ledger" or "off-ledger":
+
+* **On-Ledger XRP**: XRP that can be queried through the public RCL by specifying the public [address](https://ripple.com/build/accounts/#addresses) of the XRP holder. The counterparty to these balances is the RCL. For more information, see [Currencies](https://ripple.com/build/rippled-apis/#currencies).
+
+* **Off-Ledger XRP**: XRP that is held by the accounting system of an exchange and can be queried through the exchange interface. Off-ledger XRP balances are credit-based. The counterparty is the exchange holding the XRP.
+
+    Off-ledger XRP balances are traded between the participants of an exchange. To support these trades, the exchange must hold a balance of _on-ledger XRP_ equal to the aggregate amount of _off-ledger XRP_ that it makes available for trade.
+
+
+## Flow of Funds
+
+The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in a [previous section](#balance-sheets).
+
+There are three main steps involved in an exchange's typical flow of funds:
+
+1. [Deposit XRP into Exchange](#deposit-xrp-into-an-exchange)
+
+2. [Rebalance XRP Holdings](#rebalance-xrp-holdings)
+
+3. [Withdraw XRP from Exchange](#withdraw-xrp-from-exchange)
+
+4. [Trade XRP on the Exchange](#trade-xrp-on-the-exchange)
+
+
+This list does not include the [prerequisites](#prerequisites for Supporting XRP) required of an exchange.
+
+At this point, _Alpha Exchange_ has created [operational, standby, and issuing accounts](#accounts) on the RCL and added them to its balance sheet, but has not funded the new accounts.
+
+
+<table>
+  <tr>
+    <td><b><i>XRP Balances
+on RCL</i></b></td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
     <td></td>
     <td></td>
   </tr>
@@ -128,99 +249,7 @@ XRP Balances</b></td>
 </table>
 
 
-The new RCL accounts (_Alpha Operational_, _Alpha Standby_, _Alpha Issuing_) are in the *User* column of the *XRP Balances on RCL* table.
 
-The *Alpha Exchange XRP Balances* table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.
-
-## Flow of Funds
-
-The remainder of this document describes the flow of funds as Alpha Exchange allows users to deposit, trade, and redeem XRP balances.
-
-<table>
-  <tr>
-    <td>XRP Balances
-on RCL</td>
-    <td></td>
-    <td></td>
-    <td>Alpha Exchange
-XRP Balances</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>User</td>
-    <td>Balance</td>
-    <td></td>
-    <td>Acct #</td>
-    <td>User</td>
-    <td>Balance</td>
-  </tr>
-  <tr>
-    <td>Dave</td>
-    <td>25,000</td>
-    <td></td>
-    <td>123</td>
-    <td>Alice</td>
-    <td>0</td>
-  </tr>
-  <tr>
-    <td>Edward</td>
-    <td>45,000</td>
-    <td></td>
-    <td>456</td>
-    <td>Bob</td>
-    <td>0</td>
-  </tr>
-  <tr>
-    <td>Charlie</td>
-    <td>50,000</td>
-    <td></td>
-    <td>789</td>
-    <td>Charlie</td>
-    <td>0</td>
-  </tr>
-  <tr>
-    <td>Alpha Hot</td>
-    <td>0</td>
-    <td></td>
-    <td>...</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Alpha Warm</td>
-    <td>0</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Alpha Cold</td>
-    <td>0</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>...</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-</table>
-
-
-Figure 1 : Initial requirements for listing XRP, denoted by green table cells
-
-## Key Definitions
-
-**On Ledger XRP**: XRP that is visible by querying the public RCL blockchain via the public address of the XRP holder. The counterparty to these balances is the global, decentralized and distributed, RCL.
-
-**Off Ledger XRP**: XRP that is held by the accounting system of an exchange that is visible by querying the exchange interface. These balances are credit based, and have a counterparty as the exchange. While these XRP balances are traded between participants in an exchange, the exchange is obligated to hold a balance of On Ledger XRP equal to the aggregate amount of Off Ledger XRP available for trade.
 
 ## Deposit XRP into Exchange
 

--- a/content/tutorial-listing-xrp.md
+++ b/content/tutorial-listing-xrp.md
@@ -1,0 +1,575 @@
+# Listing XRP as an Exchange
+
+This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of `rippled` and the Ripple Consensus Ledger (RCL), see the  [Ripple Developer Center](https://ripple.com/build).
+
+## Alpha Exchange
+
+For illustrative purposes, this document uses a fictitious business called _Alpha Exchange_ to explain the high-level steps required to list XRP. For the purposes of this document, Alpha Exchange:
+
+* Currently specializes in listing BTC/USD
+
+* Wants to add BTC/XRP and XRP/USD trading pairs
+
+* Maintains balances for all of its customers
+
+* Maintains balances for each of its supported currencies
+
+### User Benefits
+
+Alpha Exchange wants to list BTC/XRP and XRP/USD trading pairs partially because listing these pairs will benefit its users. Specifically, this support will allow its users to:
+
+* Deposit XRP _to_ Alpha Exchange _from_ the RCL
+
+* Withdraw XRP _from_ Alpha Exchange _to_ the RCL
+
+* Trade XRP with other currencies, such as BTC, USD, amongst others
+
+## Prerequisites for Supporting XRP
+
+To support XRP, Alpha Exchange must:
+
+* Create and maintain new [accounts](#accounts)
+
+* Create and maintain [balance sheets](#balance-sheets)
+
+See also:
+
+* [Gateway Compliance](https://ripple.com/build/gateway-guide/#gateway-compliance) — Gateways and exchanges are different, but exchanges should also ensure that they are complying with local regulations and reporting to the appropriate agencies.
+
+* [Requirements for Sending to RCL](https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl)
+
+* [Requirements for Receiving from RCL](https://ripple.com/build/gateway-guide/#requirements-for-receiving-from-rcl)
+
+* [Gateway Precautions](https://ripple.com/build/gateway-guide/#precautions)
+
+### Accounts
+
+XRP is held in _accounts_ (also referred to as _wallets_ or _addresses_  ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, [OfferCreate](https://ripple.com/build/transactions/#offercreate) and others used for trading), RCL accounts require XRP [reserves](https://ripple.com/build/reserves/) to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, [account objects](https://ripple.com/build/ledger-format/#accountroot) describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the [Accounts](https://ripple.com/build/accounts/) article.
+
+To comply with Ripple's recommend best practices, Alpha Exchange should create at least two new [accounts](https://ripple.com/build/accounts/) on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating [_cold_, _hot_, and _warm_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:
+
+* A [_cold wallet_](https://ripple.com/build/issuing-operational-addresses/#issuing-address) to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.
+
+    For more information about the possible consequences of a compromised cold wallet, see [Issuing Account Compromise](https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise).
+
+* One or more [_hot wallets_](https://ripple.com/build/issuing-operational-addresses/#operational-addresses) to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with an opertaitional wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.
+
+    For more information about the possible consequences of a compromised hot wallet, see [Operational Account Compromise](https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise).
+
+* Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement  [multisigning](https://ripple.com/build/how-to-multi-sign/) to increase security.
+
+    For more information about the possible consequences of a compromised warm wallet, see [Standby Account Compromise](https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise).
+
+
+See also:
+
+* ["Suggested Business Practices" in the _Gateway Guide_](https://ripple.com/build/gateway-guide/#suggested-business-practices)
+
+* [Issuing and Operational Addresses](https://ripple.com/build/issuing-operational-addresses/)
+
+* [Creating Accounts](https://ripple.com/build/transactions/#creating-accounts)
+
+* [Reserves](https://ripple.com/build/reserves/)
+
+### Balance Sheets
+
+Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance(s). To do this, Alpha Exchange must create and maintain an additional balance sheet or account system. The following table illustrates what this balance sheet might look like.
+
+The new RCL accounts (_Alpha Hot_, _Alpha Warm_, _Alpha Cold_) are in the *User* column of the *XRP Balances on RCL* table.
+
+The *Alpha Exchange XRP Balances* table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.
+
+
+<table>
+  <tr>
+    <td><b><i>XRP Balances
+on RCL</i></b></td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+    <td></td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td><i>Alpha Hot</i></td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Warm</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Cold</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+#### XRP Amounts
+
+Amounts of XRP are represented on the RCL as an unsigned integer count of *drops*, where one XRP == 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.
+
+One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.
+
+For more informtion, see [Specifying Currency Amounts](https://ripple.com/build/rippled-apis/#specifying-currency-amounts).
+
+#### On-Ledger and Off-Ledger
+
+With exchanges like _Alpha Exchange_, XRP can be "on-ledger" or "off-ledger":
+
+* **On-Ledger XRP**: XRP that can be queried through the public RCL by specifying the public [address](https://ripple.com/build/accounts/#addresses) of the XRP holder. The counterparty to these balances is the RCL. For more information, see [Currencies](https://ripple.com/build/rippled-apis/#currencies).
+
+* **Off-Ledger XRP**: XRP that is held by the accounting system of an exchange and can be queried through the exchange interface. Off-ledger XRP balances are credit-based. The counterparty is the exchange holding the XRP.
+
+    Off-ledger XRP balances are traded between the participants of an exchange. To support these trades, the exchange must hold a balance of _on-ledger XRP_ equal to the aggregate amount of _off-ledger XRP_ that it makes available for trade.
+
+
+## Flow of Funds
+
+The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in the ["Balance Sheets" section](#balance-sheets).
+
+There are four main steps involved in an exchange's typical flow of funds:
+
+1. [Deposit XRP into Exchange](#deposit-xrp-into-exchange)
+
+2. [Rebalance XRP Holdings](#rebalance-xrp-holdings)
+
+3. [Withdraw XRP from Exchange](#withdraw-xrp-from-exchange)
+
+4. [Trade XRP on the Exchange](#trade-xrp-on-the-exchange)
+
+
+This list does not include the [prerequisites](#prerequisites-for-supporting-xrp) required of an exchange.
+
+At this point, _Alpha Exchange_ has created [hot, warm, and cold wallets](#accounts) on the RCL and added them to its balance sheet, but has not accepted any deposits from its users.
+
+
+<table>
+  <tr>
+    <td><b><i>XRP Balances
+on RCL</i></b></td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+    <td></td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td><i>Alpha Hot</i></td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Warm</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><i>Alpha Cold</i></td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+
+### Deposit XRP into Exchange
+
+To track [off-ledger XRP balances](#on-ledger-and-off-ledger) exchanges need to create new [balance sheets](#balance-sheets) (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.
+
+A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:
+
+1. Charlie submits a payment of 50,000  XRP (by using [RippleAPI](https://ripple.com/build/rippleapi/) or similar software) to Alpha Exchange's [cold wallet](#accounts).
+
+    a. Charlie adds an identifier (in this case, `789`) to the payment to associate it with his account at Alpha Exchange. This is called a [_destination tag_](https://ripple.com/build/gateway-guide/#source-and-destination-tags). (To use this, Alpha Exchange must have set the asfRequireDest flag on all of its accounts. This flag requires all incoming payments to have a destination tag like Charlie's. For more information, see [AccountSet Flags](https://ripple.com/build/transactions/#accountset-flags).
+
+2. The software at Alpha Exchange detects the incoming payment, and recognizes `789` as the destination tag for Charlie’s account.
+
+3. When it detects the incoming payment, Alpha Exchange's software updates its balance sheet to indicate that the 50,000 XRP it received is controlled by Charlie.
+
+    Charlie can now use up to 50,000 XRP on the exchange. For example, he can create offers to trade XRP with BTC or any of the other currencies Alpha Exchange supports.
+
+<table>
+  <tr>
+    <td><b><i>XRP Balances
+on RCL</i></b></td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+    <td></td>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Charlie</td>
+    <td><s>100,000</s>
+<br>50,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td><s>0</s>
+<br>50,000</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Hot</td>
+    <td>0</td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Warm</td>
+    <td>0</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Alpha Cold</td>
+    <td><s>0</s>
+<br>50,000</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+
+
+### Trade XRP on The Exchange
+
+Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are _off-ledger_ and independent from the RCL, so the balance changes are not recorded there.
+
+For more information about trading _on_ the RCL, see [Lifecycle of an Offer](https://ripple.com/build/transactions/#lifecycle-of-an-offer).
+
+
+### Rebalance XRP Holdings
+
+Exchanges can adjust the balances between their hot and cold wallets at any time. Each balance adjustment consumes a [transaction fee](https://ripple.com/build/fees-disambiguation/), but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's [transaction fees](https://ripple.com/build/transaction-cost/).)
+
+The following table demonstrates a balance adjustment of 80,000 XRP (via a [_payment_](https://ripple.com/build/transactions/#payment) on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debit the hot wallet and credit the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.
+
+
+<table>
+  <tr>
+    <td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</i></b></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange XRP On-Ledger Balances</i></b></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>Acct #</b></td>
+    <td><b>User</b></td>
+    <td><b>Balance</b></td>
+    <td></td>
+    <td><b>RCL Account</b></td>
+    <td><b>Balance</b></td>
+  </tr>
+  <tr>
+    <td>123</td>
+    <td>Alice</td>
+    <td>80,000</td>
+    <td></td>
+    <td>Hot</td>
+    <td><s>0</s>
+<br>80,000</td>
+  </tr>
+  <tr>
+    <td>456</td>
+    <td>Bob</td>
+    <td>50,000</td>
+    <td></td>
+    <td>Warm</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>….</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>….</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>789</td>
+    <td>Charlie</td>
+    <td>50,000</td>
+    <td></td>
+    <td>Cold</td>
+    <td><s>180,000</s>
+<br>100,000</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+  </tr>
+</table>
+
+
+### Withdraw XRP from Exchange
+
+Withdrawals allow an exchange's users to move XRP from the exchange's off-ledger balance sheet to an account on the RCL.
+
+In this example, Charlie withdraws 25,000 XRP from Alpha Exchange. This involves the following steps:
+
+1. Charlie initiates the process on Alpha Exchange’s website. He provides instructions to transfer 25,000 XRP to a specific account on the RCL (named "Charlie RCL" in the following table).
+
+2. In response to Charlie’s instructions, Alpha Exchange does the following:
+
+    a. Debits the amount (25,000 XRP) from Charlie’s account on its off-ledger balance sheet
+
+    b. Submits a payment on the RCL for the same amount (25,000 XRP), from Alpha Exchange's hot wallet to Charlie’s RCL account
+
+
+<table>
+  <tr>
+    <td><b><i>RCL On-Ledger XRP Balances</td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td><b><i>Alpha Exchange XRP On-Ledger Balances</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b>User</td>
+    <td><b>Balance</td>
+    <td></td>
+    <td><b>Acct #</td>
+    <td><b>User</td>
+    <td><b>Balance</td>
+    <td></td>
+    <td><b>RCL Account</td>
+    <td><b>Balance</td>
+  </tr>
+  <tr>
+    <td>Dave</td>
+    <td>25,000</td>
+    <td></td>
+    <td>123</td>
+    <td>Alice</td>
+    <td>80,000</td>
+    <td></td>
+    <td>Hot</td>
+    <td><s>80,000</s>
+<br>55,000</td>
+  </tr>
+  <tr>
+    <td>Edward</td>
+    <td>45,000</td>
+    <td></td>
+    <td>456</td>
+    <td>Bob</td>
+    <td>50,000</td>
+    <td></td>
+    <td>Warm</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>….</td>
+    <td></td>
+    <td></td>
+    <td>….</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>….</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Charlie RCL</td>
+    <td><s>50,000</s>
+<br>75,000</td>
+    <td></td>
+    <td>789</td>
+    <td>Charlie</td>
+    <td><s>50,000</s>
+<br>25,000</td>
+    <td></td>
+    <td>Cold</td>
+    <td>100,000</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>...</td>
+    <td></td>
+  </tr>
+</table>

--- a/content/tutorial-listing-xrp.md
+++ b/content/tutorial-listing-xrp.md
@@ -22,7 +22,7 @@ Alpha Exchange wants to list BTC/XRP and XRP/USD trading pairs partially because
 
 * Withdraw XRP _from_ Alpha Exchange _to_ the RCL
 
-* Trade XRP with other currencies, such as BTC, USD, amongst others
+* Trade XRP with other currencies, such as BTC, USD, among others
 
 ## Prerequisites for Supporting XRP
 
@@ -46,17 +46,17 @@ See also:
 
 XRP is held in _accounts_ (also referred to as _wallets_ or _addresses_  ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, [OfferCreate](https://ripple.com/build/transactions/#offercreate) and others used for trading), RCL accounts require XRP [reserves](https://ripple.com/build/reserves/) to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, [account objects](https://ripple.com/build/ledger-format/#accountroot) describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the [Accounts](https://ripple.com/build/accounts/) article.
 
-To comply with Ripple's recommend best practices, Alpha Exchange should create at least two new [accounts](https://ripple.com/build/accounts/) on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating [_cold_, _hot_, and _warm_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:
+To comply with Ripple's recommended best practices, Alpha Exchange should create at least two new [accounts](https://ripple.com/build/accounts/) on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating [_cold_, _hot_, and _warm_ accounts](https://ripple.com/build/issuing-operational-addresses/) (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:
 
 * A [_cold wallet_](https://ripple.com/build/issuing-operational-addresses/#issuing-address) to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.
 
     For more information about the possible consequences of a compromised cold wallet, see [Issuing Account Compromise](https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise).
 
-* One or more [_hot wallets_](https://ripple.com/build/issuing-operational-addresses/#operational-addresses) to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with an opertaitional wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.
+* One or more [_hot wallets_](https://ripple.com/build/issuing-operational-addresses/#operational-addresses) to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with a hot wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.
 
     For more information about the possible consequences of a compromised hot wallet, see [Operational Account Compromise](https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise).
 
-* Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement  [multisigning](https://ripple.com/build/how-to-multi-sign/) to increase security.
+* Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement [multisigning](https://ripple.com/build/how-to-multi-sign/) to increase security.
 
     For more information about the possible consequences of a compromised warm wallet, see [Standby Account Compromise](https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise).
 
@@ -159,7 +159,7 @@ XRP Balances</i></b></td>
 
 #### XRP Amounts
 
-Amounts of XRP are represented on the RCL as an unsigned integer count of *drops*, where one XRP == 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.
+Amounts of XRP are represented on the RCL as an unsigned integer count of *drops*, where one XRP = 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.
 
 One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.
 
@@ -276,7 +276,7 @@ XRP Balances</i></b></td>
 
 ### Deposit XRP into Exchange
 
-To track [off-ledger XRP balances](#on-ledger-and-off-ledger) exchanges need to create new [balance sheets](#balance-sheets) (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.
+To track [off-ledger XRP balances](#on-ledger-and-off-ledger), exchanges need to create new [balance sheets](#balance-sheets) (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.
 
 A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:
 
@@ -390,7 +390,7 @@ For more information about trading _on_ the RCL, see [Lifecycle of an Offer](htt
 
 Exchanges can adjust the balances between their hot and cold wallets at any time. Each balance adjustment consumes a [transaction fee](https://ripple.com/build/fees-disambiguation/), but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's [transaction fees](https://ripple.com/build/transaction-cost/).)
 
-The following table demonstrates a balance adjustment of 80,000 XRP (via a [_payment_](https://ripple.com/build/transactions/#payment) on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debit the hot wallet and credit the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.
+The following table demonstrates a balance adjustment of 80,000 XRP (via a [_payment_](https://ripple.com/build/transactions/#payment) on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debiting the hot wallet and crediting the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.
 
 
 <table>

--- a/data-api-v2-tool.html
+++ b/data-api-v2-tool.html
@@ -60,6 +60,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/gb-2015-05.html
+++ b/gb-2015-05.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/gb-2015-06.html
+++ b/gb-2015-06.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -158,6 +159,7 @@ Ripple’s distributed settlement network is built on open-source technology tha
                     <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                     <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                     <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                    <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
 			    </ul>
 			</div>
 			<div class="col-md-3">

--- a/reference-data-api.html
+++ b/reference-data-api.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/reference-ledger-format.html
+++ b/reference-ledger-format.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/reference-rippleapi.html
+++ b/reference-rippleapi.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/reference-rippled.html
+++ b/reference-rippled.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/reference-transaction-format.html
+++ b/reference-transaction-format.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/ripple-api-tool.html
+++ b/ripple-api-tool.html
@@ -60,6 +60,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/tool-jsonrpc.html
+++ b/tool-jsonrpc.html
@@ -60,6 +60,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -206,8 +206,8 @@ pages:
 
 # Listing XRP as an Exchange
     -   category: Tutorials
-        html: xrp-listing-guide.html
-        md: exchange-guide.md
+        html: tutorial-listing-xrp.html
+        md: tutorial-listing-xrp.md
         targets:
             - local
             - ripple.com

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -204,6 +204,14 @@ pages:
             - local
             - ripple.com
 
+# Listing XRP as an Exchange
+    -   category: Tutorials
+        html: xrp-listing-guide.html
+        md: exchange-guide.md
+        targets:
+            - local
+            - ripple.com
+
     ## Escrow Tutorial is a work in progress
     # -   md: tutorial-escrow.md
     #     html: tutorial-escrow.html

--- a/tutorial-gateway-guide.html
+++ b/tutorial-gateway-guide.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/tutorial-listing-xrp.html
+++ b/tutorial-listing-xrp.html
@@ -144,11 +144,12 @@
 <li class="level-2"><a href="#alpha-exchange">Alpha Exchange</a></li>
 <li class="level-3"><a href="#user-benefits">User Benefits</a></li>
 <li class="level-2"><a href="#prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</a></li>
+<li class="level-3"><a href="#partial-payments">Partial Payments</a></li>
 <li class="level-3"><a href="#accounts">Accounts</a></li>
 <li class="level-3"><a href="#balance-sheets">Balance Sheets</a></li>
 <li class="level-2"><a href="#flow-of-funds">Flow of Funds</a></li>
 <li class="level-3"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
-<li class="level-3"><a href="#trade-xrp-on-the-exchange">Trade XRP on The Exchange</a></li>
+<li class="level-3"><a href="#trade-xrp-on-the-exchange">Trade XRP on the Exchange</a></li>
 <li class="level-3"><a href="#rebalance-xrp-holdings">Rebalance XRP Holdings</a></li>
 <li class="level-3"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
 
@@ -202,52 +203,79 @@
 <p>See also:</p>
 <ul>
 <li>
-<p><a href="https://ripple.com/build/gateway-guide/#gateway-compliance">Gateway Compliance</a> — Gateways and exchanges are different, but exchanges should also ensure that they are complying with local regulations and reporting to the appropriate agencies.</p>
+<p><a href="tutorial-gateway-guide.html#gateway-compliance">Gateway Compliance</a> — Gateways and exchanges are different, but exchanges should also ensure that they are complying with local regulations and reporting to the appropriate agencies.</p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
+<p><a href="tutorial-gateway-guide.html#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-receiving-from-rcl">Requirements for Receiving from RCL</a></p>
+<p><a href="tutorial-gateway-guide.html#requirements-for-receiving-from-rcl">Requirements for Receiving from RCL</a></p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/gateway-guide/#precautions">Gateway Precautions</a></p>
+<p><a href="tutorial-gateway-guide.html#precautions">Gateway Precautions</a></p>
 </li>
 </ul>
+<h3 id="partial-payments">Partial Payments</h3>
+<p>Before integrating, exchanges should be aware of the <a href="reference-transaction-format.html#partial-payments">partial payments</a> feature. This feature allows RCL users to send successful payments that reduce the amount received instead of increasing the <code>SendMax</code>. This feature can be useful for <a href="tutorial-gateway-guide.html#bouncing-payments">returning payments</a> without incurring additional cost as the sender.</p>
+<h4 id="partial-payments-warning">Partial Payments Warning</h4>
+<p>When the <a href="reference-transaction-format.html#payment-flags">tfPartialPayment flag</a> is enabled, the <code>Amount</code> field <strong><em>is not guaranteed to be the amount received</em></strong>. The <code>delivered_amount</code> field of a payment's metadata indicates the amount of currency actually received by the destination account. When receiving a payment, use <code>delivered_amount</code> instead of the Amount field to determine how much your account received instead.</p>
+<p class="devportal-callout warning"><strong>Warning:</strong> Be aware that malicious actors could exploit this. For more information, see <a href="concept-partial-payments.html">Partial Payments</a>.</p>
 <h3 id="accounts">Accounts</h3>
-<p>XRP is held in <em>accounts</em> (also referred to as <em>wallets</em> or <em>addresses</em>  ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, <a href="https://ripple.com/build/transactions/#offercreate">OfferCreate</a> and others used for trading), RCL accounts require XRP <a href="https://ripple.com/build/reserves/">reserves</a> to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, <a href="https://ripple.com/build/ledger-format/#accountroot">account objects</a> describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the <a href="https://ripple.com/build/accounts/">Accounts</a> article.</p>
-<p>To comply with Ripple's recommended best practices, Alpha Exchange should create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>cold</em>, <em>hot</em>, and <em>warm</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
+<p>XRP is held in <em>accounts</em> (also referred to as <em>wallets</em> or <em>addresses</em>  ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. In the RCL, accounts can <a href="concept-accounts.html#permanence-of-accounts">never be deleted</a>, and each account must hold a separate <a href="concept-reserves.html">reserve of XRP</a> that cannot be sent to others. For these reasons, Ripple recommends that institutions not create excessive or needless accounts.</p>
+<p>To comply with Ripple's recommended best practices, Alpha Exchange should create at least two new accounts on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>cold</em>, <em>hot</em>, and <em>warm</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
 <ul>
 <li>
-<p>A <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address"><em>cold wallet</em></a> to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.</p>
-<p>For more information about the possible consequences of a compromised cold wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise">Issuing Account Compromise</a>.</p>
+<p>A <a href="concept-issuing-and-operational-addresses.html#issuing-address"><em>cold wallet</em></a> to securely hold the majority of XRP and customers' funds. For exchanges, this is also the address to which its users send <a href="#deposit-xrp-into-exchange">deposits</a>.   To provide optimal security, this account's secret key should be offline.</p>
+<p>If a malicious actor compromises an exchange's cold wallet, the possible consequences are:</p>
+<ul>
+<li>
+<p>The malicious actor gets full access to all XRP in the cold wallet.</p>
 </li>
 <li>
-<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>hot wallets</em></a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with a hot wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.</p>
-<p>For more information about the possible consequences of a compromised hot wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise">Operational Account Compromise</a>.</p>
+<p>If the master key is compromised, the malicious actor can irrevocably take control of the cold wallet forever (by disabling the master key and setting a new regular key or signer list). This would also give the malicious actor control over all future XRP received by the cold wallet.</p>
+<ul>
+<li>If this happens, the exchange has to make a new cold wallet address and tell its customers the new address.</li>
+</ul>
 </li>
 <li>
-<p>Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement <a href="https://ripple.com/build/how-to-multi-sign/">multisigning</a> to increase security.</p>
-<p>For more information about the possible consequences of a compromised warm wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise">Standby Account Compromise</a>.</p>
+<p>If the regular key or signer list are comromised, the exchange can regain control of the cold wallet. However, some of a malicious actor's actions cannot easily be undone:</p>
+<ul>
+<li>
+<p>The malicious actor could issue currency in the RCL by using the cold wallet, but that currency should not be valued by anyone (unless the exchange explicitly stated it was also a gateway).</p>
+</li>
+<li>
+<p>If a malicious actor sets the asfRequireAuth flag for the account, that cannot be unset, although this only relates issuing currency and therefore should not affect an exchange that's not also a gateway. Any other settings a malicious actor sets or unsets with a master key can be reverted.</p>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>
+<p>One or more <a href="concept-issuing-and-operational-addresses.html#operational-addresses"><em>hot wallets</em></a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with a hot wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.</p>
+<p>For more information about the possible consequences of a compromised hot wallet, see <a href="concept-issuing-and-operational-addresses.html#operational-address-compromise">Operational Account Compromise</a>.</p>
+</li>
+<li>
+<p>Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement <a href="tutorial-multisign.html">multisigning</a> to increase security.</p>
+<p>For more information about the possible consequences of a compromised warm wallet, see <a href="concept-issuing-and-operational-addresses.html#standby-address-compromise">Standby Account Compromise</a>.</p>
 </li>
 </ul>
 <p>See also:</p>
 <ul>
 <li>
-<p><a href="https://ripple.com/build/gateway-guide/#suggested-business-practices">"Suggested Business Practices" in the <em>Gateway Guide</em></a></p>
+<p><a href="tutorial-gateway-guide.html#suggested-business-practices">"Suggested Business Practices" in the <em>Gateway Guide</em></a></p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/issuing-operational-addresses/">Issuing and Operational Addresses</a></p>
+<p><a href="concept-issuing-and-operational-addresses.html">Issuing and Operational Addresses</a></p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/transactions/#creating-accounts">Creating Accounts</a></p>
+<p><a href="reference-transaction-format.html#creating-accounts">Creating Accounts</a></p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/reserves/">Reserves</a></p>
+<p><a href="concept-reserves.html">Reserves</a></p>
 </li>
 </ul>
 <h3 id="balance-sheets">Balance Sheets</h3>
-<p>Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance(s). To do this, Alpha Exchange must create and maintain an additional balance sheet or account system. The following table illustrates what this balance sheet might look like.</p>
+<p>To custody its ccustomers' XRP, Alpha Exchange must track each customer's XRP balance and its own holdings. To do this, Alpha Exchange must create and maintain an additional balance sheet or accounting system. The following table illustrates what this balance sheet might look like.</p>
 <p>The new RCL accounts (<em>Alpha Hot</em>, <em>Alpha Warm</em>, <em>Alpha Cold</em>) are in the <em>User</em> column of the <em>XRP Balances on RCL</em> table.</p>
 <p>The <em>Alpha Exchange XRP Balances</em> table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.</p>
 <table>
@@ -327,14 +355,14 @@ XRP Balances</i></b></td>
 </tr>
 </table>
 <h4 id="xrp-amounts">XRP Amounts</h4>
-<p>Amounts of XRP are represented on the RCL as an unsigned integer count of <em>drops</em>, where one XRP = 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.</p>
-<p>One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.</p>
-<p>For more informtion, see <a href="https://ripple.com/build/rippled-apis/#specifying-currency-amounts">Specifying Currency Amounts</a>.</p>
+<p>Amounts of XRP are represented on the RCL as an unsigned integer count of <em>drops</em>, where one XRP is 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.</p>
+<p>One drop (.000001 XRP) cannot be further subdivided. Keep this in mind when calculating and displaying FX rates between XRP and other assets.</p>
+<p>For more information, see <a href="reference-rippled.html#specifying-currency-amounts">Specifying Currency Amounts</a>.</p>
 <h4 id="on-ledger-and-off-ledger">On-Ledger and Off-Ledger</h4>
 <p>With exchanges like <em>Alpha Exchange</em>, XRP can be "on-ledger" or "off-ledger":</p>
 <ul>
 <li>
-<p><strong>On-Ledger XRP</strong>: XRP that can be queried through the public RCL by specifying the public <a href="https://ripple.com/build/accounts/#addresses">address</a> of the XRP holder. The counterparty to these balances is the RCL. For more information, see <a href="https://ripple.com/build/rippled-apis/#currencies">Currencies</a>.</p>
+<p><strong>On-Ledger XRP</strong>: XRP that can be queried through the public RCL by specifying the public <a href="concept-accounts.html#addresses">address</a> of the XRP holder. The counterparty to these balances is the RCL. For more information, see <a href="reference-rippled.html#currencies">Currencies</a>.</p>
 </li>
 <li>
 <p><strong>Off-Ledger XRP</strong>: XRP that is held by the accounting system of an exchange and can be queried through the exchange interface. Off-ledger XRP balances are credit-based. The counterparty is the exchange holding the XRP.</p>
@@ -441,8 +469,8 @@ XRP Balances</i></b></td>
 <p>A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:</p>
 <ol>
 <li>
-<p>Charlie submits a payment of 50,000  XRP (by using <a href="https://ripple.com/build/rippleapi/">RippleAPI</a> or similar software) to Alpha Exchange's <a href="#accounts">cold wallet</a>.</p>
-<p>a. Charlie adds an identifier (in this case, <code>789</code>) to the payment to associate it with his account at Alpha Exchange. This is called a <a href="https://ripple.com/build/gateway-guide/#source-and-destination-tags"><em>destination tag</em></a>. (To use this, Alpha Exchange must have set the asfRequireDest flag on all of its accounts. This flag requires all incoming payments to have a destination tag like Charlie's. For more information, see <a href="https://ripple.com/build/transactions/#accountset-flags">AccountSet Flags</a>.</p>
+<p>Charlie submits a payment of 50,000  XRP (by using <a href="reference-rippleapi.html">RippleAPI</a> or similar software) to Alpha Exchange's <a href="#accounts">cold wallet</a>.</p>
+<p>a. Charlie adds an identifier (in this case, <code>789</code>) to the payment to associate it with his account at Alpha Exchange. This is called a <a href="tutorial-gateway-guide.html#source-and-destination-tags"><em>destination tag</em></a>. (To use this, Alpha Exchange should have set the asfRequireDest flag on all of its accounts to require all incoming payments to have a destination tag like Charlie's. For more information, see <a href="reference-transaction-format.html#accountset-flags">AccountSet Flags</a>).</p>
 </li>
 <li>
 <p>The software at Alpha Exchange detects the incoming payment, and recognizes <code>789</code> as the destination tag for Charlie’s account.</p>
@@ -539,12 +567,12 @@ XRP Balances</i></b></td>
 <td></td>
 </tr>
 </table>
-<h3 id="trade-xrp-on-the-exchange">Trade XRP on The Exchange</h3>
-<p>Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are <em>off-ledger</em> and independent from the RCL, so the balance changes are not recorded there.</p>
-<p>For more information about trading <em>on</em> the RCL, see <a href="https://ripple.com/build/transactions/#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
+<h3 id="trade-xrp-on-the-exchange">Trade XRP on the Exchange</h3>
+<p>Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are <em>off-ledger</em> and independent from the RCL, so the balance changes are not recorded on the RCL.</p>
+<p>Customers who hold XRP in their own RCL accounts can also use the distributed exchange built into the RCL to trade currencies issued by gateways. For more information about trading <em>on</em> the RCL, see <a href="reference-transaction-format.html#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
 <h3 id="rebalance-xrp-holdings">Rebalance XRP Holdings</h3>
-<p>Exchanges can adjust the balances between their hot and cold wallets at any time. Each balance adjustment consumes a <a href="https://ripple.com/build/fees-disambiguation/">transaction fee</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's <a href="https://ripple.com/build/transaction-cost/">transaction fees</a>.)</p>
-<p>The following table demonstrates a balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debiting the hot wallet and crediting the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.</p>
+<p>Exchanges can adjust the balances between their hot and cold wallets at any time. Each balance adjustment consumes a <a href="concept-transaction-cost.html">transaction cost</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's transaction cost.)</p>
+<p>The following table demonstrates a balance adjustment of 80,000 XRP (via a <a href="reference-transaction-format.html#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debiting the hot wallet and crediting the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.</p>
 <table>
 <tr>
 <td><b><i>Alpha Exchange XRP

--- a/tutorial-listing-xrp.html
+++ b/tutorial-listing-xrp.html
@@ -1,0 +1,778 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width">
+
+    <title>Listing XRP as an Exchange - Ripple Developer Portal</title>
+
+    <!-- favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+
+    <!-- jQuery -->
+    <script src="assets/vendor/jquery-1.11.1.min.js"></script>
+
+    <!-- Custom Stylesheets. ripple.css includes bootstrap, font stuff -->
+    <link href="assets/css/ripple.css" rel="stylesheet" />
+    <link href="assets/css/devportal.css" rel="stylesheet" />
+
+    <!-- Bootstrap JS -->
+    <script src="assets/vendor/bootstrap.min.js"></script>
+
+
+    <!-- syntax highlighting -->
+    <link rel="stylesheet" href="assets/vendor/docco.min.css" />
+    <script src="assets/vendor/highlight.min.js"></script>
+
+    <!-- syntax selection js -->
+    <script src="assets/js/multicodetab.js"></script>
+    <script>
+        $(document).ready(function() {
+            $(".multicode").minitabs();
+            hljs.initHighlighting();
+            make_code_expandable();
+        });
+    </script>
+
+    <script src="assets/js/expandcode.js"></script>
+    <script src="assets/js/fixsidebarscroll.js"></script>
+
+    <!-- fontawesome icons -->
+    <link rel="stylesheet" href="assets/vendor/fontawesome/css/font-awesome.min.css" />
+
+</head>
+
+<body class="page page-template page-template-template-dev-portal page-template-template-dev-portal-php sidebar-primary wpb-js-composer js-comp-ver-3.6.2 vc_responsive">
+  <header role="banner" class="banner navbar navbar-default navbar-fixed-top initial_header">
+    <div class="container">
+      <div class="navbar-header">
+          <a href="index.html" class="navbar-brand"><img src="assets/img/ripple-logo-color.png" class="logo"></a>
+      </div><!-- /.navbar-header -->
+      <div class="nav">
+        <div class="draft-warning">DRAFT PAGE</div>
+      </div><!-- /.nav -->
+
+    </div><!-- /.container -->
+
+    <div class="subnav dev_nav">
+      <div class="container">
+        <ul id="menu-dev-menu" class="menu">
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">References <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="reference-rippleapi.html">RippleAPI</a></li>
+                  <li><a href="reference-rippled.html">rippled</a></li>
+                  <li><a href="reference-transaction-format.html">Transaction Format</a></li>
+                  <li><a href="reference-ledger-format.html">Ledger Format</a></li>
+                  <li><a href="reference-data-api.html">Ripple Data API v2</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorials <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="tutorial-multisign.html">How to Multi-Sign</a></li>
+                  <li><a href="tutorial-paychan.html">Payment Channels Tutorial</a></li>
+                  <li><a href="concept-issuing-and-operational-addresses.html">Issuing and Operational Addresses</a></li>
+                  <li><a href="tutorial-reliable-transaction-submission.html">Reliable Transaction Submission</a></li>
+                  <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
+                  <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
+                  <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">RCL Features <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="concept-accounts.html">Accounts</a></li>
+                  <li><a href="concept-amendments.html">Amendments</a></li>
+                  <li><a href="concept-fee-voting.html">Fee Voting</a></li>
+                  <li><a href="concept-fees.html">Fees (Disambiguation)</a></li>
+                  <li><a href="concept-freeze.html">Freeze</a></li>
+                  <li><a href="concept-paths.html">Paths</a></li>
+                  <li><a href="concept-reserves.html">Reserves</a></li>
+                  <li><a href="concept-stand-alone-mode.html">Stand-Alone Mode</a></li>
+                  <li><a href="concept-transaction-cost.html">Transaction Cost</a></li>
+                  <li><a href="concept-transfer-fees.html">Transfer Fees</a></li>
+                  <li><a href="concept-noripple.html">Understanding the NoRipple flag</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Gateway Bulletins <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="gb-2015-06.html">GB-2015-06: Corrections to Autobridging</a></li>
+                  <li><a href="gb-2015-05.html">GB-2015-05: Historical Ledger Query Migration</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Tools <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="ripple-api-tool.html">WebSocket API Tool</a></li>
+                  <li><a href="data-api-v2-tool.html">Data API v2 Tool</a></li>
+                  <li><a href="tool-jsonrpc.html">rippled JSON-RPC Tool</a></li>
+            </ul>
+          </li>
+
+          <li><a href="https://github.com/ripple/ripple-dev-portal" title="GitHub">Site Source</a></li>
+        </ul><!-- /#dev-menu -->
+      </div><!-- /.subnav .container -->
+    </div><!-- /.subnav -->
+  </header>
+
+
+  <div class="wrap container" role="document">
+      <aside class="sidebar" role="complementary">
+    <div class="dev_nav_wrapper">
+        <div id="cont">
+            <h5>In this category:</h5>
+            <ul class="dev_nav_sidebar">
+                <li class="level-1"><a href="index.html">Category: Tutorials</a></li>
+                <li class="level-2"><a href="tutorial-multisign.html">How to Multi-Sign</a></li>
+                <li class="level-2"><a href="tutorial-paychan.html">Payment Channels Tutorial</a></li>
+                <li class="level-2"><a href="concept-issuing-and-operational-addresses.html">Issuing and Operational Addresses</a></li>
+                <li class="level-2"><a href="tutorial-reliable-transaction-submission.html">Reliable Transaction Submission</a></li>
+                <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
+                <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
+                <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
+            </ul>
+            <hr />
+            <h5>In this page:</h5>
+            <ul class="dev_nav_sidebar" id="dactyl_toc_sidebar">
+                <li class="level-1"><a href="#listing-xrp-as-an-exchange">Listing XRP as an Exchange</a></li>
+<li class="level-2"><a href="#alpha-exchange">Alpha Exchange</a></li>
+<li class="level-3"><a href="#user-benefits">User Benefits</a></li>
+<li class="level-2"><a href="#prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</a></li>
+<li class="level-3"><a href="#accounts">Accounts</a></li>
+<li class="level-3"><a href="#balance-sheets">Balance Sheets</a></li>
+<li class="level-2"><a href="#flow-of-funds">Flow of Funds</a></li>
+<li class="level-3"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
+<li class="level-3"><a href="#trade-xrp-on-the-exchange">Trade XRP on The Exchange</a></li>
+<li class="level-3"><a href="#rebalance-xrp-holdings">Rebalance XRP Holdings</a></li>
+<li class="level-3"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
+
+            </ul>
+        </div>
+    </div>
+      </aside>
+      <main class="main" role="main">
+    <div class='content'>
+        <h1 id="listing-xrp-as-an-exchange">Listing XRP as an Exchange</h1>
+<p>This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of <code>rippled</code> and the Ripple Consensus Ledger (RCL), see the  <a href="https://ripple.com/build">Ripple Developer Center</a>.</p>
+<h2 id="alpha-exchange">Alpha Exchange</h2>
+<p>For illustrative purposes, this document uses a fictitious business called <em>Alpha Exchange</em> to explain the high-level steps required to list XRP. For the purposes of this document, Alpha Exchange:</p>
+<ul>
+<li>
+<p>Currently specializes in listing BTC/USD</p>
+</li>
+<li>
+<p>Wants to add BTC/XRP and XRP/USD trading pairs</p>
+</li>
+<li>
+<p>Maintains balances for all of its customers</p>
+</li>
+<li>
+<p>Maintains balances for each of its supported currencies</p>
+</li>
+</ul>
+<h3 id="user-benefits">User Benefits</h3>
+<p>Alpha Exchange wants to list BTC/XRP and XRP/USD trading pairs partially because listing these pairs will benefit its users. Specifically, this support will allow its users to:</p>
+<ul>
+<li>
+<p>Deposit XRP <em>to</em> Alpha Exchange <em>from</em> the RCL</p>
+</li>
+<li>
+<p>Withdraw XRP <em>from</em> Alpha Exchange <em>to</em> the RCL</p>
+</li>
+<li>
+<p>Trade XRP with other currencies, such as BTC, USD, amongst others</p>
+</li>
+</ul>
+<h2 id="prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</h2>
+<p>To support XRP, Alpha Exchange must:</p>
+<ul>
+<li>
+<p>Create and maintain new <a href="#accounts">accounts</a></p>
+</li>
+<li>
+<p>Create and maintain <a href="#balance-sheets">balance sheets</a></p>
+</li>
+</ul>
+<p>See also:</p>
+<ul>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#gateway-compliance">Gateway Compliance</a> — Gateways and exchanges are different, but exchanges should also ensure that they are complying with local regulations and reporting to the appropriate agencies.</p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-receiving-from-rcl">Requirements for Receiving from RCL</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#precautions">Gateway Precautions</a></p>
+</li>
+</ul>
+<h3 id="accounts">Accounts</h3>
+<p>XRP is held in <em>accounts</em> (also referred to as <em>wallets</em> or <em>addresses</em>  ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, <a href="https://ripple.com/build/transactions/#offercreate">OfferCreate</a> and others used for trading), RCL accounts require XRP <a href="https://ripple.com/build/reserves/">reserves</a> to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, <a href="https://ripple.com/build/ledger-format/#accountroot">account objects</a> describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the <a href="https://ripple.com/build/accounts/">Accounts</a> article.</p>
+<p>To comply with Ripple's recommend best practices, Alpha Exchange should create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>cold</em>, <em>hot</em>, and <em>warm</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
+<ul>
+<li>
+<p>A <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address"><em>cold wallet</em></a> to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.</p>
+<p>For more information about the possible consequences of a compromised cold wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise">Issuing Account Compromise</a>.</p>
+</li>
+<li>
+<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>hot wallets</em></a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with an opertaitional wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.</p>
+<p>For more information about the possible consequences of a compromised hot wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise">Operational Account Compromise</a>.</p>
+</li>
+<li>
+<p>Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement  <a href="https://ripple.com/build/how-to-multi-sign/">multisigning</a> to increase security.</p>
+<p>For more information about the possible consequences of a compromised warm wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise">Standby Account Compromise</a>.</p>
+</li>
+</ul>
+<p>See also:</p>
+<ul>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#suggested-business-practices">"Suggested Business Practices" in the <em>Gateway Guide</em></a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/issuing-operational-addresses/">Issuing and Operational Addresses</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/transactions/#creating-accounts">Creating Accounts</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/reserves/">Reserves</a></p>
+</li>
+</ul>
+<h3 id="balance-sheets">Balance Sheets</h3>
+<p>Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance(s). To do this, Alpha Exchange must create and maintain an additional balance sheet or account system. The following table illustrates what this balance sheet might look like.</p>
+<p>The new RCL accounts (<em>Alpha Hot</em>, <em>Alpha Warm</em>, <em>Alpha Cold</em>) are in the <em>User</em> column of the <em>XRP Balances on RCL</em> table.</p>
+<p>The <em>Alpha Exchange XRP Balances</em> table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.</p>
+<table>
+<tr>
+<td><b><i>XRP Balances
+on RCL</i></b></td>
+<td></td>
+<td></td>
+<td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td>50,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td>0</td>
+</tr>
+<tr>
+<td><i>Alpha Hot</i></td>
+<td>0</td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><i>Alpha Warm</i></td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><i>Alpha Cold</i></td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<h4 id="xrp-amounts">XRP Amounts</h4>
+<p>Amounts of XRP are represented on the RCL as an unsigned integer count of <em>drops</em>, where one XRP == 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.</p>
+<p>One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.</p>
+<p>For more informtion, see <a href="https://ripple.com/build/rippled-apis/#specifying-currency-amounts">Specifying Currency Amounts</a>.</p>
+<h4 id="on-ledger-and-off-ledger">On-Ledger and Off-Ledger</h4>
+<p>With exchanges like <em>Alpha Exchange</em>, XRP can be "on-ledger" or "off-ledger":</p>
+<ul>
+<li>
+<p><strong>On-Ledger XRP</strong>: XRP that can be queried through the public RCL by specifying the public <a href="https://ripple.com/build/accounts/#addresses">address</a> of the XRP holder. The counterparty to these balances is the RCL. For more information, see <a href="https://ripple.com/build/rippled-apis/#currencies">Currencies</a>.</p>
+</li>
+<li>
+<p><strong>Off-Ledger XRP</strong>: XRP that is held by the accounting system of an exchange and can be queried through the exchange interface. Off-ledger XRP balances are credit-based. The counterparty is the exchange holding the XRP.</p>
+<p>Off-ledger XRP balances are traded between the participants of an exchange. To support these trades, the exchange must hold a balance of <em>on-ledger XRP</em> equal to the aggregate amount of <em>off-ledger XRP</em> that it makes available for trade.</p>
+</li>
+</ul>
+<h2 id="flow-of-funds">Flow of Funds</h2>
+<p>The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in the <a href="#balance-sheets">"Balance Sheets" section</a>.</p>
+<p>There are four main steps involved in an exchange's typical flow of funds:</p>
+<ol>
+<li>
+<p><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></p>
+</li>
+<li>
+<p><a href="#rebalance-xrp-holdings">Rebalance XRP Holdings</a></p>
+</li>
+<li>
+<p><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></p>
+</li>
+<li>
+<p><a href="#trade-xrp-on-the-exchange">Trade XRP on the Exchange</a></p>
+</li>
+</ol>
+<p>This list does not include the <a href="#prerequisites-for-supporting-xrp">prerequisites</a> required of an exchange.</p>
+<p>At this point, <em>Alpha Exchange</em> has created <a href="#accounts">hot, warm, and cold wallets</a> on the RCL and added them to its balance sheet, but has not accepted any deposits from its users.</p>
+<table>
+<tr>
+<td><b><i>XRP Balances
+on RCL</i></b></td>
+<td></td>
+<td></td>
+<td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td>50,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td>0</td>
+</tr>
+<tr>
+<td><i>Alpha Hot</i></td>
+<td>0</td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><i>Alpha Warm</i></td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><i>Alpha Cold</i></td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<h3 id="deposit-xrp-into-exchange">Deposit XRP into Exchange</h3>
+<p>To track <a href="#on-ledger-and-off-ledger">off-ledger XRP balances</a> exchanges need to create new <a href="#balance-sheets">balance sheets</a> (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.</p>
+<p>A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:</p>
+<ol>
+<li>
+<p>Charlie submits a payment of 50,000  XRP (by using <a href="https://ripple.com/build/rippleapi/">RippleAPI</a> or similar software) to Alpha Exchange's <a href="#accounts">cold wallet</a>.</p>
+<p>a. Charlie adds an identifier (in this case, <code>789</code>) to the payment to associate it with his account at Alpha Exchange. This is called a <a href="https://ripple.com/build/gateway-guide/#source-and-destination-tags"><em>destination tag</em></a>. (To use this, Alpha Exchange must have set the asfRequireDest flag on all of its accounts. This flag requires all incoming payments to have a destination tag like Charlie's. For more information, see <a href="https://ripple.com/build/transactions/#accountset-flags">AccountSet Flags</a>.</p>
+</li>
+<li>
+<p>The software at Alpha Exchange detects the incoming payment, and recognizes <code>789</code> as the destination tag for Charlie’s account.</p>
+</li>
+<li>
+<p>When it detects the incoming payment, Alpha Exchange's software updates its balance sheet to indicate that the 50,000 XRP it received is controlled by Charlie.</p>
+<p>Charlie can now use up to 50,000 XRP on the exchange. For example, he can create offers to trade XRP with BTC or any of the other currencies Alpha Exchange supports.</p>
+</li>
+</ol>
+<table>
+<tr>
+<td><b><i>XRP Balances
+on RCL</i></b></td>
+<td></td>
+<td></td>
+<td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td><s>100,000</s>
+<br/>50,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td><s>0</s>
+<br/>50,000</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Hot</td>
+<td>0</td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Warm</td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Cold</td>
+<td><s>0</s>
+<br/>50,000</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<h3 id="trade-xrp-on-the-exchange">Trade XRP on The Exchange</h3>
+<p>Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are <em>off-ledger</em> and independent from the RCL, so the balance changes are not recorded there.</p>
+<p>For more information about trading <em>on</em> the RCL, see <a href="https://ripple.com/build/transactions/#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
+<h3 id="rebalance-xrp-holdings">Rebalance XRP Holdings</h3>
+<p>Exchanges can adjust the balances between their hot and cold wallets at any time. Each balance adjustment consumes a <a href="https://ripple.com/build/fees-disambiguation/">transaction fee</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's <a href="https://ripple.com/build/transaction-cost/">transaction fees</a>.)</p>
+<p>The following table demonstrates a balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debit the hot wallet and credit the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.</p>
+<table>
+<tr>
+<td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</i></b></td>
+<td></td>
+<td></td>
+<td></td>
+<td><b><i>Alpha Exchange XRP On-Ledger Balances</i></b></td>
+<td></td>
+</tr>
+<tr>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>RCL Account</b></td>
+<td><b>Balance</b></td>
+</tr>
+<tr>
+<td>123</td>
+<td>Alice</td>
+<td>80,000</td>
+<td></td>
+<td>Hot</td>
+<td><s>0</s>
+<br/>80,000</td>
+</tr>
+<tr>
+<td>456</td>
+<td>Bob</td>
+<td>50,000</td>
+<td></td>
+<td>Warm</td>
+<td>0</td>
+</tr>
+<tr>
+<td>….</td>
+<td></td>
+<td></td>
+<td></td>
+<td>….</td>
+<td></td>
+</tr>
+<tr>
+<td>789</td>
+<td>Charlie</td>
+<td>50,000</td>
+<td></td>
+<td>Cold</td>
+<td><s>180,000</s>
+<br/>100,000</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td>...</td>
+<td></td>
+</tr>
+</table>
+<h3 id="withdraw-xrp-from-exchange">Withdraw XRP from Exchange</h3>
+<p>Withdrawals allow an exchange's users to move XRP from the exchange's off-ledger balance sheet to an account on the RCL.</p>
+<p>In this example, Charlie withdraws 25,000 XRP from Alpha Exchange. This involves the following steps:</p>
+<ol>
+<li>
+<p>Charlie initiates the process on Alpha Exchange’s website. He provides instructions to transfer 25,000 XRP to a specific account on the RCL (named "Charlie RCL" in the following table).</p>
+</li>
+<li>
+<p>In response to Charlie’s instructions, Alpha Exchange does the following:</p>
+<p>a. Debits the amount (25,000 XRP) from Charlie’s account on its off-ledger balance sheet</p>
+<p>b. Submits a payment on the RCL for the same amount (25,000 XRP), from Alpha Exchange's hot wallet to Charlie’s RCL account</p>
+</li>
+</ol>
+<table>
+<tr>
+<td><b><i>RCL On-Ledger XRP Balances</i></b></td>
+<td></td>
+<td></td>
+<td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</i></b></td>
+<td></td>
+<td></td>
+<td></td>
+<td><b><i>Alpha Exchange XRP On-Ledger Balances</i></b></td>
+<td></td>
+</tr>
+<tr>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>RCL Account</b></td>
+<td><b>Balance</b></td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>80,000</td>
+<td></td>
+<td>Hot</td>
+<td><s>80,000</s>
+<br/>55,000</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>50,000</td>
+<td></td>
+<td>Warm</td>
+<td>0</td>
+</tr>
+<tr>
+<td>….</td>
+<td></td>
+<td></td>
+<td>….</td>
+<td></td>
+<td></td>
+<td></td>
+<td>….</td>
+<td></td>
+</tr>
+<tr>
+<td>Charlie RCL</td>
+<td><s>50,000</s>
+<br/>75,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td><s>50,000</s>
+<br/>25,000</td>
+<td></td>
+<td>Cold</td>
+<td>100,000</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td>...</td>
+<td></td>
+</tr>
+</table>
+    </div>
+      </main>
+  </div>
+
+<footer class="content-info" role="contentinfo">
+    <div class="container">
+        <div class="row">
+            <section class="col-sm-3 widget nav_menu-3 widget_nav_menu">
+                <h4>Resources<hr></h4>
+                <ul id="menu-resources" class="menu">
+                    <li class="menu-insights"><a href="https://ripple.com/insights/">Insights</a></li>
+                    <li class="menu-events"><a href="https://ripple.com/events/">Events</a></li>
+                    <li class="menu-collateral"><a href="https://ripple.com/collateral/">Collateral</a></li>
+                    <li class="menu-press-center"><a href="https://ripple.com/press-center/">Press Center</a></li>
+                    <li class="menu-media-kit"><a href="https://ripple.com/media-kit/">Media Kit</a></li>
+                    <li class="menu-xrp-portal"><a href="https://ripple.com/xrp-portal/">XRP Portal</a></li>
+                </ul>
+            </section>
+            <section class="col-sm-3 widget nav_menu-5 widget_nav_menu">
+                <h4>Regulators<hr></h4>
+                <ul id="menu-compliance-regulatory-relations" class="menu">
+                    <li class="menu-compliance"><a href="https://ripple.com/compliance/">Compliance</a></li>
+                    <li class="menu-policy-framework"><a href="https://ripple.com/policy-framework/">Policy Framework</a></li>
+                </ul>
+            </section>
+            <section class="col-sm-3 widget nav_menu-4 widget_nav_menu">
+                <h4>Support<hr></h4>
+                <ul id="menu-dev-footer-menu" class="menu">
+                    <li class="menu-contact-us"><a href="https://ripple.com/contact/">Contact Us</a></li>
+                    <li class="active menu-developer-center"><a href="https://ripple.com/build/">Developer Center</a></li>
+                    <li class="menu-knowledge-center"><a href="https://ripple.com/learn/">Knowledge Center</a></li>
+                    <li class="menu-ripple-forum"><a target="_blank" href="https://forum.ripple.com/">Ripple Forum</a></li>
+                </ul>
+            </section>
+            <section class="col-sm-3 widget nav_menu-2 widget_nav_menu">
+                <h4>About<hr></h4>
+                <ul id="menu-company-footer" class="menu">
+                    <li class="menu-our-company"><a href="https://ripple.com/company/">Our Company</a></li>
+                    <li class="menu-careers"><a href="https://ripple.com/company/careers/">Careers</a></li>
+                </ul>
+            </section>
+
+       		<div class="col-sm-12 absolute_bottom_footer">
+       			<div class="col-sm-8">
+                    <span>&copy; 2013 - 2016 Ripple Labs, Inc. All Rights Reserved.</span>
+                    <span><a href="/terms-of-use/">Terms</a></span>
+                    <span><a href="/privacy-policy/">Privacy</a></span>
+                </div>
+            </div><!-- /.absolute_bottom_footer -->
+
+        </div><!-- /.row -->
+    </div><!-- /.container -->
+</footer>
+</body>
+</html>

--- a/tutorial-listing-xrp.html
+++ b/tutorial-listing-xrp.html
@@ -186,7 +186,7 @@
 <p>Withdraw XRP <em>from</em> Alpha Exchange <em>to</em> the RCL</p>
 </li>
 <li>
-<p>Trade XRP with other currencies, such as BTC, USD, amongst others</p>
+<p>Trade XRP with other currencies, such as BTC, USD, among others</p>
 </li>
 </ul>
 <h2 id="prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</h2>
@@ -216,18 +216,18 @@
 </ul>
 <h3 id="accounts">Accounts</h3>
 <p>XRP is held in <em>accounts</em> (also referred to as <em>wallets</em> or <em>addresses</em>  ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, <a href="https://ripple.com/build/transactions/#offercreate">OfferCreate</a> and others used for trading), RCL accounts require XRP <a href="https://ripple.com/build/reserves/">reserves</a> to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, <a href="https://ripple.com/build/ledger-format/#accountroot">account objects</a> describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the <a href="https://ripple.com/build/accounts/">Accounts</a> article.</p>
-<p>To comply with Ripple's recommend best practices, Alpha Exchange should create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>cold</em>, <em>hot</em>, and <em>warm</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
+<p>To comply with Ripple's recommended best practices, Alpha Exchange should create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>cold</em>, <em>hot</em>, and <em>warm</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The hot/warm/cold model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
 <ul>
 <li>
 <p>A <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address"><em>cold wallet</em></a> to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.</p>
 <p>For more information about the possible consequences of a compromised cold wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise">Issuing Account Compromise</a>.</p>
 </li>
 <li>
-<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>hot wallets</em></a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with an opertaitional wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.</p>
+<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>hot wallets</em></a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with a hot wallet, exchanges can securely support these types of automated XRP transfers. Hot wallets need to be online to service instant withdrawal requests.</p>
 <p>For more information about the possible consequences of a compromised hot wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise">Operational Account Compromise</a>.</p>
 </li>
 <li>
-<p>Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement  <a href="https://ripple.com/build/how-to-multi-sign/">multisigning</a> to increase security.</p>
+<p>Optionally, one or more warm wallets to provide an additional layer of security between the cold and hot wallets. Unlike a hot wallet, the secret key of a warm wallet does not need to be online. Additionally, you can distribute the secret keys for the warm wallet to several different people and implement <a href="https://ripple.com/build/how-to-multi-sign/">multisigning</a> to increase security.</p>
 <p>For more information about the possible consequences of a compromised warm wallet, see <a href="https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise">Standby Account Compromise</a>.</p>
 </li>
 </ul>
@@ -327,7 +327,7 @@ XRP Balances</i></b></td>
 </tr>
 </table>
 <h4 id="xrp-amounts">XRP Amounts</h4>
-<p>Amounts of XRP are represented on the RCL as an unsigned integer count of <em>drops</em>, where one XRP == 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.</p>
+<p>Amounts of XRP are represented on the RCL as an unsigned integer count of <em>drops</em>, where one XRP = 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.</p>
 <p>One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.</p>
 <p>For more informtion, see <a href="https://ripple.com/build/rippled-apis/#specifying-currency-amounts">Specifying Currency Amounts</a>.</p>
 <h4 id="on-ledger-and-off-ledger">On-Ledger and Off-Ledger</h4>
@@ -437,7 +437,7 @@ XRP Balances</i></b></td>
 </tr>
 </table>
 <h3 id="deposit-xrp-into-exchange">Deposit XRP into Exchange</h3>
-<p>To track <a href="#on-ledger-and-off-ledger">off-ledger XRP balances</a> exchanges need to create new <a href="#balance-sheets">balance sheets</a> (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.</p>
+<p>To track <a href="#on-ledger-and-off-ledger">off-ledger XRP balances</a>, exchanges need to create new <a href="#balance-sheets">balance sheets</a> (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.</p>
 <p>A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:</p>
 <ol>
 <li>
@@ -544,7 +544,7 @@ XRP Balances</i></b></td>
 <p>For more information about trading <em>on</em> the RCL, see <a href="https://ripple.com/build/transactions/#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
 <h3 id="rebalance-xrp-holdings">Rebalance XRP Holdings</h3>
 <p>Exchanges can adjust the balances between their hot and cold wallets at any time. Each balance adjustment consumes a <a href="https://ripple.com/build/fees-disambiguation/">transaction fee</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's <a href="https://ripple.com/build/transaction-cost/">transaction fees</a>.)</p>
-<p>The following table demonstrates a balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debit the hot wallet and credit the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.</p>
+<p>The following table demonstrates a balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's cold wallet and its hot wallet, where the cold wallet was debited and the hot wallet was credited. If the payment were reversed (debiting the hot wallet and crediting the cold wallet), the hot wallet balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online hot wallets.</p>
 <table>
 <tr>
 <td><b><i>Alpha Exchange XRP

--- a/tutorial-multisign.html
+++ b/tutorial-multisign.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/tutorial-paychan.html
+++ b/tutorial-paychan.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/tutorial-reliable-transaction-submission.html
+++ b/tutorial-reliable-transaction-submission.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/tutorial-rippleapi-beginners-guide.html
+++ b/tutorial-rippleapi-beginners-guide.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/tutorial-rippled-setup.html
+++ b/tutorial-rippled-setup.html
@@ -79,6 +79,7 @@
                   <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                   <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                   <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -135,6 +136,7 @@
                 <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
                 <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
                 <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="tutorial-listing-xrp.html">Listing XRP as an Exchange</a></li>
             </ul>
             <hr />
             <h5>In this page:</h5>

--- a/xrp-listing-guide.html
+++ b/xrp-listing-guide.html
@@ -149,7 +149,7 @@
 <li class="level-2"><a href="#flow-of-funds">Flow of Funds</a></li>
 <li class="level-3"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
 <li class="level-3"><a href="#trade-xrp-on-the-exchange">Trade XRP on The Exchange</a></li>
-<li class="level-3"><a href="#rebalancing-xrp-holdings">Rebalancing XRP Holdings</a></li>
+<li class="level-3"><a href="#rebalance-xrp-holdings">Rebalance XRP Holdings</a></li>
 <li class="level-3"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
 
             </ul>
@@ -346,7 +346,7 @@ XRP Balances</i></b></td>
 <p>There are four main steps involved in an exchange's typical flow of funds:</p>
 <ol>
 <li>
-<p><a href="#deposit-xrp-into-an-exchange">Deposit XRP into Exchange</a></p>
+<p><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></p>
 </li>
 <li>
 <p><a href="#rebalance-xrp-holdings">Rebalance XRP Holdings</a></p>
@@ -542,7 +542,7 @@ XRP Balances</i></b></td>
 <h3 id="trade-xrp-on-the-exchange">Trade XRP on The Exchange</h3>
 <p>Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are <em>off-ledger</em> and independent from the RCL, so the balance changes are not recorded there.</p>
 <p>For more information about trading <em>on</em> the RCL, see <a href="https://ripple.com/build/transactions/#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
-<h3 id="rebalancing-xrp-holdings">Rebalancing XRP Holdings</h3>
+<h3 id="rebalance-xrp-holdings">Rebalance XRP Holdings</h3>
 <p>Exchanges can adjust the balances between their operational and issuing accounts at any time. Each balance adjustment consumes a <a href="https://ripple.com/build/fees-disambiguation/">transaction fee</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's <a href="https://ripple.com/build/transaction-cost/">transaction fees</a>.)</p>
 <p>The following table demonstrates balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was debited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.</p>
 <table>

--- a/xrp-listing-guide.html
+++ b/xrp-listing-guide.html
@@ -208,7 +208,7 @@
 <p><a href="https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
 </li>
 <li>
-<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
+<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-receiving-from-rcl">Requirements for Receiving from RCL</a></p>
 </li>
 <li>
 <p><a href="https://ripple.com/build/gateway-guide/#precautions">Gateway Precautions</a></p>
@@ -490,12 +490,12 @@ XRP Balances</i></b></td>
 <tr>
 <td>Charlie</td>
 <td><s>100,000</s>
-<br>50,000</br></td>
+<br/>50,000</td>
 <td></td>
 <td>789</td>
 <td>Charlie</td>
 <td><s>0</s>
-<br>50,000</br></td>
+<br/>50,000</td>
 </tr>
 <tr>
 <td></td>
@@ -524,7 +524,7 @@ XRP Balances</i></b></td>
 <tr>
 <td>Alpha Issuing</td>
 <td><s>0</s>
-<br>50,000</br></td>
+<br/>50,000</td>
 <td></td>
 <td></td>
 <td></td>
@@ -544,7 +544,7 @@ XRP Balances</i></b></td>
 <p>For more information about trading <em>on</em> the RCL, see <a href="https://ripple.com/build/transactions/#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
 <h3 id="rebalance-xrp-holdings">Rebalance XRP Holdings</h3>
 <p>Exchanges can adjust the balances between their operational and issuing accounts at any time. Each balance adjustment consumes a <a href="https://ripple.com/build/fees-disambiguation/">transaction fee</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's <a href="https://ripple.com/build/transaction-cost/">transaction fees</a>.)</p>
-<p>The following table demonstrates balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was debited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.</p>
+<p>The following table demonstrates a balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was credited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.</p>
 <table>
 <tr>
 <td><b><i>Alpha Exchange XRP
@@ -570,7 +570,7 @@ Off-Ledger Balances</i></b></td>
 <td></td>
 <td>Operational</td>
 <td><s>0</s>
-<br>80,000</br></td>
+<br/>80,000</td>
 </tr>
 <tr>
 <td>456</td>
@@ -595,7 +595,7 @@ Off-Ledger Balances</i></b></td>
 <td></td>
 <td>Issuing</td>
 <td><s>180,000</s>
-<br>100,000</br></td>
+<br/>100,000</td>
 </tr>
 <tr>
 <td></td>
@@ -661,7 +661,7 @@ Off-Ledger Balances</i></b></td>
 <td></td>
 <td>Operational</td>
 <td><s>80,000</s>
-<br>55,000</br></td>
+<br/>55,000</td>
 </tr>
 <tr>
 <td>Edward</td>
@@ -688,12 +688,12 @@ Off-Ledger Balances</i></b></td>
 <tr>
 <td>Charlie RCL</td>
 <td><s>50,000</s>
-<br>75,000</br></td>
+<br/>75,000</td>
 <td></td>
 <td>789</td>
 <td>Charlie</td>
 <td><s>50,000</s>
-<br>25,000</br></td>
+<br/>25,000</td>
 <td></td>
 <td>Issuing</td>
 <td>100,000</td>

--- a/xrp-listing-guide.html
+++ b/xrp-listing-guide.html
@@ -146,14 +146,11 @@
 <li class="level-2"><a href="#prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</a></li>
 <li class="level-3"><a href="#accounts">Accounts</a></li>
 <li class="level-3"><a href="#balance-sheets">Balance Sheets</a></li>
-<li class="level-2"><a href="#on-ledger-and-off-ledger">On-Ledger and Off-Ledger</a></li>
 <li class="level-2"><a href="#flow-of-funds">Flow of Funds</a></li>
-<li class="level-2"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
-<li class="level-2"><a href="#rebalancing-xrp-holdings">Rebalancing XRP Holdings</a></li>
-<li class="level-2"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
-<li class="level-2"><a href="#trade-xrp-on-the-exchange">Trade XRP on The Exchange</a></li>
-<li class="level-1"><a href="#about-xrp-accounts">About XRP Accounts</a></li>
-<li class="level-1"><a href="#about-xrp-balances">About XRP Balances</a></li>
+<li class="level-3"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
+<li class="level-3"><a href="#trade-xrp-on-the-exchange">Trade XRP on The Exchange</a></li>
+<li class="level-3"><a href="#rebalancing-xrp-holdings">Rebalancing XRP Holdings</a></li>
+<li class="level-3"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
 
             </ul>
         </div>
@@ -202,15 +199,31 @@
 <p>Create and maintain <a href="#balance-sheets">balance sheets</a></p>
 </li>
 </ul>
+<p>See also:</p>
+<ul>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#gateway-compliance">Gateway Compliance</a> — Gateways and exchanges are different, but exchanges should also ensure that they are complying with local regulations and reporting to the appropriate agencies.</p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#requirements-for-sending-to-rcl">Requirements for Sending to RCL</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#precautions">Gateway Precautions</a></p>
+</li>
+</ul>
 <h3 id="accounts">Accounts</h3>
-<p>Alpha Exchange must create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> (also referred to as "wallets") on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>issuing</em>, <em>operational</em>, and <em>standby</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The operational/standby/issuing model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
+<p>XRP is held in <em>accounts</em> (sometimes referred to as <em>wallets</em> ) on the Ripple Consensus Ledger (RCL). Accounts on the RCL are different than accounts on other blockchain ledgers, such as Bitcoin, where accounts incur little to no overhead. To submit transactions (for example, <a href="https://ripple.com/build/transactions/#offercreate">OfferCreate</a> and others used for trading), RCL accounts require XRP <a href="https://ripple.com/build/reserves/">reserves</a> to protect the ledger against spam and malicious usage. On other blockchains, balances are derived from the previous block. On the RCL, <a href="https://ripple.com/build/ledger-format/#accountroot">account objects</a> describe several other properties of the account in addition to balances, so accounts are represented in each ledger and can never be destroyed or removed. Exchanges do not need to create accounts for each customer that holds XRP; they can store all of their customers’ XRP in just a few RCL accounts. For more information about RCL accounts, see the <a href="https://ripple.com/build/accounts/">Accounts</a> article.</p>
+<p>To comply with Ripple's recommend best practices, Alpha Exchange should create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>issuing</em>, <em>operational</em>, and <em>standby</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The operational/standby/issuing model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
 <ul>
 <li>
 <p>An <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address"><em>issuing</em> account</a> to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.</p>
 <p>For more information about the possible consequences of a compromised issuing account, see <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise">Issuing Account Compromise</a>.</p>
 </li>
 <li>
-<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>operational</em> accounts</a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. Operational accounts need to be online to service instant withdrawal requests.</p>
+<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>operational</em> accounts</a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. For example, with an opertaitional wallet, exchanges can securely support these types of automated XRP transfers. Operational accounts need to be online to service instant withdrawal requests.</p>
 <p>For more information about the possible consequences of a compromised operational account, see <a href="https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise">Operational Account Compromise</a>.</p>
 </li>
 <li>
@@ -218,13 +231,19 @@
 <p>For more information about the possible consequences of a compromised standby account, see <a href="https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise">Standby Account Compromise</a>.</p>
 </li>
 </ul>
-<p>For more information, see:</p>
+<p>See also:</p>
 <ul>
 <li>
 <p><a href="https://ripple.com/build/gateway-guide/#suggested-business-practices">"Suggested Business Practices" in the <em>Gateway Guide</em></a></p>
 </li>
 <li>
 <p><a href="https://ripple.com/build/issuing-operational-addresses/">Issuing and Operational Addresses</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/transactions/#creating-accounts">Creating Accounts</a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/reserves/">Reserves</a></p>
 </li>
 </ul>
 <h3 id="balance-sheets">Balance Sheets</h3>
@@ -307,7 +326,11 @@ XRP Balances</i></b></td>
 <td></td>
 </tr>
 </table>
-<h2 id="on-ledger-and-off-ledger">On-Ledger and Off-Ledger</h2>
+<h4 id="xrp-amounts">XRP Amounts</h4>
+<p>Amounts of XRP are represented on the RCL as an unsigned integer count of <em>drops</em>, where one XRP == 1,000,000 drops. Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values. However, user interfaces should present balances in units of XRP.</p>
+<p>One drop (.000001 XRP) cannot be further subdivided. Bear this in mind when calculating and displaying FX rates between XRP and other assets.</p>
+<p>For more informtion, see <a href="https://ripple.com/build/rippled-apis/#specifying-currency-amounts">Specifying Currency Amounts</a>.</p>
+<h4 id="on-ledger-and-off-ledger">On-Ledger and Off-Ledger</h4>
 <p>With exchanges like <em>Alpha Exchange</em>, XRP can be "on-ledger" or "off-ledger":</p>
 <ul>
 <li>
@@ -319,8 +342,8 @@ XRP Balances</i></b></td>
 </li>
 </ul>
 <h2 id="flow-of-funds">Flow of Funds</h2>
-<p>The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in a <a href="#balance-sheets">previous section</a>.</p>
-<p>There are three main steps involved in an exchange's typical flow of funds:</p>
+<p>The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in the <a href="#balance-sheets">"Balance Sheets" section</a>.</p>
+<p>There are four main steps involved in an exchange's typical flow of funds:</p>
 <ol>
 <li>
 <p><a href="#deposit-xrp-into-an-exchange">Deposit XRP into Exchange</a></p>
@@ -335,7 +358,8 @@ XRP Balances</i></b></td>
 <p><a href="#trade-xrp-on-the-exchange">Trade XRP on the Exchange</a></p>
 </li>
 </ol>
-<p>At this point, <em>Alpha Exchange</em> has created <a href="#accounts">operational, standby, and issuing accounts</a> on the RCL and added them to its balance sheet, but has not funded the new accounts.</p>
+<p>This list does not include the <a href="#prerequisites-for-supporting-xrp">prerequisites</a> required of an exchange.</p>
+<p>At this point, <em>Alpha Exchange</em> has created <a href="#accounts">operational, standby, and issuing accounts</a> on the RCL and added them to its balance sheet, but has not accepted any deposits from its users.</p>
 <table>
 <tr>
 <td><b><i>XRP Balances
@@ -412,27 +436,40 @@ XRP Balances</i></b></td>
 <td></td>
 </tr>
 </table>
-<h2 id="deposit-xrp-into-exchange">Deposit XRP into Exchange</h2>
-<p>The exchange is required to create a new accounting system to track off ledger XRP balances. Figure 1 shows the initial condition of this new account system, where all user balances start with a value of zero.</p>
-<p>Example deposit : The user Charlie wishes to deposit 50,000 XRP to Alpha Exchange. Through the interface that Alpha Exchange provides, Charlie is instructed to submit a payment (via Ripple API or wallet software) for that amount to Alpha Exchange’s cold wallet address, and to associate a numerical identifier (say 789) with the payment.</p>
+<h3 id="deposit-xrp-into-exchange">Deposit XRP into Exchange</h3>
+<p>To track <a href="#on-ledger-and-off-ledger">off-ledger XRP balances</a> exchanges need to create new <a href="#balance-sheets">balance sheets</a> (or similar accounting systems). The following table illustrates the balance changes that take place on Alpha Exchange's new balance sheet as users begin to deposit XRP.</p>
+<p>A user named Charlie wants to deposit 50,000 XRP to Alpha Exchange. Doing this involves the following steps:</p>
+<ol>
+<li>
+<p>Charlie submits a payment of 50,000  XRP (by using <a href="https://ripple.com/build/rippleapi/">RippleAPI</a> or similar software) to Alpha Exchange's <a href="#accounts">issuing account</a>.</p>
+<p>a. Charlie adds an identifier (in this case, <code>789</code>) to the payment to associate it with his account at Alpha Exchange. This is called a <a href="https://ripple.com/build/gateway-guide/#source-and-destination-tags"><em>destination tag</em></a>. (To use this, Alpha Exchange must have set the asfRequireDest flag on all of its accounts. This flag requires all incoming payments to have a destination tag like Charlie's. For more information, see <a href="https://ripple.com/build/transactions/#accountset-flags">AccountSet Flags</a>.</p>
+</li>
+<li>
+<p>The software at Alpha Exchange detects the incoming payment, and recognizes <code>789</code> as the destination tag for Charlie’s account.</p>
+</li>
+<li>
+<p>When it detects the incoming payment, Alpha Exchange's software updates its balance sheet to indicate that the 50,000 XRP it received is controlled by Charlie.</p>
+<p>Charlie can now use up to 50,000 XRP on the exchange. For example, he can create offers to trade XRP with BTC or any of the other currencies Alpha Exchange supports.</p>
+</li>
+</ol>
 <table>
 <tr>
-<td>XRP Balances
-on RCL</td>
+<td><b><i>XRP Balances
+on RCL</i></b></td>
 <td></td>
 <td></td>
-<td>Alpha Exchange
-XRP Balances</td>
+<td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
 <td></td>
 <td></td>
 </tr>
 <tr>
-<td>User</td>
-<td>Balance</td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 <td></td>
-<td>Acct #</td>
-<td>User</td>
-<td>Balance</td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 </tr>
 <tr>
 <td>Dave</td>
@@ -452,13 +489,13 @@ XRP Balances</td>
 </tr>
 <tr>
 <td>Charlie</td>
-<td>100,000
-50,000</td>
+<td><s>100,000</s>
+<br>50,000</br></td>
 <td></td>
 <td>789</td>
 <td>Charlie</td>
-<td> 0
-50,000</td>
+<td><s>0</s>
+<br>50,000</br></td>
 </tr>
 <tr>
 <td></td>
@@ -469,7 +506,7 @@ XRP Balances</td>
 <td></td>
 </tr>
 <tr>
-<td>Alpha Hot</td>
+<td>Alpha Operational</td>
 <td>0</td>
 <td></td>
 <td>...</td>
@@ -477,7 +514,7 @@ XRP Balances</td>
 <td></td>
 </tr>
 <tr>
-<td>Alpha Warm</td>
+<td>Alpha Standby</td>
 <td>0</td>
 <td></td>
 <td></td>
@@ -485,9 +522,9 @@ XRP Balances</td>
 <td></td>
 </tr>
 <tr>
-<td>Alpha Cold</td>
-<td> 0
-50,000</td>
+<td>Alpha Issuing</td>
+<td><s>0</s>
+<br>50,000</br></td>
 <td></td>
 <td></td>
 <td></td>
@@ -502,45 +539,45 @@ XRP Balances</td>
 <td></td>
 </tr>
 </table>
-<p>Figure 2 : Before and after a XRP deposit is made by Charlie to Alpha Exchange</p>
-<p>The software at Alpha Exchange detects the incoming payment, and recognizes 789 as the identifier associated with Charlie’s account. The number 789 is a field known as a "Destination Tag" on the RCL. (Alpha Exchange has set a flag, called asfRequireDest, on its wallets to ensure that all incoming payment have a destination tag.)</p>
-<p><a href="https://ripple.com/build/transactions/#accountset-flags">https://ripple.com/build/transactions/#accountset-flags</a></p>
-<p>Upon detecting the incoming payment, Alpha Exchange software updates the balance sheet to reflect the 50,000 XRP received is controlled by Charlie.  Charlie is now able to use up to 50,000 XRP on the exchange, for example to create orders trading XRP to other supported currencies on Alpha Exchange.</p>
-<h2 id="rebalancing-xrp-holdings">Rebalancing XRP Holdings</h2>
-<p>In order to securely support automated transfers of XRP, the exchange will keep a portion of XRP holdings in one (or more) operational "hot" wallets. In most XRP integrations, an exchange will elect to have their middleware software make payments automatically from the hot wallet (a withdrawal payment, for example), while a cold wallet will require human intervention.</p>
+<h3 id="trade-xrp-on-the-exchange">Trade XRP on The Exchange</h3>
+<p>Alpha Exchange users (like Charlie) can trade credit-based balances on Alpha Exchange. Alpha Exchange should keep track of user balances on its new balance sheet as these trades are made. These trades are <em>off-ledger</em> and independent from the RCL, so the balance changes are not recorded there.</p>
+<p>For more information about trading <em>on</em> the RCL, see <a href="https://ripple.com/build/transactions/#lifecycle-of-an-offer">Lifecycle of an Offer</a>.</p>
+<h3 id="rebalancing-xrp-holdings">Rebalancing XRP Holdings</h3>
+<p>Exchanges can adjust the balances between their operational and issuing accounts at any time. Each balance adjustment consumes a <a href="https://ripple.com/build/fees-disambiguation/">transaction fee</a>, but does not otherwise affect the aggregate balance of all the accounts. The aggregate, on-ledger balance should always exceed the total balance available for trade on the exchange. (The excess should be sufficient to cover the RCL's <a href="https://ripple.com/build/transaction-cost/">transaction fees</a>.)</p>
+<p>The following table demonstrates balance adjustment of 80,000 XRP (via a <a href="https://ripple.com/build/transactions/#payment"><em>payment</em></a> on the RCL) between Alpha Exchange's issuing account and its operational account, where the issuing account was debited and the operational account was debited. If the payment were reversed (debit the operational account and credit the issuing account), the operational account balance would decrease. Balance adjustments like these allow an exchange to limit the risks associated with holding XRP in online operational accounts.</p>
 <table>
 <tr>
-<td>Alpha Exchange XRP
-Off Ledger Balances</td>
+<td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</i></b></td>
 <td></td>
 <td></td>
 <td></td>
-<td>Alpha Exchange XRP On Ledger Balances</td>
+<td><b><i>Alpha Exchange XRP On-Ledger Balances</i></b></td>
 <td></td>
 </tr>
 <tr>
-<td>Acct #</td>
-<td>User</td>
-<td>Balance</td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 <td></td>
-<td>Wallet</td>
-<td>Balance</td>
+<td><b>RCL Account</b></td>
+<td><b>Balance</b></td>
 </tr>
 <tr>
 <td>123</td>
 <td>Alice</td>
 <td>80,000</td>
 <td></td>
-<td>Hot</td>
-<td>0
-80,000</td>
+<td>Operational</td>
+<td><s>0</s>
+<br>80,000</br></td>
 </tr>
 <tr>
 <td>456</td>
 <td>Bob</td>
 <td>50,000</td>
 <td></td>
-<td>Warm</td>
+<td>Standby</td>
 <td>0</td>
 </tr>
 <tr>
@@ -556,9 +593,9 @@ Off Ledger Balances</td>
 <td>Charlie</td>
 <td>50,000</td>
 <td></td>
-<td>Cold</td>
-<td>180,000
-100,000</td>
+<td>Issuing</td>
+<td><s>180,000</s>
+<br>100,000</br></td>
 </tr>
 <tr>
 <td></td>
@@ -577,35 +614,42 @@ Off Ledger Balances</td>
 <td></td>
 </tr>
 </table>
-<p>Figure 3 : Without fractional reserve, XRP moves to operational hot wallet</p>
-<p>The exchange can adjust balances between hot and cold wallets at any time.  While each such adjustment consumes a fee, it does not otherwise affect the overall balance, which is an aggregate of all the holding wallets.  This aggregate On Ledger balance should at all times exceed the total available for trade on the exchange.  (Where the excess is sufficient to cover ledger transaction fees.)</p>
-<p>Figure 3 shows a balance adjustment via a payment of 80,000 XRP from Cold wallet to Hot wallet.  A payment made in reverse (debit the hot wallet, credit the cold wallet; not shown) would decrease the hot wallet balance. These balance adjustments allow an exchange to limit the risk associated with holding XRP in an online Hot wallet, by holding a balance in an offline Cold wallet.</p>
-<h2 id="withdraw-xrp-from-exchange">Withdraw XRP from Exchange</h2>
-<p>The <em>withdraw</em> feature allows customers to move XRP from Alpha Exchange to a wallet on the Ripple Consensus Ledger.</p>
-<p>In this example, Charlie initiates the process on the Alpha Exchange’s website.  He provides instructions to transfer 25,000 XRP to a specific Ripple wallet on RCL (named "Charlie" in figure 4).</p>
+<h3 id="withdraw-xrp-from-exchange">Withdraw XRP from Exchange</h3>
+<p>Withdrawals allow an exchange's users to move XRP from the exchange's off-ledger balance sheet to an account on the RCL.</p>
+<p>In this example, Charlie withdraws 25,000 XRP from Alpha Exchange. This involves the following steps:</p>
+<ol>
+<li>
+<p>Charlie initiates the process on Alpha Exchange’s website. He provides instructions to transfer 25,000 XRP to a specific account on the RCL (named "Charlie RCL" in the following table).</p>
+</li>
+<li>
+<p>In response to Charlie’s instructions, Alpha Exchange does the following:</p>
+<p>a. Debits the amount (25,000 XRP) from Charlie’s account on its off-ledger balance sheet</p>
+<p>b. Submits a payment on the RCL for the same amount (25,000 XRP), from Alpha Exchange's operational account to Charlie’s RCL account</p>
+</li>
+</ol>
 <table>
 <tr>
-<td>RCL On Ledger XRP Balances</td>
+<td><b><i>RCL On-Ledger XRP Balances</i></b></td>
 <td></td>
 <td></td>
-<td>Alpha Exchange XRP
-Off Ledger Balances</td>
+<td><b><i>Alpha Exchange XRP
+Off-Ledger Balances</i></b></td>
 <td></td>
 <td></td>
 <td></td>
-<td>Alpha Exchange XRP On Ledger Balances</td>
+<td><b><i>Alpha Exchange XRP On-Ledger Balances</i></b></td>
 <td></td>
 </tr>
 <tr>
-<td>User</td>
-<td>Balance</td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 <td></td>
-<td>Acct #</td>
-<td>User</td>
-<td>Balance</td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 <td></td>
-<td>Wallet</td>
-<td>Balance</td>
+<td><b>RCL Account</b></td>
+<td><b>Balance</b></td>
 </tr>
 <tr>
 <td>Dave</td>
@@ -615,9 +659,9 @@ Off Ledger Balances</td>
 <td>Alice</td>
 <td>80,000</td>
 <td></td>
-<td>Hot</td>
-<td>80,000
-55,000</td>
+<td>Operational</td>
+<td><s>80,000</s>
+<br>55,000</br></td>
 </tr>
 <tr>
 <td>Edward</td>
@@ -627,7 +671,7 @@ Off Ledger Balances</td>
 <td>Bob</td>
 <td>50,000</td>
 <td></td>
-<td>Warm</td>
+<td>Standby</td>
 <td>0</td>
 </tr>
 <tr>
@@ -642,16 +686,16 @@ Off Ledger Balances</td>
 <td></td>
 </tr>
 <tr>
-<td>Charlie</td>
-<td>50,000
-75,000</td>
+<td>Charlie RCL</td>
+<td><s>50,000</s>
+<br>75,000</br></td>
 <td></td>
 <td>789</td>
 <td>Charlie</td>
-<td>50,000
-25,000</td>
+<td><s>50,000</s>
+<br>25,000</br></td>
 <td></td>
-<td>Cold</td>
+<td>Issuing</td>
 <td>100,000</td>
 </tr>
 <tr>
@@ -677,26 +721,6 @@ Off Ledger Balances</td>
 <td></td>
 </tr>
 </table>
-<p>Figure 4 : Before and after a XRP withdrawal by Charlie</p>
-<p>In response to Charlie’s instruction to withdraw 25,000 XRP, Alpha Exchange performs the following tasks, shown in figure 4, in this order:</p>
-<ul>
-<li>
-<p>Debit the amount from Charlie’s row on the balance sheet</p>
-</li>
-<li>
-<p>Submit a Ripple payment for the same amount, from Alpha Exchange hot wallet to Charlie’s RCL wallet</p>
-</li>
-</ul>
-<h2 id="trade-xrp-on-the-exchange">Trade XRP on The Exchange</h2>
-<p>Users of Alpha Exchange can trade the credit based balances on Alpha Exchange, and Alpha should be expected to keep track of all users balances as the trades are made. These trades are independent of, and not reflected on, RCL.</p>
-<h1 id="about-xrp-accounts">About XRP Accounts</h1>
-<p>XRP is held in Ripple Consensus Ledger <em>accounts</em> (sometimes referred to as <em>wallets</em> or <em>addresses</em>).  This document shows that an exchange is able to store all of the customers’ XRP in relatively few wallets.  (Technically, all the XRP could be managed in a single wallet.  It is for security reasons that an exchange should manage a set of hot, warm, and cold wallets.)</p>
-<p>An exchange should not create a Ripple wallet for each customer who holds XRP with the exchange.  The RCL differs from other blockchains such as Bitcoin where additional wallets incur essentially no overhead.  A Bitcoin balance is a collation of multiple UTXOs from prior blocks.  A Ripple account, in contrast, is represented in each iteration of the ledger, and can never be destroyed or removed (similar to Ethereum).  The Ripple account object includes an XRP balance as well as other properties.  Also, each Ripple account requires an XRP reserve, which adds a cost to creating a large number of wallets.</p>
-<p>See <a href="https://ripple.com/build/transactions/#creating-accounts">https://ripple.com/build/transactions/#creating-accounts</a> and <a href="https://ripple.com/build/reserves/">https://ripple.com/build/reserves/</a>.</p>
-<h1 id="about-xrp-balances">About XRP Balances</h1>
-<p>Amounts of XRP are represented on the Ripple Consensus Ledger as an unsigned integer count of <em>drops</em>, where one XRP == 1,000,000 drops.  Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values.  However all user interfaces should present balances in units of XRP.</p>
-<p>One drop (or .000001 XRP) cannot be further subdivided.  Bear this in mind when calculating and displaying FX rates between XRP and other assets.</p>
-<p>See <a href="https://ripple.com/build/rippled-apis/#specifying-currency-amounts">https://ripple.com/build/rippled-apis/#specifying-currency-amounts</a> for additional detail.</p>
     </div>
       </main>
   </div>

--- a/xrp-listing-guide.html
+++ b/xrp-listing-guide.html
@@ -146,8 +146,8 @@
 <li class="level-2"><a href="#prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</a></li>
 <li class="level-3"><a href="#accounts">Accounts</a></li>
 <li class="level-3"><a href="#balance-sheets">Balance Sheets</a></li>
+<li class="level-2"><a href="#on-ledger-and-off-ledger">On-Ledger and Off-Ledger</a></li>
 <li class="level-2"><a href="#flow-of-funds">Flow of Funds</a></li>
-<li class="level-2"><a href="#key-definitions">Key Definitions</a></li>
 <li class="level-2"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
 <li class="level-2"><a href="#rebalancing-xrp-holdings">Rebalancing XRP Holdings</a></li>
 <li class="level-2"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
@@ -162,9 +162,9 @@
       <main class="main" role="main">
     <div class='content'>
         <h1 id="listing-xrp-as-an-exchange">Listing XRP as an Exchange</h1>
-<p>This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of <code>rippled</code> and the Ripple Consensus Ledger (RCL), see <a href="https://ripple.com/build">https://ripple.com/build</a>.</p>
+<p>This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of <code>rippled</code> and the Ripple Consensus Ledger (RCL), see the  <a href="https://ripple.com/build">Ripple Developer Center</a>.</p>
 <h2 id="alpha-exchange">Alpha Exchange</h2>
-<p>For illustrative purposes, this document uses a fictitious business called <em>Alpha Exchange</em> that has the following characteristics:</p>
+<p>For illustrative purposes, this document uses a fictitious business called <em>Alpha Exchange</em> to explain the high-level steps required to list XRP. For the purposes of this document, Alpha Exchange:</p>
 <ul>
 <li>
 <p>Currently specializes in listing BTC/USD</p>
@@ -203,11 +203,21 @@
 </li>
 </ul>
 <h3 id="accounts">Accounts</h3>
-<p>Alpha Exchange must create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> (also referred to as "wallets") on the RCL. To minimize the risk associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>issuing</em>, <em>operational</em>, and <em>standby</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). This model is intended to balance security and convenience.</p>
-<pre><code>* An _issuing_ account to securely hold the majority of XRP and customers' funds. This account should be offline.
-
-* One or more _operational_ (and, perhaps, _standby_) accounts to conduct the day-to-day business of accepting customers' XRP withdrawals and deposits. Standby accounts can be online if you use the [Multisign](https://ripple.com/build/how-to-multi-sign/) feature. Operational accounts need to be online to service instant withdrawal requests.
-</code></pre>
+<p>Alpha Exchange must create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> (also referred to as "wallets") on the RCL. To minimize the risks associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>issuing</em>, <em>operational</em>, and <em>standby</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). The operational/standby/issuing model is intended to balance security and convenience. Exchanges listing XRP should create the following accounts:</p>
+<ul>
+<li>
+<p>An <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address"><em>issuing</em> account</a> to securely hold the majority of XRP and customers' funds. To provide optimal security, this account should be offline.</p>
+<p>For more information about the possible consequences of a compromised issuing account, see <a href="https://ripple.com/build/issuing-operational-addresses/#issuing-address-compromise">Issuing Account Compromise</a>.</p>
+</li>
+<li>
+<p>One or more <a href="https://ripple.com/build/issuing-operational-addresses/#operational-addresses"><em>operational</em> accounts</a> to conduct the day-to-day business of managing customers' XRP withdrawals and deposits. Operational accounts need to be online to service instant withdrawal requests.</p>
+<p>For more information about the possible consequences of a compromised operational account, see <a href="https://ripple.com/build/issuing-operational-addresses/#operational-address-compromise">Operational Account Compromise</a>.</p>
+</li>
+<li>
+<p>Optionally, one or more standby accounts to provide an additional layer of security between the issuing and operational accounts. Unlike an operational account, the secret key of a standby account does not need to be online. Additionally, you can distribute the secret keys for the standby account to several different people and implement  <a href="https://ripple.com/build/how-to-multi-sign/">multisigning</a> to increase security.</p>
+<p>For more information about the possible consequences of a compromised standby account, see <a href="https://ripple.com/build/issuing-operational-addresses/#standby-address-compromise">Standby Account Compromise</a>.</p>
+</li>
+</ul>
 <p>For more information, see:</p>
 <ul>
 <li>
@@ -218,15 +228,17 @@
 </li>
 </ul>
 <h3 id="balance-sheets">Balance Sheets</h3>
-<p>Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance. To do this, Alpha Exchange must create and maintain an additional balance sheet. The following table illustrates what this balance sheet might look like.</p>
+<p>Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance(s). To do this, Alpha Exchange must create and maintain an additional balance sheet. The following table illustrates what this balance sheet might look like.</p>
+<p>The new RCL accounts (<em>Alpha Operational</em>, <em>Alpha Standby</em>, <em>Alpha Issuing</em>) are in the <em>User</em> column of the <em>XRP Balances on RCL</em> table.</p>
+<p>The <em>Alpha Exchange XRP Balances</em> table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.</p>
 <table>
 <tr>
-<td><b>XRP Balances
-on RCL</b></td>
+<td><b><i>XRP Balances
+on RCL</i></b></td>
 <td></td>
 <td></td>
-<td><b>Alpha Exchange
-XRP Balances</b></td>
+<td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
 <td></td>
 <td></td>
 </tr>
@@ -295,28 +307,53 @@ XRP Balances</b></td>
 <td></td>
 </tr>
 </table>
-<p>The new RCL accounts (<em>Alpha Operational</em>, <em>Alpha Standby</em>, <em>Alpha Issuing</em>) are in the <em>User</em> column of the <em>XRP Balances on RCL</em> table.</p>
-<p>The <em>Alpha Exchange XRP Balances</em> table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.</p>
+<h2 id="on-ledger-and-off-ledger">On-Ledger and Off-Ledger</h2>
+<p>With exchanges like <em>Alpha Exchange</em>, XRP can be "on-ledger" or "off-ledger":</p>
+<ul>
+<li>
+<p><strong>On-Ledger XRP</strong>: XRP that can be queried through the public RCL by specifying the public <a href="https://ripple.com/build/accounts/#addresses">address</a> of the XRP holder. The counterparty to these balances is the RCL. For more information, see <a href="https://ripple.com/build/rippled-apis/#currencies">Currencies</a>.</p>
+</li>
+<li>
+<p><strong>Off-Ledger XRP</strong>: XRP that is held by the accounting system of an exchange and can be queried through the exchange interface. Off-ledger XRP balances are credit-based. The counterparty is the exchange holding the XRP.</p>
+<p>Off-ledger XRP balances are traded between the participants of an exchange. To support these trades, the exchange must hold a balance of <em>on-ledger XRP</em> equal to the aggregate amount of <em>off-ledger XRP</em> that it makes available for trade.</p>
+</li>
+</ul>
 <h2 id="flow-of-funds">Flow of Funds</h2>
-<p>The remainder of this document describes the flow of funds as Alpha Exchange allows users to deposit, trade, and redeem XRP balances.</p>
+<p>The remaining sections describe how funds flow through the accounts managed by Alpha Exchange as its users begin to deposit, trade, and redeem XRP balances. To illustrate the flow of funds, this document uses the tables introduced in a <a href="#balance-sheets">previous section</a>.</p>
+<p>There are three main steps involved in an exchange's typical flow of funds:</p>
+<ol>
+<li>
+<p><a href="#deposit-xrp-into-an-exchange">Deposit XRP into Exchange</a></p>
+</li>
+<li>
+<p><a href="#rebalance-xrp-holdings">Rebalance XRP Holdings</a></p>
+</li>
+<li>
+<p><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></p>
+</li>
+<li>
+<p><a href="#trade-xrp-on-the-exchange">Trade XRP on the Exchange</a></p>
+</li>
+</ol>
+<p>At this point, <em>Alpha Exchange</em> has created <a href="#accounts">operational, standby, and issuing accounts</a> on the RCL and added them to its balance sheet, but has not funded the new accounts.</p>
 <table>
 <tr>
-<td>XRP Balances
-on RCL</td>
+<td><b><i>XRP Balances
+on RCL</i></b></td>
 <td></td>
 <td></td>
-<td>Alpha Exchange
-XRP Balances</td>
+<td><b><i>Alpha Exchange
+XRP Balances</i></b></td>
 <td></td>
 <td></td>
 </tr>
 <tr>
-<td>User</td>
-<td>Balance</td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 <td></td>
-<td>Acct #</td>
-<td>User</td>
-<td>Balance</td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
 </tr>
 <tr>
 <td>Dave</td>
@@ -343,7 +380,7 @@ XRP Balances</td>
 <td>0</td>
 </tr>
 <tr>
-<td>Alpha Hot</td>
+<td><i>Alpha Operational</i></td>
 <td>0</td>
 <td></td>
 <td>...</td>
@@ -351,7 +388,7 @@ XRP Balances</td>
 <td></td>
 </tr>
 <tr>
-<td>Alpha Warm</td>
+<td><i>Alpha Standby</i></td>
 <td>0</td>
 <td></td>
 <td></td>
@@ -359,7 +396,7 @@ XRP Balances</td>
 <td></td>
 </tr>
 <tr>
-<td>Alpha Cold</td>
+<td><i>Alpha Issuing</i></td>
 <td>0</td>
 <td></td>
 <td></td>
@@ -375,10 +412,6 @@ XRP Balances</td>
 <td></td>
 </tr>
 </table>
-<p>Figure 1 : Initial requirements for listing XRP, denoted by green table cells</p>
-<h2 id="key-definitions">Key Definitions</h2>
-<p><strong>On Ledger XRP</strong>: XRP that is visible by querying the public RCL blockchain via the public address of the XRP holder. The counterparty to these balances is the global, decentralized and distributed, RCL.</p>
-<p><strong>Off Ledger XRP</strong>: XRP that is held by the accounting system of an exchange that is visible by querying the exchange interface. These balances are credit based, and have a counterparty as the exchange. While these XRP balances are traded between participants in an exchange, the exchange is obligated to hold a balance of On Ledger XRP equal to the aggregate amount of Off Ledger XRP available for trade.</p>
 <h2 id="deposit-xrp-into-exchange">Deposit XRP into Exchange</h2>
 <p>The exchange is required to create a new accounting system to track off ledger XRP balances. Figure 1 shows the initial condition of this new account system, where all user balances start with a value of zero.</p>
 <p>Example deposit : The user Charlie wishes to deposit 50,000 XRP to Alpha Exchange. Through the interface that Alpha Exchange provides, Charlie is instructed to submit a payment (via Ripple API or wallet software) for that amount to Alpha Exchange’s cold wallet address, and to associate a numerical identifier (say 789) with the payment.</p>

--- a/xrp-listing-guide.html
+++ b/xrp-listing-guide.html
@@ -1,0 +1,721 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width">
+
+    <title>Listing XRP as an Exchange - Ripple Developer Portal</title>
+
+    <!-- favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+
+    <!-- jQuery -->
+    <script src="assets/vendor/jquery-1.11.1.min.js"></script>
+
+    <!-- Custom Stylesheets. ripple.css includes bootstrap, font stuff -->
+    <link href="assets/css/ripple.css" rel="stylesheet" />
+    <link href="assets/css/devportal.css" rel="stylesheet" />
+
+    <!-- Bootstrap JS -->
+    <script src="assets/vendor/bootstrap.min.js"></script>
+
+
+    <!-- syntax highlighting -->
+    <link rel="stylesheet" href="assets/vendor/docco.min.css" />
+    <script src="assets/vendor/highlight.min.js"></script>
+
+    <!-- syntax selection js -->
+    <script src="assets/js/multicodetab.js"></script>
+    <script>
+        $(document).ready(function() {
+            $(".multicode").minitabs();
+            hljs.initHighlighting();
+            make_code_expandable();
+        });
+    </script>
+
+    <script src="assets/js/expandcode.js"></script>
+    <script src="assets/js/fixsidebarscroll.js"></script>
+
+    <!-- fontawesome icons -->
+    <link rel="stylesheet" href="assets/vendor/fontawesome/css/font-awesome.min.css" />
+
+</head>
+
+<body class="page page-template page-template-template-dev-portal page-template-template-dev-portal-php sidebar-primary wpb-js-composer js-comp-ver-3.6.2 vc_responsive">
+  <header role="banner" class="banner navbar navbar-default navbar-fixed-top initial_header">
+    <div class="container">
+      <div class="navbar-header">
+          <a href="index.html" class="navbar-brand"><img src="assets/img/ripple-logo-color.png" class="logo"></a>
+      </div><!-- /.navbar-header -->
+      <div class="nav">
+        <div class="draft-warning">DRAFT PAGE</div>
+      </div><!-- /.nav -->
+
+    </div><!-- /.container -->
+
+    <div class="subnav dev_nav">
+      <div class="container">
+        <ul id="menu-dev-menu" class="menu">
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">References <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="reference-rippleapi.html">RippleAPI</a></li>
+                  <li><a href="reference-rippled.html">rippled</a></li>
+                  <li><a href="reference-transaction-format.html">Transaction Format</a></li>
+                  <li><a href="reference-ledger-format.html">Ledger Format</a></li>
+                  <li><a href="reference-data-api.html">Ripple Data API v2</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorials <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="tutorial-multisign.html">How to Multi-Sign</a></li>
+                  <li><a href="tutorial-paychan.html">Payment Channels Tutorial</a></li>
+                  <li><a href="concept-issuing-and-operational-addresses.html">Issuing and Operational Addresses</a></li>
+                  <li><a href="tutorial-reliable-transaction-submission.html">Reliable Transaction Submission</a></li>
+                  <li><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
+                  <li><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
+                  <li><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                  <li><a href="xrp-listing-guide.html">Listing XRP as an Exchange</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">RCL Features <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="concept-accounts.html">Accounts</a></li>
+                  <li><a href="concept-amendments.html">Amendments</a></li>
+                  <li><a href="concept-fee-voting.html">Fee Voting</a></li>
+                  <li><a href="concept-fees.html">Fees (Disambiguation)</a></li>
+                  <li><a href="concept-freeze.html">Freeze</a></li>
+                  <li><a href="concept-paths.html">Paths</a></li>
+                  <li><a href="concept-reserves.html">Reserves</a></li>
+                  <li><a href="concept-stand-alone-mode.html">Stand-Alone Mode</a></li>
+                  <li><a href="concept-transaction-cost.html">Transaction Cost</a></li>
+                  <li><a href="concept-transfer-fees.html">Transfer Fees</a></li>
+                  <li><a href="concept-noripple.html">Understanding the NoRipple flag</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Gateway Bulletins <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="gb-2015-06.html">GB-2015-06: Corrections to Autobridging</a></li>
+                  <li><a href="gb-2015-05.html">GB-2015-05: Historical Ledger Query Migration</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Tools <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                  <li><a href="ripple-api-tool.html">WebSocket API Tool</a></li>
+                  <li><a href="data-api-v2-tool.html">Data API v2 Tool</a></li>
+                  <li><a href="tool-jsonrpc.html">rippled JSON-RPC Tool</a></li>
+            </ul>
+          </li>
+
+          <li><a href="https://github.com/ripple/ripple-dev-portal" title="GitHub">Site Source</a></li>
+        </ul><!-- /#dev-menu -->
+      </div><!-- /.subnav .container -->
+    </div><!-- /.subnav -->
+  </header>
+
+
+  <div class="wrap container" role="document">
+      <aside class="sidebar" role="complementary">
+    <div class="dev_nav_wrapper">
+        <div id="cont">
+            <h5>In this category:</h5>
+            <ul class="dev_nav_sidebar">
+                <li class="level-1"><a href="index.html">Category: Tutorials</a></li>
+                <li class="level-2"><a href="tutorial-multisign.html">How to Multi-Sign</a></li>
+                <li class="level-2"><a href="tutorial-paychan.html">Payment Channels Tutorial</a></li>
+                <li class="level-2"><a href="concept-issuing-and-operational-addresses.html">Issuing and Operational Addresses</a></li>
+                <li class="level-2"><a href="tutorial-reliable-transaction-submission.html">Reliable Transaction Submission</a></li>
+                <li class="level-2"><a href="tutorial-rippleapi-beginners-guide.html">RippleAPI Beginners Guide</a></li>
+                <li class="level-2"><a href="tutorial-rippled-setup.html">rippled Setup</a></li>
+                <li class="level-2"><a href="tutorial-gateway-guide.html">Gateway Guide</a></li>
+                <li class="level-2"><a href="xrp-listing-guide.html">Listing XRP as an Exchange</a></li>
+            </ul>
+            <hr />
+            <h5>In this page:</h5>
+            <ul class="dev_nav_sidebar" id="dactyl_toc_sidebar">
+                <li class="level-1"><a href="#listing-xrp-as-an-exchange">Listing XRP as an Exchange</a></li>
+<li class="level-2"><a href="#alpha-exchange">Alpha Exchange</a></li>
+<li class="level-3"><a href="#user-benefits">User Benefits</a></li>
+<li class="level-2"><a href="#prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</a></li>
+<li class="level-3"><a href="#accounts">Accounts</a></li>
+<li class="level-3"><a href="#balance-sheets">Balance Sheets</a></li>
+<li class="level-2"><a href="#flow-of-funds">Flow of Funds</a></li>
+<li class="level-2"><a href="#key-definitions">Key Definitions</a></li>
+<li class="level-2"><a href="#deposit-xrp-into-exchange">Deposit XRP into Exchange</a></li>
+<li class="level-2"><a href="#rebalancing-xrp-holdings">Rebalancing XRP Holdings</a></li>
+<li class="level-2"><a href="#withdraw-xrp-from-exchange">Withdraw XRP from Exchange</a></li>
+<li class="level-2"><a href="#trade-xrp-on-the-exchange">Trade XRP on The Exchange</a></li>
+<li class="level-1"><a href="#about-xrp-accounts">About XRP Accounts</a></li>
+<li class="level-1"><a href="#about-xrp-balances">About XRP Balances</a></li>
+
+            </ul>
+        </div>
+    </div>
+      </aside>
+      <main class="main" role="main">
+    <div class='content'>
+        <h1 id="listing-xrp-as-an-exchange">Listing XRP as an Exchange</h1>
+<p>This document describes the steps that an exchange needs to take to list XRP. For details about other aspects of <code>rippled</code> and the Ripple Consensus Ledger (RCL), see <a href="https://ripple.com/build">https://ripple.com/build</a>.</p>
+<h2 id="alpha-exchange">Alpha Exchange</h2>
+<p>For illustrative purposes, this document uses a fictitious business called <em>Alpha Exchange</em> that has the following characteristics:</p>
+<ul>
+<li>
+<p>Currently specializes in listing BTC/USD</p>
+</li>
+<li>
+<p>Wants to add BTC/XRP and XRP/USD trading pairs</p>
+</li>
+<li>
+<p>Maintains balances for all of its customers</p>
+</li>
+<li>
+<p>Maintains balances for each of its supported currencies</p>
+</li>
+</ul>
+<h3 id="user-benefits">User Benefits</h3>
+<p>Alpha Exchange wants to list BTC/XRP and XRP/USD trading pairs partially because listing these pairs will benefit its users. Specifically, this support will allow its users to:</p>
+<ul>
+<li>
+<p>Deposit XRP <em>to</em> Alpha Exchange <em>from</em> the RCL</p>
+</li>
+<li>
+<p>Withdraw XRP <em>from</em> Alpha Exchange <em>to</em> the RCL</p>
+</li>
+<li>
+<p>Trade XRP with other currencies, such as BTC, USD, amongst others</p>
+</li>
+</ul>
+<h2 id="prerequisites-for-supporting-xrp">Prerequisites for Supporting XRP</h2>
+<p>To support XRP, Alpha Exchange must:</p>
+<ul>
+<li>
+<p>Create and maintain new <a href="#accounts">accounts</a></p>
+</li>
+<li>
+<p>Create and maintain <a href="#balance-sheets">balance sheets</a></p>
+</li>
+</ul>
+<h3 id="accounts">Accounts</h3>
+<p>Alpha Exchange must create at least two new <a href="https://ripple.com/build/accounts/">accounts</a> (also referred to as "wallets") on the RCL. To minimize the risk associated with a compromised secret key, Ripple recommends creating <a href="https://ripple.com/build/issuing-operational-addresses/"><em>issuing</em>, <em>operational</em>, and <em>standby</em> accounts</a> (these are sometimes referred to, respectively, as cold, hot, and warm wallets). This model is intended to balance security and convenience.</p>
+<pre><code>* An _issuing_ account to securely hold the majority of XRP and customers' funds. This account should be offline.
+
+* One or more _operational_ (and, perhaps, _standby_) accounts to conduct the day-to-day business of accepting customers' XRP withdrawals and deposits. Standby accounts can be online if you use the [Multisign](https://ripple.com/build/how-to-multi-sign/) feature. Operational accounts need to be online to service instant withdrawal requests.
+</code></pre>
+<p>For more information, see:</p>
+<ul>
+<li>
+<p><a href="https://ripple.com/build/gateway-guide/#suggested-business-practices">"Suggested Business Practices" in the <em>Gateway Guide</em></a></p>
+</li>
+<li>
+<p><a href="https://ripple.com/build/issuing-operational-addresses/">Issuing and Operational Addresses</a></p>
+</li>
+</ul>
+<h3 id="balance-sheets">Balance Sheets</h3>
+<p>Alpha Exchange will custody its customers' XRP, so it needs to track each customer's balance. To do this, Alpha Exchange must create and maintain an additional balance sheet. The following table illustrates what this balance sheet might look like.</p>
+<table>
+<tr>
+<td><b>XRP Balances
+on RCL</b></td>
+<td></td>
+<td></td>
+<td><b>Alpha Exchange
+XRP Balances</b></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+<td></td>
+<td><b>Acct #</b></td>
+<td><b>User</b></td>
+<td><b>Balance</b></td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td>50,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td>0</td>
+</tr>
+<tr>
+<td><i>Alpha Operational</i></td>
+<td>0</td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><i>Alpha Standby</i></td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td><i>Alpha Issuing</i></td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<p>The new RCL accounts (<em>Alpha Operational</em>, <em>Alpha Standby</em>, <em>Alpha Issuing</em>) are in the <em>User</em> column of the <em>XRP Balances on RCL</em> table.</p>
+<p>The <em>Alpha Exchange XRP Balances</em> table represents new, additional balance sheet. Alpha Exchange’s software manages their users’ balances of XRP on this accounting system.</p>
+<h2 id="flow-of-funds">Flow of Funds</h2>
+<p>The remainder of this document describes the flow of funds as Alpha Exchange allows users to deposit, trade, and redeem XRP balances.</p>
+<table>
+<tr>
+<td>XRP Balances
+on RCL</td>
+<td></td>
+<td></td>
+<td>Alpha Exchange
+XRP Balances</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>User</td>
+<td>Balance</td>
+<td></td>
+<td>Acct #</td>
+<td>User</td>
+<td>Balance</td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td>50,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Alpha Hot</td>
+<td>0</td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Warm</td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Cold</td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<p>Figure 1 : Initial requirements for listing XRP, denoted by green table cells</p>
+<h2 id="key-definitions">Key Definitions</h2>
+<p><strong>On Ledger XRP</strong>: XRP that is visible by querying the public RCL blockchain via the public address of the XRP holder. The counterparty to these balances is the global, decentralized and distributed, RCL.</p>
+<p><strong>Off Ledger XRP</strong>: XRP that is held by the accounting system of an exchange that is visible by querying the exchange interface. These balances are credit based, and have a counterparty as the exchange. While these XRP balances are traded between participants in an exchange, the exchange is obligated to hold a balance of On Ledger XRP equal to the aggregate amount of Off Ledger XRP available for trade.</p>
+<h2 id="deposit-xrp-into-exchange">Deposit XRP into Exchange</h2>
+<p>The exchange is required to create a new accounting system to track off ledger XRP balances. Figure 1 shows the initial condition of this new account system, where all user balances start with a value of zero.</p>
+<p>Example deposit : The user Charlie wishes to deposit 50,000 XRP to Alpha Exchange. Through the interface that Alpha Exchange provides, Charlie is instructed to submit a payment (via Ripple API or wallet software) for that amount to Alpha Exchange’s cold wallet address, and to associate a numerical identifier (say 789) with the payment.</p>
+<table>
+<tr>
+<td>XRP Balances
+on RCL</td>
+<td></td>
+<td></td>
+<td>Alpha Exchange
+XRP Balances</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>User</td>
+<td>Balance</td>
+<td></td>
+<td>Acct #</td>
+<td>User</td>
+<td>Balance</td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>0</td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td>100,000
+50,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td> 0
+50,000</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Hot</td>
+<td>0</td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Warm</td>
+<td>0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Alpha Cold</td>
+<td> 0
+50,000</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<p>Figure 2 : Before and after a XRP deposit is made by Charlie to Alpha Exchange</p>
+<p>The software at Alpha Exchange detects the incoming payment, and recognizes 789 as the identifier associated with Charlie’s account. The number 789 is a field known as a "Destination Tag" on the RCL. (Alpha Exchange has set a flag, called asfRequireDest, on its wallets to ensure that all incoming payment have a destination tag.)</p>
+<p><a href="https://ripple.com/build/transactions/#accountset-flags">https://ripple.com/build/transactions/#accountset-flags</a></p>
+<p>Upon detecting the incoming payment, Alpha Exchange software updates the balance sheet to reflect the 50,000 XRP received is controlled by Charlie.  Charlie is now able to use up to 50,000 XRP on the exchange, for example to create orders trading XRP to other supported currencies on Alpha Exchange.</p>
+<h2 id="rebalancing-xrp-holdings">Rebalancing XRP Holdings</h2>
+<p>In order to securely support automated transfers of XRP, the exchange will keep a portion of XRP holdings in one (or more) operational "hot" wallets. In most XRP integrations, an exchange will elect to have their middleware software make payments automatically from the hot wallet (a withdrawal payment, for example), while a cold wallet will require human intervention.</p>
+<table>
+<tr>
+<td>Alpha Exchange XRP
+Off Ledger Balances</td>
+<td></td>
+<td></td>
+<td></td>
+<td>Alpha Exchange XRP On Ledger Balances</td>
+<td></td>
+</tr>
+<tr>
+<td>Acct #</td>
+<td>User</td>
+<td>Balance</td>
+<td></td>
+<td>Wallet</td>
+<td>Balance</td>
+</tr>
+<tr>
+<td>123</td>
+<td>Alice</td>
+<td>80,000</td>
+<td></td>
+<td>Hot</td>
+<td>0
+80,000</td>
+</tr>
+<tr>
+<td>456</td>
+<td>Bob</td>
+<td>50,000</td>
+<td></td>
+<td>Warm</td>
+<td>0</td>
+</tr>
+<tr>
+<td>….</td>
+<td></td>
+<td></td>
+<td></td>
+<td>….</td>
+<td></td>
+</tr>
+<tr>
+<td>789</td>
+<td>Charlie</td>
+<td>50,000</td>
+<td></td>
+<td>Cold</td>
+<td>180,000
+100,000</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td>...</td>
+<td></td>
+</tr>
+</table>
+<p>Figure 3 : Without fractional reserve, XRP moves to operational hot wallet</p>
+<p>The exchange can adjust balances between hot and cold wallets at any time.  While each such adjustment consumes a fee, it does not otherwise affect the overall balance, which is an aggregate of all the holding wallets.  This aggregate On Ledger balance should at all times exceed the total available for trade on the exchange.  (Where the excess is sufficient to cover ledger transaction fees.)</p>
+<p>Figure 3 shows a balance adjustment via a payment of 80,000 XRP from Cold wallet to Hot wallet.  A payment made in reverse (debit the hot wallet, credit the cold wallet; not shown) would decrease the hot wallet balance. These balance adjustments allow an exchange to limit the risk associated with holding XRP in an online Hot wallet, by holding a balance in an offline Cold wallet.</p>
+<h2 id="withdraw-xrp-from-exchange">Withdraw XRP from Exchange</h2>
+<p>The <em>withdraw</em> feature allows customers to move XRP from Alpha Exchange to a wallet on the Ripple Consensus Ledger.</p>
+<p>In this example, Charlie initiates the process on the Alpha Exchange’s website.  He provides instructions to transfer 25,000 XRP to a specific Ripple wallet on RCL (named "Charlie" in figure 4).</p>
+<table>
+<tr>
+<td>RCL On Ledger XRP Balances</td>
+<td></td>
+<td></td>
+<td>Alpha Exchange XRP
+Off Ledger Balances</td>
+<td></td>
+<td></td>
+<td></td>
+<td>Alpha Exchange XRP On Ledger Balances</td>
+<td></td>
+</tr>
+<tr>
+<td>User</td>
+<td>Balance</td>
+<td></td>
+<td>Acct #</td>
+<td>User</td>
+<td>Balance</td>
+<td></td>
+<td>Wallet</td>
+<td>Balance</td>
+</tr>
+<tr>
+<td>Dave</td>
+<td>25,000</td>
+<td></td>
+<td>123</td>
+<td>Alice</td>
+<td>80,000</td>
+<td></td>
+<td>Hot</td>
+<td>80,000
+55,000</td>
+</tr>
+<tr>
+<td>Edward</td>
+<td>45,000</td>
+<td></td>
+<td>456</td>
+<td>Bob</td>
+<td>50,000</td>
+<td></td>
+<td>Warm</td>
+<td>0</td>
+</tr>
+<tr>
+<td>….</td>
+<td></td>
+<td></td>
+<td>….</td>
+<td></td>
+<td></td>
+<td></td>
+<td>….</td>
+<td></td>
+</tr>
+<tr>
+<td>Charlie</td>
+<td>50,000
+75,000</td>
+<td></td>
+<td>789</td>
+<td>Charlie</td>
+<td>50,000
+25,000</td>
+<td></td>
+<td>Cold</td>
+<td>100,000</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>...</td>
+<td></td>
+<td></td>
+<td>...</td>
+<td></td>
+<td></td>
+<td></td>
+<td>...</td>
+<td></td>
+</tr>
+</table>
+<p>Figure 4 : Before and after a XRP withdrawal by Charlie</p>
+<p>In response to Charlie’s instruction to withdraw 25,000 XRP, Alpha Exchange performs the following tasks, shown in figure 4, in this order:</p>
+<ul>
+<li>
+<p>Debit the amount from Charlie’s row on the balance sheet</p>
+</li>
+<li>
+<p>Submit a Ripple payment for the same amount, from Alpha Exchange hot wallet to Charlie’s RCL wallet</p>
+</li>
+</ul>
+<h2 id="trade-xrp-on-the-exchange">Trade XRP on The Exchange</h2>
+<p>Users of Alpha Exchange can trade the credit based balances on Alpha Exchange, and Alpha should be expected to keep track of all users balances as the trades are made. These trades are independent of, and not reflected on, RCL.</p>
+<h1 id="about-xrp-accounts">About XRP Accounts</h1>
+<p>XRP is held in Ripple Consensus Ledger <em>accounts</em> (sometimes referred to as <em>wallets</em> or <em>addresses</em>).  This document shows that an exchange is able to store all of the customers’ XRP in relatively few wallets.  (Technically, all the XRP could be managed in a single wallet.  It is for security reasons that an exchange should manage a set of hot, warm, and cold wallets.)</p>
+<p>An exchange should not create a Ripple wallet for each customer who holds XRP with the exchange.  The RCL differs from other blockchains such as Bitcoin where additional wallets incur essentially no overhead.  A Bitcoin balance is a collation of multiple UTXOs from prior blocks.  A Ripple account, in contrast, is represented in each iteration of the ledger, and can never be destroyed or removed (similar to Ethereum).  The Ripple account object includes an XRP balance as well as other properties.  Also, each Ripple account requires an XRP reserve, which adds a cost to creating a large number of wallets.</p>
+<p>See <a href="https://ripple.com/build/transactions/#creating-accounts">https://ripple.com/build/transactions/#creating-accounts</a> and <a href="https://ripple.com/build/reserves/">https://ripple.com/build/reserves/</a>.</p>
+<h1 id="about-xrp-balances">About XRP Balances</h1>
+<p>Amounts of XRP are represented on the Ripple Consensus Ledger as an unsigned integer count of <em>drops</em>, where one XRP == 1,000,000 drops.  Ripple recommends that software store XRP balances as integer amounts of drops, and perform integer arithmetic on these values.  However all user interfaces should present balances in units of XRP.</p>
+<p>One drop (or .000001 XRP) cannot be further subdivided.  Bear this in mind when calculating and displaying FX rates between XRP and other assets.</p>
+<p>See <a href="https://ripple.com/build/rippled-apis/#specifying-currency-amounts">https://ripple.com/build/rippled-apis/#specifying-currency-amounts</a> for additional detail.</p>
+    </div>
+      </main>
+  </div>
+
+<footer class="content-info" role="contentinfo">
+    <div class="container">
+        <div class="row">
+            <section class="col-sm-3 widget nav_menu-3 widget_nav_menu">
+                <h4>Resources<hr></h4>
+                <ul id="menu-resources" class="menu">
+                    <li class="menu-insights"><a href="https://ripple.com/insights/">Insights</a></li>
+                    <li class="menu-events"><a href="https://ripple.com/events/">Events</a></li>
+                    <li class="menu-collateral"><a href="https://ripple.com/collateral/">Collateral</a></li>
+                    <li class="menu-press-center"><a href="https://ripple.com/press-center/">Press Center</a></li>
+                    <li class="menu-media-kit"><a href="https://ripple.com/media-kit/">Media Kit</a></li>
+                    <li class="menu-xrp-portal"><a href="https://ripple.com/xrp-portal/">XRP Portal</a></li>
+                </ul>
+            </section>
+            <section class="col-sm-3 widget nav_menu-5 widget_nav_menu">
+                <h4>Regulators<hr></h4>
+                <ul id="menu-compliance-regulatory-relations" class="menu">
+                    <li class="menu-compliance"><a href="https://ripple.com/compliance/">Compliance</a></li>
+                    <li class="menu-policy-framework"><a href="https://ripple.com/policy-framework/">Policy Framework</a></li>
+                </ul>
+            </section>
+            <section class="col-sm-3 widget nav_menu-4 widget_nav_menu">
+                <h4>Support<hr></h4>
+                <ul id="menu-dev-footer-menu" class="menu">
+                    <li class="menu-contact-us"><a href="https://ripple.com/contact/">Contact Us</a></li>
+                    <li class="active menu-developer-center"><a href="https://ripple.com/build/">Developer Center</a></li>
+                    <li class="menu-knowledge-center"><a href="https://ripple.com/learn/">Knowledge Center</a></li>
+                    <li class="menu-ripple-forum"><a target="_blank" href="https://forum.ripple.com/">Ripple Forum</a></li>
+                </ul>
+            </section>
+            <section class="col-sm-3 widget nav_menu-2 widget_nav_menu">
+                <h4>About<hr></h4>
+                <ul id="menu-company-footer" class="menu">
+                    <li class="menu-our-company"><a href="https://ripple.com/company/">Our Company</a></li>
+                    <li class="menu-careers"><a href="https://ripple.com/company/careers/">Careers</a></li>
+                </ul>
+            </section>
+
+       		<div class="col-sm-12 absolute_bottom_footer">
+       			<div class="col-sm-8">
+                    <span>&copy; 2013 - 2016 Ripple Labs, Inc. All Rights Reserved.</span>
+                    <span><a href="/terms-of-use/">Terms</a></span>
+                    <span><a href="/privacy-policy/">Privacy</a></span>
+                </div>
+            </div><!-- /.absolute_bottom_footer -->
+
+        </div><!-- /.row -->
+    </div><!-- /.container -->
+</footer>
+</body>
+</html>


### PR DESCRIPTION
This pull request revises the guide that @warpaul @yana-novikova and others originally wrote for clarity and to conform to our doc style and formatting guidelines. 

Note that this is a high-level document intended to explain the basics of listing XRP and the flow of funds. [DOC-934](https://ripplelabs.atlassian.net/browse/DOC-934) tracks the effort to create a detailed technical tutorial. Once that's created, we will add cross-references between them. 