### PR TITLE
RippleAPI use docs from XRP Ledger rebranded commit

### DIFF
--- a/concept-freeze.html
+++ b/concept-freeze.html
@@ -311,7 +311,7 @@
 <tr>
 <td>counterparty</td>
 <td>String</td>
-<td>The <a href="reference-rippleapi.html#ripple-address">XRP Ledger address</a> of the counterparty</td>
+<td>The <a href="reference-rippleapi.html#address">XRP Ledger address</a> of the counterparty</td>
 </tr>
 <tr>
 <td>limit</td>

--- a/content/concept-freeze.md
+++ b/content/concept-freeze.md
@@ -119,7 +119,7 @@ To enable or disable Individual Freeze on a specific trust line, prepare a *Trus
 | Field        | Value  | Description |
 |--------------|--------|-------------|
 | currency     | String | The [currency](reference-rippleapi.html#currency) of the trust line to freeze |
-| counterparty | String | The [XRP Ledger address](reference-rippleapi.html#ripple-address) of the counterparty |
+| counterparty | String | The [XRP Ledger address](reference-rippleapi.html#address) of the counterparty |
 | limit        | String | The amount of currency you trust this counterparty to issue to you, as a quoted number. From the perspective of a financial institution, this is typically `"0"`. |
 | frozen       | Boolean | `true` to enable Individual Freeze on this trust line. `false` to disable Individual Freeze. |
 

--- a/reference-rippleapi.html
+++ b/reference-rippleapi.html
@@ -146,7 +146,7 @@
 <li class="level-3"><a href="#installation">Installation</a></li>
 <li class="level-2"><a href="#offline-functionality">Offline functionality</a></li>
 <li class="level-1"><a href="#basic-types">Basic Types</a></li>
-<li class="level-2"><a href="#ripple-address">Ripple Address</a></li>
+<li class="level-2"><a href="#address">Address</a></li>
 <li class="level-2"><a href="#account-sequence-number">Account Sequence Number</a></li>
 <li class="level-2"><a href="#currency">Currency</a></li>
 <li class="level-2"><a href="#value">Value</a></li>
@@ -246,86 +246,98 @@
 <li class="level-3"><a href="#parameters-16">Parameters</a></li>
 <li class="level-3"><a href="#return-value-15">Return Value</a></li>
 <li class="level-3"><a href="#example-26">Example</a></li>
-<li class="level-2"><a href="#getledger">getLedger</a></li>
+<li class="level-2"><a href="#getpaymentchannel">getPaymentChannel</a></li>
 <li class="level-3"><a href="#parameters-17">Parameters</a></li>
 <li class="level-3"><a href="#return-value-16">Return Value</a></li>
 <li class="level-3"><a href="#example-27">Example</a></li>
-<li class="level-2"><a href="#preparepayment">preparePayment</a></li>
+<li class="level-2"><a href="#getledger">getLedger</a></li>
 <li class="level-3"><a href="#parameters-18">Parameters</a></li>
 <li class="level-3"><a href="#return-value-17">Return Value</a></li>
 <li class="level-3"><a href="#example-28">Example</a></li>
-<li class="level-2"><a href="#preparetrustline">prepareTrustline</a></li>
+<li class="level-2"><a href="#preparepayment">preparePayment</a></li>
 <li class="level-3"><a href="#parameters-19">Parameters</a></li>
 <li class="level-3"><a href="#return-value-18">Return Value</a></li>
 <li class="level-3"><a href="#example-29">Example</a></li>
-<li class="level-2"><a href="#prepareorder">prepareOrder</a></li>
+<li class="level-2"><a href="#preparetrustline">prepareTrustline</a></li>
 <li class="level-3"><a href="#parameters-20">Parameters</a></li>
 <li class="level-3"><a href="#return-value-19">Return Value</a></li>
 <li class="level-3"><a href="#example-30">Example</a></li>
-<li class="level-2"><a href="#prepareordercancellation">prepareOrderCancellation</a></li>
+<li class="level-2"><a href="#prepareorder">prepareOrder</a></li>
 <li class="level-3"><a href="#parameters-21">Parameters</a></li>
 <li class="level-3"><a href="#return-value-20">Return Value</a></li>
 <li class="level-3"><a href="#example-31">Example</a></li>
-<li class="level-2"><a href="#preparesettings">prepareSettings</a></li>
+<li class="level-2"><a href="#prepareordercancellation">prepareOrderCancellation</a></li>
 <li class="level-3"><a href="#parameters-22">Parameters</a></li>
 <li class="level-3"><a href="#return-value-21">Return Value</a></li>
 <li class="level-3"><a href="#example-32">Example</a></li>
-<li class="level-2"><a href="#prepareescrowcreation">prepareEscrowCreation</a></li>
+<li class="level-2"><a href="#preparesettings">prepareSettings</a></li>
 <li class="level-3"><a href="#parameters-23">Parameters</a></li>
 <li class="level-3"><a href="#return-value-22">Return Value</a></li>
 <li class="level-3"><a href="#example-33">Example</a></li>
-<li class="level-2"><a href="#prepareescrowcancellation">prepareEscrowCancellation</a></li>
+<li class="level-2"><a href="#prepareescrowcreation">prepareEscrowCreation</a></li>
 <li class="level-3"><a href="#parameters-24">Parameters</a></li>
 <li class="level-3"><a href="#return-value-23">Return Value</a></li>
 <li class="level-3"><a href="#example-34">Example</a></li>
-<li class="level-2"><a href="#prepareescrowexecution">prepareEscrowExecution</a></li>
+<li class="level-2"><a href="#prepareescrowcancellation">prepareEscrowCancellation</a></li>
 <li class="level-3"><a href="#parameters-25">Parameters</a></li>
 <li class="level-3"><a href="#return-value-24">Return Value</a></li>
 <li class="level-3"><a href="#example-35">Example</a></li>
-<li class="level-2"><a href="#preparepaymentchannelcreate">preparePaymentChannelCreate</a></li>
+<li class="level-2"><a href="#prepareescrowexecution">prepareEscrowExecution</a></li>
 <li class="level-3"><a href="#parameters-26">Parameters</a></li>
 <li class="level-3"><a href="#return-value-25">Return Value</a></li>
 <li class="level-3"><a href="#example-36">Example</a></li>
-<li class="level-2"><a href="#preparepaymentchannelclaim">preparePaymentChannelClaim</a></li>
+<li class="level-2"><a href="#preparepaymentchannelcreate">preparePaymentChannelCreate</a></li>
 <li class="level-3"><a href="#parameters-27">Parameters</a></li>
 <li class="level-3"><a href="#return-value-26">Return Value</a></li>
 <li class="level-3"><a href="#example-37">Example</a></li>
-<li class="level-2"><a href="#preparepaymentchannelfund">preparePaymentChannelFund</a></li>
+<li class="level-2"><a href="#preparepaymentchannelclaim">preparePaymentChannelClaim</a></li>
 <li class="level-3"><a href="#parameters-28">Parameters</a></li>
 <li class="level-3"><a href="#return-value-27">Return Value</a></li>
 <li class="level-3"><a href="#example-38">Example</a></li>
-<li class="level-2"><a href="#sign">sign</a></li>
+<li class="level-2"><a href="#preparepaymentchannelfund">preparePaymentChannelFund</a></li>
 <li class="level-3"><a href="#parameters-29">Parameters</a></li>
 <li class="level-3"><a href="#return-value-28">Return Value</a></li>
 <li class="level-3"><a href="#example-39">Example</a></li>
-<li class="level-2"><a href="#combine">combine</a></li>
+<li class="level-2"><a href="#sign">sign</a></li>
 <li class="level-3"><a href="#parameters-30">Parameters</a></li>
 <li class="level-3"><a href="#return-value-29">Return Value</a></li>
 <li class="level-3"><a href="#example-40">Example</a></li>
-<li class="level-2"><a href="#submit">submit</a></li>
+<li class="level-2"><a href="#combine">combine</a></li>
 <li class="level-3"><a href="#parameters-31">Parameters</a></li>
 <li class="level-3"><a href="#return-value-30">Return Value</a></li>
 <li class="level-3"><a href="#example-41">Example</a></li>
-<li class="level-2"><a href="#generateaddress">generateAddress</a></li>
+<li class="level-2"><a href="#submit">submit</a></li>
 <li class="level-3"><a href="#parameters-32">Parameters</a></li>
 <li class="level-3"><a href="#return-value-31">Return Value</a></li>
 <li class="level-3"><a href="#example-42">Example</a></li>
-<li class="level-2"><a href="#computeledgerhash">computeLedgerHash</a></li>
+<li class="level-2"><a href="#generateaddress">generateAddress</a></li>
 <li class="level-3"><a href="#parameters-33">Parameters</a></li>
 <li class="level-3"><a href="#return-value-32">Return Value</a></li>
 <li class="level-3"><a href="#example-43">Example</a></li>
-<li class="level-1"><a href="#api-events">API Events</a></li>
-<li class="level-2"><a href="#ledger">ledger</a></li>
+<li class="level-2"><a href="#signpaymentchannelclaim">signPaymentChannelClaim</a></li>
+<li class="level-3"><a href="#parameters-34">Parameters</a></li>
 <li class="level-3"><a href="#return-value-33">Return Value</a></li>
 <li class="level-3"><a href="#example-44">Example</a></li>
-<li class="level-2"><a href="#error">error</a></li>
+<li class="level-2"><a href="#verifypaymentchannelclaim">verifyPaymentChannelClaim</a></li>
+<li class="level-3"><a href="#parameters-35">Parameters</a></li>
 <li class="level-3"><a href="#return-value-34">Return Value</a></li>
 <li class="level-3"><a href="#example-45">Example</a></li>
-<li class="level-2"><a href="#connected">connected</a></li>
-<li class="level-3"><a href="#example-46">Example</a></li>
-<li class="level-2"><a href="#disconnected">disconnected</a></li>
+<li class="level-2"><a href="#computeledgerhash">computeLedgerHash</a></li>
+<li class="level-3"><a href="#parameters-36">Parameters</a></li>
 <li class="level-3"><a href="#return-value-35">Return Value</a></li>
+<li class="level-3"><a href="#example-46">Example</a></li>
+<li class="level-1"><a href="#api-events">API Events</a></li>
+<li class="level-2"><a href="#ledger">ledger</a></li>
+<li class="level-3"><a href="#return-value-36">Return Value</a></li>
 <li class="level-3"><a href="#example-47">Example</a></li>
+<li class="level-2"><a href="#error">error</a></li>
+<li class="level-3"><a href="#return-value-37">Return Value</a></li>
+<li class="level-3"><a href="#example-48">Example</a></li>
+<li class="level-2"><a href="#connected">connected</a></li>
+<li class="level-3"><a href="#example-49">Example</a></li>
+<li class="level-2"><a href="#disconnected">disconnected</a></li>
+<li class="level-3"><a href="#return-value-38">Return Value</a></li>
+<li class="level-3"><a href="#example-50">Example</a></li>
 
             </ul>
         </div>
@@ -333,21 +345,20 @@
       </aside>
       <main class="main" role="main">
     <div class='content'>
-        <p style="margin-top: 1em; font-style: italic">Updated for <a href="https://github.com/ripple/ripple-lib/releases/0.17.6" title="view on GitHub">version 0.17.6</a></p>
-<h1 id="introduction">Introduction</h1>
-<p>RippleAPI is the official client library to the Ripple Consensus Ledger. Currently, RippleAPI is only available in JavaScript. 
+        <h1 id="introduction">Introduction</h1>
+<p>RippleAPI is the official client library to the XRP Ledger. Currently, RippleAPI is only available in JavaScript.
 Using RippleAPI, you can:</p>
 <ul>
-<li><a href="#gettransaction">Query transactions from the network</a></li>
+<li><a href="#gettransaction">Query transactions from the XRP Ledger history</a></li>
 <li><a href="#sign">Sign</a> transactions securely without connecting to any server</li>
-<li><a href="#submit">Submit</a> transactions to the Ripple Consensus Ledger, including <a href="#payment">Payments</a>, <a href="#order">Orders</a>, <a href="#settings">Settings changes</a>, and <a href="#transaction-types">other types</a></li>
-<li><a href="#generateaddress">Generate a new Ripple Address</a></li>
+<li><a href="#submit">Submit</a> transactions to the XRP Ledger, including <a href="#payment">Payments</a>, <a href="#order">Orders</a>, <a href="#settings">Settings changes</a>, and <a href="#transaction-types">other types</a></li>
+<li><a href="#generateaddress">Generate a new XRP Ledger Address</a></li>
 <li>... and <a href="#api-methods">much more</a>.</li>
 </ul>
 <p>RippleAPI only provides access to <em>validated</em>, <em>immutable</em> transaction data.</p>
 <h2 id="boilerplate">Boilerplate</h2>
 <p>Use the following <a href="https://en.wikipedia.org/wiki/Boilerplate_code">boilerplate code</a> to wrap your custom code using RippleAPI.</p>
-<pre><code class="javascript">const {RippleAPI} = require('ripple-lib');
+<pre><code class="javascript">const RippleAPI = require('ripple-lib').RippleAPI;
 
 const api = new RippleAPI({
   server: 'wss://s1.ripple.com' // Public rippled server hosted by Ripple, Inc.
@@ -369,8 +380,8 @@ api.connect().then(() =&gt; {
   return api.disconnect();
 }).catch(console.error);
 </code></pre>
-<p>RippleAPI is designed to work in <a href="https://nodejs.org">NodeJS</a> (version <code>0.12.0</code> or greater) using <a href="https://babeljs.io/">Babel</a> for <a href="https://babeljs.io/docs/learn-es2015/">ECMAScript 6</a> support.</p>
-<p>The code samples in this documentation are written in ES6, but <code>RippleAPI</code> will work with ES5 also. Regardless of whether you use ES5 or ES6, the methods that return promises will return <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">ES6-style promises</a>.</p>
+<p>RippleAPI is designed to work in <a href="https://nodejs.org">Node.js</a> version <strong>6.9.0</strong> or later. RippleAPI may work on older Node.js versions if you use <a href="https://babeljs.io/">Babel</a> for <a href="https://babeljs.io/docs/learn-es2015/">ECMAScript 6</a> support.</p>
+<p>The code samples in this documentation are written with ECMAScript 6 (ES6) features, but <code>RippleAPI</code> also works with ECMAScript 5 (ES5). Regardless of whether you use ES5 or ES6, the methods that return Promises return <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">ES6-style promises</a>.</p>
 <aside class="notice">
 All the code snippets in this documentation assume that you have surrounded them with this boilerplate.
 </aside>
@@ -451,26 +462,22 @@ The "error" event is emitted whenever an error occurs that cannot be associated 
 <p>If you omit the <code>server</code> parameter, RippleAPI operates <a href="#offline-functionality">offline</a>.</p>
 <h3 id="installation">Installation</h3>
 <ol>
-<li>Install <a href="https://nodejs.org">NodeJS</a> and the Node Package Manager (npm). Most Linux distros have a package for NodeJS, but make sure you have version <code>0.12.0</code> or higher.</li>
-<li>Use npm to install <a href="https://babeljs.io/">Babel</a> globally:
-      <code>npm install -g babel-cli</code></li>
+<li>Install <a href="https://nodejs.org">Node.js</a> and the Node Package Manager (npm). Most Linux distros have a package for Node.js, but make sure you have version <strong>6.9.0</strong> or higher.</li>
 <li>Use npm to install RippleAPI:
       <code>npm install ripple-lib</code></li>
 </ol>
-<p>After you have installed ripple-lib, you can create scripts using the <a href="#boilerplate">boilerplate</a> and run them using babel-node:
-      <code>babel-node script.js</code></p>
-<aside class="notice">
-Instead of using babel-node in production, we recommend using Babel to transpile to ECMAScript 5 first.
-</aside>
+<p>After you have installed ripple-lib, you can create scripts using the <a href="#boilerplate">boilerplate</a> and run them using the Node.js executable, typically named <code>node</code>:</p>
+<pre><code>  `node script.js`
+</code></pre>
 <h2 id="offline-functionality">Offline functionality</h2>
 <p>RippleAPI can also function without internet connectivity. This can be useful in order to generate secrets and sign transactions from a secure, isolated machine.</p>
 <p>To instantiate RippleAPI in offline mode, use the following boilerplate code:</p>
-<pre><code class="javascript">const {RippleAPI} = require('ripple-lib');
+<pre><code class="javascript">const RippleAPI = require('ripple-lib').RippleAPI;
 
 const api = new RippleAPI();
 /* insert code here */
 </code></pre>
-<p>Methods that depend on the state of the Ripple Consensus Ledger are unavailable in offline mode. To prepare transactions offline, you <strong>must</strong> specify  the <code>fee</code>, <code>sequence</code>, and <code>maxLedgerVersion</code> parameters in the <a href="#transaction-instructions">transaction instructions</a>. The following methods should work offline:</p>
+<p>Methods that depend on the state of the XRP Ledger are unavailable in offline mode. To prepare transactions offline, you <strong>must</strong> specify  the <code>fee</code>, <code>sequence</code>, and <code>maxLedgerVersion</code> parameters in the <a href="#transaction-instructions">transaction instructions</a>. You can use the following methods while offline:</p>
 <ul>
 <li><a href="#preparepayment">preparePayment</a></li>
 <li><a href="#preparetrustline">prepareTrustline</a></li>
@@ -485,14 +492,14 @@ const api = new RippleAPI();
 <li><a href="#computeledgerhash">computeLedgerHash</a></li>
 </ul>
 <h1 id="basic-types">Basic Types</h1>
-<h2 id="ripple-address">Ripple Address</h2>
+<h2 id="address">Address</h2>
 <pre><code class="json">"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
 </code></pre>
-<p>Every Ripple account has an <em>address</em>, which is a base58-encoding of a hash of the account's public key. Ripple addresses always start with the lowercase letter <code>r</code>.</p>
+<p>Every XRP Ledger account has an <em>address</em>, which is a base58-encoding of a hash of the account's public key. XRP Ledger addresses always start with the lowercase letter <code>r</code>.</p>
 <h2 id="account-sequence-number">Account Sequence Number</h2>
-<p>Every Ripple account has a <em>sequence number</em> that is used to keep transactions in order. Every transaction must have a sequence number. A transaction can only be executed if it has the next sequence number in order, of the account sending it. This prevents one transaction from executing twice and transactions executing out of order. The sequence number starts at <code>1</code> and increments for each transaction that the account makes.</p>
+<p>Every XRP Ledger account has a <em>sequence number</em> that is used to keep transactions in order. Every transaction must have a sequence number. A transaction can only be executed if it has the next sequence number in order, of the account sending it. This prevents one transaction from executing twice and transactions executing out of order. The sequence number starts at <code>1</code> and increments for each transaction that the account makes.</p>
 <h2 id="currency">Currency</h2>
-<p>Currencies are represented as either 3-character currency codes or 40-character uppercase hexadecimal strings. We recommend using uppercase <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Codes</a> only. The string "XRP" is disallowed on trustlines because it is reserved for the Ripple native currency. The following characters are permitted: all uppercase and lowercase letters, digits, as well as the symbols <code>?</code>, <code>!</code>, <code>@</code>, <code>#</code>, <code>$</code>, <code>%</code>, <code>^</code>, <code>&amp;</code>, <code>*</code>, <code>&lt;</code>, <code>&gt;</code>, <code>(</code>, <code>)</code>, <code>{</code>, <code>}</code>, <code>[</code>, <code>]</code>, and <code>|</code>.</p>
+<p>Currencies are represented as either 3-character currency codes or 40-character uppercase hexadecimal strings. We recommend using uppercase <a href="http://www.xe.com/iso4217.php">ISO 4217 Currency Codes</a> only. The string "XRP" is disallowed on trustlines because it is reserved for the XRP Ledger's native currency. The following characters are permitted: all uppercase and lowercase letters, digits, as well as the symbols <code>?</code>, <code>!</code>, <code>@</code>, <code>#</code>, <code>$</code>, <code>%</code>, <code>^</code>, <code>&amp;</code>, <code>*</code>, <code>&lt;</code>, <code>&gt;</code>, <code>(</code>, <code>)</code>, <code>{</code>, <code>}</code>, <code>[</code>, <code>]</code>, and <code>|</code>.</p>
 <h2 id="value">Value</h2>
 <p>A <em>value</em> is a quantity of a currency represented as a decimal string. Be careful: JavaScript's native number format does not have sufficient precision to represent all values. XRP has different precision from other currencies.</p>
 <p><strong>XRP</strong> has 6 significant digits past the decimal point. In other words, XRP cannot be divided into positive values smaller than <code>0.000001</code> (1e-6). XRP has a maximum value of <code>100000000000</code> (1e11).</p>
@@ -558,11 +565,11 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td><a href="#order">order</a></td>
-<td>An <code>order</code> transaction creates a limit order. It defines an intent to exchange currencies, and creates an order in the Ripple Consensus Ledger's order book if not completely fulfilled when placed. Orders can be partially fulfilled.</td>
+<td>An <code>order</code> transaction creates a limit order. It defines an intent to exchange currencies, and creates an order in the XRP Ledger's order book if not completely fulfilled when placed. Orders can be partially fulfilled.</td>
 </tr>
 <tr>
 <td><a href="#order-cancellation">orderCancellation</a></td>
-<td>An <code>orderCancellation</code> transaction cancels an order in the Ripple Consensus Ledger's order book.</td>
+<td>An <code>orderCancellation</code> transaction cancels an order in the XRP Ledger's order book.</td>
 </tr>
 <tr>
 <td><a href="#trustline">trustline</a></td>
@@ -570,11 +577,11 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td><a href="#settings">settings</a></td>
-<td>A <code>settings</code> transaction modifies the settings of an account in the Ripple Consensus Ledger.</td>
+<td>A <code>settings</code> transaction modifies the settings of an account in the XRP Ledger.</td>
 </tr>
 <tr>
 <td><a href="#escrow-creation">escrowCreation</a></td>
-<td>An <code>escrowCreation</code> transaction creates an escrow on the ledger, which locks XRP until a cryptographic condition is met or it expires. It is like an escrow service where the Ripple network acts as the escrow agent.</td>
+<td>An <code>escrowCreation</code> transaction creates an escrow on the ledger, which locks XRP until a cryptographic condition is met or it expires. It is like an escrow service where the XRP Ledger acts as the escrow agent.</td>
 </tr>
 <tr>
 <td><a href="#escrow-cancellation">escrowCancellation</a></td>
@@ -586,7 +593,6 @@ const api = new RippleAPI();
 </tr>
 </tbody>
 </table>
-<p>The three "escrow" transaction types are not supported by the production Ripple peer-to-peer network at this time. They are available for testing purposes if you <a href="#boilerplate">configure RippleAPI</a> to connect to the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> instead.</p>
 <h2 id="transaction-flow">Transaction Flow</h2>
 <p>Executing a transaction with <code>RippleAPI</code> requires the following four steps:</p>
 <ol>
@@ -606,7 +612,7 @@ const api = new RippleAPI();
 <li>Verify - Verify that the transaction got validated by querying with <a href="#gettransaction">getTransaction</a>. This is necessary because transactions may fail even if they were successfully submitted.</li>
 </ol>
 <h2 id="transaction-fees">Transaction Fees</h2>
-<p>Every transaction must destroy a small amount of XRP as a cost to send the transaction. This is also called a <em>transaction fee</em>. The transaction cost is designed to increase along with the load on the Ripple network, making it very expensive to deliberately or inadvertently overload the network.</p>
+<p>Every transaction must destroy a small amount of XRP as a cost to send the transaction. This is also called a <em>transaction fee</em>. The transaction cost is designed to increase along with the load on the XRP Ledger, making it very expensive to deliberately or inadvertently overload the peer-to-peer network that powers the XRP Ledger.</p>
 <p>You can choose the size of the fee you want to pay or let a default be used. You can get an estimate of the fee required to be included in the next ledger closing with the <a href="#getfee">getFee</a> method.</p>
 <h2 id="transaction-instructions">Transaction Instructions</h2>
 <p>Transaction instructions indicate how to execute a transaction, complementary with the <a href="#transaction-specifications">transaction specification</a>.</p>
@@ -651,7 +657,7 @@ const api = new RippleAPI();
 </tr>
 </tbody>
 </table>
-<p>We recommended that you specify a <code>maxLedgerVersion</code> so that you can quickly determine that a failed transaction will never succeeed in the future. It is impossible for a transaction to succeed after the network ledger version exceeds the transaction's <code>maxLedgerVersion</code>. If you omit <code>maxLedgerVersion</code>, the "prepare<em>" method automatically supplies a <code>maxLedgerVersion</code> equal to the current ledger plus 3, which it includes in the return value from the "prepare</em>" method.</p>
+<p>We recommended that you specify a <code>maxLedgerVersion</code> so that you can quickly determine that a failed transaction will never succeeed in the future. It is impossible for a transaction to succeed after the XRP Ledger's consensus-validated ledger version exceeds the transaction's <code>maxLedgerVersion</code>. If you omit <code>maxLedgerVersion</code>, the "prepare<em>" method automatically supplies a <code>maxLedgerVersion</code> equal to the current ledger plus 3, which it includes in the return value from the "prepare</em>" method.</p>
 <h2 id="transaction-id">Transaction ID</h2>
 <pre><code class="json">"F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF"
 </code></pre>
@@ -1147,7 +1153,7 @@ const api = new RippleAPI();
 <tr>
 <td>condition</td>
 <td>string</td>
-<td><em>Optional</em> If present, fulfillment is required upon execution.</td>
+<td><em>Optional</em> A hex value representing a <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-02#section-8.1">PREIMAGE-SHA-256 crypto-condition</a>. If present, <code>fulfillment</code> is required upon execution.</td>
 </tr>
 <tr>
 <td>destinationTag</td>
@@ -1231,12 +1237,12 @@ const api = new RippleAPI();
 <tr>
 <td>condition</td>
 <td>string</td>
-<td><em>Optional</em> The original <code>condition</code> from the escrow creation transaction. This is sha256 hash of <code>fulfillment</code> string. It is replicated here so that the relatively expensive hashing operation can be delegated to a server without ledger history and the server with ledger history only has to do a quick comparison of the old condition with the new condition.</td>
+<td><em>Optional</em> A hex value representing a <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-02#section-8.1">PREIMAGE-SHA-256 crypto-condition</a>. This must match the original <code>condition</code> from the escrow creation transaction.</td>
 </tr>
 <tr>
 <td>fulfillment</td>
 <td>string</td>
-<td><em>Optional</em> A value that produces the condition when hashed. It must be 32 charaters long and contain only 8-bit characters.</td>
+<td><em>Optional</em> A hex value representing the <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-02#section-8.1">PREIMAGE-SHA-256 crypto-condition</a> fulfillment for <code>condition</code>.</td>
 </tr>
 <tr>
 <td>memos</td>
@@ -1277,7 +1283,7 @@ const api = new RippleAPI();
 <tr>
 <td>settleDelay</td>
 <td>number</td>
-<td>Amount of time the source address must wait before closing the channel if it has unclaimed XRP.</td>
+<td>Amount of seconds the source address must wait before closing the channel if it has unclaimed XRP.</td>
 </tr>
 <tr>
 <td>publicKey</td>
@@ -4243,10 +4249,120 @@ return api.getAccountInfo(address).then(info =&gt;
   "previousAffectingTransactionLedgerVersion": 6614625
 }
 </code></pre>
+<h2 id="getpaymentchannel">getPaymentChannel</h2>
+<p><code>getPaymentChannel(id: string): Promise&lt;Object&gt;</code></p>
+<p>Returns specified payment channel.</p>
+<h3 id="parameters-17">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>id</td>
+<td>string</td>
+<td>256-bit hexadecimal channel identifier.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="return-value-16">Return Value</h3>
+<p>This method returns a promise that resolves with an object with the following structure:</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>account</td>
+<td><a href="#ripple-address">address</a></td>
+<td>Address that created the payment channel.</td>
+</tr>
+<tr>
+<td>destination</td>
+<td><a href="#ripple-address">address</a></td>
+<td>Address to receive XRP claims against this channel.</td>
+</tr>
+<tr>
+<td>amount</td>
+<td><a href="#value">value</a></td>
+<td>The total amount of XRP funded in this channel.</td>
+</tr>
+<tr>
+<td>balance</td>
+<td><a href="#value">value</a></td>
+<td>The total amount of XRP delivered by this channel.</td>
+</tr>
+<tr>
+<td>settleDelay</td>
+<td>number</td>
+<td>Amount of seconds the source address must wait before closing the channel if it has unclaimed XRP.</td>
+</tr>
+<tr>
+<td>previousAffectingTransactionID</td>
+<td>string</td>
+<td>Hash value representing the most recent transaction that affected this payment channel.</td>
+</tr>
+<tr>
+<td>previousAffectingTransactionLedgerVersion</td>
+<td>integer</td>
+<td>The ledger version that the transaction identified by the <code>previousAffectingTransactionID</code> was validated in.</td>
+</tr>
+<tr>
+<td>cancelAfter</td>
+<td>date-time string</td>
+<td><em>Optional</em> Time when this channel expires as specified at creation.</td>
+</tr>
+<tr>
+<td>destinationTag</td>
+<td>integer</td>
+<td><em>Optional</em> Destination tag.</td>
+</tr>
+<tr>
+<td>expiration</td>
+<td>date-time string</td>
+<td><em>Optional</em> Time when this channel expires.</td>
+</tr>
+<tr>
+<td>publicKey</td>
+<td>string</td>
+<td><em>Optional</em> Public key of the key pair the source will use to sign claims against this channel.</td>
+</tr>
+<tr>
+<td>sourceTag</td>
+<td>integer</td>
+<td><em>Optional</em> Source tag.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="example-27">Example</h3>
+<pre><code class="javascript">const channelId =
+  'E30E709CF009A1F26E0E5C48F7AA1BFB79393764F15FB108BDC6E06D3CBD8415';
+return api.getPaymentChannel(channelId).then(channel =&gt;
+  {/* ... */});
+</code></pre>
+<pre><code class="json">{
+  "account": "r6ZtfQFWbCkp4XqaUygzHaXsQXBT67xLj",
+  "amount": "10",
+  "balance": "0",
+  "destination": "rQf9vCwQtzQQwtnGvr6zc1fqzqg7QBuj7G",
+  "publicKey": "02A05282CB6197E34490BACCD9405E81D9DFBE123B0969F9F40EC3F9987AD9A97D",
+  "settleDelay": 10000,
+  "previousAffectingTransactionID": "F939A0BEF139465403C56CCDC49F59A77C868C78C5AEC184E29D15E9CD1FF675",
+  "previousAffectingTransactionLedgerVersion": 151322
+}
+</code></pre>
 <h2 id="getledger">getLedger</h2>
 <p><code>getLedger(options: Object): Promise&lt;Object&gt;</code></p>
 <p>Returns header information for the specified ledger (or the most recent validated ledger if no ledger is specified). Optionally, all the transactions that were validated in the ledger or the account state information can be returned with the ledger header.</p>
-<h3 id="parameters-17">Parameters</h3>
+<h3 id="parameters-18">Parameters</h3>
 <table>
 <thead>
 <tr>
@@ -4283,7 +4399,7 @@ return api.getAccountInfo(address).then(info =&gt;
 </tr>
 </tbody>
 </table>
-<h3 id="return-value-16">Return Value</h3>
+<h3 id="return-value-17">Return Value</h3>
 <p>This method returns a promise that resolves with an object with the following structure:</p>
 <table>
 <thead>
@@ -4371,7 +4487,7 @@ return api.getAccountInfo(address).then(info =&gt;
 </tr>
 </tbody>
 </table>
-<h3 id="example-27">Example</h3>
+<h3 id="example-28">Example</h3>
 <pre><code class="javascript">return api.getLedger()
   .then(ledger =&gt; {/* ... */});
 </code></pre>
@@ -4391,7 +4507,7 @@ return api.getAccountInfo(address).then(info =&gt;
 <h2 id="preparepayment">preparePayment</h2>
 <p><code>preparePayment(address: string, payment: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
 <p>Prepare a payment transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<h3 id="parameters-18">Parameters</h3>
+<h3 id="parameters-19">Parameters</h3>
 <table>
 <thead>
 <tr>
@@ -4410,109 +4526,6 @@ return api.getAccountInfo(address).then(info =&gt;
 <td>payment</td>
 <td><a href="#payment">payment</a></td>
 <td>The specification of the payment to prepare.</td>
-</tr>
-<tr>
-<td>instructions</td>
-<td><a href="#transaction-instructions">instructions</a></td>
-<td><em>Optional</em> Instructions for executing the transaction</td>
-</tr>
-</tbody>
-</table>
-<h3 id="return-value-17">Return Value</h3>
-<p>This method returns a promise that resolves with an object with the following structure:</p>
-<aside class="notice">
-All "prepare*" methods have the same return type.
-</aside>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>txJSON</td>
-<td>string</td>
-<td>The prepared transaction in rippled JSON format.</td>
-</tr>
-<tr>
-<td>instructions</td>
-<td>object</td>
-<td>The instructions for how to execute the transaction after adding automatic defaults.</td>
-</tr>
-<tr>
-<td><em>instructions.</em> fee</td>
-<td><a href="#value">value</a></td>
-<td>An exact fee to pay for the transaction. See <a href="#transaction-fees">Transaction Fees</a> for more information.</td>
-</tr>
-<tr>
-<td><em>instructions.</em> sequence</td>
-<td><a href="#account-sequence-number">sequence</a></td>
-<td>The initiating account's sequence number for this transaction.</td>
-</tr>
-<tr>
-<td><em>instructions.</em> maxLedgerVersion</td>
-<td>integer,null</td>
-<td>The highest ledger version that the transaction can be included in. Set to <code>null</code> if there is no maximum.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="example-28">Example</h3>
-<pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const payment = {
-  "source": {
-    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "maxAmount": {
-      "value": "0.01",
-      "currency": "USD",
-      "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-    }
-  },
-  "destination": {
-    "address": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-    "amount": {
-      "value": "0.01",
-      "currency": "USD",
-      "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-    }
-  }
-};
-return api.preparePayment(address, payment).then(prepared =&gt;
-  {/* ... */});
-</code></pre>
-<pre><code class="json">{
-  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"Payment\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Destination\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"Amount\":{\"value\":\"0.01\",\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\"},\"SendMax\":{\"value\":\"0.01\",\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\"},\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
-  "instructions": {
-    "fee": "0.000012",
-    "sequence": 23,
-    "maxLedgerVersion": 8820051
-  }
-}
-</code></pre>
-<h2 id="preparetrustline">prepareTrustline</h2>
-<p><code>prepareTrustline(address: string, trustline: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare a trustline transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<h3 id="parameters-19">Parameters</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>address</td>
-<td><a href="#ripple-address">address</a></td>
-<td>The address of the account that is creating the transaction.</td>
-</tr>
-<tr>
-<td>trustline</td>
-<td><a href="#trustline">trustline</a></td>
-<td>The specification of the trustline to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -4564,27 +4577,29 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-29">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const trustline = {
-  "currency": "USD",
-  "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
-  "limit": "10000",
-  "qualityIn": 0.91,
-  "qualityOut": 0.87,
-  "ripplingDisabled": true,
-  "frozen": false,
-  "memos": [
-    {
-      "type": "test",
-      "format": "plain/text",
-      "data": "texted data"
+const payment = {
+  "source": {
+    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "maxAmount": {
+      "value": "0.01",
+      "currency": "USD",
+      "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
     }
-  ]
+  },
+  "destination": {
+    "address": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+    "amount": {
+      "value": "0.01",
+      "currency": "USD",
+      "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
+    }
+  }
 };
-return api.prepareTrustline(address, trustline).then(prepared =&gt;
+return api.preparePayment(address, payment).then(prepared =&gt;
   {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"TransactionType\":\"TrustSet\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"LimitAmount\":{\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\",\"value\":\"10000\"},\"Flags\":2149711872,\"QualityIn\":910000000,\"QualityOut\":870000000,\"Memos\":[{\"Memo\":{\"MemoData\":\"7465787465642064617461\",\"MemoType\":\"74657374\",\"MemoFormat\":\"706C61696E2F74657874\"}}],\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"Payment\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Destination\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"Amount\":{\"value\":\"0.01\",\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\"},\"SendMax\":{\"value\":\"0.01\",\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\"},\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
   "instructions": {
     "fee": "0.000012",
     "sequence": 23,
@@ -4592,9 +4607,9 @@ return api.prepareTrustline(address, trustline).then(prepared =&gt;
   }
 }
 </code></pre>
-<h2 id="prepareorder">prepareOrder</h2>
-<p><code>prepareOrder(address: string, order: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare an order transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
+<h2 id="preparetrustline">prepareTrustline</h2>
+<p><code>prepareTrustline(address: string, trustline: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare a trustline transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-20">Parameters</h3>
 <table>
 <thead>
@@ -4611,9 +4626,9 @@ return api.prepareTrustline(address, trustline).then(prepared =&gt;
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>order</td>
-<td><a href="#order">order</a></td>
-<td>The specification of the order to prepare.</td>
+<td>trustline</td>
+<td><a href="#trustline">trustline</a></td>
+<td>The specification of the trustline to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -4665,35 +4680,37 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-30">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const order = {
-  "direction": "buy",
-  "quantity": {
-    "currency": "USD",
-    "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
-    "value": "10.1"
-  },
-  "totalPrice": {
-    "currency": "XRP",
-    "value": "2"
-  },
-  "passive": true,
-  "fillOrKill": true
+const trustline = {
+  "currency": "USD",
+  "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
+  "limit": "10000",
+  "qualityIn": 0.91,
+  "qualityOut": 0.87,
+  "ripplingDisabled": true,
+  "frozen": false,
+  "memos": [
+    {
+      "type": "test",
+      "format": "plain/text",
+      "data": "texted data"
+    }
+  ]
 };
-return api.prepareOrder(address, order)
-  .then(prepared =&gt; {/* ... */});
+return api.prepareTrustline(address, trustline).then(prepared =&gt;
+  {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"Flags\":2147811328,\"TransactionType\":\"OfferCreate\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"TakerGets\":\"2000000\",\"TakerPays\":{\"value\":\"10.1\",\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\"},\"LastLedgerSequence\":8819954,\"Fee\":\"12\",\"Sequence\":23}",
+  "txJSON": "{\"TransactionType\":\"TrustSet\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"LimitAmount\":{\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\",\"value\":\"10000\"},\"Flags\":2149711872,\"QualityIn\":910000000,\"QualityOut\":870000000,\"Memos\":[{\"Memo\":{\"MemoData\":\"7465787465642064617461\",\"MemoType\":\"74657374\",\"MemoFormat\":\"706C61696E2F74657874\"}}],\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
   "instructions": {
     "fee": "0.000012",
     "sequence": 23,
-    "maxLedgerVersion": 8819954
+    "maxLedgerVersion": 8820051
   }
 }
 </code></pre>
-<h2 id="prepareordercancellation">prepareOrderCancellation</h2>
-<p><code>prepareOrderCancellation(address: string, orderCancellation: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare an order cancellation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
+<h2 id="prepareorder">prepareOrder</h2>
+<p><code>prepareOrder(address: string, order: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare an order transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-21">Parameters</h3>
 <table>
 <thead>
@@ -4710,9 +4727,9 @@ return api.prepareOrder(address, order)
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>orderCancellation</td>
-<td><a href="#order-cancellation">orderCancellation</a></td>
-<td>The specification of the order cancellation to prepare.</td>
+<td>order</td>
+<td><a href="#order">order</a></td>
+<td>The specification of the order to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -4764,22 +4781,35 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-31">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const orderCancellation = {orderSequence: 123};
-return api.prepareOrderCancellation(address, orderCancellation)
+const order = {
+  "direction": "buy",
+  "quantity": {
+    "currency": "USD",
+    "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
+    "value": "10.1"
+  },
+  "totalPrice": {
+    "currency": "XRP",
+    "value": "2"
+  },
+  "passive": true,
+  "fillOrKill": true
+};
+return api.prepareOrder(address, order)
   .then(prepared =&gt; {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"OfferCancel\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"OfferSequence\":23,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "txJSON": "{\"Flags\":2147811328,\"TransactionType\":\"OfferCreate\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"TakerGets\":\"2000000\",\"TakerPays\":{\"value\":\"10.1\",\"currency\":\"USD\",\"issuer\":\"rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM\"},\"LastLedgerSequence\":8819954,\"Fee\":\"12\",\"Sequence\":23}",
   "instructions": {
     "fee": "0.000012",
     "sequence": 23,
-    "maxLedgerVersion": 8820051
+    "maxLedgerVersion": 8819954
   }
 }
 </code></pre>
-<h2 id="preparesettings">prepareSettings</h2>
-<p><code>prepareSettings(address: string, settings: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare a settings transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
+<h2 id="prepareordercancellation">prepareOrderCancellation</h2>
+<p><code>prepareOrderCancellation(address: string, orderCancellation: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare an order cancellation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-22">Parameters</h3>
 <table>
 <thead>
@@ -4796,9 +4826,9 @@ return api.prepareOrderCancellation(address, orderCancellation)
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>settings</td>
-<td><a href="#settings">settings</a></td>
-<td>The specification of the settings to prepare.</td>
+<td>orderCancellation</td>
+<td><a href="#order-cancellation">orderCancellation</a></td>
+<td>The specification of the order cancellation to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -4850,34 +4880,22 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-32">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const settings = {
-  "domain": "ripple.com",
-  "memos": [
-    {
-      "type": "test",
-      "format": "plain/text",
-      "data": "texted data"
-    }
-  ]
-};
-return api.prepareSettings(address, settings)
+const orderCancellation = {orderSequence: 123};
+return api.prepareOrderCancellation(address, orderCancellation)
   .then(prepared =&gt; {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "domain": "ripple.com",
-  "memos": [
-    {
-      "type": "test",
-      "format": "plain/text",
-      "data": "texted data"
-    }
-  ]
+  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"OfferCancel\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"OfferSequence\":23,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "instructions": {
+    "fee": "0.000012",
+    "sequence": 23,
+    "maxLedgerVersion": 8820051
+  }
 }
 </code></pre>
-<h2 id="prepareescrowcreation">prepareEscrowCreation</h2>
-<p><code>prepareEscrowCreation(address: string, escrowCreation: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare an escrow creation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<p class="devportal-callout caution"><strong>Caution:</strong> Escrow is currently available on the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> only.</p>
+<h2 id="preparesettings">prepareSettings</h2>
+<p><code>prepareSettings(address: string, settings: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare a settings transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-23">Parameters</h3>
 <table>
 <thead>
@@ -4894,9 +4912,9 @@ return api.prepareSettings(address, settings)
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>escrowCreation</td>
-<td><a href="#escrow-creation">escrowCreation</a></td>
-<td>The specification of the escrow creation to prepare.</td>
+<td>settings</td>
+<td><a href="#settings">settings</a></td>
+<td>The specification of the settings to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -4948,27 +4966,33 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-33">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const escrowCreation = {
-  "destination": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-  "amount": "0.01",
-  "allowCancelAfter": "2014-09-24T21:21:50.000Z"
+const settings = {
+  "domain": "ripple.com",
+  "memos": [
+    {
+      "type": "test",
+      "format": "plain/text",
+      "data": "texted data"
+    }
+  ]
 };
-return api.prepareEscrowCreation(address, escrowCreation).then(prepared =&gt;
-  {/* ... */});
+return api.prepareSettings(address, settings)
+  .then(prepared =&gt; {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"EscrowCreate\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Destination\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"Amount\":\"10000\",\"CancelAfter\":464908910,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
-  "instructions": {
-    "fee": "0.000012",
-    "sequence": 23,
-    "maxLedgerVersion": 8820051
-  }
+  "domain": "ripple.com",
+  "memos": [
+    {
+      "type": "test",
+      "format": "plain/text",
+      "data": "texted data"
+    }
+  ]
 }
 </code></pre>
-<h2 id="prepareescrowcancellation">prepareEscrowCancellation</h2>
-<p><code>prepareEscrowCancellation(address: string, escrowCancellation: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare an escrow cancellation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<p class="devportal-callout caution"><strong>Caution:</strong> Escrow is currently available on the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> only.</p>
+<h2 id="prepareescrowcreation">prepareEscrowCreation</h2>
+<p><code>prepareEscrowCreation(address: string, escrowCreation: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare an escrow creation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-24">Parameters</h3>
 <table>
 <thead>
@@ -4985,9 +5009,9 @@ return api.prepareEscrowCreation(address, escrowCreation).then(prepared =&gt;
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>escrowCancellation</td>
-<td><a href="#escrow-cancellation">escrowCancellation</a></td>
-<td>The specification of the escrow cancellation to prepare.</td>
+<td>escrowCreation</td>
+<td><a href="#escrow-creation">escrowCreation</a></td>
+<td>The specification of the escrow creation to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -5039,15 +5063,16 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-34">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const escrowCancellation = {
-  "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-  "escrowSequence": 1234
+const escrowCreation = {
+  "destination": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+  "amount": "0.01",
+  "allowCancelAfter": "2014-09-24T21:21:50.000Z"
 };
-return api.prepareEscrowCancellation(address, escrowCancellation).then(prepared =&gt;
+return api.prepareEscrowCreation(address, escrowCreation).then(prepared =&gt;
   {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"EscrowCancel\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Owner\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"OfferSequence\":1234,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"EscrowCreate\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Destination\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"Amount\":\"10000\",\"CancelAfter\":464908910,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
   "instructions": {
     "fee": "0.000012",
     "sequence": 23,
@@ -5055,10 +5080,9 @@ return api.prepareEscrowCancellation(address, escrowCancellation).then(prepared 
   }
 }
 </code></pre>
-<h2 id="prepareescrowexecution">prepareEscrowExecution</h2>
-<p><code>prepareEscrowExecution(address: string, escrowExecution: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare an escrow execution transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<p class="devportal-callout caution"><strong>Caution:</strong> Escrow is currently available on the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> only.</p>
+<h2 id="prepareescrowcancellation">prepareEscrowCancellation</h2>
+<p><code>prepareEscrowCancellation(address: string, escrowCancellation: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare an escrow cancellation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-25">Parameters</h3>
 <table>
 <thead>
@@ -5075,9 +5099,9 @@ return api.prepareEscrowCancellation(address, escrowCancellation).then(prepared 
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>escrowExecution</td>
-<td><a href="#escrow-execution">escrowExecution</a></td>
-<td>The specification of the escrow execution to prepare.</td>
+<td>escrowCancellation</td>
+<td><a href="#escrow-cancellation">escrowCancellation</a></td>
+<td>The specification of the escrow cancellation to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -5129,28 +5153,25 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-35">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const escrowExecution = {
+const escrowCancellation = {
   "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-  "escrowSequence": 1234,
-  "condition": "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
-  "fulfillment": "A0028000"
+  "escrowSequence": 1234
 };
-return api.prepareEscrowExecution(address, escrowExecution).then(prepared =&gt;
+return api.prepareEscrowCancellation(address, escrowCancellation).then(prepared =&gt;
   {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"EscrowFinish\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Owner\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"OfferSequence\":1234,\"Condition\":\"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100\",\"Fulfillment\":\"A0028000\",\"LastLedgerSequence\":8820051,\"Fee\":\"396\",\"Sequence\":23}",
+  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"EscrowCancel\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Owner\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"OfferSequence\":1234,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
   "instructions": {
-    "fee": "0.000396",
+    "fee": "0.000012",
     "sequence": 23,
     "maxLedgerVersion": 8820051
   }
 }
 </code></pre>
-<h2 id="preparepaymentchannelcreate">preparePaymentChannelCreate</h2>
-<p><code>preparePaymentChannelCreate(address: string, paymentChannelCreate: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare a payment channel creation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<p class="devportal-callout caution"><strong>Caution:</strong> Payment channels are currently available on the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> only.</p>
+<h2 id="prepareescrowexecution">prepareEscrowExecution</h2>
+<p><code>prepareEscrowExecution(address: string, escrowExecution: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare an escrow execution transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-26">Parameters</h3>
 <table>
 <thead>
@@ -5167,9 +5188,9 @@ return api.prepareEscrowExecution(address, escrowExecution).then(prepared =&gt;
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>paymentChannelCreate</td>
-<td><a href="#payment-channel-create">paymentChannelCreate</a></td>
-<td>The specification of the payment channel to create.</td>
+<td>escrowExecution</td>
+<td><a href="#escrow-execution">escrowExecution</a></td>
+<td>The specification of the escrow execution to prepare.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -5221,28 +5242,27 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-36">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const paymentChannelCreate = {
-  "amount": "1",
-  "destination": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
-  "settleDelay": 86400,
-  "publicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
+const escrowExecution = {
+  "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "escrowSequence": 1234,
+  "condition": "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
+  "fulfillment": "A0028000"
 };
-return api.preparePaymentChannelCreate(address, paymentChannelCreate).then(prepared =&gt;
+return api.prepareEscrowExecution(address, escrowExecution).then(prepared =&gt;
   {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON":"{\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"TransactionType\":\"PaymentChannelCreate\",\"Amount\":\"1000000\",\"Destination\":\"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\"SettleDelay\":86400,\"PublicKey\":\"32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A\",\"Flags\":2147483648,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "txJSON": "{\"Flags\":2147483648,\"TransactionType\":\"EscrowFinish\",\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"Owner\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"OfferSequence\":1234,\"Condition\":\"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100\",\"Fulfillment\":\"A0028000\",\"LastLedgerSequence\":8820051,\"Fee\":\"396\",\"Sequence\":23}",
   "instructions": {
-    "fee": "0.000012",
+    "fee": "0.000396",
     "sequence": 23,
     "maxLedgerVersion": 8820051
   }
 }
 </code></pre>
-<h2 id="preparepaymentchannelclaim">preparePaymentChannelClaim</h2>
-<p><code>preparePaymentChannelClaim(address: string, paymentChannelClaim: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare a payment channel claim transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<p class="devportal-callout caution"><strong>Caution:</strong> Payment channels are currently available on the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> only.</p>
+<h2 id="preparepaymentchannelcreate">preparePaymentChannelCreate</h2>
+<p><code>preparePaymentChannelCreate(address: string, paymentChannelCreate: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare a payment channel creation transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-27">Parameters</h3>
 <table>
 <thead>
@@ -5259,9 +5279,9 @@ return api.preparePaymentChannelCreate(address, paymentChannelCreate).then(prepa
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>paymentChannelClaim</td>
-<td><a href="#payment-channel-claim">paymentChannelClaim</a></td>
-<td>Details of the channel and claim.</td>
+<td>paymentChannelCreate</td>
+<td><a href="#payment-channel-create">paymentChannelCreate</a></td>
+<td>The specification of the payment channel to create.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -5313,14 +5333,17 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-37">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-const paymentChannelClaim = {
-  "channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198"
+const paymentChannelCreate = {
+  "amount": "1",
+  "destination": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+  "settleDelay": 86400,
+  "publicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
 };
-return api.preparePaymentChannelClaim(address, paymentChannelClaim).then(prepared =&gt;
+return api.preparePaymentChannelCreate(address, paymentChannelCreate).then(prepared =&gt;
   {/* ... */});
 </code></pre>
 <pre><code class="json">{
-  "txJSON": "{\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"TransactionType\":\"PaymentChannelClaim\",\"Channel\":\"C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198\",\"Flags\":2147483648,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "txJSON":"{\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"TransactionType\":\"PaymentChannelCreate\",\"Amount\":\"1000000\",\"Destination\":\"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\"SettleDelay\":86400,\"PublicKey\":\"32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A\",\"Flags\":2147483648,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
   "instructions": {
     "fee": "0.000012",
     "sequence": 23,
@@ -5328,10 +5351,9 @@ return api.preparePaymentChannelClaim(address, paymentChannelClaim).then(prepare
   }
 }
 </code></pre>
-<h2 id="preparepaymentchannelfund">preparePaymentChannelFund</h2>
-<p><code>preparePaymentChannelFund(address: string, paymentChannelFund: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
-<p>Prepare a payment channel fund transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
-<p class="devportal-callout caution"><strong>Caution:</strong> Payment channels are currently available on the <a href="https://ripple.com/build/ripple-test-net/">Ripple Test Net</a> only.</p>
+<h2 id="preparepaymentchannelclaim">preparePaymentChannelClaim</h2>
+<p><code>preparePaymentChannelClaim(address: string, paymentChannelClaim: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare a payment channel claim transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
 <h3 id="parameters-28">Parameters</h3>
 <table>
 <thead>
@@ -5348,9 +5370,9 @@ return api.preparePaymentChannelClaim(address, paymentChannelClaim).then(prepare
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
-<td>paymentChannelFund</td>
-<td><a href="#payment-channel-fund">paymentChannelFund</a></td>
-<td>The channel to fund, and the details of how to fund it.</td>
+<td>paymentChannelClaim</td>
+<td><a href="#payment-channel-claim">paymentChannelClaim</a></td>
+<td>Details of the channel and claim.</td>
 </tr>
 <tr>
 <td>instructions</td>
@@ -5402,6 +5424,94 @@ All "prepare*" methods have the same return type.
 </table>
 <h3 id="example-38">Example</h3>
 <pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
+const paymentChannelClaim = {
+  "channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198"
+};
+return api.preparePaymentChannelClaim(address, paymentChannelClaim).then(prepared =&gt;
+  {/* ... */});
+</code></pre>
+<pre><code class="json">{
+  "txJSON": "{\"Account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"TransactionType\":\"PaymentChannelClaim\",\"Channel\":\"C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198\",\"Flags\":2147483648,\"LastLedgerSequence\":8820051,\"Fee\":\"12\",\"Sequence\":23}",
+  "instructions": {
+    "fee": "0.000012",
+    "sequence": 23,
+    "maxLedgerVersion": 8820051
+  }
+}
+</code></pre>
+<h2 id="preparepaymentchannelfund">preparePaymentChannelFund</h2>
+<p><code>preparePaymentChannelFund(address: string, paymentChannelFund: Object, instructions: Object): Promise&lt;Object&gt;</code></p>
+<p>Prepare a payment channel fund transaction. The prepared transaction must subsequently be <a href="#sign">signed</a> and <a href="#submit">submitted</a>.</p>
+<h3 id="parameters-29">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>address</td>
+<td><a href="#ripple-address">address</a></td>
+<td>The address of the account that is creating the transaction.</td>
+</tr>
+<tr>
+<td>paymentChannelFund</td>
+<td><a href="#payment-channel-fund">paymentChannelFund</a></td>
+<td>The channel to fund, and the details of how to fund it.</td>
+</tr>
+<tr>
+<td>instructions</td>
+<td><a href="#transaction-instructions">instructions</a></td>
+<td><em>Optional</em> Instructions for executing the transaction</td>
+</tr>
+</tbody>
+</table>
+<h3 id="return-value-28">Return Value</h3>
+<p>This method returns a promise that resolves with an object with the following structure:</p>
+<aside class="notice">
+All "prepare*" methods have the same return type.
+</aside>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>txJSON</td>
+<td>string</td>
+<td>The prepared transaction in rippled JSON format.</td>
+</tr>
+<tr>
+<td>instructions</td>
+<td>object</td>
+<td>The instructions for how to execute the transaction after adding automatic defaults.</td>
+</tr>
+<tr>
+<td><em>instructions.</em> fee</td>
+<td><a href="#value">value</a></td>
+<td>An exact fee to pay for the transaction. See <a href="#transaction-fees">Transaction Fees</a> for more information.</td>
+</tr>
+<tr>
+<td><em>instructions.</em> sequence</td>
+<td><a href="#account-sequence-number">sequence</a></td>
+<td>The initiating account's sequence number for this transaction.</td>
+</tr>
+<tr>
+<td><em>instructions.</em> maxLedgerVersion</td>
+<td>integer,null</td>
+<td>The highest ledger version that the transaction can be included in. Set to <code>null</code> if there is no maximum.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="example-39">Example</h3>
+<pre><code class="javascript">const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
 const paymentChannelFund = {
   "channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
   "amount": "1"
@@ -5421,7 +5531,7 @@ return api.preparePaymentChannelFund(address, paymentChannelFund).then(prepared 
 <h2 id="sign">sign</h2>
 <p><code>sign(txJSON: string, secret: string, options: Object): {signedTransaction: string, id: string}</code></p>
 <p>Sign a prepared transaction. The signed transaction must subsequently be <a href="#submit">submitted</a>.</p>
-<h3 id="parameters-29">Parameters</h3>
+<h3 id="parameters-30">Parameters</h3>
 <table>
 <thead>
 <tr>
@@ -5453,59 +5563,6 @@ return api.preparePaymentChannelFund(address, paymentChannelFund).then(prepared 
 </tr>
 </tbody>
 </table>
-<h3 id="return-value-28">Return Value</h3>
-<p>This method returns an object with the following structure:</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>signedTransaction</td>
-<td>string</td>
-<td>The signed transaction represented as an uppercase hexadecimal string.</td>
-</tr>
-<tr>
-<td>id</td>
-<td><a href="#transaction-id">id</a></td>
-<td>The <a href="#transaction-id">Transaction ID</a> of the signed transaction.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="example-39">Example</h3>
-<pre><code class="javascript">const txJSON = '{"Flags":2147483648,"TransactionType":"AccountSet","Account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59","Domain":"726970706C652E636F6D","LastLedgerSequence":8820051,"Fee":"12","Sequence":23}';
-const secret = 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV';
-return api.sign(txJSON, secret);
-</code></pre>
-<pre><code class="json">{
-  "signedTransaction": "12000322800000002400000017201B0086955368400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D874473045022100BDE09A1F6670403F341C21A77CF35BA47E45CDE974096E1AA5FC39811D8269E702203D60291B9A27F1DCABA9CF5DED307B4F23223E0B6F156991DB601DFB9C41CE1C770A726970706C652E636F6D81145E7B112523F68D2F5E879DB4EAC51C6698A69304",
-  "id": "02ACE87F1996E3A23690A5BB7F1774BF71CCBA68F79805831B42ABAD5913D6F4"
-}
-</code></pre>
-<h2 id="combine">combine</h2>
-<p><code>combine(signedTransactions: Array&lt;string&gt;): {signedTransaction: string, id: string}</code></p>
-<p>Combines signed transactions from multiple accounts for a multisignature transaction. The signed transaction must subsequently be <a href="#submit">submitted</a>.</p>
-<h3 id="parameters-30">Parameters</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>signedTransactions</td>
-<td>array\&lt;string&gt;</td>
-<td>An array of signed transactions (from the output of <a href="#sign">sign</a>) to combine.</td>
-</tr>
-</tbody>
-</table>
 <h3 id="return-value-29">Return Value</h3>
 <p>This method returns an object with the following structure:</p>
 <table>
@@ -5530,6 +5587,59 @@ return api.sign(txJSON, secret);
 </tbody>
 </table>
 <h3 id="example-40">Example</h3>
+<pre><code class="javascript">const txJSON = '{"Flags":2147483648,"TransactionType":"AccountSet","Account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59","Domain":"726970706C652E636F6D","LastLedgerSequence":8820051,"Fee":"12","Sequence":23}';
+const secret = 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV';
+return api.sign(txJSON, secret);
+</code></pre>
+<pre><code class="json">{
+  "signedTransaction": "12000322800000002400000017201B0086955368400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D874473045022100BDE09A1F6670403F341C21A77CF35BA47E45CDE974096E1AA5FC39811D8269E702203D60291B9A27F1DCABA9CF5DED307B4F23223E0B6F156991DB601DFB9C41CE1C770A726970706C652E636F6D81145E7B112523F68D2F5E879DB4EAC51C6698A69304",
+  "id": "02ACE87F1996E3A23690A5BB7F1774BF71CCBA68F79805831B42ABAD5913D6F4"
+}
+</code></pre>
+<h2 id="combine">combine</h2>
+<p><code>combine(signedTransactions: Array&lt;string&gt;): {signedTransaction: string, id: string}</code></p>
+<p>Combines signed transactions from multiple accounts for a multisignature transaction. The signed transaction must subsequently be <a href="#submit">submitted</a>.</p>
+<h3 id="parameters-31">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>signedTransactions</td>
+<td>array\&lt;string&gt;</td>
+<td>An array of signed transactions (from the output of <a href="#sign">sign</a>) to combine.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="return-value-30">Return Value</h3>
+<p>This method returns an object with the following structure:</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>signedTransaction</td>
+<td>string</td>
+<td>The signed transaction represented as an uppercase hexadecimal string.</td>
+</tr>
+<tr>
+<td>id</td>
+<td><a href="#transaction-id">id</a></td>
+<td>The <a href="#transaction-id">Transaction ID</a> of the signed transaction.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="example-41">Example</h3>
 <pre><code class="javascript">const signedTransactions = [ "12000322800000002400000004201B000000116840000000000F42407300770B6578616D706C652E636F6D811407C532442A675C881BA1235354D4AB9D023243A6F3E0107321026C784C1987F83BACBF02CD3E484AFC84ADE5CA6B36ED4DCA06D5BA233B9D382774473045022100E484F54FF909469FA2033E22EFF3DF8EDFE62217062680BB2F3EDF2F185074FE0220350DB29001C710F0450DAF466C5D819DC6D6A3340602DE9B6CB7DA8E17C90F798114FE9337B0574213FA5BCC0A319DBB4A7AC0CCA894E1F1",
   "12000322800000002400000004201B000000116840000000000F42407300770B6578616D706C652E636F6D811407C532442A675C881BA1235354D4AB9D023243A6F3E01073210287AAAB8FBE8C4C4A47F6F1228C6E5123A7ED844BFE88A9B22C2F7CC34279EEAA74473045022100B09DDF23144595B5A9523B20E605E138DC6549F5CA7B5984D7C32B0E3469DF6B022018845CA6C203D4B6288C87DDA439134C83E7ADF8358BD41A8A9141A9B631419F8114517D9B9609229E0CDFE2428B586738C5B2E84D45E1F1" ];
 return api.combine(signedTransactions);
@@ -5542,7 +5652,7 @@ return api.combine(signedTransactions);
 <h2 id="submit">submit</h2>
 <p><code>submit(signedTransaction: string): Promise&lt;Object&gt;</code></p>
 <p>Submits a signed transaction. The transaction is not guaranteed to succeed; it must be verified with <a href="#gettransaction">getTransaction</a>.</p>
-<h3 id="parameters-31">Parameters</h3>
+<h3 id="parameters-32">Parameters</h3>
 <table>
 <thead>
 <tr>
@@ -5559,7 +5669,7 @@ return api.combine(signedTransactions);
 </tr>
 </tbody>
 </table>
-<h3 id="return-value-30">Return Value</h3>
+<h3 id="return-value-31">Return Value</h3>
 <p>This method returns an object with the following structure:</p>
 <table>
 <thead>
@@ -5582,7 +5692,7 @@ return api.combine(signedTransactions);
 </tr>
 </tbody>
 </table>
-<h3 id="example-41">Example</h3>
+<h3 id="example-42">Example</h3>
 <pre><code class="javascript">const signedTransaction = '12000322800000002400000017201B0086955368400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D874473045022100BDE09A1F6670403F341C21A77CF35BA47E45CDE974096E1AA5FC39811D8269E702203D60291B9A27F1DCABA9CF5DED307B4F23223E0B6F156991DB601DFB9C41CE1C770A726970706C652E636F6D81145E7B112523F68D2F5E879DB4EAC51C6698A69304';
 return api.submit(signedTransaction)
   .then(result =&gt; {/* ... */});
@@ -5594,8 +5704,8 @@ return api.submit(signedTransaction)
 </code></pre>
 <h2 id="generateaddress">generateAddress</h2>
 <p><code>generateAddress(): {address: string, secret: string}</code></p>
-<p>Generate a new Ripple address and corresponding secret.</p>
-<h3 id="parameters-32">Parameters</h3>
+<p>Generate a new XRP Ledger address and corresponding secret.</p>
+<h3 id="parameters-33">Parameters</h3>
 <table>
 <thead>
 <tr>
@@ -5622,7 +5732,7 @@ return api.submit(signedTransaction)
 </tr>
 </tbody>
 </table>
-<h3 id="return-value-31">Return Value</h3>
+<h3 id="return-value-32">Return Value</h3>
 <p>This method returns an object with the following structure:</p>
 <table>
 <thead>
@@ -5645,7 +5755,7 @@ return api.submit(signedTransaction)
 </tr>
 </tbody>
 </table>
-<h3 id="example-42">Example</h3>
+<h3 id="example-43">Example</h3>
 <pre><code class="javascript">return api.generateAddress();
 </code></pre>
 <pre><code class="json">{
@@ -5653,10 +5763,132 @@ return api.submit(signedTransaction)
   "secret": "sp6JS7f14BuwFY8Mw6bTtLKWauoUs"
 }
 </code></pre>
+<h2 id="signpaymentchannelclaim">signPaymentChannelClaim</h2>
+<p><code>signPaymentChannelClaim(channel: string, amount: string, privateKey: string): string</code></p>
+<p>Sign a payment channel claim. The signature can be submitted in a subsequent <a href="#preparePaymmentChannelClaim">PaymentChannelClaim</a> transaction.</p>
+<h3 id="parameters-34">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>channel</td>
+<td>string</td>
+<td>256-bit hexadecimal channel identifier.</td>
+</tr>
+<tr>
+<td>amount</td>
+<td><a href="#value">value</a></td>
+<td>Amount of XRP authorized by the claim.</td>
+</tr>
+<tr>
+<td>privateKey</td>
+<td>string</td>
+<td>The private key to sign the payment channel claim.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="return-value-33">Return Value</h3>
+<p>This method returns a signature string:</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+<td>string</td>
+<td>The hexadecimal representation of a signature.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="example-44">Example</h3>
+<pre><code class="javascript">const channel =
+  '3E18C05AD40319B809520F1A136370C4075321B285217323396D6FD9EE1E9037';
+const amount = '.00001';
+const privateKey =
+  'ACCD3309DB14D1A4FC9B1DAE608031F4408C85C73EE05E035B7DC8B25840107A';
+return api.signPaymentChannelClaim(channel, amount, privateKey);
+</code></pre>
+<pre><code class="json">"3045022100B5C54654221F154347679B97AE7791CBEF5E6772A3F894F9C781B8F1B400F89F022021E466D29DC5AEB5DFAFC76E8A88D2E388EBD25A84143B6AC3B647F479CB89B7"
+</code></pre>
+<h2 id="verifypaymentchannelclaim">verifyPaymentChannelClaim</h2>
+<p><code>verifyPaymentChannelClaim(channel: string, amount: string, signature: string, publicKey: string): boolean</code></p>
+<p>Verify a payment channel claim signature.</p>
+<h3 id="parameters-35">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>channel</td>
+<td>string</td>
+<td>256-bit hexadecimal channel identifier.</td>
+</tr>
+<tr>
+<td>amount</td>
+<td><a href="#value">value</a></td>
+<td>Amount of XRP authorized by the claim.</td>
+</tr>
+<tr>
+<td>signature</td>
+<td>string</td>
+<td>Signature of this claim.</td>
+</tr>
+<tr>
+<td>publicKey</td>
+<td>string</td>
+<td>Public key of the channel's sender</td>
+</tr>
+</tbody>
+</table>
+<h3 id="return-value-34">Return Value</h3>
+<p>This method returns <code>true</code> if the claim signature is valid.</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+<td>boolean</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<h3 id="example-45">Example</h3>
+<pre><code class="javascript">const channel =
+  '3E18C05AD40319B809520F1A136370C4075321B285217323396D6FD9EE1E9037';
+const amount = '.00001';
+const signature = "3045022100B5C54654221F154347679B97AE7791CBEF5E6772A3F894F9C781B8F1B400F89F022021E466D29DC5AEB5DFAFC76E8A88D2E388EBD25A84143B6AC3B647F479CB89B7";
+const publicKey =
+  '02F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D8';
+return api.verifyPaymentChannelClaim(channel, amount, signature, publicKey);
+</code></pre>
+<pre><code class="json">true
+</code></pre>
 <h2 id="computeledgerhash">computeLedgerHash</h2>
 <p><code>computeLedgerHash(ledger: Object): string</code></p>
 <p>Compute the hash of a ledger.</p>
-<h3 id="parameters-33">Parameters</h3>
+<h3 id="parameters-36">Parameters</h3>
 <aside class="notice">
 The parameter to this method has the same structure as the return value of getLedger.
 </aside>
@@ -5751,9 +5983,9 @@ The parameter to this method has the same structure as the return value of getLe
 </tr>
 </tbody>
 </table>
-<h3 id="return-value-32">Return Value</h3>
+<h3 id="return-value-35">Return Value</h3>
 <p>This method returns an uppercase hexadecimal string representing the hash of the ledger.</p>
-<h3 id="example-43">Example</h3>
+<h3 id="example-46">Example</h3>
 <pre><code class="javascript">const ledger = {
   "stateHash": "D9ABF622DA26EEEE48203085D4BC23B0F77DC6F8724AC33D975DA3CA492D2E44",
   "closeTime": "2015-08-12T01:01:10.000Z",
@@ -5772,7 +6004,7 @@ return api.computeLedgerHash(ledger);
 <h1 id="api-events">API Events</h1>
 <h2 id="ledger">ledger</h2>
 <p>This event is emitted whenever a new ledger version is validated on the connected server.</p>
-<h3 id="return-value-33">Return Value</h3>
+<h3 id="return-value-36">Return Value</h3>
 <table>
 <thead>
 <tr>
@@ -5824,7 +6056,7 @@ return api.computeLedgerHash(ledger);
 </tr>
 </tbody>
 </table>
-<h3 id="example-44">Example</h3>
+<h3 id="example-47">Example</h3>
 <pre><code class="javascript">api.on('ledger', ledger =&gt; {
   console.log(JSON.stringify(ledger, null, 2));
 });
@@ -5842,7 +6074,7 @@ return api.computeLedgerHash(ledger);
 </code></pre>
 <h2 id="error">error</h2>
 <p>This event is emitted when there is an error on the connection to the server that cannot be associated to a specific request.</p>
-<h3 id="return-value-34">Return Value</h3>
+<h3 id="return-value-37">Return Value</h3>
 <p>The first parameter is a string indicating the error type:
 <em> <code>badMessage</code> - rippled returned a malformed message
 </em> <code>websocket</code> - the websocket library emitted an error
@@ -5852,7 +6084,7 @@ return api.computeLedgerHash(ledger);
 <em> the message that caused the error for <code>badMessage</code>
 </em> the error object emitted for <code>websocket</code>
 * the parsed response for rippled errors</p>
-<h3 id="example-45">Example</h3>
+<h3 id="example-48">Example</h3>
 <pre><code class="javascript">api.on('error', (errorCode, errorMessage, data) =&gt; {
   console.log(errorCode + ': ' + errorMessage);
 });
@@ -5861,16 +6093,16 @@ return api.computeLedgerHash(ledger);
 </code></pre>
 <h2 id="connected">connected</h2>
 <p>This event is emitted after connection successfully opened.</p>
-<h3 id="example-46">Example</h3>
+<h3 id="example-49">Example</h3>
 <pre><code class="javascript">api.on('connected', () =&gt; {
   console.log('Connection is open now.');
 });
 </code></pre>
 <h2 id="disconnected">disconnected</h2>
 <p>This event is emitted when connection is closed.</p>
-<h3 id="return-value-35">Return Value</h3>
+<h3 id="return-value-38">Return Value</h3>
 <p>The only parameter is a number containing the <a href="https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent">close code</a> send by the server.</p>
-<h3 id="example-47">Example</h3>
+<h3 id="example-50">Example</h3>
 <pre><code class="javascript">api.on('disconnected', (code) =&gt; {
   if (code !== 1000) {
     console.log('Connection is closed due to error.');

--- a/reference-rippleapi.html
+++ b/reference-rippleapi.html
@@ -538,7 +538,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td>counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> The Ripple address of the account that owes or is owed the funds (omitted if <code>currency</code> is "XRP")</td>
 </tr>
 <tr>
@@ -711,7 +711,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td><em>source.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to send from.</td>
 </tr>
 <tr>
@@ -736,7 +736,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td><em>destination.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to receive at.</td>
 </tr>
 <tr>
@@ -751,7 +751,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td><em>destination.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to send to.</td>
 </tr>
 <tr>
@@ -829,7 +829,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td>counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account this trustline extends trust to.</td>
 </tr>
 <tr>
@@ -1057,7 +1057,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td>regularKey</td>
-<td><a href="#ripple-address">address</a>,null</td>
+<td><a href="#address">address</a>,null</td>
 <td><em>Optional</em> The public key of a new keypair, to use as the regular key to this account, as a base-58-encoded string in the same format as an account address. Use <code>null</code> to remove the regular key.</td>
 </tr>
 <tr>
@@ -1092,7 +1092,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td><em>signers.weights[].</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>A Ripple account address</td>
 </tr>
 <tr>
@@ -1137,7 +1137,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td>destination</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>Address to receive escrowed XRP.</td>
 </tr>
 <tr>
@@ -1192,7 +1192,7 @@ const api = new RippleAPI();
 <tbody>
 <tr>
 <td>owner</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the owner of the escrow to cancel.</td>
 </tr>
 <tr>
@@ -1226,7 +1226,7 @@ const api = new RippleAPI();
 <tbody>
 <tr>
 <td>owner</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the owner of the escrow to execute.</td>
 </tr>
 <tr>
@@ -1277,7 +1277,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td>destination</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>Address to receive XRP claims against this channel.</td>
 </tr>
 <tr>
@@ -1672,7 +1672,7 @@ const api = new RippleAPI();
 </tr>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that initiated the transaction.</td>
 </tr>
 <tr>
@@ -1891,7 +1891,7 @@ return api.getTransaction(id).then(transaction =&gt; {
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account to get transactions for.</td>
 </tr>
 <tr>
@@ -1906,7 +1906,7 @@ return api.getTransaction(id).then(transaction =&gt; {
 </tr>
 <tr>
 <td><em>options.</em> counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> If provided, only return transactions with this account as a counterparty to the transaction.</td>
 </tr>
 <tr>
@@ -2171,7 +2171,7 @@ return api.getTransactions(address).then(transaction =&gt; {
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account to get trustlines for.</td>
 </tr>
 <tr>
@@ -2181,7 +2181,7 @@ return api.getTransactions(address).then(transaction =&gt; {
 </tr>
 <tr>
 <td><em>options.</em> counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> Only return trustlines with this counterparty.</td>
 </tr>
 <tr>
@@ -2374,7 +2374,7 @@ return api.getTrustlines(address).then(trustlines =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account to get balances for.</td>
 </tr>
 <tr>
@@ -2384,7 +2384,7 @@ return api.getTrustlines(address).then(trustlines =&gt;
 </tr>
 <tr>
 <td><em>options.</em> counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> Only return balances with this counterparty.</td>
 </tr>
 <tr>
@@ -2427,7 +2427,7 @@ return api.getTrustlines(address).then(trustlines =&gt;
 </tr>
 <tr>
 <td>counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> The Ripple address of the account that owes or is owed the funds.</td>
 </tr>
 </tbody>
@@ -2579,7 +2579,7 @@ return api.getBalances(address).then(balances =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The Ripple address of the account to get the balance sheet of.</td>
 </tr>
 <tr>
@@ -2589,7 +2589,7 @@ return api.getBalances(address).then(balances =&gt;
 </tr>
 <tr>
 <td><em>options.</em> excludeAddresses</td>
-<td>array\&lt;<a href="#ripple-address">address</a>&gt;</td>
+<td>array\&lt;<a href="#address">address</a>&gt;</td>
 <td><em>Optional</em> Addresses to exclude from the balance totals.</td>
 </tr>
 <tr>
@@ -2727,7 +2727,7 @@ return api.getBalanceSheet(address).then(balanceSheet =&gt;
 </tr>
 <tr>
 <td><em>pathfind.source.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The Ripple address of the account where funds will come from.</td>
 </tr>
 <tr>
@@ -2752,7 +2752,7 @@ return api.getBalanceSheet(address).then(balanceSheet =&gt;
 </tr>
 <tr>
 <td><em>pathfind.source.currencies[].</em> counterparty</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> The counterparty for the currency; if omitted any counterparty may be used.</td>
 </tr>
 <tr>
@@ -2762,7 +2762,7 @@ return api.getBalanceSheet(address).then(balanceSheet =&gt;
 </tr>
 <tr>
 <td><em>pathfind.destination.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to send to.</td>
 </tr>
 <tr>
@@ -2790,7 +2790,7 @@ return api.getBalanceSheet(address).then(balanceSheet =&gt;
 </tr>
 <tr>
 <td><em>source.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to send from.</td>
 </tr>
 <tr>
@@ -2815,7 +2815,7 @@ return api.getBalanceSheet(address).then(balanceSheet =&gt;
 </tr>
 <tr>
 <td><em>destination.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to receive at.</td>
 </tr>
 <tr>
@@ -2830,7 +2830,7 @@ return api.getBalanceSheet(address).then(balanceSheet =&gt;
 </tr>
 <tr>
 <td><em>destination.</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address to send to.</td>
 </tr>
 <tr>
@@ -2934,7 +2934,7 @@ return api.getPaths(pathfind)
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The Ripple address of the account to get open orders for.</td>
 </tr>
 <tr>
@@ -2977,7 +2977,7 @@ return api.getPaths(pathfind)
 </tr>
 <tr>
 <td><em>properties.</em> maker</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that submitted the order.</td>
 </tr>
 <tr>
@@ -3353,7 +3353,7 @@ return api.getOrders(address).then(orders =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>Address of an account to use as point-of-view. (This affects which unfunded offers are returned.)</td>
 </tr>
 <tr>
@@ -3421,7 +3421,7 @@ return api.getOrders(address).then(orders =&gt;
 </tr>
 <tr>
 <td><em>bids[].properties.</em> maker</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that submitted the order.</td>
 </tr>
 <tr>
@@ -3471,7 +3471,7 @@ return api.getOrders(address).then(orders =&gt;
 </tr>
 <tr>
 <td><em>asks[].properties.</em> maker</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that submitted the order.</td>
 </tr>
 <tr>
@@ -4017,7 +4017,7 @@ return api.getOrderbook(address, orderbook)
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account to get the settings of.</td>
 </tr>
 <tr>
@@ -4100,7 +4100,7 @@ return api.getOrderbook(address, orderbook)
 </tr>
 <tr>
 <td>regularKey</td>
-<td><a href="#ripple-address">address</a>,null</td>
+<td><a href="#address">address</a>,null</td>
 <td><em>Optional</em> The public key of a new keypair, to use as the regular key to this account, as a base-58-encoded string in the same format as an account address. Use <code>null</code> to remove the regular key.</td>
 </tr>
 <tr>
@@ -4135,7 +4135,7 @@ return api.getOrderbook(address, orderbook)
 </tr>
 <tr>
 <td><em>signers.weights[].</em> address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>A Ripple account address</td>
 </tr>
 <tr>
@@ -4178,7 +4178,7 @@ return api.getSettings(address).then(settings =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account to get the account info of.</td>
 </tr>
 <tr>
@@ -4282,12 +4282,12 @@ return api.getAccountInfo(address).then(info =&gt;
 <tbody>
 <tr>
 <td>account</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>Address that created the payment channel.</td>
 </tr>
 <tr>
 <td>destination</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>Address to receive XRP claims against this channel.</td>
 </tr>
 <tr>
@@ -4519,7 +4519,7 @@ return api.getPaymentChannel(channelId).then(channel =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -4622,7 +4622,7 @@ return api.preparePayment(address, payment).then(prepared =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -4723,7 +4723,7 @@ return api.prepareTrustline(address, trustline).then(prepared =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -4822,7 +4822,7 @@ return api.prepareOrder(address, order)
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -4908,7 +4908,7 @@ return api.prepareOrderCancellation(address, orderCancellation)
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5005,7 +5005,7 @@ return api.prepareSettings(address, settings)
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5095,7 +5095,7 @@ return api.prepareEscrowCreation(address, escrowCreation).then(prepared =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5184,7 +5184,7 @@ return api.prepareEscrowCancellation(address, escrowCancellation).then(prepared 
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5275,7 +5275,7 @@ return api.prepareEscrowExecution(address, escrowExecution).then(prepared =&gt;
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5366,7 +5366,7 @@ return api.preparePaymentChannelCreate(address, paymentChannelCreate).then(prepa
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5454,7 +5454,7 @@ return api.preparePaymentChannelClaim(address, paymentChannelClaim).then(prepare
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>The address of the account that is creating the transaction.</td>
 </tr>
 <tr>
@@ -5558,7 +5558,7 @@ return api.preparePaymentChannelFund(address, paymentChannelFund).then(prepared 
 </tr>
 <tr>
 <td><em>options.</em> signAs</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td><em>Optional</em> The account that the signature should count for in multisigning.</td>
 </tr>
 </tbody>
@@ -5745,7 +5745,7 @@ return api.submit(signedTransaction)
 <tbody>
 <tr>
 <td>address</td>
-<td><a href="#ripple-address">address</a></td>
+<td><a href="#address">address</a></td>
 <td>A randomly generated Ripple account address.</td>
 </tr>
 <tr>
@@ -5765,7 +5765,7 @@ return api.submit(signedTransaction)
 </code></pre>
 <h2 id="signpaymentchannelclaim">signPaymentChannelClaim</h2>
 <p><code>signPaymentChannelClaim(channel: string, amount: string, privateKey: string): string</code></p>
-<p>Sign a payment channel claim. The signature can be submitted in a subsequent <a href="#preparePaymmentChannelClaim">PaymentChannelClaim</a> transaction.</p>
+<p>Sign a payment channel claim. The signature can be submitted in a subsequent <a href="#preparepaymentchannelclaim">PaymentChannelClaim</a> transaction.</p>
 <h3 id="parameters-34">Parameters</h3>
 <table>
 <thead>

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -115,7 +115,7 @@ pages:
         category: References
         html: reference-rippleapi.html
         # Currently this is the only page that's fetched remotely.
-        md: https://raw.githubusercontent.com/ripple/ripple-lib/bf36cf03d6761e62e7b6cf04c59fc2af9e381067/docs/index.md
+        md: https://raw.githubusercontent.com/ripple/ripple-lib/e6d71471e26ca253e762fc7034859951b5d31c47/docs/index.md
         filters:
             - remove_doctoc
             - add_version

--- a/tool/dactyl-config.yml
+++ b/tool/dactyl-config.yml
@@ -115,7 +115,7 @@ pages:
         category: References
         html: reference-rippleapi.html
         # Currently this is the only page that's fetched remotely.
-        md: https://raw.githubusercontent.com/ripple/ripple-lib/0.17.6/docs/index.md
+        md: https://raw.githubusercontent.com/ripple/ripple-lib/bf36cf03d6761e62e7b6cf04c59fc2af9e381067/docs/index.md
         filters:
             - remove_doctoc
             - add_version


### PR DESCRIPTION
This updates RippleAPI to use the docs from the current develop branch, which is close to 0.17.7 but has some doc changes for rebranding "Ripple Consensus Ledger" to "XRP Ledger". This also adds the Payment Channels support that wasn't in 0.17.6.

Using a commit ID that's later than the 0.17.7 release, instead of a proper release tag, is a stopgap measure for the time being while the tests on the ripple-lib repo are broken.