### PR TITLE
Amendments ledger object & ledger format cleanup

### DIFF
--- a/content/concept-accounts.md
+++ b/content/concept-accounts.md
@@ -11,7 +11,7 @@ An "Account" in the XRP Ledger represents a holder of XRP and a sender of [trans
     - A "regular" key pair that [can be rotated](reference-transaction-format.html#setregularkey).
     - A signer list for [multi-signing](reference-transaction-format.html#multi-signing). (Stored separately from the account's core data.)
 
-In the ledger's data tree, an account's core data is stored in the [AccountRoot](reference-ledger-format.html#accountroot) ledger node type. An account can also be the owner (or partial owner) of several other types of data.
+In the ledger's data tree, an account's core data is stored in the [AccountRoot](reference-ledger-format.html#accountroot) ledger object type. An account can also be the owner (or partial owner) of several other types of data.
 
 **Tip:** An "Account" in the XRP Ledger is somewhere between the financial usage (like "bank account") and the computing usage (like "UNIX account"). Non-XRP currencies and assets aren't stored in an XRP Ledger Account itself; each such asset is stored in an accounting relationship called a "Trust Line" that connects two parties.
 
@@ -47,12 +47,12 @@ Unlike Bitcoin and many other crypto-currencies, each new version of the XRP Led
 
 ## Transaction History
 
-In the XRP Ledger, transaction history is tracked by a "thread" of transactions linked by a transaction's identifying hash and the ledger index. The `AccountRoot` ledger node has the identifying hash and ledger of the transaction that most recently modified it; the metadata of that transaction includes the previous state of the `AccountRoot` node, so it is possible to iterate through the history of a single account this way. This transaction history includes any transactions that modify the `AccountRoot` node directly, including:
+In the XRP Ledger, transaction history is tracked by a "thread" of transactions linked by a transaction's identifying hash and the ledger index. The `AccountRoot` ledger object has the identifying hash and ledger of the transaction that most recently modified it; the metadata of that transaction includes the previous state of the `AccountRoot` node, so it is possible to iterate through the history of a single account this way. This transaction history includes any transactions that modify the `AccountRoot` node directly, including:
 
 - Transactions sent by the account, because they modify the account's `Sequence` number. These transactions also modify the account's XRP balance because of the [transaction cost](concept-transaction-cost.html).
 - Transactions that modified the account's XRP balance, including incoming [Payment transactions][] and other types of transactions such as [PaymentChannelClaim][] and [EscrowFinish][].
 
-The _conceptual_ transaction history of an account also includes transactions that modified the account's owned objects and non-XRP balances. These objects are separate ledger nodes, each with their own thread of transactions that affected them. If you have an account's full ledger history, you can follow it forward to find the ledger node objects created or modified by it. A "complete" transaction history includes the history of objects owned by a transaction, such as:
+The _conceptual_ transaction history of an account also includes transactions that modified the account's owned objects and non-XRP balances. These objects are separate ledger objects, each with their own thread of transactions that affected them. If you have an account's full ledger history, you can follow it forward to find the ledger objects created or modified by it. A "complete" transaction history includes the history of objects owned by a transaction, such as:
 
 - `RippleState` objects (Trust Lines) connected to the account.
 - `DirectoryNode` objects, especially the owner directory tracking the account's owned objects.

--- a/content/concept-amendments.md
+++ b/content/concept-amendments.md
@@ -169,7 +169,7 @@ Examples of invariant checks:
 
 Replaces the [SusPay](#suspay) and [CryptoConditions](#cryptoconditions) amendments.
 
-Provides "suspended payments" for XRP for escrow within the XRP Ledger, including support for [Interledger Protocol Crypto-Conditions](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02). Creates a new ledger node type for suspended payments and new transaction types to create, execute, and cancel suspended payments.
+Provides "suspended payments" for XRP for escrow within the XRP Ledger, including support for [Interledger Protocol Crypto-Conditions](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02). Creates a new ledger object type for suspended payments and new transaction types to create, execute, and cancel suspended payments.
 
 
 
@@ -249,7 +249,7 @@ This is a previous version of the [Flow](#flow) amendment. It was [rejected due 
 |:-----------------------------------------------------------------|:--------|
 | 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 | Enabled |
 
-Introduces [multi-signing](reference-transaction-format.html#multi-signing) as a way to authorize transactions. Creates the [`SignerList` ledger node type](reference-ledger-format.html#signerlist) and the [`SignerListSet` transaction type](reference-transaction-format.html#signerlistset). Adds the optional `Signers` field to all transaction types. Modifies some transaction result codes.
+Introduces [multi-signing](reference-transaction-format.html#multi-signing) as a way to authorize transactions. Creates the [`SignerList` ledger object type](reference-ledger-format.html#signerlist) and the [`SignerListSet` transaction type](reference-transaction-format.html#signerlistset). Adds the optional `Signers` field to all transaction types. Modifies some transaction result codes.
 
 This amendment allows addresses to have a list of signers who can authorize transactions from that address in a multi-signature. The list has a quorum and 1 to 8 weighted signers. This allows various configurations, such as "any 3-of-5" or "signature from A plus any other two signatures."
 
@@ -285,7 +285,7 @@ This Amendment requires the [Flow Amendment](#flow) to be enabled.
 
 Creates "Payment Channels" for XRP. Payment channels are a tool for facilitating repeated, unidirectional payments or temporary credit between two parties. Ripple expects this feature to be useful for the [Interledger Protocol](https://interledger.org/). One party creates a Payment Channel and sets aside some XRP in that channel for a predetermined expiration. Then, through off-ledger secure communications, the sender can send "Claim" messages to the receiver. The receiver can redeem the Claim messages before the expiration, or choose not to in case the payment is not needed. The receiver can verify Claims individually without actually distributing them to the network and waiting for the consensus process to redeem them, then redeem the batched content of many small Claims later, as long as it is within the expiration.
 
-Creates three new transaction types:[PaymentChannelCreate][], [PaymentChannelClaim][], and [PaymentChannelFund][]. Creates a new ledger node type, [PayChannel](reference-ledger-format.html#paychannel). Defines an off-ledger data structure called a `Claim`, used in the ChannelClaim transaction. Creates new `rippled` API methods: [`channel_authorize`](reference-rippled.html#channel-authorize) (creates a signed Claim), [`channel_verify`](reference-rippled.html#channel-verify) (verifies a signed Claim), and [`account_channels`](reference-rippled.html#account-channels) (lists Channels associated with an account).
+Creates three new transaction types:[PaymentChannelCreate][], [PaymentChannelClaim][], and [PaymentChannelFund][]. Creates a new ledger object type, [PayChannel](reference-ledger-format.html#paychannel). Defines an off-ledger data structure called a `Claim`, used in the ChannelClaim transaction. Creates new `rippled` API methods: [`channel_authorize`](reference-rippled.html#channel-authorize) (creates a signed Claim), [`channel_verify`](reference-rippled.html#channel-verify) (verifies a signed Claim), and [`account_channels`](reference-rippled.html#account-channels) (lists Channels associated with an account).
 
 For more information, see the [Payment Channels Tutorial](tutorial-paychan.html).
 
@@ -318,7 +318,7 @@ This amendment is currently enabled on the [Ripple Test Net](https://ripple.com/
 
 Allows pre-authorization of accounting relationships (zero-balance trust lines) when using [Authorized Accounts](tutorial-gateway-guide.html#authorized-accounts).
 
-With this amendment enabled, a `TrustSet` transaction with [`tfSetfAuth` enabled](reference-transaction-format.html#trustset-flags) can create a new [`RippleState` ledger node](reference-ledger-format.html#ripplestate) even if it keeps all the other values of the `RippleState` node in their default state. The new `RippleState` node has the [`lsfLowAuth` or `lsfHighAuth` flag](reference-ledger-format.html#ripplestate-flags) enabled, depending on whether the sender of the transaction is considered the low node or the high node. The sender of the transaction must have already enabled [`lsfRequireAuth`](reference-ledger-format.html#accountroot-flags) by sending an [AccountSet transaction](reference-transaction-format.html#accountset) with the [asfRequireAuth flag enabled](reference-transaction-format.html#accountset-flags).
+With this amendment enabled, a `TrustSet` transaction with [`tfSetfAuth` enabled](reference-transaction-format.html#trustset-flags) can create a new [`RippleState` ledger object](reference-ledger-format.html#ripplestate) even if it keeps all the other values of the `RippleState` node in their default state. The new `RippleState` node has the [`lsfLowAuth` or `lsfHighAuth` flag](reference-ledger-format.html#ripplestate-flags) enabled, depending on whether the sender of the transaction is considered the low node or the high node. The sender of the transaction must have already enabled [`lsfRequireAuth`](reference-ledger-format.html#accountroot-flags) by sending an [AccountSet transaction](reference-transaction-format.html#accountset) with the [asfRequireAuth flag enabled](reference-transaction-format.html#accountset-flags).
 
 ## TickSize
 
@@ -337,7 +337,7 @@ Introduces a `TickSize` field to accounts, which can be set with the [AccountSet
 |:-----------------------------------------------------------------|:----------|
 | C1B8D934087225F509BEB5A8EC24447854713EE447D277F69545ABFA0E0FD490 | In development |
 
-Introduces Tickets as a way to reserve a transaction sequence number for later execution. Creates the `Ticket` ledger node type and the transaction types `TicketCreate` and `TicketCancel`.
+Introduces Tickets as a way to reserve a transaction sequence number for later execution. Creates the `Ticket` ledger object type and the transaction types `TicketCreate` and `TicketCancel`.
 
 **Caution:** This amendment is still in development.
 

--- a/content/concept-reserves.md
+++ b/content/concept-reserves.md
@@ -24,7 +24,7 @@ Many objects in the ledger are owned by a particular address, and count toward t
 - A single [SignerList](reference-ledger-format.html#signerlist) counts as 3 to 10 objects for purposes of the owner reserve, depending on how many members it has. See also: [SignerLists and Reserves](reference-ledger-format.html#signerlists-and-reserves).
 - [Held Payments (Escrow)](reference-ledger-format.html#escrow) are owned by the address that placed them.
 - [Payment Channels](tutorial-paychan.html) are owned by the address that created them.
-- [Owner directories](reference-ledger-format.html#directorynode) list all the ledger nodes that contribute to an address's owner reserve. However, the owner directory itself does not count towards the reserve.
+- [Owner directories](reference-ledger-format.html#directorynode) list all the ledger objects that contribute to an address's owner reserve. However, the owner directory itself does not count towards the reserve.
 
 #### Owner Reserve Edge Cases ####
 

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -182,7 +182,7 @@ Example `Amendments` object:
 
 Amendments are added to the `Amendments` table by an [EnableAmendment][] pseudo-transaction with no flags as the result of the [amendment process](concept-amendments.html#amendment-process).
 
-**Note:** Technically, all transactions in a ledger are processed based on which amendments are enabled in the ledger versions immediately before it. While applying transactions to a ledger version where an amendment becomes enabled, the rules don't change mid-ledger. After the ledger is closed, the next ledger uses the new rules as defined by any new amendments that applied.
+**Note:** Technically, all transactions in a ledger are processed based on which amendments are enabled in the ledger version immediately before it. While applying transactions to a ledger version where an amendment becomes enabled, the rules don't change mid-ledger. After the ledger is closed, the next ledger uses the new rules as defined by any new amendments that applied.
 
 ### Amendments ID Format
 

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -155,18 +155,19 @@ Example `Amendments` object:
 
 ```json
 {
+    "Majorities": [
+        {
+            "Majority": {
+                "Amendment": "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146",
+                "CloseTime": 535589001
+            }
+        }
+    ],
     "Amendments": [
         "42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE",
         "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373",
         "6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC",
-        "740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11",
-        "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146",
-        "532651B4FD58DF8922A49BA101AB3E996E5BFBF95A913B3E392504863E63B164",
-        "08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647",
-        "E2E6F2866106419B88C50045ACE96368558C345566AC8F2BDF5A5B5587F0E6FA",
-        "07D43DCE529B15A10827E5E04943B496762F9A88E3268269D69C44BE49E21104",
-        "42EEA5E28A97824821D4EF97081FE36A54E9593C6E4F20CBAE098C69D2E072DC",
-        "DC9CA96AEA1DCF83E527D1AFC916EFAF5D27388ECA4060A88817C1238CAEE0BF"
+        "740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11"
     ],
     "Flags": 0,
     "LedgerEntryType": "Amendments",
@@ -176,11 +177,19 @@ Example `Amendments` object:
 
 | Name              | JSON Type | [Internal Type][] | Description |
 |-------------------|-----------|-------------------|-------------|
-| `Amendments`      | Array     | STI_VECTOR256     | Array of 256-bit [amendment IDs](concept-amendments.html#about-amendments) for all currently-enabled amendments. |
+| `Amendments`      | Array     | STI_VECTOR256     | _(Optional)_ Array of 256-bit [amendment IDs](concept-amendments.html#about-amendments) for all currently-enabled amendments. If omitted, there are no enabled amendments. |
+| `Majorities`      | Array     | STI_ARRAY | _(Optional)_ Array of objects describing the status of amendments that have majority support but are not yet enabled. If omitted, there are no pending amendments with majority support. |
 | `Flags`           | Number    | UInt32    | Not used. |
 | `LedgerEntryType` | String    | UInt16    |  The value `0x66`, mapped to the string `Amendments`, indicates that this is the Amendments object. |
 
-Amendments are added to the `Amendments` table by an [EnableAmendment][] pseudo-transaction with no flags as the result of the [amendment process](concept-amendments.html#amendment-process).
+Each member of the `Majorities` field, if it is present, is an object with a one field, `Majority`, whose contents are a nested object with the following fields:
+
+| Name              | JSON Type | [Internal Type][] | Description |
+|-------------------|-----------|-------------------|-------------|
+| `Amendment`       | String    | Hash256           | The Amendment ID of the pending amendment. |
+| `CloseTime`       | Number    | UInt32            | The [`close_time` field](#header-format) of the ledger version where this amendment most recently gained a majority. |
+
+In the [amendment process](concept-amendments.html#amendment-process), a consensus of validators adds a new amendment to the `Majorities` field using an [EnableAmendment][] pseudo-transaction with the `tfGotMajority` flag when 80% or more of validators support it. If support for a pending amendment goes below 80%, an [EnableAmendment][] pseudo-transaction with the `tfLostMajority` flag removes the amendment from the `Majorities` array. If an amendment remains in the `Majorities` field for at least 2 weeks, an [EnableAmendment][] pseudo-transaction with no flags removes it from `Majorities` and permanently adds it to the `Amendments` field.
 
 **Note:** Technically, all transactions in a ledger are processed based on which amendments are enabled in the ledger version immediately before it. While applying transactions to a ledger version where an amendment becomes enabled, the rules don't change mid-ledger. After the ledger is closed, the next ledger uses the new rules as defined by any new amendments that applied.
 

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -1,4 +1,4 @@
-# The Ledger #
+# XRP Ledger Data Format
 
 The XRP Ledger is a shared, global ledger that is open to all. Individual participants can trust the integrity of the ledger without having to trust any single institution to manage it. The `rippled` server software accomplishes this by managing a ledger database that can only be updated according to very specific rules. Each instance of `rippled` keeps a full copy of the ledger, and the peer-to-peer network of `rippled` servers distributes candidate transactions among themselves. The consensus process determines which transactions get applied to each new version of the ledger. See also: [The Consensus Process](https://ripple.com/build/ripple-ledger-consensus-process/).
 
@@ -8,26 +8,28 @@ The shared global ledger is actually a series of individual ledgers, or ledger v
 
 A single ledger version consists of several parts:
 
-![Diagram: A ledger has transactions, a state node, and a header with the close time and validation info](img/ledger-components.png)
+![Diagram: A ledger has transactions, a state tree, and a header with the close time and validation info](img/ledger-components.png)
 
 * A **header** - The [ledger index](#ledger-index), hashes of its other contents, and other metadata.
 * A **transaction tree** - The [transactions](reference-transaction-format.html) that were applied to the previous ledger to make this one. Transactions are the _only_ way to change the ledger.
-* A **state tree** - All the [ledger nodes](#ledger-node-types) that contain the settings, balances, and objects in the ledger as of this version.
+* A **state tree** - All the [ledger objects](#ledger-object-types) that contain the settings, balances, and objects in the ledger as of this version.
 
 
-## Tree Format ##
+## Tree Format
 
-As its name might suggest, a ledger's state tree is a tree data structure, with each node identified by a 256-bit value called an `index`. In JSON, a ledger node's index value is represented as a 64-character hexadecimal string like `"193C591BF62482468422313F9D3274B5927CA80B4DD3707E42015DD609E39C94"`. Every node in the state tree has an index that you can use as a key to look up the node in the state tree; every transaction has an indentifying hash that you can use to look up the transaction in the transaction tree. Do not confuse the `index` (key) of a ledger node with the [`ledger_index` (sequence number) of a ledger](#ledger-index).
+As its name might suggest, a ledger's state tree is a tree data structure. Each object in the state tree is identified by a 256-bit object ID. In JSON, a ledger object's ID is the `index` field, which contains a 64-character hexadecimal string like `"193C591BF62482468422313F9D3274B5927CA80B4DD3707E42015DD609E39C94"`. Every object in the state tree has an ID that you can use to look up that object; every transaction has an indentifying hash that you can use to look up the transaction in the transaction tree. Do not confuse the `index` (ID) of a ledger object with the [`ledger_index` (sequence number) of a ledger](#ledger-index).
+
+**Tip:** Sometimes, an object in the ledger's state tree is called a "ledger node". For example, transaction metadata returns a list of `AffectedNodes`. Do not confuse this with a "node" (server) in the peer-to-peer network.
 
 In the case of transactions, the identifying hash is based on the signed transaction instructions, but the contents of the transaction object when you look it up also contain the results and metadata of the transaction, which are not taken into account when generating the hash.
 
-In the case of state nodes, `rippled` usually includes the `index` of the node along with its contents. However, the index itself is not part of the contents. The index is derived by hashing important contents of the node, along with a [namespace identifier](https://github.com/ripple/rippled/blob/ceff6bc2713eaf80feafe56a02f4d636827b89a9/src/ripple/protocol/LedgerFormats.h#L94). The ledger node type determines which namespace identifier to use as well as which contents to include in the hash. This ensures every index is unique. For a hash function, `rippled` uses SHA-512 and then truncates the result to the first 256 bytes. This algorithm, informally called SHA-512Half, provides an output that has comparable security to SHA-256, but runs faster on 64-bit processors.
+In the case of ledger objects, `rippled`'s APIs usually return an object's ID as the `index` field, at the same level as the object's contents. Strictly speaking, the ID itself is not part of the contents of the object. The ID is derived by hashing important contents of the object, along with a [namespace identifier](https://github.com/ripple/rippled/blob/ceff6bc2713eaf80feafe56a02f4d636827b89a9/src/ripple/protocol/LedgerFormats.h#L94). The ledger object type determines which namespace identifier to use and which contents to include in the hash. This ensures every ID is unique. To calculate the hash, `rippled` uses SHA-512 and then truncates the result to the first 256 bytes. This algorithm, informally called SHA-512Half, provides an output that has comparable security to SHA-256, but runs faster on 64-bit processors.
 
-![Diagram: rippled uses SHA-512Half to generate indexes for ledger nodes. The space key prevents indexes for different node types from colliding.](img/ledger-indexes.png)
+![Diagram: rippled uses SHA-512Half to generate IDs for ledger objects. The space key prevents IDs for different object types from colliding.](img/ledger-indexes.png)
 
 
-## Header Format ##
-[[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/ledger/ReadView.h#L68 "Source")
+## Header Format
+[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/ledger/ReadView.h#L71 "Source")
 
 Every ledger version has a unique header that describes the contents. You can look up a ledger's header information with the [`ledger` command](reference-rippled.html#ledger). The contents of the ledger header are as follows:
 
@@ -47,11 +49,11 @@ Every ledger version has a unique header that describes the contents. You can lo
 [Internal Type]: https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp
 
 
-### Ledger Index ###
+### Ledger Index
 {% include 'data_types/ledger_index.md' %}
 [Hash]: reference-rippled.html#hashes
 
-### Close Flags ###
+### Close Flags
 
 The ledger has only one flag defined for closeFlags: **sLCF_NoConsensusTime** (value `1`). If this flag is enabled, it means that validators had different close times for the ledger, but built otherwise the same ledger, so they declared consensus while "agreeing to disagree" on the close time. In this case, the consensus ledger version contains a `close_time` value that is 1 second after that of the previous ledger. (In this case, there is no official close time, but the actual real-world close time is probably 3-6 seconds later than the specified `close_time`.)
 
@@ -59,24 +61,24 @@ The `closeFlags` field is not included in any JSON representations of a ledger, 
 
 
 
-# Ledger Node Types #
+# Ledger Object Types
 
-There are several different kinds of nodes that can appear in the ledger's state tree:
+There are several different kinds of objects that can appear in the ledger's state tree:
 
 * [**AccountRoot** - The settings, XRP balance, and other metadata for one account.](#accountroot)
-* [**DirectoryNode** - Contains links to other nodes.](#directorynode)
+* [**DirectoryNode** - Contains links to other objects.](#directorynode)
 * [**Escrow** - Contains XRP held for a conditional payment](#escrow)
 * [**Offer** - An offer to exchange currencies, known in finance as an _order_.](#offer)
 * [**PayChannel** - A channel for asynchronous XRP payments.](#paychannel)
-* [**RippleState** - Links two accounts, tracking the balance of one currency between them. The concept of a _trust line_ is really an abstraction of this node type.](#ripplestate)
+* [**RippleState** - Links two accounts, tracking the balance of one currency between them. The concept of a _trust line_ is really an abstraction of this object type.](#ripplestate)
 * [**SignerList** - A list of addresses for multi-signing transactions.](#signerlist)
 
-Each ledger node consists of several fields. In the peer protocol that `rippled` servers use to communicate with each other, ledger nodes are represented in their raw binary format. In other [`rippled` APIs](reference-rippled.html), ledger nodes are represented as JSON objects.
+Each ledger object consists of several fields. In the peer protocol that `rippled` servers use to communicate with each other, ledger objects are represented in their raw binary format. In other [`rippled` APIs](reference-rippled.html), ledger objects are represented as JSON objects.
 
-## AccountRoot ##
+## AccountRoot
 [[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L27 "Source")
 
-The `AccountRoot` node type describes a single _account_ object. Example `AccountRoot` node:
+The `AccountRoot` object type describes a single _account_ object. Example `AccountRoot` object:
 
 ```
 {
@@ -97,18 +99,18 @@ The `AccountRoot` node type describes a single _account_ object. Example `Accoun
 }
 ```
 
-The `AccountRoot` node has the following fields:
+The `AccountRoot` object has the following fields:
 
 | Field           | JSON Type | [Internal Type][] | Description |
 |-----------------|-----------|---------------|-------------|
-| `LedgerEntryType` | String | UInt16 | The value `0x61`, mapped to the string `AccountRoot`, indicates that this node is an AccountRoot object. |
+| `LedgerEntryType` | String | UInt16 | The value `0x61`, mapped to the string `AccountRoot`, indicates that this object is an AccountRoot object. |
 | `Account`         | String | AccountID | The identifying address of this account, such as rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn. |
 | [Flags](#accountroot-flags) | Number | UInt32 | A bit-map of boolean flags enabled for this account. |
 | `Sequence`        | Number | UInt32 | The sequence number of the next valid transaction for this account. (Each account starts with Sequence = 1 and increases each time a transaction is made.) |
 | `Balance`         | String | Amount | The account's current [XRP balance in drops][XRP, in drops], represented as a string. |
 | `OwnerCount`      | Number | UInt32 | The number of objects this account owns in the ledger, which contributes to its owner reserve. |
-| `PreviousTxnID`   | String | Hash256 | The identifying hash of the transaction that most recently modified this node. |
-| `PreviousTxnLgrSeq` | Number | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this node. |
+| `PreviousTxnID`   | String | Hash256 | The identifying hash of the transaction that most recently modified this object. |
+| `PreviousTxnLgrSeq` | Number | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this object. |
 | `AccountTxnID`    | String | Hash256 | (Optional) The identifying hash of the transaction most recently submitted by this account. |
 | `RegularKey`      | String | AccountID | (Optional) The address of a keypair that can be used to sign transactions for this account instead of the master key. Use a [SetRegularKey transaction][] to change this value. |
 | `EmailHash`       | String | Hash128 | (Optional) The md5 hash of an email address. Clients can use this to look up an avatar through services such as [Gravatar](https://en.gravatar.com/). |
@@ -119,11 +121,11 @@ The `AccountRoot` node has the following fields:
 | `TransferRate`    | Number | UInt32  | (Optional) A [transfer fee](https://ripple.com/knowledge_center/transfer-fees/) to charge other users for sending currency issued by this account to each other. |
 | `Domain`          | String | VariableLength | (Optional) A domain associated with this account. In JSON, this is the hexadecimal for the ASCII representation of the domain. |
 
-### AccountRoot Flags ###
+### AccountRoot Flags
 
 There are several options which can be either enabled or disabled for an account. These options can be changed with an [AccountSet transaction][]. In the ledger, flags are represented as binary values that can be combined with bitwise-or operations. The bit values for the flags in the ledger are different than the values used to enable or disable those flags in a transaction. Ledger flags have names that begin with _lsf_.
 
-AccountRoot nodes can have the following flag values:
+AccountRoot objects can have the following flag values:
 
 | Flag Name | Hex Value | Decimal Value | Description | Corresponding [AccountSet Flag](reference-transaction-format.html#accountset-flags) |
 |-----------|-----------|---------------|-------------|-------------------------------|
@@ -136,22 +138,22 @@ AccountRoot nodes can have the following flag values:
 | lsfGlobalFreeze | 0x00400000 | 4194304 |　All assets issued by this address are frozen. | asfGlobalFreeze |
 | lsfDefaultRipple | 0x00800000 | 8388608 | Enable [rippling](concept-noripple.html) on this addresses's trust lines by default. Required for issuing addresses; discouraged for others. | asfDefaultRipple |
 
-### AccountRoot Index Format ###
+### AccountRoot ID Format
 
-The `index` of an AccountRoot node is the SHA-512Half of the following values put together:
+The ID of an AccountRoot object is the SHA-512Half of the following values put together:
 
 * The Account space key (`a`)
 * The AccountID of the account
 
 
-## DirectoryNode ##
+## DirectoryNode
 [[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L44 "Source")
 
-The `DirectoryNode` node type provides a list of links to other nodes in the ledger's state tree. A single conceptual _Directory_　takes the form of a doubly linked list, with one or more DirectoryNode objects each containing up to 32 [indexes](#tree-format) of other nodes. The first node is called the root of the directory, and all nodes other than the root node can be added or deleted as necessary.
+The `DirectoryNode` object type provides a list of links to other objects in the ledger's state tree. A single conceptual _Directory_　takes the form of a doubly linked list, with one or more DirectoryNode objects each containing up to 32 [IDs](#tree-format) of other objects. The first object is called the root of the directory, and all objects other than the root object can be added or deleted as necessary.
 
 There are two kinds of Directories:
 
-* **Owner directories** list other nodes owned by an account, such as RippleState or Offer nodes.
+* **Owner directories** list other objects owned by an account, such as RippleState or Offer objects.
 * **Offer directories** list the offers available in the distributed exchange. A single Offer Directory contains all the offers that have the same exchange rate for the same issuances.
 
 Example Directories:
@@ -197,12 +199,12 @@ Example Directories:
 
 | Name              | JSON Type | [Internal Type][] | Description |
 |-------------------|-----------|---------------|-------------|
-| `LedgerEntryType`   | Number    | UInt16    | The value `0x64`, mapped to the string `DirectoryNode`, indicates that this node is part of a Directory. |
+| `LedgerEntryType`   | Number    | UInt16    | The value `0x64`, mapped to the string `DirectoryNode`, indicates that this object is part of a Directory. |
 | `Flags`             | Number    | UInt32    | A bit-map of boolean flags enabled for this directory. Currently, the protocol defines no flags for DirectoryNode objects. |
-| `RootIndex`         | Number    | Hash256   | The index of root node for this directory. |
-| `Indexes`           | Array     | Vector256 | The contents of this Directory: an array of indexes to other nodes. |
-| `IndexNext`         | Number    | UInt64    | (Optional) If this Directory consists of multiple pages, this index links to the next node in the chain, wrapping around at the end. |
-| `IndexPrevious`     | Number    | UInt64    | (Optional) If this Directory consists of multiple pages, this index links to the previous node in the chain, wrapping around at the beginning. |
+| `RootIndex`         | Number    | Hash256   | The ID of root object for this directory. |
+| `Indexes`           | Array     | Vector256 | The contents of this Directory: an array of IDs of other objects. |
+| `IndexNext`         | Number    | UInt64    | (Optional) If this Directory consists of multiple pages, this ID links to the next object in the chain, wrapping around at the end. |
+| `IndexPrevious`     | Number    | UInt64    | (Optional) If this Directory consists of multiple pages, this ID links to the previous object in the chain, wrapping around at the beginning. |
 | `Owner`             | String    | AccountID | (Owner Directories only) The address of the account that owns the objects in this directory. |
 | `ExchangeRate`      | Number    | UInt64    | (Offer Directories only) **DEPRECATED**. Do not use. |
 | `TakerPaysCurrency` | String    | Hash160   | (Offer Directories only) The currency code of the TakerPays amount from the offers in this directory. |
@@ -210,20 +212,20 @@ Example Directories:
 | `TakerGetsCurrency` | String    | Hash160   | (Offer Directories only) The currency code of the TakerGets amount from the offers in this directory. |
 | `TakerGetsIssuer`   | String    | Hash160   | (Offer Directories only) The issuer of the TakerGets amount from the offers in this directory. |
 
-### Directory Index Formats ###
+### Directory ID Formats
 
-There are three different formulas for creating the index of a DirectoryNode, depending on whether the DirectoryNode represents:
+There are three different formulas for creating the ID of a DirectoryNode, depending on which of the following the DirectoryNode represents:
 
-* The first page (also called the root) of an Owner Directory,
-* The first page of an Offer Directory, _or_
+* The first page (also called the root) of an Owner Directory
+* The first page of an Offer Directory
 * Later pages of either type
 
-**The first page of an Owner Directory** has an `index` that is the SHA-512Half of the following values put together:
+**The first page of an Owner Directory** has an ID that is the SHA-512Half of the following values put together:
 
 * The Owner Directory space key (`O`, capital letter O)
 * The AccountID from the `Owner` field.
 
-**The first page of an Offer Directory** has a special `index`: the higher 192 bits define the order book, and the remaining 64 bits define the exchange rate of the offers in that directory. (An index is big-endian, so the book is in the more significant bits, which come first, and the quality is in the less significant bits which come last.) This provides a way to iterate through an order book from best offers to worst. Specifically: the first 192 bits are the first 192 bits of the SHA-512Half of the following values put together:
+**The first page of an Offer Directory** has a special ID: the higher 192 bits define the order book, and the remaining 64 bits define the exchange rate of the offers in that directory. (The ID is big-endian, so the book is in the more significant bits, which come first, and the quality is in the less significant bits which come last.) This provides a way to iterate through an order book from best offers to worst. Specifically: the first 192 bits are the first 192 bits of the SHA-512Half of the following values put together:
 
 * The Book Directory space key (`B`)
 * The 160-bit currency code from the `TakerPaysCurrency`
@@ -231,13 +233,13 @@ There are three different formulas for creating the index of a DirectoryNode, de
 * The AccountID from the `TakerPaysIssuer`
 * The AccountID from the `TakerGetsIssuer`
 
-The lower 64 bits of an Offer Directory's index represent the TakerPays amount divided by TakerGets amount from the offer(s) in that directory as a 64-bit number in the XRP Ledger's internal amount format.
+The lower 64 bits of an Offer Directory's ID represent the TakerPays amount divided by TakerGets amount from the offer(s) in that directory as a 64-bit number in the XRP Ledger's internal amount format.
 
-**If the DirectoryNode is not the first page in the Directory** (regardless of whether it is an Owner Directory or an Offer Directory), then it has an `index` that is the SHA-512Half of the following values put together:
+**If the DirectoryNode is not the first page in the Directory** (regardless of whether it is an Owner Directory or an Offer Directory), then it has an ID that is the SHA-512Half of the following values put together:
 
-* The Directory Node space key (`d`)
-* The `index` of the root DirectoryNode
-* The page number of this node. (Since 0 is the root DirectoryNode, this value is an integer 1 or higher.)
+* The DirectoryNode space key (`d`)
+* The ID of the root DirectoryNode
+* The page number of this object. (Since 0 is the root DirectoryNode, this value is an integer 1 or higher.)
 
 
 ## Escrow
@@ -245,14 +247,14 @@ The lower 64 bits of an Offer Directory's index represent the TakerPays amount d
 
 _(Requires the [Escrow Amendment](concept-amendments.html#paychan).)_
 
-The `Escrow` node type represents a held payment of XRP waiting to be executed or canceled. An [EscrowCreate transaction][] creates an Escrow node in the ledger. A successful [EscrowFinish][] or [EscrowCancel][] transaction deletes the node. If the Escrow node has a [_crypto-condition_](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02), the payment can only succeed if an EscrowFinish transaction provides the corresponding _fulfillment_ that satisfies the condition. (The only supported crypto-condition type is [PREIMAGE-SHA-256](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02#section-8.1).) If the Escrow node has a `FinishAfter` time, the held payment can only execute after that time.
+The `Escrow` object type represents a held payment of XRP waiting to be executed or canceled. An [EscrowCreate transaction][] creates an Escrow object in the ledger. A successful [EscrowFinish][] or [EscrowCancel][] transaction deletes the object. If the Escrow object has a [_crypto-condition_](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02), the payment can only succeed if an EscrowFinish transaction provides the corresponding _fulfillment_ that satisfies the condition. (The only supported crypto-condition type is [PREIMAGE-SHA-256](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02#section-8.1).) If the Escrow object has a `FinishAfter` time, the held payment can only execute after that time.
 
-An Escrow node is associated with two addresses:
+An Escrow object is associated with two addresses:
 
-- The owner, who provides the XRP when creating the Escrow node. If the held payment is canceled, the XRP returns to the owner.
+- The owner, who provides the XRP when creating the Escrow object. If the held payment is canceled, the XRP returns to the owner.
 - The destination, where the XRP is paid when the held payment succeeds. The destination can be the same as the owner.
 
-Example Escrow node:
+Example Escrow object:
 
 ```
 {
@@ -273,7 +275,7 @@ Example Escrow node:
 }
 ```
 
-An Escrow node has the following fields:
+An Escrow object has the following fields:
 
 | Name              | JSON Type | [Internal Type][] | Description |
 |-------------------|-----------|---------------|-------------|
@@ -285,29 +287,29 @@ An Escrow node has the following fields:
 | `FinishAfter`       | Number | UInt32 | _(Optional)_ The time, in [seconds since the Ripple Epoch](reference-rippled.html#specifying-time), after which this held payment can be finished. Any [EscrowFinish transaction][] before this time fails. (Specifically, this is compared with the close time of the previous validated ledger.) |
 | `SourceTag`         | Number | UInt32 | _(Optional)_ An arbitrary tag to further specify the source for this held payment, such as a hosted recipient at the owner's address. |
 | `DestinationTag`    | Number | UInt32 | _(Optional)_ An arbitrary tag to further specify the destination for this held payment, such as a hosted recipient at the destination address. |
-| `OwnerNode`         | String    | UInt64    | A hint indicating which page of the owner directory links to this node, in case the directory consists of multiple pages. **Note:** The node does not contain a direct link to the owner directory containing it, since that value can be derived from the `Account`. |
-| `PreviousTxnID`     | String | Hash256 | The identifying hash of the transaction that most recently modified this node. |
-| `PreviousTxnLgrSeq` | Number | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this node. |
+| `OwnerNode`         | String    | UInt64    | A hint indicating which page of the owner directory links to this object, in case the directory consists of multiple pages. **Note:** The object does not contain a direct link to the owner directory containing it, since that value can be derived from the `Account`. |
+| `PreviousTxnID`     | String | Hash256 | The identifying hash of the transaction that most recently modified this object. |
+| `PreviousTxnLgrSeq` | Number | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this object. |
 
 
-### Escrow Index Format ###
+### Escrow ID Format
 
-The `index` of an Escrow node is the SHA-512Half of the following values put together:
+The ID of an Escrow object is the SHA-512Half of the following values put together:
 
 * The Escrow space key (`u`)
-* The AccountID of the sender of the [EscrowCreate transaction][] that created the Escrow node
-* The Sequence number of the [EscrowCreate transaction][] that created the Escrow node
+* The AccountID of the sender of the [EscrowCreate transaction][] that created the Escrow object
+* The Sequence number of the [EscrowCreate transaction][] that created the Escrow object
 
 
 
-## Offer ##
+## Offer
 [[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L57 "Source")
 
-The `Offer` node type describes an offer to exchange currencies, more traditionally known as an _order_, in the XRP Ledger's distributed exchange. An [OfferCreate transaction][] only creates an Offer node in the ledger when the offer cannot be fully executed immediately by consuming other offers already in the ledger.
+The `Offer` object type describes an offer to exchange currencies, more traditionally known as an _order_, in the XRP Ledger's distributed exchange. An [OfferCreate transaction][] only creates an Offer object in the ledger when the offer cannot be fully executed immediately by consuming other offers already in the ledger.
 
 An offer can become unfunded through other activities in the network, while remaining in the ledger. However, `rippled` automatically prunes any unfunded offers it happens across in the course of transaction processing (and _only_ transaction processing, because the ledger state must only be changed by transactions). For more information, see [lifecycle of an offer](reference-transaction-format.html#lifecycle-of-an-offer).
 
-Example Offer node:
+Example Offer object:
 
 ```
 {
@@ -330,37 +332,37 @@ Example Offer node:
 }
 ```
 
-An Offer node has the following fields:
+An Offer object has the following fields:
 
 | Name              | JSON Type | [Internal Type][] | Description |
 |-------------------|-----------|---------------|-------------|
-| `LedgerEntryType`   | String    | UInt16    | The value `0x6F`, mapped to the string `Offer`, indicates that this node is an Offer object. |
+| `LedgerEntryType`   | String    | UInt16    | The value `0x6F`, mapped to the string `Offer`, indicates that this object is an Offer object. |
 | `Flags`             | Number    | UInt32    | A bit-map of boolean flags enabled for this offer. |
 | `Account`           | String    | AccountID | The address of the account that owns this offer. |
-| `Sequence`          | Number    | UInt32    | The `Sequence` value of the [OfferCreate][] transaction that created this Offer node. Used in combination with the `Account` to identify this Offer. |
+| `Sequence`          | Number    | UInt32    | The `Sequence` value of the [OfferCreate][] transaction that created this Offer object. Used in combination with the `Account` to identify this Offer. |
 | `TakerPays`         | String or Object | Amount | The remaining amount and type of currency requested by the offer creator. |
 | `TakerGets`         | String or Object | Amount | The remaining amount and type of currency being provided by the offer creator. |
-| `BookDirectory`     | String    | UInt256   | The index of the [Offer Directory](#directorynode) that links to this offer. |
-| `BookNode`          | String    | UInt64    | A hint indicating which page of the offer directory links to this node, in case the directory consists of multiple pages. |
-| `OwnerNode`         | String    | UInt64    | A hint indicating which page of the owner directory links to this node, in case the directory consists of multiple pages. **Note:** The offer does not contain a direct link to the owner directory containing it, since that value can be derived from the `Account`. |
-| `PreviousTxnID`     | String | Hash256 | The identifying hash of the transaction that most recently modified this node. |
-| `PreviousTxnLgrSeq` | Number | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this node. |
+| `BookDirectory`     | String    | UInt256   | The ID of the [Offer Directory](#directorynode) that links to this offer. |
+| `BookNode`          | String    | UInt64    | A hint indicating which page of the offer directory links to this object, in case the directory consists of multiple pages. |
+| `OwnerNode`         | String    | UInt64    | A hint indicating which page of the owner directory links to this object, in case the directory consists of multiple pages. **Note:** The offer does not contain a direct link to the owner directory containing it, since that value can be derived from the `Account`. |
+| `PreviousTxnID`     | String | Hash256 | The identifying hash of the transaction that most recently modified this object. |
+| `PreviousTxnLgrSeq` | Number | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this object. |
 | `Expiration`        | Number    | UInt32    | (Optional) Indicates the time after which this offer is considered unfunded. See [Specifying Time](reference-rippled.html#specifying-time) for details. |
 
-### Offer Flags ###
+### Offer Flags
 
-There are several options which can be either enabled or disabled when an [OfferCreate transaction][] creates an offer node. In the ledger, flags are represented as binary values that can be combined with bitwise-or operations. The bit values for the flags in the ledger are different than the values used to enable or disable those flags in a transaction. Ledger flags have names that begin with _lsf_.
+There are several options which can be either enabled or disabled when an [OfferCreate transaction][] creates an offer object. In the ledger, flags are represented as binary values that can be combined with bitwise-or operations. The bit values for the flags in the ledger are different than the values used to enable or disable those flags in a transaction. Ledger flags have names that begin with _lsf_.
 
-Offer nodes can have the following flag values:
+Offer objects can have the following flag values:
 
 | Flag Name | Hex Value | Decimal Value | Description | Corresponding [OfferCreate Flag](reference-transaction-format.html#offercreate-flags) |
 |-----------|-----------|---------------|-------------|------------------------|
-| lsfPassive | 0x00010000 | 65536 | The node was placed as a passive offer. This has no effect on the node in the ledger. | tfPassive |
-| lsfSell   | 0x00020000 | 131072 | The node was placed as a sell offer. This has no effect on the node in the ledger (because tfSell only matters if you get a better rate than you asked for, which cannot happen after the node enters the ledger). | tfSell |
+| lsfPassive | 0x00010000 | 65536 | The object was placed as a passive offer. This has no effect on the object in the ledger. | tfPassive |
+| lsfSell   | 0x00020000 | 131072 | The object was placed as a sell offer. This has no effect on the object in the ledger (because tfSell only matters if you get a better rate than you asked for, which cannot happen after the object enters the ledger). | tfSell |
 
-### Offer Index Format ###
+### Offer ID Format
 
-The `index` of an Offer node is the SHA-512Half of the following values put together:
+The ID of an Offer object is the SHA-512Half of the following values put together:
 
 * The Offer space key (`o`)
 * The AccountID of the account placing the offer
@@ -368,14 +370,14 @@ The `index` of an Offer node is the SHA-512Half of the following values put toge
 
 
 
-## PayChannel ##
+## PayChannel
 [[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/LedgerFormats.cpp#L134 "Source")
 
 _(Requires the [PayChan Amendment](concept-amendments.html#paychan).)_
 
-The `PayChannel` node type represents a payment channel. Payment channels enable small, rapid off-ledger payments of XRP that can be later reconciled with the consensus ledger. A payment channel holds a balance of XRP that can only be paid out to a specific destination address until the channel is closed. Any unspent XRP is returned to the channel's owner (the source address that created and funded it) when the channel closes.
+The `PayChannel` object type represents a payment channel. Payment channels enable small, rapid off-ledger payments of XRP that can be later reconciled with the consensus ledger. A payment channel holds a balance of XRP that can only be paid out to a specific destination address until the channel is closed. Any unspent XRP is returned to the channel's owner (the source address that created and funded it) when the channel closes.
 
-The [PaymentChannelCreate transaction][] type creates a `PayChannel` node. The [PaymentChannelFund][] and [PaymentChannelClaim transaction][] types modify existing `PayChannel` nodes.
+The [PaymentChannelCreate transaction][] type creates a `PayChannel` object. The [PaymentChannelFund][] and [PaymentChannelClaim transaction][] types modify existing `PayChannel` objects.
 
 When a payment channel expires, at first it remains on the ledger, because only new transactions can modify ledger contents. Transaction processing automatically closes a payment channel when any transaction accesses it after the expiration. To close an expired channel and return the unspent XRP to the owner, some address must send a new PaymentChannelClaim or PaymentChannelFund transaction accessing the channel.
 
@@ -383,7 +385,7 @@ For an example of using payment channels, see the [Payment Channels Tutorial](tu
 
 <!--{# TODO: provide cross-references to tutorial, concept, and tx types when they are ready #}-->
 
-Example PayChannel node:
+Example PayChannel object:
 
 ```json
 {
@@ -406,21 +408,21 @@ Example PayChannel node:
 }
 ```
 
-A `PayChannel` node has the following fields:
+A `PayChannel` object has the following fields:
 
 | Name                | JSON Type | [Internal Type][] | Description            |
 |:--------------------|:----------|:------------------|:-----------------------|
-| `LedgerEntryType`   | String    | UInt16            | The value `0x78`, mapped to the string `PayChannel`, indicates that this node is a payment channel object. |
+| `LedgerEntryType`   | String    | UInt16            | The value `0x78`, mapped to the string `PayChannel`, indicates that this object is a payment channel object. |
 | `Account`           | String    | AccountID         | The source address that owns this payment channel. This comes from the sending address of the transaction that created the channel. |
 | `Destination`       | String    | AccountID         | The destination address for this payment channel. While the payment channel is open, this address is the only one that can receive XRP from the channel. This comes from the `Destination` field of the transaction that created the channel. |
 | `Amount`            | String    | Amount            | Total [XRP, in drops][], that has been allocated to this channel. This includes XRP that has been paid to the destination address. This is initially set by the transaction that created the channel and can be increased if the source address sends a PaymentChannelFund transaction. |
 | `Balance`           | String    | Amount            | Total [XRP, in drops][], already paid out by the channel. The difference between this value and the `Amount` field is how much XRP can still be paid to the destination address with PaymentChannelClaim transactions. If the channel closes, the remaining difference is returned to the source address. |
 | `PublicKey`         | String    | PubKey            | Public key, in hexadecimal, of the key pair that can be used to sign claims against this channel. This can be any valid secp256k1 or Ed25519 public key. This is set by the transaction that created the channel and must match the public key used in claims against the channel. The channel source address can also send XRP from this channel to the destination without signed claims. |
 | `SettleDelay`       | Number    | UInt32            | Number of seconds the source address must wait to close the channel if it still has any XRP in it. Smaller values mean that the destination address has less time to redeem any outstanding claims after the source address requests to close the channel. Can be any value that fits in a 32-bit unsigned integer (0 to 2^32-1). This is set by the transaction that creates the channel. |
-| `OwnerNode`         | String    | UInt64            | A hint indicating which page of the source address's owner directory links to this node, in case the directory consists of multiple pages. |
-| `PreviousTxnID`     | String    | Hash256           | The identifying hash of the transaction that most recently modified this node. |
-| `PreviousTxnLgrSeq` | Number    | UInt32            | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this node. |
-| `Flags`             | Number    | UInt32            | A bit-map of boolean flags enabled for this payment channel. Currently, the protocol defines no flags for `PayChannel` nodes. |
+| `OwnerNode`         | String    | UInt64            | A hint indicating which page of the source address's owner directory links to this object, in case the directory consists of multiple pages. |
+| `PreviousTxnID`     | String    | Hash256           | The identifying hash of the transaction that most recently modified this object. |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this object. |
+| `Flags`             | Number    | UInt32            | A bit-map of boolean flags enabled for this payment channel. Currently, the protocol defines no flags for `PayChannel` objects. |
 | `Expiration`        | Number    | UInt32            | _(Optional)_ The mutable expiration time for this payment channel, in [seconds since the Ripple Epoch](reference-rippled.html#specifying-time). The channel is expired if this value is present and smaller than the previous ledger's [`close_time` field](#header-format). See [Setting Channel Expiration](#setting-channel-expiration) for more details. |
 | `CancelAfter`       | Number    | UInt32            | _(Optional)_ The immutable expiration time for this payment channel, in [seconds since the Ripple Epoch](reference-rippled.html#specifying-time). This channel is expired if this value is present and smaller than the previous ledger's [`close_time` field](#header-format). This is optionally set by the transaction that created the channel, and cannot be changed. |
 | `SourceTag`           | Number    | UInt32            | _(Optional)_ An arbitrary tag to further specify the source for this payment channel, such as a hosted recipient at the owner's address. |
@@ -430,7 +432,7 @@ A `PayChannel` node has the following fields:
 
 ### Setting Channel Expiration
 
-The `Expiration` field of a payment channel is the mutable expiration time, in contrast to the immutable expiration time represented by the `CancelAfter` field. The expiration of a channel is always considered relative to the [`close_time` field](#header-format) of the previous ledger. The `Expiration` field is omitted when a `PayChannel` node is created. There are several ways the `Expiration` field of a `PayChannel` node can be updated, which can be summarized as follows: a channel's source address can set the `Expiration` of the channel freely as long as the channel always remains open at least `SettleDelay` seconds after the first attempt to close it.
+The `Expiration` field of a payment channel is the mutable expiration time, in contrast to the immutable expiration time represented by the `CancelAfter` field. The expiration of a channel is always considered relative to the [`close_time` field](#header-format) of the previous ledger. The `Expiration` field is omitted when a `PayChannel` object is created. There are several ways the `Expiration` field of a `PayChannel` object can be updated, which can be summarized as follows: a channel's source address can set the `Expiration` of the channel freely as long as the channel always remains open at least `SettleDelay` seconds after the first attempt to close it.
 
 #### Source Address
 
@@ -457,9 +459,9 @@ The destination address cannot set the `Expiration` field. However, the destinat
 If any other address attempts to set an `Expiration` field, the transaction fails with the `tecNO_PERMISSION` error code. However, if the channel is already expired, the transaction causes the channel to close and results in `tesSUCCESS` instead.
 
 
-### PayChannel Index Format ###
+### PayChannel ID Format
 
-The `index` of a PayChannel node is the SHA-512Half of the following values put together:
+The ID of a PayChannel object is the SHA-512Half of the following values put together:
 
 * The PayChannel space key (`x`)
 * The AccountID of the source account
@@ -468,14 +470,14 @@ The `index` of a PayChannel node is the SHA-512Half of the following values put 
 
 
 
-## RippleState ##
+## RippleState
 [[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L70 "Source")
 
-The `RippleState` node type connects two accounts in a single currency. Conceptually, a RippleState node represents two _trust lines_ between the accounts, one from each side. Each account can change the settings for its side of the RippleState node, but the balance is a single shared value. A trust line that is entirely in its default state is considered the same as trust line that does not exist, so `rippled` deletes RippleState nodes when their properties are entirely default.
+The `RippleState` object type connects two accounts in a single currency. Conceptually, a RippleState object represents two _trust lines_ between the accounts, one from each side. Each account can change the settings for its side of the RippleState object, but the balance is a single shared value. A trust line that is entirely in its default state is considered the same as trust line that does not exist, so `rippled` deletes RippleState objects when their properties are entirely default.
 
-Since no account is privileged in the XRP Ledger, a RippleState node sorts their account addresses numerically, to ensure a canonical form. Whichever address is numerically lower is deemed the "low account" and the other is the "high account".
+Since no account is privileged in the XRP Ledger, a RippleState object sorts their account addresses numerically, to ensure a canonical form. Whichever address is numerically lower is deemed the "low account" and the other is the "high account".
 
-Example RippleState node:
+Example RippleState object:
 
 ```
 {
@@ -504,34 +506,34 @@ Example RippleState node:
 }
 ```
 
-A RippleState node has the following fields:
+A RippleState object has the following fields:
 
 | Name            | JSON Type | Internal Type | Description |
 |-----------------|-----------|---------------|-------------|
-| `LedgerEntryType` | String    | UInt16 | The value `0x72`, mapped to the string `RippleState`, indicates that this node is a RippleState object. |
-| `Flags`           | Number    | UInt32 | A bit-map of boolean options enabled for this node. |
+| `LedgerEntryType` | String    | UInt16 | The value `0x72`, mapped to the string `RippleState`, indicates that this object is a RippleState object. |
+| `Flags`           | Number    | UInt32 | A bit-map of boolean options enabled for this object. |
 | `Balance`         | Object    | Amount | The balance of the trust line, from the perspective of the low account. A negative balance indicates that the low account has issued currency to the high account. The issuer in this is always set to the neutral value [ACCOUNT_ONE](concept-accounts.html#special-addresses). |
 | `LowLimit`        | Object    | Amount | The limit that the low account has set on the trust line. The `issuer` is the address of the low account that set this limit. |
 | `HighLimit`       | Object    | Amount | The limit that the high account has set on the trust line. The `issuer` is the address of the high account that set this limit. |
-| `PreviousTxnID`   | String    | Hash256 | The identifying hash of the transaction that most recently modified this node. |
-| `PreviousTxnLgrSeq` | Number  | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this node. |
-| `LowNode`         | String    | UInt64 | (Omitted in some historical ledgers) A hint indicating which page of the low account's owner directory links to this node, in case the directory consists of multiple pages. |
-| `HighNode`        | String    | UInt64 | (Omitted in some historical ledgers) A hint indicating which page of the high account's owner directory links to this node, in case the directory consists of multiple pages. |
+| `PreviousTxnID`   | String    | Hash256 | The identifying hash of the transaction that most recently modified this object. |
+| `PreviousTxnLgrSeq` | Number  | UInt32 | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this object. |
+| `LowNode`         | String    | UInt64 | (Omitted in some historical ledgers) A hint indicating which page of the low account's owner directory links to this object, in case the directory consists of multiple pages. |
+| `HighNode`        | String    | UInt64 | (Omitted in some historical ledgers) A hint indicating which page of the high account's owner directory links to this object, in case the directory consists of multiple pages. |
 | `LowQualityIn`    | Number    | UInt32 | (Optional) The inbound quality set by the low account, as an integer in the implied ratio LowQualityIn:1,000,000,000. The value 0 is equivalent to 1 billion, or face value. |
 | `LowQualityOut`   | Number    | UInt32 | (Optional) The outbound quality set by the low account, as an integer in the implied ratio LowQualityOut:1,000,000,000. The value 0 is equivalent to 1 billion, or face value. |
 | `HighQualityIn`   | Number    | UInt32 | (Optional) The inbound quality set by the high account, as an integer in the implied ratio HighQualityIn:1,000,000,000. The value 0 is equivalent to 1 billion, or face value. |
 | `HighQualityOut`  | Number    | UInt32 | (Optional) The outbound quality set by the high account, as an integer in the implied ratio HighQualityOut:1,000,000,000. The value 0 is equivalent to 1 billion, or face value. |
 
-### RippleState Flags ###
+### RippleState Flags
 
 There are several options which can be either enabled or disabled for a trust line. These options can be changed with a [TrustSet transaction](reference-transaction-format.html#trustset). In the ledger, flags are represented as binary values that can be combined with bitwise-or operations. The bit values for the flags in the ledger are different than the values used to enable or disable those flags in a transaction. Ledger flags have names that begin with _lsf_.
 
-RippleState nodes can have the following flag values:
+RippleState objects can have the following flag values:
 
 | Flag Name | Hex Value | Decimal Value | Description | Corresponding [TrustSet Flag](reference-transaction-format.html#trustset-flags) |
 |-----------|-----------|---------------|-------------|------------------------|
-| lsfLowReserve | 0x00010000 | 65536 | This RippleState node [contributes to the low account's owner reserve](#contributing-to-the-owner-reserve). | (None) |
-| lsfHighReserve | 0x00020000 |131072 | This RippleState node [contributes to the high account's owner reserve](#contributing-to-the-owner-reserve). | (None) |
+| lsfLowReserve | 0x00010000 | 65536 | This RippleState object [contributes to the low account's owner reserve](#contributing-to-the-owner-reserve). | (None) |
+| lsfHighReserve | 0x00020000 |131072 | This RippleState object [contributes to the high account's owner reserve](#contributing-to-the-owner-reserve). | (None) |
 | lsfLowAuth | 0x00040000 | 262144 | The low account has authorized the high account to hold the low account's issuances. | tfSetAuth |
 | lsfHighAuth | 0x00080000 | 524288 |  The high account has authorized the low account to hold the high account's issuances. | tfSetAuth |
 | lsfLowNoRipple | 0x00100000 | 1048576 | The low account [has disabled rippling](concept-noripple.html) from this trust line to other trust lines with the same account's NoRipple flag set. | tfSetNoRipple |
@@ -539,9 +541,9 @@ RippleState nodes can have the following flag values:
 | lsfLowFreeze | 0x00400000 | 4194304 | The low account has frozen the trust line, preventing the high account from transferring the asset. | tfSetFreeze |
 | lsfHighFreeze | 0x00800000 | 8388608 | The high account has frozen the trust line, preventing the low account from transferring the asset. | tfSetFreeze |
 
-### Contributing to the Owner Reserve ###
+### Contributing to the Owner Reserve
 
-If an account modifies a trust line to put it in a non-default state, then that trust line counts towards the account's [owner reserve](concept-reserves.html#owner-reserves). In a RippleState node, the `lsfLowReserve` and `lsfHighReserve` flags indicate which account(s) are responsible for the owner reserve. The `rippled` server automatically sets these flags when it modifies a trust line.
+If an account modifies a trust line to put it in a non-default state, then that trust line counts towards the account's [owner reserve](concept-reserves.html#owner-reserves). In a RippleState object, the `lsfLowReserve` and `lsfHighReserve` flags indicate which account(s) are responsible for the owner reserve. The `rippled` server automatically sets these flags when it modifies a trust line.
 
 The values that count towards a trust line's non-default state are as follows:
 
@@ -556,13 +558,15 @@ The values that count towards a trust line's non-default state are as follows:
 
 The **lsfLowAuth** and **lsfHighAuth** flags do not count against the default state, because they cannot be disabled.
 
-The default state of the two NoRipple flags depends on the state of the [lsfDefaultRipple flag](#accountroot-flags) in their corresponding AccountRoot nodes. If DefaultRipple is disabled (the default), then the default state of the lsfNoRipple flag is _enabled_ for all of an account's trust lines. If an account enables DefaultRipple, then the lsfNoRipple flag is _disabled_ (rippling is enabled) for an account's trust lines by default. **Note:** Prior to the introduction of the DefaultRipple flags in `rippled` version 0.27.3 (March 10, 2015), the default state for all trust lines was with lsfNoRipple disabled (rippling enabled).
+The default state of the two NoRipple flags depends on the state of the [lsfDefaultRipple flag](#accountroot-flags) in their corresponding AccountRoot objects. If DefaultRipple is disabled (the default), then the default state of the lsfNoRipple flag is _enabled_ for all of an account's trust lines. If an account enables DefaultRipple, then the lsfNoRipple flag is _disabled_ (rippling is enabled) for an account's trust lines by default.
+
+**Note:** Prior to the introduction of the DefaultRipple flags in `rippled` version 0.27.3 (March 10, 2015), the default state for all trust lines was with both NoRipple flags disabled (rippling enabled).
 
 Fortunately, `rippled` uses lazy evaluation to calculate the owner reserve. This means that even if an account changes the default state of all its trust lines by changing the DefaultRipple flag, that account's reserve stays the same initially. If an account modifies a trust line, `rippled` re-evaluates whether that individual trust line is in its default state and should contribute the owner reserve.
 
-### RippleState Index Format ###
+### RippleState ID Format
 
-The `index` of a RippleState node is the SHA-512Half of the following values put together:
+The ID of a RippleState object is the SHA-512Half of the following values put together:
 
 * The RippleState space key (`r`)
 * The AccountID of the low account
@@ -570,12 +574,12 @@ The `index` of a RippleState node is the SHA-512Half of the following values put
 * The 160-bit currency code of the trust line(s)
 
 
-## SignerList ##
+## SignerList
 [[Source]<br>](https://github.com/ripple/rippled/blob/6d2e3da30696bd10e3bb11a5ff6d45d2c4dae90f/src/ripple/protocol/impl/LedgerFormats.cpp#L127 "Source")
 
-The `SignerList` node type represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a SignerList using the [SignerListSet transaction type](reference-transaction-format.html#signerlistset) This node type is introduced by the [MultiSign amendment](concept-amendments.html#multisign). [New in: rippled 0.31.0][]
+The `SignerList` object type represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a SignerList using the [SignerListSet transaction type](reference-transaction-format.html#signerlistset) This object type is introduced by the [MultiSign amendment](concept-amendments.html#multisign). [New in: rippled 0.31.0][]
 
-Example SignerList node:
+Example SignerList object:
 
 ```
 {
@@ -610,20 +614,20 @@ Example SignerList node:
 }
 ```
 
-A SignerList node has the following fields:
+A SignerList object has the following fields:
 
 | Name            | JSON Type | Internal Type | Description |
 |-----------------|-----------|---------------|-------------|
-| `OwnerNode`       | String    | UInt64        | A hint indicating which page of the owner directory links to this node, in case the directory consists of multiple pages. |
+| `OwnerNode`       | String    | UInt64        | A hint indicating which page of the owner directory links to this object, in case the directory consists of multiple pages. |
 | `SignerQuorum`    | Number    | UInt32        | A target number for signer weights. To produce a valid signature for the owner of this SignerList, the signers must provide valid signatures whose weights sum to this value or more. |
 | `SignerEntries`   | Array     | Array         | An array of SignerEntry objects representing the parties who are part of this signer list. |
 | `SignerListID`    | Number    | UInt32        | An ID for this signer list. Currently always set to `0`. If a future [amendment](concept-amendments.html) allows multiple signer lists for an account, this may change. |
-| `PreviousTxnID`   | String    | Hash256       | The identifying hash of the transaction that most recently modified this node. |
-| `PreviousTxnLgrSeq` | Number  | UInt32        | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this node. |
+| `PreviousTxnID`   | String    | Hash256       | The identifying hash of the transaction that most recently modified this object. |
+| `PreviousTxnLgrSeq` | Number  | UInt32        | The [index of the ledger](#ledger-index) that contains the transaction that most recently modified this object. |
 
 The `SignerEntries` may be any combination of funded and unfunded addresses that use either secp256k1 or ed25519 keys.
 
-### SignerEntry Object ###
+### SignerEntry Object
 
 Each member of the `SignerEntries` field is an object that describes that signer in the list. A SignerEntry has the following fields:
 
@@ -632,15 +636,15 @@ Each member of the `SignerEntries` field is an object that describes that signer
 | `Account`         | String    | AccountID     | An XRP Ledger address whose signature contributes to the multi-signature. It does not need to be a funded address in the ledger. |
 | `SignerWeight`    | Number    | UInt16        | The weight of a signature from this signer. A multi-signature is only valid if the sum weight of the signatures provided meets or exceeds the SignerList's `SignerQuorum` value. |
 
-When processing a multi-signed transaction, the server dereferences the `Account` values with respect to the ledger at the time of transaction execution. If the address _does not_ correspond to a funded [AccountRoot node](#accountroot), then only the master secret associated with that address can be used to produce a valid signature. If the account _does_ exist in the ledger, then it depends on the state of that account. If the account has a Regular Key configured, the Regular Key can be used. The account's master key can only be used if it is not disabled. A multi-signature cannot be used as part of another multi-signature.
+When processing a multi-signed transaction, the server dereferences the `Account` values with respect to the ledger at the time of transaction execution. If the address _does not_ correspond to a funded [AccountRoot object](#accountroot), then only the master secret associated with that address can be used to produce a valid signature. If the account _does_ exist in the ledger, then it depends on the state of that account. If the account has a Regular Key configured, the Regular Key can be used. The account's master key can only be used if it is not disabled. A multi-signature cannot be used as part of another multi-signature.
 
-### SignerLists and Reserves ###
+### SignerLists and Reserves
 
-A SignerList contributes to its owner's [reserve requirement](concept-reserves.html). The SignerList itself counts as two objects, and each member of the list counts as one. As a result, the total owner reserve associated with a SignerList is anywhere from 3 times to 10 times the reserve required by a single trust line ([RippleState](#ripplestate)) or [Offer](#offer) node in the ledger.
+A SignerList contributes to its owner's [reserve requirement](concept-reserves.html). The SignerList itself counts as two objects, and each member of the list counts as one. As a result, the total owner reserve associated with a SignerList is anywhere from 3 times to 10 times the reserve required by a single trust line ([RippleState](#ripplestate)) or [Offer](#offer) object in the ledger.
 
-### SignerList Index Format
+### SignerList ID Format
 
-The `index` of a SignerList node is the SHA-512Half of the following values put together:
+The ID of a SignerList object is the SHA-512Half of the following values put together:
 
 * The RippleState space key (`S`)
 * The AccountID of the owner of the SignerList

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -142,7 +142,7 @@ AccountRoot objects can have the following flag values:
 
 The ID of an AccountRoot object is the SHA-512Half of the following values put together:
 
-* The Account space key (`a`)
+* The Account space key (`0x0061`)
 * The AccountID of the account
 
 
@@ -195,7 +195,7 @@ In the [amendment process](concept-amendments.html#amendment-process), a consens
 
 ### Amendments ID Format
 
-The `Amendments` object ID is the hash of the `Amendments` space key (`f`) only. This means that the ID of the Amendments object in a ledger is always:
+The `Amendments` object ID is the hash of the `Amendments` space key (`0x0066`) only. This means that the ID of the Amendments object in a ledger is always:
 
 ```
 7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4
@@ -280,12 +280,12 @@ There are three different formulas for creating the ID of a DirectoryNode, depen
 
 **The first page of an Owner Directory** has an ID that is the SHA-512Half of the following values put together:
 
-* The Owner Directory space key (`O`, capital letter O)
+* The Owner Directory space key (`0x004F`)
 * The AccountID from the `Owner` field.
 
 **The first page of an Offer Directory** has a special ID: the higher 192 bits define the order book, and the remaining 64 bits define the exchange rate of the offers in that directory. (The ID is big-endian, so the book is in the more significant bits, which come first, and the quality is in the less significant bits which come last.) This provides a way to iterate through an order book from best offers to worst. Specifically: the first 192 bits are the first 192 bits of the SHA-512Half of the following values put together:
 
-* The Book Directory space key (`B`)
+* The Book Directory space key (`0x0042`)
 * The 160-bit currency code from the `TakerPaysCurrency`
 * The 160-bit currency code from the `TakerGetsCurrency`
 * The AccountID from the `TakerPaysIssuer`
@@ -295,7 +295,7 @@ The lower 64 bits of an Offer Directory's ID represent the TakerPays amount divi
 
 **If the DirectoryNode is not the first page in the Directory** (regardless of whether it is an Owner Directory or an Offer Directory), then it has an ID that is the SHA-512Half of the following values put together:
 
-* The DirectoryNode space key (`d`)
+* The DirectoryNode space key (`0x0064`)
 * The ID of the root DirectoryNode
 * The page number of this object. (Since 0 is the root DirectoryNode, this value is an integer 1 or higher.)
 
@@ -354,7 +354,7 @@ An Escrow object has the following fields:
 
 The ID of an Escrow object is the SHA-512Half of the following values put together:
 
-* The Escrow space key (`u`)
+* The Escrow space key (`0x0075`)
 * The AccountID of the sender of the [EscrowCreate transaction][] that created the Escrow object
 * The Sequence number of the [EscrowCreate transaction][] that created the Escrow object
 
@@ -422,7 +422,7 @@ Offer objects can have the following flag values:
 
 The ID of an Offer object is the SHA-512Half of the following values put together:
 
-* The Offer space key (`o`)
+* The Offer space key (`0x006F`)
 * The AccountID of the account placing the offer
 * The Sequence number of the [OfferCreate transaction][] that created the offer
 
@@ -521,7 +521,7 @@ If any other address attempts to set an `Expiration` field, the transaction fail
 
 The ID of a PayChannel object is the SHA-512Half of the following values put together:
 
-* The PayChannel space key (`x`)
+* The PayChannel space key (`0x0078`)
 * The AccountID of the source account
 * The AccountID of the destination account
 * The Sequence number of the transaction that created the channel
@@ -626,7 +626,7 @@ Fortunately, `rippled` uses lazy evaluation to calculate the owner reserve. This
 
 The ID of a RippleState object is the SHA-512Half of the following values put together:
 
-* The RippleState space key (`r`)
+* The RippleState space key (`0x0072`)
 * The AccountID of the low account
 * The AccountID of the high account
 * The 160-bit currency code of the trust line(s)
@@ -704,7 +704,7 @@ A SignerList contributes to its owner's [reserve requirement](concept-reserves.h
 
 The ID of a SignerList object is the SHA-512Half of the following values put together:
 
-* The RippleState space key (`S`)
+* The RippleState space key (`0x0053`)
 * The AccountID of the owner of the SignerList
 * The SignerListID (currently always `0`)
 

--- a/content/reference-ledger-format.md
+++ b/content/reference-ledger-format.md
@@ -80,7 +80,7 @@ Each ledger object consists of several fields. In the peer protocol that `ripple
 
 The `AccountRoot` object type describes a single _account_ object. Example `AccountRoot` object:
 
-```
+```json
 {
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
     "AccountTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
@@ -146,6 +146,55 @@ The ID of an AccountRoot object is the SHA-512Half of the following values put t
 * The AccountID of the account
 
 
+## Amendments
+[[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/LedgerFormats.cpp#L110-L113 "Source")
+
+The `Amendments` object type contains a list of [Amendments](concept-amendments.html) that are currently active. Each ledger version contains **at most one** `Amendments` object.
+
+Example `Amendments` object:
+
+```json
+{
+    "Amendments": [
+        "42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE",
+        "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373",
+        "6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC",
+        "740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11",
+        "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146",
+        "532651B4FD58DF8922A49BA101AB3E996E5BFBF95A913B3E392504863E63B164",
+        "08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647",
+        "E2E6F2866106419B88C50045ACE96368558C345566AC8F2BDF5A5B5587F0E6FA",
+        "07D43DCE529B15A10827E5E04943B496762F9A88E3268269D69C44BE49E21104",
+        "42EEA5E28A97824821D4EF97081FE36A54E9593C6E4F20CBAE098C69D2E072DC",
+        "DC9CA96AEA1DCF83E527D1AFC916EFAF5D27388ECA4060A88817C1238CAEE0BF"
+    ],
+    "Flags": 0,
+    "LedgerEntryType": "Amendments",
+    "index": "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"
+}
+```
+
+| Name              | JSON Type | [Internal Type][] | Description |
+|-------------------|-----------|-------------------|-------------|
+| `Amendments`      | Array     | STI_VECTOR256     | Array of 256-bit [amendment IDs](concept-amendments.html#about-amendments) for all currently-enabled amendments. |
+| `Flags`           | Number    | UInt32    | Not used. |
+| `LedgerEntryType` | String    | UInt16    |  The value `0x66`, mapped to the string `Amendments`, indicates that this is the Amendments object. |
+
+Amendments are added to the `Amendments` table by an [EnableAmendment][] pseudo-transaction with no flags as the result of the [amendment process](concept-amendments.html#amendment-process).
+
+**Note:** Technically, all transactions in a ledger are processed based on which amendments are enabled in the ledger versions immediately before it. While applying transactions to a ledger version where an amendment becomes enabled, the rules don't change mid-ledger. After the ledger is closed, the next ledger uses the new rules as defined by any new amendments that applied.
+
+### Amendments ID Format
+
+The `Amendments` object ID is the hash of the `Amendments` space key (`f`) only. This means that the ID of the Amendments object in a ledger is always:
+
+```
+7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4
+```
+
+(Don't mix up the ID of the `Amendments` ledger object type with the Amendment ID of an individual amendment.)
+
+
 ## DirectoryNode
 [[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L44 "Source")
 
@@ -162,7 +211,7 @@ Example Directories:
 
 *Offer Directory*
 
-```
+```json
 {
     "ExchangeRate": "4F069BA8FF484000",
     "Flags": 0,
@@ -181,7 +230,7 @@ Example Directories:
 
 *Owner Directory*
 
-```
+```json
 {
     "Flags": 0,
     "Indexes": [
@@ -256,7 +305,7 @@ An Escrow object is associated with two addresses:
 
 Example Escrow object:
 
-```
+```json
 {
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
     "Amount": "10000",
@@ -311,7 +360,7 @@ An offer can become unfunded through other activities in the network, while rema
 
 Example Offer object:
 
-```
+```json
 {
     "Account": "rBqb89MRQJnMPq8wTwEbtz4kvxrEDfcYvt",
     "BookDirectory": "ACC27DE91DBA86FC509069EAF4BC511D73128B780F2E54BF5E07A369E2446000",
@@ -479,7 +528,7 @@ Since no account is privileged in the XRP Ledger, a RippleState object sorts the
 
 Example RippleState object:
 
-```
+```json
 {
     "Balance": {
         "currency": "USD",
@@ -581,7 +630,7 @@ The `SignerList` object type represents a list of parties that, as a group, are 
 
 Example SignerList object:
 
-```
+```json
 {
     "Flags": 0,
     "LedgerEntryType": "SignerList",

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -343,7 +343,7 @@ All methods can potentially return any of the following values for the `error` c
 
 The WebSocket and JSON-RPC APIs generally take the same arguments, although they're provided in a different way (See [Request Formatting](#request-formatting) for details). Many similar parameters appear throughout the APIs, and there are conventions for how to specify these parameters.
 
-All field names are case-sensitive. In responses, fields that are taken directly from Ledger Node or Transaction objects start with upper-case letters. Other fields, including ones that are dynamically generated for a response, are lower case.
+All field names are case-sensitive. In responses, fields that are taken directly from ledger objects or transaction instructions start with upper-case letters. Other fields, including ones that are dynamically generated for a response, are lower case.
 
 ## Basic Data Types ##
 
@@ -387,8 +387,8 @@ Many API methods require you to specify an instance of the ledger, with the data
 2. Specify a ledger by its [Hash][] value in the `ledger_hash` parameter.
 3. Specify a ledger by one of the following shortcuts, in the `ledger_index` parameter:
     * `validated` for the most recent ledger that has been validated by the whole network
-    * `closed` for the most recent ledger that has been closed for modifications and proposed for validation by the node
-    * `current` for the node's current working version of the ledger.
+    * `closed` for the most recent ledger that has been closed for modifications and proposed for validation
+    * `current` for the server's current working version of the ledger.
 
 There is also a deprecated `ledger` parameter which accepts any of the above three formats. *Do not* use this parameter; it may be removed without further notice.
 
@@ -512,7 +512,7 @@ For more information on the various transactions you can submit, see the [Transa
 
 # API Methods #
 
-API methods for the Websocket and JSON-RPC APIs are defined by command names, and are divided into Public Commands and Admin Commands. Public Commands are not necessarily meant for the general public, but they are used by any client attached to the server. (Think of Public Commands as being for members or customers of the organization running the server, while the Admin Commands are for the personnel in charge of keeping the server operational.) Public Commands include operations such as checking the state of the ledger, finding a path to connecting users, and submitting a transaction, among others. Admin Commands, on the other hand, are meant only for trusted server operators, and include commands for managing the state of the server, the nodes it uses for validation, and other administrative features.
+API methods for the Websocket and JSON-RPC APIs are defined by command names, and are divided into Public Commands and Admin Commands. Public Commands are not necessarily meant for the general public, but they are used by any client attached to the server. (Think of Public Commands as being for members or customers of the organization running the server, while the Admin Commands are for the personnel in charge of keeping the server operational.) Public Commands include operations such as checking the state of the ledger, finding a path to connecting users, and submitting a transaction, among others. Admin Commands, on the other hand, are meant only for trusted server operators, and include commands for managing, monitoring, and debugging the server.
 
 
 ## List of Public Commands ##
@@ -1094,8 +1094,8 @@ The response follows the [standard format](#response-formatting), with the resul
 
 | `Field`                | Type    | Description                               |
 |:-----------------------|:--------|:------------------------------------------|
-| `account_data`         | Object  | The [AccountRoot ledger node](reference-ledger-format.html#accountroot) with this account's information, as stored in the ledger. |
-| `signer_lists`         | Array   | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger nodes](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most one SignerList, this array must have exactly one member if it is present. [New in: rippled 0.31.0][] |
+| `account_data`         | Object  | The [AccountRoot ledger object](reference-ledger-format.html#accountroot) with this account's information, as stored in the ledger. |
+| `signer_lists`         | Array   | (Omitted unless the request specified `signer_lists` and at least one SignerList is associated with the account.) Array of [SignerList ledger objects](reference-ledger-format.html#signerlist) associated with this account for [Multi-Signing](reference-transaction-format.html#multi-signing). Since an account can own at most one SignerList, this array must have exactly one member if it is present. [New in: rippled 0.31.0][] |
 | `ledger_current_index` | Integer | (Omitted if `ledger_index` is provided instead) The sequence number of the most-current ledger, which was used when retrieving this information. The information does not contain any changes from ledgers newer than this one. |
 | `ledger_index`         | Integer | (Omitted if `ledger_current_index` is provided instead) The sequence number of the ledger used when retrieving this information. The information does not contain any changes from ledgers newer than this one. |
 | `queue_data`           | Object  | (Omitted unless `queue` specified as `true` and querying the current open ledger.) Information about [queued transactions](concept-transaction-cost.html#queued-transactions) sent by this account. This information describes the state of the local `rippled` server, which may be different from other servers in the consensus network. Some fields may be omitted because the values are calculated "lazily" by the queuing mechanism. |
@@ -1515,11 +1515,11 @@ The `account_objects` command returns the raw [ledger format][] for all objects 
 
 The types of objects that may appear in the `account_objects` response for an account include:
 
-- [Offer nodes](reference-ledger-format.html#offer) for orders that are currently live, unfunded, or expired but not yet removed. (See [Lifecycle of an Offer](reference-transaction-format.html#lifecycle-of-an-offer) for more information.)
-- [RippleState nodes](reference-ledger-format.html#ripplestate) for trust lines where this account's side is not in the default state.
-- The account's [SignerList node](reference-ledger-format.html#signerlist), if the account has [multi-signing](reference-transaction-format.html#multi-signing) enabled.
-- [Escrow nodes](reference-ledger-format.html#escrow) for held payments that have not yet been executed or canceled.
-- [PayChannel nodes](reference-ledger-format.html#paychannel) for open payment channels.
+- [Offer objects](reference-ledger-format.html#offer) for orders that are currently live, unfunded, or expired but not yet removed. (See [Lifecycle of an Offer](reference-transaction-format.html#lifecycle-of-an-offer) for more information.)
+- [RippleState objects](reference-ledger-format.html#ripplestate) for trust lines where this account's side is not in the default state.
+- The account's [SignerList](reference-ledger-format.html#signerlist), if the account has [multi-signing](reference-transaction-format.html#multi-signing) enabled.
+- [Escrow objects](reference-ledger-format.html#escrow) for held payments that have not yet been executed or canceled.
+- [PayChannel objects](reference-ledger-format.html#paychannel) for open payment channels.
 
 
 #### Request Format ####
@@ -1571,7 +1571,7 @@ The request includes the following parameters:
 | `Field`        | Type                                       | Description    |
 |:---------------|:-------------------------------------------|:---------------|
 | `account`      | String                                     | A unique identifier for the account, most commonly the account's address. |
-| `type`         | String                                     | _(Optional)_ If included, filter results to include only this type of ledger node. The valid types are: `offer`, `signer_list`, `state` (trust line), `escrow`, and `payment_channel`. <!-- Author's note: Omitted types from this list that can't be owned by an account: https://github.com/ripple/rippled/blob/1dbc5a57e6b0e90a9da0d6e56f2f5a99e6ac1d8c/src/ripple/rpc/impl/RPCHelpers.cpp#L676-L686 --> |
+| `type`         | String                                     | _(Optional)_ If included, filter results to include only this type of ledger object. The valid types are: `offer`, `signer_list`, `state` (trust line), `escrow`, and `payment_channel`. <!-- Author's note: Omitted types from this list that can't be owned by an account: https://github.com/ripple/rippled/blob/1dbc5a57e6b0e90a9da0d6e56f2f5a99e6ac1d8c/src/ripple/rpc/impl/RPCHelpers.cpp#L676-L686 --> |
 | `ledger_hash`  | String                                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | `ledger_index` | String or Unsigned Integer                 | _(Optional)_ The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers)) |
 | `limit`        | Unsigned Integer                           | _(Optional)_ The maximum number of objects to include in the results. Must be within the inclusive range 10 to 400 on non-admin connections. Defaults to 200. |
@@ -3741,8 +3741,8 @@ A request can include the following fields:
 | `id`           | (Arbitrary)                                | (WebSocket only) Any identifier to separate this request from others in case the responses are delayed or out of order. |
 | `ledger_hash`  | String                                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | `ledger_index` | String or Unsigned Integer                 | _(Optional)_ The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers)) |
-| `binary`       | Boolean                                    | (Optional, defaults to False) If set to true, return data nodes as hashed hex strings instead of JSON. |
-| `limit`        | Integer                                    | (Optional, default varies) Limit the number of nodes to retrieve. The server is not required to honor this value. |
+| `binary`       | Boolean                                    | (Optional, defaults to False) If set to true, return ledger objects as hashed hex strings instead of JSON. |
+| `limit`        | Integer                                    | (Optional, default varies) Limit the number of ledger objects to retrieve. The server is not required to honor this value. |
 | `marker`       | [(Not Specified)](#markers-and-pagination) | Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 The `ledger` field is deprecated and may be removed without further notice.
@@ -3941,7 +3941,7 @@ The format of each object in the `state` array depends on whether `binary` was s
 | `Field`             | Type      | Description                                |
 |:--------------------|:----------|:-------------------------------------------|
 | `data`              | String    | (Only included if `"binary":true`) Hex representation of the requested data |
-| `LedgerEntryType`   | String    | (Only included if `"binary":false`) String indicating what type of ledger node this object represents. See [ledger format][] for the full list. |
+| `LedgerEntryType`   | String    | (Only included if `"binary":false`) String indicating what type of ledger object this object represents. See [ledger format][] for the full list. |
 | (Additional fields) | (Various) | (Only included if `"binary":false`) Additional fields describing this object, depending on which LedgerEntryType it is. |
 | `index`             | String    | Unique identifier for this ledger entry, as hex. |
 
@@ -3955,7 +3955,7 @@ The format of each object in the `state` array depends on whether `binary` was s
 ## ledger_entry ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerEntry.cpp "Source")
 
-The `ledger_entry` method returns a single ledger node from the XRP Ledger in its raw format. See [ledger format][] for information on the different types of objects you can retrieve.
+The `ledger_entry` method returns a single ledger object from the XRP Ledger in its raw format. See [ledger format][] for information on the different types of objects you can retrieve.
 
 **Note:** There is no commandline version of this method. You can use the [`json` command](#json) to access this method from the commandline instead.
 
@@ -3998,11 +3998,11 @@ An example of the request format:
 
 This method can retrieve several different types of data. You can select which type of item to retrieve by passing the appropriate parameters. Specifically, you should provide exactly one of the following fields:
 
-1. `index` - Retrieve any type of ledger node by its unique index
-2. `account_root` - Retrieve an [AccountRoot node](reference-ledger-format.html#accountroot). This is roughly equivalent to the [account_info](#account-info) command.
-3. `directory` - Retrieve a [DirectoryNode](reference-ledger-format.html#directorynode), which contains a list of other nodes
-4. `offer` - Retrieve an [Offer node](reference-ledger-format.html#offer), which defines an offer to exchange currency
-5. `ripple_state` - Retrieve a [RippleState node](reference-ledger-format.html#ripplestate), which tracks a (non-XRP) currency balance between two accounts.
+1. `index` - Retrieve any type of ledger object by its unique ID
+2. `account_root` - Retrieve an [AccountRoot object](reference-ledger-format.html#accountroot). This is roughly equivalent to the [account_info](#account-info) command.
+3. `directory` - Retrieve a [DirectoryNode](reference-ledger-format.html#directorynode), which contains a list of other ledger objects
+4. `offer` - Retrieve an [Offer object](reference-ledger-format.html#offer), which defines an offer to exchange currency
+5. `ripple_state` - Retrieve a [RippleState object](reference-ledger-format.html#ripplestate), which tracks a (non-XRP) currency balance between two accounts.
 
 If you specify more than one of the above items, the server retrieves only of them; it is undefined which it chooses.
 
@@ -4011,18 +4011,18 @@ The full list of parameters recognized by this method is as follows:
 | `Field`                 | Type                       | Description           |
 |:------------------------|:---------------------------|:----------------------|
 | `index`                 | String                     | _(Optional)_ Specify the unique identifier of a single ledger entry to retrieve. |
-| `account_root`          | String - [Address][]       | _(Optional)_ Specify an [AccountRoot node](reference-ledger-format.html#accountroot) to retrieve. |
-| `directory`             | Object or String           | _(Optional)_ Specify a [DirectoryNode](reference-ledger-format.html#directorynode). (Directory nodes each contain a list of IDs for things contained in them.) If a string, interpret as the [unique index](reference-ledger-format.html#tree-format) to the directory, in hex. If an object, requires either `dir_root` or `owner` as a sub-field, plus optionally a `sub_index` sub-field. |
-| `directory.sub_index`   | Unsigned Integer           | _(Optional)_ If provided, jumps to a further sub-node in the [DirectoryNode](reference-ledger-format.html#directorynode). |
+| `account_root`          | String - [Address][]       | _(Optional)_ Specify an [AccountRoot object](reference-ledger-format.html#accountroot) to retrieve. |
+| `directory`             | Object or String           | _(Optional)_ Specify a [DirectoryNode](reference-ledger-format.html#directorynode). (DirectoryNode objects each contain a list of IDs for things contained in them.) If a string, interpret as the [unique index](reference-ledger-format.html#tree-format) to the directory, in hex. If an object, requires either `dir_root` or `owner` as a sub-field, plus optionally a `sub_index` sub-field. |
+| `directory.sub_index`   | Unsigned Integer           | _(Optional)_ If provided, jumps to a later "page" of the [Directory](reference-ledger-format.html#directorynode). |
 | `directory.dir_root`    | String                     | (Required if `directory` is specified as an object and `directory.owner` is not provided) Unique index identifying the directory to retrieve, as a hex string. |
 | `directory.owner`       | String                     | (Required if `directory` is specified as an object and `directory.dir_root` is not provided) Unique address of the account associated with this directory |
-| `offer`                 | Object or String           | _(Optional)_ Specify an [Offer node](reference-ledger-format.html#offer) to retrieve. If a string, interpret as the [unique index](reference-ledger-format.html#tree-format) to the Offer. If an object, requires the sub-fields `account` and `seq` to uniquely identify the offer. |
+| `offer`                 | Object or String           | _(Optional)_ Specify an [Offer object](reference-ledger-format.html#offer) to retrieve. If a string, interpret as the [unique index](reference-ledger-format.html#tree-format) to the Offer. If an object, requires the sub-fields `account` and `seq` to uniquely identify the offer. |
 | `offer.account`         | String - [Address][]       | (Required if `offer` specified) The account that placed the offer. |
-| `offer.seq`             | Unsigned Integer           | (Required if `offer` specified) The sequence number of the transaction that created the Offer node. |
-| `ripple_state`          | Object                     | _(Optional)_ Object specifying the RippleState (trust line) node to retrieve. The `accounts` and `currency` sub-fields are required to uniquely specify the RippleState entry to retrieve. |
-| `ripple_state.accounts` | Array                      | (Required if `ripple_state` specified) 2-length array of account [Address][]es, defining the two accounts linked by this [RippleState node](reference-ledger-format.html#ripplestate) |
-| `ripple_state.currency` | String                     | (Required if `ripple_state` specified) [Currency Code][] of the [RippleState node](reference-ledger-format.html#ripplestate) to retrieve. |
-| `binary`                | Boolean                    | (Optional, defaults to false) If true, return the requested ledger node's contents as a hex string. Otherwise, return data in JSON format. |
+| `offer.seq`             | Unsigned Integer           | (Required if `offer` specified) The sequence number of the transaction that created the Offer object. |
+| `ripple_state`          | Object                     | _(Optional)_ Object specifying the RippleState (trust line) object to retrieve. The `accounts` and `currency` sub-fields are required to uniquely specify the RippleState entry to retrieve. |
+| `ripple_state.accounts` | Array                      | (Required if `ripple_state` specified) 2-length array of account [Address][]es, defining the two accounts linked by this [RippleState object](reference-ledger-format.html#ripplestate) |
+| `ripple_state.currency` | String                     | (Required if `ripple_state` specified) [Currency Code][] of the [RippleState object](reference-ledger-format.html#ripplestate) to retrieve. |
+| `binary`                | Boolean                    | _(Optional)_ If true, return the requested ledger object's contents as a hex string. Otherwise, return data in JSON format. The default is `true` if searching by `index` and `false` otherwise. |
 | `ledger_hash`           | String                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying a Ledger](#specifying-ledgers)) |
 | `ledger_index`          | String or Unsigned Integer | _(Optional)_ The sequence number of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying a Ledger](#specifying-ledgers)) |
 
@@ -4091,8 +4091,8 @@ The response follows the [standard format](#response-formatting), with a success
 |:---------------|:-----------------|:-----------------------------------------|
 | `index`        | String           | Unique identifying key for this ledger_entry |
 | `ledger_index` | Unsigned Integer | Unique sequence number of the ledger from which this data was retrieved |
-| `node`         | Object           | (Omitted if `"binary": true` specified.) Object containing the data of this ledger node, according to the [ledger format][]. |
-| `node_binary`  | String           | (Omitted unless `"binary":true` specified) Binary data of the ledger node, as hex. |
+| `node`         | Object           | (Omitted if `"binary": true` specified.) Object containing the data of this ledger object, according to the [ledger format][]. |
+| `node_binary`  | String           | (Omitted unless `"binary":true` specified) Binary data of the ledger object, as hex. |
 
 #### Possible Errors ####
 
@@ -4269,8 +4269,8 @@ When the server is in the progress of fetching a ledger, but has not yet finishe
 | `have_header`               | Boolean          | Whether the server has the header section of the requested ledger. |
 | `have_state`                | Boolean          | (May be omitted) Whether the server has the [account-state section](reference-ledger-format.html#tree-format) of the requested ledger. |
 | `have_transactions`         | Boolean          | (May be omitted) Whether the server has the transaction section of the requested ledger. |
-| `needed_state_hashes`       | Array of Strings | (May be omitted) Up to 16 hashes of nodes in the [state tree](reference-ledger-format.html#tree-format) that the server still needs to retrieve. |
-| `needed_transaction_hashes` | Array of Strings | (May be omitted) Up to 16 hashes of nodes in the transaction tree that the server still needs to retrieve. |
+| `needed_state_hashes`       | Array of Strings | (May be omitted) Up to 16 hashes of objects in the [state tree](reference-ledger-format.html#tree-format) that the server still needs to retrieve. |
+| `needed_transaction_hashes` | Array of Strings | (May be omitted) Up to 16 hashes of objects in the transaction tree that the server still needs to retrieve. |
 | `peers`                     | Number           | How many peers the server is querying to find this ledger. |
 | `timeouts`                  | Number           | Number of times fetching this ledger has timed out so far. |
 
@@ -8950,9 +8950,9 @@ The `info` object may have some arrangement of the following fields:
 | `load_factor_fee_escalation`        | Number                    | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the open ledger. [New in: rippled 0.32.0][] |
 | `load_factor_fee_queue`             | Number                    | (May be omitted) The current multiplier to the [transaction cost][] that a transaction must pay to get into the queue, if the queue is full. [New in: rippled 0.32.0][] |
 | `load_factor_server`                | Number                    | (May be omitted) The load factor the server is enforcing, not including the [open ledger cost](concept-transaction-cost.html#open-ledger-cost). [New in: rippled 0.33.0][] |
-| `peers`                             | Number                    | How many other `rippled` servers the node is currently connected to. |
-| `pubkey_node`                       | String                    | Public key used to verify this node for internal communications; this key is automatically generated by the server the first time it starts up. (If deleted, the node can create a new pair of keys.) |
-| `pubkey_validator`                  | String                    | *Admin only* Public key used by this node to sign ledger validations. |
+| `peers`                             | Number                    | How many other `rippled` servers this one is currently connected to. |
+| `pubkey_node`                       | String                    | Public key used to verify this server for peer-to-peer communications; this key is automatically generated by the server the first time it starts up. (If deleted, the server can create a new pair of keys.) |
+| `pubkey_validator`                  | String                    | *Admin only* Public key used by this server to sign ledger validations. |
 | `server_state`                      | String                    | A string indicating to what extent the server is participating in the network. See [Possible Server States](#possible-server-states) for more details. |
 | `state_accounting`                  | Object                    | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. [New in: rippled 0.30.1][] |
 | `state_accounting.*.duration_us`    | String                    | The number of microseconds the server has spent in this state. (This is updated whenever the server transitions into another state.) [New in: rippled 0.30.1][] |
@@ -9240,8 +9240,8 @@ The `state` object may have some arrangement of the following fields:
 | `load_factor_fee_queue`          | Integer          | (May be omitted) The current multiplier to the [transaction cost][] to get into the queue, if the queue is full, in [fee levels][]. [New in: rippled 0.32.0][] |
 | `load_factor_fee_reference`      | Integer          | (May be omitted) The [transaction cost][] with no load scaling, in [fee levels][]. [New in: rippled 0.32.0][] |
 | `load_factor_server`             | Number           | (May be omitted) The load factor the server is enforcing, not including the [open ledger cost](concept-transaction-cost.html#open-ledger-cost). [New in: rippled 0.33.0][] |
-| `peers`                          | Number           | How many other `rippled` servers the node is currently connected to. |
-| `pubkey_node`                    | String           | Public key used by this server (along with the corresponding private key) for secure communications between nodes. This key pair is automatically created and stored in `rippled`'s local database the first time it starts up; if lost or deleted, a new key pair can be generated with no ill effects. |
+| `peers`                          | Number           | How many other `rippled` servers this one is currently connected to. |
+| `pubkey_node`                    | String           | Public key used to verify this server for peer-to-peer communications; this key pair is automatically generated by the server the first time it starts up. (If deleted, the server can create a new pair of keys.)  |
 | `pubkey_validator`               | String           | *Admin only* Public key of the keypair used by this server to sign proposed ledgers for validation. |
 | `server_state`                   | String           | A string indicating to what extent the server is participating in the network. See [Possible Server States](#possible-server-states) for more details. |
 | `state_accounting`               | Object           | A map of various [server states](#possible-server-states) with information about the time the server spends in each. This can be useful for tracking the long-term health of your server's connectivity to the network. [New in: rippled 0.30.1][] |
@@ -9711,12 +9711,12 @@ The fields describing a fetch in progress are subject to change without notice. 
 
 | `Field`               | Type                    | Description                |
 |:----------------------|:------------------------|:---------------------------|
-| `hash`                | String                  | The hash of the object being fetched. |
+| `hash`                | String                  | The hash of the item being fetched. |
 | `have_header`         | Boolean                 | For a ledger, whether this server has already obtained the ledger's header section. |
 | `have_transactions`   | Boolean                 | For a ledger, whether this server has already obtained the transaction section of that ledger. |
-| `needed_state_hashes` | Array of (Hash) Strings | The hash values of state nodes still needed from this object. If more than 16 are needed, the response contains only the first 16. |
-| `peers`               | Number                  | The number of peers who have this object available. |
-| `timeouts`            | Number                  | The number of times that fetching this object has resulted in a timeout (2.5 seconds). |
+| `needed_state_hashes` | Array of (Hash) Strings | The hash values of state objects still needed from this item. If more than 16 are needed, the response contains only the first 16. |
+| `peers`               | Number                  | The number of peers who have this item available. |
+| `timeouts`            | Number                  | The number of times that fetching this item has resulted in a timeout (2.5 seconds). |
 
 #### Possible Errors ####
 
@@ -10257,9 +10257,9 @@ The request includes the following parameters:
 | `ledger`      | Number (Ledger Sequence Number) | _(Optional)_ If provided, check and correct this specific ledger only. |
 | `max_ledger`  | Number (Ledger Sequence Number) | _(Optional)_ Configure the ledger cleaner to check ledgers with sequence numbers equal or lower than this. |
 | `min_ledger`  | Number (Ledger Sequence Number) | _(Optional)_ Configure the ledger cleaner to check ledgers with sequence numbers equal or higher than this. |
-| `full`        | Boolean                         | _(Optional)_ If true, fix ledger state nodes and transations in the specified ledger(s). Defaults to false. Automatically set to `true` if `ledger` is provided. |
+| `full`        | Boolean                         | _(Optional)_ If true, fix ledger state objects and transations in the specified ledger(s). Defaults to false. Automatically set to `true` if `ledger` is provided. |
 | `fix_txns`    | Boolean                         | _(Optional)_ If true, correct transaction in the specified ledger(s). Overrides `full` if provided. |
-| `check_nodes` | Boolean                         | _(Optional)_ If true, correct ledger state nodes in the specified ledger(s). Overrides `full` if provided. |
+| `check_nodes` | Boolean                         | _(Optional)_ If true, correct ledger state objects in the specified ledger(s). Overrides `full` if provided. |
 | `stop`        | Boolean                         | _(Optional)_ If true, disable the ledger cleaner. |
 
 #### Response Format ####
@@ -10512,7 +10512,7 @@ The response follows the [standard format](#response-formatting), with a success
 ## validation_create ##
 [[Source]<br>](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/ValidationCreate.cpp "Source")
 
-Use the `validation_create` command to generate the keys for a rippled [validating node](tutorial-rippled-setup.html#validator-setup). Similar to the [wallet_propose](#wallet-propose) command, this command makes no real changes, but only generates a set of keys in the proper format.
+Use the `validation_create` command to generate the keys for a rippled [validator](tutorial-rippled-setup.html#validator-setup). Similar to the [wallet_propose](#wallet-propose) command, this command makes no real changes, but only generates a set of keys in the proper format.
 
 _The `validation_create` method is an [admin command](#connecting-to-rippled) that cannot be run by unprivileged users._
 
@@ -11092,7 +11092,7 @@ Each member of the `peers` array is a peer object with the following fields:
 |:-------------------|:--------|:----------------------------------------------|
 | `address`          | String  | The IP address and port where this peer is connected |
 | `cluster`          | Boolean | (May be omitted) If `true`, the current server and the peer server are part of the same `rippled` cluster. |
-| `name`             | String  | (May be omitted) If the peer is part of the same cluster, this is the display name for that node as defined in the config file. |
+| `name`             | String  | (May be omitted) If the peer is part of the same cluster, this is the display name for that server as defined in the config file. |
 | `complete_ledgers` | String  | Range expression indicating the sequence numbers of the ledger versions the peer `rippled` has available |
 | `inbound`          | Boolean | (May be omitted) If `true`, the peer is connecting to the local server. |
 | `latency`          | Number  | The network latency to the peer (in milliseconds) |

--- a/content/reference-transaction-format.md
+++ b/content/reference-transaction-format.md
@@ -429,7 +429,7 @@ There are several options which can be either enabled or disabled for an account
 
 * The `AccountSet` transaction type has several "AccountSet Flags" (prefixed **asf**) that can enable an option when passed as the `SetFlag` parameter, or disable an option when passed as the `ClearFlag` parameter.
 * The `AccountSet` transaction type has several transaction flags (prefixed **tf**) that can be used to enable or disable specific account options when passed in the `Flags` parameter. This style is discouraged. New account options do not have corresponding transaction (tf) flags.
-* The `AccountRoot` ledger node type has several ledger-specific-flags (prefixed **lsf**) which represent the state of particular account options within a particular ledger. Naturally, the values apply until a later ledger version changes them.
+* The `AccountRoot` ledger object type has several ledger-specific-flags (prefixed **lsf**) which represent the state of particular account options within a particular ledger. Naturally, the values apply until a later ledger version changes them.
 
 The preferred way to enable and disable Account Flags is using the `SetFlag` and `ClearFlag` parameters of an AccountSet transaction. AccountSet flags have names that begin with **asf**.
 
@@ -590,7 +590,7 @@ Any account may submit an EscrowFinish transaction.
 
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp "Source")
 
-An OfferCancel transaction removes an Offer node from the XRP Ledger.
+An OfferCancel transaction removes an Offer object from the XRP Ledger.
 
 ```
 {
@@ -606,7 +606,7 @@ An OfferCancel transaction removes an Offer node from the XRP Ledger.
 
 | Field         | JSON Type        | [Internal Type][] | Description           |
 |:--------------|:-----------------|:------------------|:----------------------|
-| OfferSequence | Unsigned Integer | UInt32            | The sequence number of a previous OfferCreate transaction. If specified, cancel any offer node in the ledger that was created by that transaction. It is not considered an error if the offer specified does not exist. |
+| OfferSequence | Unsigned Integer | UInt32            | The sequence number of a previous OfferCreate transaction. If specified, cancel any offer object in the ledger that was created by that transaction. It is not considered an error if the offer specified does not exist. |
 
 *Tip:* To remove an old offer and replace it with a new one, you can use an [OfferCreate transaction][] with an `OfferSequence` parameter, instead of using OfferCancel and another OfferCreate.
 
@@ -618,7 +618,7 @@ The OfferCancel method returns [tesSUCCESS](#transaction-results) even if it did
 
 [[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CreateOffer.cpp "Source")
 
-An OfferCreate transaction is effectively a [limit order](http://en.wikipedia.org/wiki/limit_order). It defines an intent to exchange currencies, and creates an Offer node in the XRP Ledger if not completely fulfilled when placed. Offers can be partially fulfilled.
+An OfferCreate transaction is effectively a [limit order](http://en.wikipedia.org/wiki/limit_order). It defines an intent to exchange currencies, and creates an Offer object in the XRP Ledger if not completely fulfilled when placed. Offers can be partially fulfilled.
 
 ```
 {
@@ -646,7 +646,7 @@ An OfferCreate transaction is effectively a [limit order](http://en.wikipedia.or
 
 ### Lifecycle of an Offer ###
 
-When an OfferCreate transaction is processed, it automatically consumes matching or crossing offers to the extent possible. (If existing offers provide a better rate than requested, the offer creator could pay less than the full `TakerGets` amount to receive the entire `TakerPays` amount.) If that does not completely fulfill the `TakerPays` amount, then the offer becomes an Offer node in the ledger. (You can use [OfferCreate Flags](#offercreate-flags) to modify this behavior.)
+When an OfferCreate transaction is processed, it automatically consumes matching or crossing offers to the extent possible. (If existing offers provide a better rate than requested, the offer creator could pay less than the full `TakerGets` amount to receive the entire `TakerPays` amount.) If that does not completely fulfill the `TakerPays` amount, then the offer becomes an Offer object in the ledger. (You can use [OfferCreate Flags](#offercreate-flags) to modify this behavior.)
 
 An offer in the ledger can be fulfilled either by additional OfferCreate transactions that match up with the existing offers, or by [Payments](#payment) that use the offer to connect the payment path. Offers can be partially fulfilled and partially funded. A single transaction can consume up to 850 Offers from the ledger. (Any more than that, and the metadata becomes too large, resulting in [`tecOVERSIZE`](#tec-codes).)
 
@@ -729,8 +729,8 @@ Transactions of the OfferCreate type support additional values in the [`Flags` f
 
 | Flag Name           | Hex Value  | Decimal Value | Description               |
 |:--------------------|:-----------|:--------------|:--------------------------|
-| tfPassive           | 0x00010000 | 65536         | If enabled, the offer does not consume offers that exactly match it, and instead becomes an Offer node in the ledger. It still consumes offers that cross it. |
-| tfImmediateOrCancel | 0x00020000 | 131072        | Treat the offer as an [Immediate or Cancel order](http://en.wikipedia.org/wiki/Immediate_or_cancel). If enabled, the offer never becomes a ledger node: it only tries to match existing offers in the ledger. |
+| tfPassive           | 0x00010000 | 65536         | If enabled, the offer does not consume offers that exactly match it, and instead becomes an Offer object in the ledger. It still consumes offers that cross it. |
+| tfImmediateOrCancel | 0x00020000 | 131072        | Treat the offer as an [Immediate or Cancel order](http://en.wikipedia.org/wiki/Immediate_or_cancel). If enabled, the offer never becomes a ledger object: it only tries to match existing offers in the ledger. |
 | tfFillOrKill        | 0x00040000 | 262144        | Treat the offer as a [Fill or Kill order](http://en.wikipedia.org/wiki/Fill_or_kill). Only try to match existing offers in the ledger, and only do so if the entire `TakerPays` quantity can be obtained. |
 | tfSell              | 0x00080000 | 524288        | Exchange the entire `TakerGets` amount, even if it means obtaining more than the `TakerPays` amount in exchange. |
 
@@ -787,7 +787,7 @@ Most of the time, the `issuer` field of a non-XRP [Currency Amount][] indicates 
 
 ### Creating Accounts ###
 
-The Payment transaction type is the only way to create new accounts in the XRP Ledger. To do so, send an amount of XRP that is equal or greater than the [account reserve](concept-reserves.html) to a mathematically-valid account address that does not exist yet. When the Payment is processed, a new [AccountRoot node](reference-ledger-format.html#accountroot) is added to the ledger.
+The Payment transaction type is the only way to create new accounts in the XRP Ledger. To do so, send an amount of XRP that is equal or greater than the [account reserve](concept-reserves.html) to a mathematically-valid account address that does not exist yet. When the Payment is processed, a new [AccountRoot object](reference-ledger-format.html#accountroot) is added to the ledger.
 
 If you send an insufficient amount of XRP, or any other currency, the Payment fails.
 
@@ -1279,11 +1279,11 @@ Some fields that may appear in transaction metadata include:
 
 | Field                                 | Value               | Description    |
 |:--------------------------------------|:--------------------|:---------------|
-| AffectedNodes                         | Array               | List of nodes that were created, deleted, or modified by this transaction, and specific changes to each. |
-| DeliveredAmount                       | [Currency Amount][] | **DEPRECATED.** Replaced by `delivered_amount`. Omitted if not a partial payment. |
-| TransactionIndex                      | Unsigned Integer    | The transaction's position within the ledger that included it. (For example, the value `2` means it was the 2nd transaction in that ledger.) |
-| TransactionResult                     | String              | A [result code](#result-categories) indicating whether the transaction succeeded or how it failed. |
-| [delivered_amount](#delivered-amount) | [Currency Amount][] | The [Currency Amount][] actually received by the `Destination` account. Use this field to determine how much was delivered, regardless of whether the transaction is a [partial payment](#partial-payments). [New in: rippled 0.27.0][] |
+| `AffectedNodes`                       | Array               | List of [ledger objects](reference-ledger-format.html#ledger-object-types) that were created, deleted, or modified by this transaction, and specific changes to each. |
+| `DeliveredAmount`                     | [Currency Amount][] | **DEPRECATED.** Replaced by `delivered_amount`. Omitted if not a partial payment. |
+| `TransactionIndex`                    | Unsigned Integer    | The transaction's position within the ledger that included it. (For example, the value `2` means it was the 2nd transaction in that ledger.) |
+| `TransactionResult`                   | String              | A [result code](#result-categories) indicating whether the transaction succeeded or how it failed. |
+| [`delivered_amount`](#delivered-amount) | [Currency Amount][] | The [Currency Amount][] actually received by the `Destination` account. Use this field to determine how much was delivered, regardless of whether the transaction is a [partial payment](#partial-payments). [New in: rippled 0.27.0][] |
 
 ### delivered_amount ###
 
@@ -1444,7 +1444,7 @@ These codes indicate that the transaction failed, but it was applied to a ledger
 | `tecNO_LINE_REDUNDANT`     | 127   | The transaction failed because it tried to set a trust line to its default state, but the trust line did not exist. |
 | `tecNO_PERMISSION`         | 139   | The sender does not have permission to do this operation. For example, the [EscrowFinish transaction][] tried to release a held payment before its `FinishAfter` time, or someone tried to use [PaymentChannelFund][] on a channel the sender does not own. |
 | `tecNO_REGULAR_KEY`        | 131   | The [AccountSet transaction][] tried to disable the master key, but the account does not have another way to [authorize transactions](#authorizing-transactions). If [multi-signing](#multi-signing) is enabled, this code is deprecated and `tecNO_ALTERNATIVE_KEY` is used instead. |
-| `tecNO_TARGET`             | 138   | The transaction referenced an Escrow or PayChannel ledger node that doesn't exist, either because it never existed or it has already been deleted. (For example, another [EscrowFinish transaction][] has already executed the held payment.) Alternatively, the destination account has `asfDisallowXRP` set so it cannot be the destination of this [PaymentChannelCreate][] or [EscrowCreate][] transaction. |
+| `tecNO_TARGET`             | 138   | The transaction referenced an Escrow or PayChannel ledger object that doesn't exist, either because it never existed or it has already been deleted. (For example, another [EscrowFinish transaction][] has already executed the held payment.) Alternatively, the destination account has `asfDisallowXRP` set so it cannot be the destination of this [PaymentChannelCreate][] or [EscrowCreate][] transaction. |
 | `tecOVERSIZE`              | 145   | This transaction could not be processed, because the server created an excessively large amount of metadata when it tried to apply the transaction. [New in: rippled 0.29.0-hf1][] |
 | `tecOWNERS`                | 132   | The transaction requires that account sending it has a nonzero "owners count", so the transaction cannot succeed. For example, an account cannot enable the [`lsfRequireAuth`](#accountset-flags) flag if it has any trust lines or available offers. |
 | `tecPATH_DRY`              | 128   | The transaction failed because the provided paths did not have enough liquidity to send anything at all. This could mean that the source and destination accounts are not linked by trust lines. |

--- a/content/snippets/tx-type-links.md
+++ b/content/snippets/tx-type-links.md
@@ -13,6 +13,10 @@
     "SignerListSet",
     "TrustSet"
 ] %}
+{% set pstxtypes = [
+  "EnableAmendment",
+  "SetFee"
+] %}
 
 {% if currentpage.html == "reference-transaction-format.html" %}
   {% set basepage = "" %}
@@ -24,4 +28,10 @@
 [{{tx}}]: {{basepage}}#{{tx|lower}}
 [{{tx}} transaction]: {{basepage}}#{{tx|lower}}
 [{{tx}} transactions]: {{basepage}}#{{tx|lower}}
+{% endfor %}
+
+{% for tx in pstxtypes %}
+[{{tx}}]: {{basepage}}#{{tx|lower}}
+[{{tx}} pseudo-transaction]: {{basepage}}#{{tx|lower}}
+[{{tx}} pseudo-transactions]: {{basepage}}#{{tx|lower}}
 {% endfor %}

--- a/content/tutorial-paychan.md
+++ b/content/tutorial-paychan.md
@@ -165,7 +165,7 @@ In the response from the JSON-RPC, the payer should look for the following:
 - In the transaction's `meta` field, confirm that the `TransactionResult` is `tesSUCCESS`.
 - Confirm that the response has `"validated":true` to indicate the data comes from a validated ledger. (The result `tesSUCCESS` is only [final](reference-transaction-format.html#finality-of-results) if it appears in a validated ledger version.)
 - In the `AffectedNodes` array of the transaction's `meta` field, look for a `CreatedNode` object with the `LedgerEntryType` of `PayChannel`. The `LedgerIndex` field of the `CreatedNode` object indicates the Channel ID. (In the above example, this is a hex string starting with "5DB0...") The Channel ID is necessary later to sign claims.
-    For more information on the PayChannel ledger object type, see [PayChannel ledger node type](reference-ledger-format.html#paychannel).
+    For more information on the PayChannel ledger object type, see [PayChannel ledger object](reference-ledger-format.html#paychannel).
 
 
 ## 2. The payee checks specifics of the payment channel.


### PR DESCRIPTION
- Style changes to the "Ledger Format" reference
- Terminology changes. Uses "ledger object ID" instead of "ledger node index" to avoid ambiguity with ledger indexes and server nodes.
- Adds the missing `Amendments` object type