### PR TITLE
account_lines - Add authorized and peer_authorized

### DIFF
--- a/content/rippled-api-methods/account_lines.md
+++ b/content/rippled-api-methods/account_lines.md
@@ -172,6 +172,8 @@ Each trust line object has some combination of the following fields:
 | `quality_out`    | Unsigned Integer | Rate at which the account values outgoing balances on this trust line, as a ratio of this value per 1 billion units. (For example, a value of 500 million represents a 0.5:1 ratio.) As a special case, 0 is treated as a 1:1 ratio. |
 | `no_ripple`      | Boolean          | (May be omitted) `true` if this account has enabled the [NoRipple flag](concept-noripple.html) for this line. If omitted, that is the same as `false`. |
 | `no_ripple_peer` | Boolean          | (May be omitted) `true` if the peer account has enabled the [NoRipple flag](concept-noripple.html). If omitted, that is the same as `false`. |
+| `authorized`     | Boolean          | (May be omitted) `true` if this account has set the tfSetAuth flag on this trust line. If omitted, that is the same as `false`. |
+| `peer_authorized`| Boolean          | (May be omitted) `true` if the peer account has set the tfSetAuth flag on this trust line. If omitted, that is the same as `false`. |
 | `freeze`         | Boolean          | (May be omitted) `true` if this account has [frozen](concept-freeze.html) this trust line. If omitted, that is the same as `false`. |
 | `freeze_peer`    | Boolean          | (May be omitted) `true` if the peer account has [frozen](concept-freeze.html) this trust line. If omitted, that is the same as `false`. |
 


### PR DESCRIPTION
I checked the fields in [JsonFields.h](https://github.com/ripple/rippled/blob/3e9e0c4b53aa29775b02f5a092c79587cebef8d0/src/ripple/protocol/JsonFields.h) that had the comment `out: AccountLines` (or had `AccountLines` on a subsequent line, for fields that apply to multiple types). `authorized` and `peer_authorized` were missing.

(This check was kicked off by [this comment](https://github.com/ripple/ripple-lib/pull/843#discussion_r166193834))