### PR TITLE
Update tutorial-rippled-setup.md - more validators

### DIFF
--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -55,7 +55,7 @@ There are several properties that define a good validator. The more of these pro
 * **Identified**. It should be clear who runs the validator. Ideally, a list of trusted validators should include validators operated by different owners in multiple legal jurisdictions and geographic areas, to reduce the chance that any localized events could interfere with the validator's impartial operation.
     * Setting up [Domain Verification](#domain-verification) is a good start.
 
-At present, Ripple (the company) cannot recommend any validators aside from the 5 core validators run by Ripple: these validators are included in the default `rippled` configuration. However, we are collecting data on other validators and building tools to report on their performance. For metrics on validators, see [validators.ripple.com](https://validators.ripple.com).
+At present, Ripple (the company) cannot recommend any validators aside from those in the default validator list. However, we are collecting data on other validators and building tools to report on their performance. For metrics on validators, see [validators.ripple.com](https://validators.ripple.com).
 
 
 # Installing rippled


### PR DESCRIPTION
There are now more than 5 core validators.

The default validator list is in the example validators.txt file: https://github.com/ripple/rippled/blob/release/doc/validators-example.txt