### PR TITLE
Updates 0.90.0 badge, adds it to sharding concept article

### DIFF
--- a/content/concept-history-sharding.md
+++ b/content/concept-history-sharding.md
@@ -1,6 +1,6 @@
-New in `rippled` 0.90.0
-
 # History Sharding
+
+[Introduced in: rippled 0.90.0][New in: rippled 0.90.0]
 
 As servers operate, they naturally produce a database containing data about the ledgers they witnessed or acquired during network runtime. Each `rippled` server stores that ledger data in its ledger store, but the online delete logic rotates these databases when the number of stored ledgers exceeds configured space limitations.
 
@@ -53,3 +53,4 @@ Determining a suitable size for the shard store involves careful consideration. 
 -  A shard occupies approximately 200 MB to 4 GB based on the age of the shard. Older shards are smaller because there was less activity in the XRP Ledger at the time.
 - A shard occupies approximately 200 MB to 4 GB based on the age of the shard. Older shards are smaller because there was less activity in the XRP Ledger at the time.
 
+{% include 'snippets/rippled_versions.md' %}

--- a/content/snippets/rippled_versions.md
+++ b/content/snippets/rippled_versions.md
@@ -29,3 +29,4 @@
 [New in: rippled 0.70.0]: https://github.com/ripple/rippled/releases/tag/0.70.0 "BADGE_BLUE"
 [New in: rippled 0.70.2]: https://github.com/ripple/rippled/releases/tag/0.70.2 "BADGE_BLUE"
 [New in: rippled 0.80.1]: https://github.com/ripple/rippled/releases/tag/0.80.1 "BADGE_BLUE"
+[New in: rippled 0.90.0]: https://github.com/ripple/rippled/releases/tag/0.90.0 "BADGE_BLUE"

--- a/content/snippets/rippled_versions.md
+++ b/content/snippets/rippled_versions.md
@@ -29,4 +29,5 @@
 [New in: rippled 0.70.0]: https://github.com/ripple/rippled/releases/tag/0.70.0 "BADGE_BLUE"
 [New in: rippled 0.70.2]: https://github.com/ripple/rippled/releases/tag/0.70.2 "BADGE_BLUE"
 [New in: rippled 0.80.1]: https://github.com/ripple/rippled/releases/tag/0.80.1 "BADGE_BLUE"
-[New in: rippled 0.90.0]: https://github.com/ripple/rippled/releases/tag/0.90.0 "BADGE_BLUE"
+[New in: rippled 0.90.0]: # "BADGE_BLUE"
+<!-- {# TODO: [New in: rippled 0.90.0]: https://github.com/ripple/rippled/releases/tag/0.90.0 "BADGE_BLUE" #} -->


### PR DESCRIPTION
This PR takes on two small details that needed address: 
- Adds new `0.90.0` snippet
- Corrects badge to display properly:
![screen shot 2018-02-12 at 11 30 37 am](https://user-images.githubusercontent.com/5075567/36116033-c54e9866-0fe9-11e8-8d77-1f5278a9ca3c.png)
