### PR TITLE
Ports Capacity Planning recommendations to /rippled-setup

### DIFF
--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -32,9 +32,7 @@ Before you can run any commands against a `rippled` server, you must know which 
 
 Alternatively, you can [run your own local copy of `rippled`](tutorial-rippled-setup.html). This is required if you want to access any of the [Admin Commands](#list-of-admin-commands). In this case, you should use whatever IP and port you configured the server to bind. (For example, `127.0.0.1:54321`) Additionally, to access admin functionality, you must connect from a port/IP address marked as admin in the config file.
 
-The [example config file](https://github.com/ripple/rippled/blob/release/cfg/rippled-example.cfg#L907-L930) listens for connections on the local loopback network (127.0.0.1), with JSON-RPC (HTTP) on port 5005 and WebSocket (WS) on port 6006, and treats all connected clients as admin.
-
-
+The [example config file](https://github.com/ripple/rippled/blob/release/doc/rippled-example.cfg#L907-L930) listens for connections on the local loopback network (127.0.0.1), with JSON-RPC (HTTP) on port 5005 and WebSocket (WS) on port 6006, and treats all connected clients as admin.
 
 ### WebSocket API
 
@@ -740,7 +738,7 @@ Servers in the XRP Ledger communicate to each other using the XRP Ledger peer pr
 
 To participate in the XRP Ledger, `rippled` servers connects to arbitrary peers using the peer protocol. (All such peers are treated as untrusted, unless they are [clustered](tutorial-rippled-setup.html#clustering) with the current server.)
 
-Ideally, the server should be able to send _and_ receive connections on the peer port. You should forward the port used for the peer protocol through your firewall to the `rippled` server. The [default `rippled` configuration file](https://github.com/ripple/rippled/blob/develop/doc/rippled-example.cfg) listens for incoming peer protocol connections on port 51235 on all network interfaces. You can change the port used by editing the appropriate stanza in your `rippled.cfg` file.
+Ideally, the server should be able to send _and_ receive connections on the peer port. You should forward the port used for the peer protocol through your firewall to the `rippled` server. The [default `rippled` configuration file](https://github.com/ripple/rippled/blob/release/doc/rippled-example.cfg) listens for incoming peer protocol connections on port 51235 on all network interfaces. You can change the port used by editing the appropriate stanza in your `rippled.cfg` file.
 
 Example:
 

--- a/content/reference-rippled.md
+++ b/content/reference-rippled.md
@@ -32,7 +32,7 @@ Before you can run any commands against a `rippled` server, you must know which 
 
 Alternatively, you can [run your own local copy of `rippled`](tutorial-rippled-setup.html). This is required if you want to access any of the [Admin Commands](#list-of-admin-commands). In this case, you should use whatever IP and port you configured the server to bind. (For example, `127.0.0.1:54321`) Additionally, to access admin functionality, you must connect from a port/IP address marked as admin in the config file.
 
-The [example config file](https://github.com/ripple/rippled/blob/release/doc/rippled-example.cfg#L907-L930) listens for connections on the local loopback network (127.0.0.1), with JSON-RPC (HTTP) on port 5005 and WebSocket (WS) on port 6006, and treats all connected clients as admin.
+The [example config file](https://github.com/ripple/rippled/blob/release/cfg/rippled-example.cfg#L907-L930) listens for connections on the local loopback network (127.0.0.1), with JSON-RPC (HTTP) on port 5005 and WebSocket (WS) on port 6006, and treats all connected clients as admin.
 
 
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -1,16 +1,16 @@
 # Capacity Planning
 
 
-Even the most minimally functional `rippled` server must contain the latest completed Ledgers to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these, consider the following server requirements:
+Even the most minimally functional `rippled` server must contain the most recently validated Ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these, consider the following server requirements:
 
 - Handling ever-increasing transaction volume
 - Servicing transaction reporting information to clients
 - Maintaining varying amounts of historical data
 
-Planning for the server resources required to run `rippled` relies on understanding the impact of two factors:
+Capacity planning for `rippled` involves two factors:
 
 - The [configuration settings](#configuration-settings) that affect resource utilization
-- The commodity [network and hardware](#network-and-hardware) requirements to achieve scalable architecture with consistent performance across the XRP Ledger Network
+- The [network and hardware] (#network and hardware) requirements to achieve consistent, good performance across the XRP Ledger network
 
 ## Configuration Settings
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -1,7 +1,7 @@
 # Capacity Planning
 
 
-Even the most minimally functional `rippled` server must contain the most recently validated Ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these, consider the following server requirements:
+Even the most minimally functional `rippled` server must contain the most recently validated ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these, consider the following server requirements:
 
 - Handling ever-increasing transaction volume
 - Servicing transaction reporting information to clients
@@ -18,7 +18,16 @@ Ripple recommends the following guidelines to improve performance. You can set t
 
 ### Node Size
 
-The `node_size` parameter determines the size of database caches. Ripple recommends you always set it to `huge` for production servers. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance better is that memory requirements increase.
+The `node_size` parameter determines the size of database caches. Ripple recommends you always set it to `huge` for production servers. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance is that memory requirements increase.
+
+The `node_size` parameter determines the size of database caches. Larger database caches decrease disk I/O requirements at a cost of higher memory requirements. Ripple recommends you always use the largest database cache your available memory can support. For production servers with the recommended 32 GB of RAM, set `node_size` to `huge`. For `node_size` guidelines, see the following table:
+
+| Available RAM for `rippled` | Recommended `node_size` value | Notes                              |
+|:----------------------------|:------------------------------|:-----------------------------------|
+| < 8 GB                      | `tiny`                        | Not recommended                    |
+| 8 GB                        | `low`                         |                                    |
+| 16 GB                       | `medium`                      |                                    |
+| 32 GB                       | `huge`                        | Recommended for production servers |
 
 ### Node DB Type
 
@@ -27,7 +36,7 @@ The `type` field in the `node_db` section of the `rippled.cfg` file sets the typ
 #### RocksDB vs NuDB
 RocksDB requires approximately one-third less disk storage than NuDB and provides a corresponding improvement in I/O latency. However, this comes at a cost of increased memory utilization as storage size grows. NuDB, on the other hand, has nearly constant performance and memory footprint regardless of storage.
 
-For `rippled` servers that operate as validators, which keep only a few days' worth of data or less, Ripple recommends using RocksDB. For all other uses, Ripple recommends users configure NuDB for the Ledger Store. NuDB has no performance-related configuration options. But tuning parameters are available for RocksDB that have been used to help achieve maximum tested transaction processing throughput, and are as follows:
+For `rippled` servers that operate as validators, which keep only a few days' worth of data or less, Ripple recommends using RocksDB. For all other uses, Ripple recommends users configure NuDB for the Ledger Store. NuDB has no performance-related configuration settings. However, tuning parameters are available for RocksDB that have been used to  achieve the maximum tested transaction processing throughput, shown here:
 
 ```
 [node_db]
@@ -42,7 +51,7 @@ path={path_to_ledger_store}
 
 ### Historical Data
 
-The amount of historical data kept online, as set in the `online_delete` and  `advisory_delete` field, is a major contributor to required storage space. Currently, about 12GB of data is stored per day. However, you should expect this amount to grow as transaction volume increases across the XRP Ledger network.
+The amount of historical data kept online, as set in the `online_delete` and  `advisory_delete` fields, is a major contributor to required storage space. Currently, about 12GB of data is stored per day. However, you can expect this amount to grow as transaction volume increases across the XRP Ledger network.
 
 ### Log Level
 
@@ -68,10 +77,11 @@ For best performance in enterprise production environments, Ripple recommends ru
 
 #### SSD Storage
 
-SSD Storage should support several thousand both read and write IOPS. Maximum read IOPS come from heavily used servers such as those behind https://s1.ripple.com and https://s2.ripple.com, which service transaction and ledger history retrieval requests. This is sometimes over 10,000 reads per second! Maximum write IOPS have come from performance testing in which up to 7,000 writes/s have been observed.
+SSD Storage should support several thousand both read and write IOPS.
+The maximum reads and writes per second that Ripple engineers have observed are over 10,000 reads per second (in heavily-used public server clusters), and over 7,000 writes per second (in dedicated performance testing).
 
 #### CPU Utilization and Virtualization
-Ripple perfmance engineering finds that bare metal servers acheive maximum throughput. However, it is likely that hypervisors would cause minimal degradation in performance.
+Ripple performance engineering finds that bare metal servers achieve maximum throughput. However, it is likely that hypervisors cause minimal degradation in performance.
 
 #### Network
 
@@ -79,18 +89,19 @@ Any enterprise or carrier-class data center should have plenty of network bandwi
 
 #### Storage
 
-Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RockDB requires around 8GB per day. However, future storage requirements are not known and extra capacity should be available to account for future growth. Currently, a server with all XRP Ledger history requires 6.8TB.
+Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RocksDB requires around 8GB per day. However, the data per day changes with activity in the network. You should provision extra capacity to prepare for future growth. Currently, a server with all XRP Ledger history requires 6.8TB.
 
 <!-- {# ***TODO: Update the dated storage consideration above, as needed. ***#} -->
-<!-- {# ***TODO: Create historic metrics that a user can use to derive what will be required. For ex, a chart with 1TB in 2014, 3TB in 2015, 7TB in 2018 ***#} -->
+<!-- {# ***TODO: DOC-1331 tracks: Create historic metrics that a user can use to derive what will be required. For ex, a chart with 1TB in 2014, 3TB in 2015, 7TB in 2018 ***#} -->
 
 #### Memory
 
-Memory requirements are mainly a function of the `node_size` configuration option and the amount of client traffic retrieving historical data. As mentioned, production servers should maximize performance and set this parameter to `huge`. A smaller memory footprint can be achieved by setting the parameter lower, but that should only be used for testing. With a `node_size` of `medium`, a `rippled` server can be reasonably stable in a test Linux system with as little as 8GB of RAM.
+Memory requirements are mainly a function of the `node_size` configuration setting and the amount of client traffic retrieving historical data. As mentioned, production servers should maximize performance and set this parameter to `huge`.
+You can set the `node_size` parameter lower to use less memory, but you should only do this for testing. With a `node_size` of `medium`, a `rippled` server can be reasonably stable in a test Linux system with as little as 8GB of RAM.
 
 #### Amazon Web Servives
 
-Amazon Web Services (AWS) is a popular virtualized hosting environment, and you can run `rippled`  in that environment. However, using EBS storage is not recommended, because the maximum number of IOPS (5,000) may not be able to keep up with the heaviest demands, yet it is very expensive.
+Amazon Web Services (AWS) is a popular virtualized hosting environment, and you can run `rippled`  in that environment. However, using Elastic Block Storage (EBS) is not recommended, because the maximum number of IOPS (5,000) may not be able to keep up with the heaviest demands, yet it is very expensive.
 
 AWS instance stores (`ephemeral` storage) do not have these constraints. Therefore, Ripple recommends deploying `rippled` servers with host types such as `M3` that have instance storage. The `database_path` and `node_db` path should each reside on instance storage.
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -1,6 +1,6 @@
 # Capacity Planning
 
-This section describe some of the challenges related to scaling `rippled` servers for testing and production deployments. Additionally, it describes how hardware and configuration settings relate to those challenges. Finally, this section offers recommendations to assist you in properly setting up `rippled` to meet the goals for the use-case of your deployment.
+This section describes some of the challenges related to scaling `rippled` servers for testing and production deployments. Additionally, it describes how hardware and configuration settings relate to those challenges. Finally, this section offers recommendations to assist you in properly setting up `rippled` to meet the goals for the use-case of your deployment.
 
 Even the most minimally functional `rippled` server must contain the most recently validated ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these requirements, consider the following possible business requirements:
 
@@ -56,7 +56,9 @@ path={path_to_ledger_store}
 
 ### Historical Data
 
-The amount of historical data that a `rippled` server keeps online is a major contributor to required storage space. Currently, about 12GB of data is stored per day. You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
+The amount of historical data that a `rippled` server keeps online is a major contributor to required storage space. Currently, a `rippled` server stores about 12GB of data per day (2018-03-01). You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
+
+Online deletion enables pruning of `rippled` ledgers from databases with no disruption of service. Without online deletion, those databases grow without bounds. Freeing disk space requires stopping the process and manually removing database files. Online deletion only removes records that are not part of the current ledgers.
 
 <!-- {# ***TODO***: Add link to online_delete section, when complete, per https://ripplelabs.atlassian.net/browse/DOC-1313  #} -->
 
@@ -68,7 +70,7 @@ The default `rippled.cfg` file sets the logging verbosity to `warning`. This set
 
 ## Network and Hardware
 
-Each `rippled` server in the XRP Ledger network performs all of the transaction processing work of the network. It is unknown how soon volumes will approach maximum network capacity. Therefore, the baseline hardware for production `rippled` servers should be similar to that used in Ripple's [performance testing](https://ripple.com/dev-blog/demonstrably-scalable-blockchain/).
+Each `rippled` server in the XRP Ledger network performs all of the transaction processing work of the network. It is unknown when volumes will approach maximum network capacity. Therefore, the baseline hardware for production `rippled` servers should be similar to that used in Ripple's [performance testing](https://ripple.com/dev-blog/demonstrably-scalable-blockchain/).
 
 ### Recommendation
 
@@ -84,18 +86,18 @@ For best performance in enterprise production environments, Ripple recommends ru
 
 #### SSD Storage
 
-SSD Storage should support several thousand of both read and write IOPS. The maximum reads and writes per second that Ripple engineers have observed are over 10,000 reads per second (in heavily-used public server clusters), and over 7,000 writes per second (in dedicated performance testing).
+SSD storage should support several thousand of both read and write IOPS. The maximum reads and writes per second that Ripple engineers have observed are over 10,000 reads per second (in heavily-used public server clusters), and over 7,000 writes per second (in dedicated performance testing).
 
 #### CPU Utilization and Virtualization
 Ripple performance engineering has determined that bare metal servers achieve maximum throughput. However, it is likely that hypervisors cause minimal degradation in performance.
 
 #### Network
 
-Any enterprise or carrier-class data center should have substantial network bandwidth to support running `rippled` servers. The minimum requirements are roughly 2Mbps transmit and 2Mbps receive for current transaction volumes. However, these can burst up to 100MBps transmissions when serving up historical ledger and transaction reports. When a `rippled` server initially starts up, it can burst to well over 20Mbps receive.
+Any enterprise or carrier-class data center should have substantial network bandwidth to support running `rippled` servers. The minimum requirements are roughly 2Mbps transmit and 2Mbps receive for current transaction volumes. However, these can burst up to 100MBps transmissions when serving historical ledger and transaction reports. When a `rippled` server initially starts up, it can burst to over 20Mbps receive.
 
 #### Storage
 
-Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RocksDB requires around 8GB per day. However, the data per day changes with activity in the network. You should provision extra capacity to prepare for future growth. Currently, a server with all XRP Ledger history requires 6.8TB.
+Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RocksDB requires around 8GB per day. However, the data per day changes with activity in the network. You should provision extra capacity to prepare for future growth. Currently, a server with all XRP Ledger history requires 6.8TB (2018-03-01).
 
 <!-- {# ***TODO: Update the dated storage consideration above, as needed. ***#} -->
 <!-- {# ***TODO: DOC-1331 tracks: Create historic metrics that a user can use to derive what will be required. For ex, a chart with 1TB in 2014, 3TB in 2015, 7TB in 2018 ***#} -->

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -2,7 +2,7 @@
 
 This section describes some of the challenges related to scaling `rippled` servers for testing and production deployments. Additionally, it describes how hardware and configuration settings relate to those challenges. Finally, this section offers recommendations to assist you in properly setting up `rippled` to meet the goals for the use-case of your deployment.
 
-Even the most minimally functional `rippled` server must contain the most recently validated ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these requirements, consider the following possible business requirements:
+Even the most minimally functional `rippled` server must contain the most recently validated ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these requirements, consider the following possible business needs:
 
 - Handling ever-increasing transaction volume
 - Servicing transaction reporting information to clients
@@ -57,7 +57,7 @@ path={path_to_ledger_store}
 
 ### Historical Data
 
-The amount of historical data that a `rippled` server keeps online is a major contributor to required storage space. Currently, a `rippled` server stores about 12GB of data per day (2018-03-01). You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
+The amount of historical data that a `rippled` server keeps online is a major contributor to required storage space. At the time of writing (2018-03-01), a `rippled` server stores about 12GB of data per day. You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
 
 Online deletion enables pruning of `rippled` ledgers from databases with no disruption of service. Without online deletion, those databases grow without bounds. Freeing disk space requires stopping the process and manually removing database files. Online deletion only removes records that are not part of the current ledgers.
 
@@ -98,7 +98,7 @@ Any enterprise or carrier-class data center should have substantial network band
 
 #### Storage
 
-Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RocksDB requires around 8GB per day. However, the data per day changes with activity in the network. You should provision extra capacity to prepare for future growth. Currently, a server with all XRP Ledger history requires 6.8TB (2018-03-01).
+Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RocksDB requires around 8GB per day. However, the data per day changes with activity in the network. You should provision extra capacity to prepare for future growth. At the time of writing (2018-03-01), a server with all XRP Ledger history requires 6.8TB.
 
 <!-- {# ***TODO: Update the dated storage consideration above, as needed. ***#} -->
 <!-- {# ***TODO: DOC-1331 tracks: Create historic metrics that a user can use to derive what will be required. For ex, a chart with 1TB in 2014, 3TB in 2015, 7TB in 2018 ***#} -->
@@ -110,7 +110,7 @@ You can set the `node_size` parameter lower to use less memory, but you should o
 
 #### Amazon Web Servives
 
-Amazon Web Services (AWS) is a popular virtualized hosting environment. You can run `rippled`  in that environment. Ripple does not recommend using Elastic Block Storage (EBS), because the maximum number of IOPS (5,000) may not be able to keep up with the heaviest demands, but it is very expensive.
+Amazon Web Services (AWS) is a popular virtualized hosting environment. You can run rippled in AWS, but Ripple does not recommend using Elastic Block Storage (EBS). Elastic Block Storage's maximum number of IOPS (5,000) is insufficient for `rippled`'s heaviest loads, despite being very expensive.
 
 AWS instance stores (`ephemeral` storage) do not have these constraints. Therefore, Ripple recommends deploying `rippled` servers with host types such as `M3` that have instance storage. The `database_path` and `node_db` path should each reside on instance storage.
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -14,20 +14,20 @@ Capacity planning for `rippled` involves two factors:
 
 ## Configuration Settings
 
-Ripple recommends the following guidelines to improve performance, based on how our performance engineers evaluate the configuration properties listed. You can set the following parameters in the `rippled.cfg` file to improve performance for your `rippled` server.
+Ripple recommends the following guidelines to improve performance. You can set the following parameters in the `rippled.cfg` file to improve performance for your `rippled` server.
 
 ### Node Size
 
-The `node_size` parameter determines the size of database caches. For production systems, Ripple recommends that you always set it to `huge`. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance better is that memory requirements increase.
+The `node_size` parameter determines the size of database caches. For production systems, Ripple recommends that for production servers, you always set it to `huge`. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance better is that memory requirements increase.
 
 ### Node DB Type
 
 The `type` field in the `node_db` section of the `rippled.cfg` file sets the type of key-value store that `rippled` uses to persist the XRP Ledger in the Ledger Store. You can set the value to either `rocksdb` or `nudb`. For setting the store that `rippled` uses to persist history shards, if you are participating in history sharding, see [History Sharding](XREF: concept-history-sharding.md#shard-store-configuration).
 
 #### RocksDB vs NuDB
-RocksDB requires approximately one-third less disk storage than NuDB and provides a corresponding improvement in I/O latency. However, this comes at a cost of increased memory utilization as storage size grows. Nudb, on the other hand, has nearly constant performance and memory footprint regardless of storage.
+RocksDB requires approximately one-third less disk storage than NuDB and provides a corresponding improvement in I/O latency. However, this comes at a cost of increased memory utilization as storage size grows. NuDB, on the other hand, has nearly constant performance and memory footprint regardless of storage.
 
-For `rippled` servers that operate as validators, which keep only a few days' worth of data or less, Ripple recommends using RocksDB. For all other uses, Ripple recommends users configure NuDB for the Ledger Store. Nudb has no performance-related configuration options. But tuning parameters are available for RocksDB that have been used to help achieve maximum tested transaction processing throughput, and are as follows:
+For `rippled` servers that operate as validators, which keep only a few days' worth of data or less, Ripple recommends using RocksDB. For all other uses, Ripple recommends users configure NuDB for the Ledger Store. NuDB has no performance-related configuration options. But tuning parameters are available for RocksDB that have been used to help achieve maximum tested transaction processing throughput, and are as follows:
 
 ```
 [node_db]
@@ -42,12 +42,13 @@ path={path_to_ledger_store}
 
 ### Historical Data
 
-The amount of historical data kept online, as set in the `online_delete` and  `advisory_delete` field, is a major contributor to required storage space. Currently, about 12GB of data is stored per day. However, you should expect this amount to grow as transaction volume increases across the XRP Ledger Network.
+The amount of historical data kept online, as set in the `online_delete` and  `advisory_delete` field, is a major contributor to required storage space. Currently, about 12GB of data is stored per day. However, you should expect this amount to grow as transaction volume increases across the XRP Ledger network.
 
 ### Log Level
 
-The default logging verbosity for `rippled` in the `log_level` field is set to `debug` and requires several GB or more per day, depending on transaction volumes and client activity. Setting this to a lower level, such as warning, greatly reduces the space and I/O write requirements. The trade-off to a lower setting is decreased visibility for trouble-shooting problems.
+The default `rippled.cfg` file configures the logging verbosity to `warning`. This setting greatly reduces disk space and I/O requirements over more verbose logging. However, more verbose logging provides increased visibility when troubleshooting.
 
+**Note:** If you omit the `log_level` command from the `[rpc_startup]` stanza, `rippled` falls back to `debug` level logging, which requires several more GB of disk space per day, depending on transaction volumes and client activity.
 
 ## Network and Hardware
 
@@ -91,5 +92,4 @@ Amazon Web Services (AWS) is a popular virtualized hosting environment, and you 
 
 AWS instance stores (`ephemeral` storage) do not have these constraints. Therefore, Ripple recommends deploying `rippled` servers with host types such as `M3` that have instance storage. The `database_path` and `node_db` path should each reside on instance storage.
 
-**Caution:** AWS instance storage is not guaranteed to provide durability in the event of hard drive failure. Further, data will be lost when the instance is stopped and restarted (but not when just rebooted).
-
+**Caution:** AWS instance storage is not guaranteed to provide durability in the event of hard drive failure. Further, data that is lost when the instance stops and restarts (but not when just rebooted). This loss can be acceptable for a `rippled` server because an individual server can usually re-acquire that data from its peer servers.

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -53,6 +53,8 @@ path={path_to_ledger_store}
 
 The amount of historical data kept online, as set in the `online_delete` and  `advisory_delete` fields, is a major contributor to required storage space. Currently, about 12GB of data is stored per day. However, you can expect this amount to grow as transaction volume increases across the XRP Ledger network.
 
+<!-- {# ***TODO***: Add link to online_delete section, when complete, per https://ripplelabs.atlassian.net/browse/DOC-1313  #} -->
+
 ### Log Level
 
 The default `rippled.cfg` file configures the logging verbosity to `warning`. This setting greatly reduces disk space and I/O requirements over more verbose logging. However, more verbose logging provides increased visibility when troubleshooting.

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -1,0 +1,95 @@
+# Capacity Planning
+
+
+Even the most minimally functional `rippled` server must contain the latest completed Ledgers to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these, consider the following server requirements:
+
+- Handling ever-increasing transaction volume
+- Servicing transaction reporting information to clients
+- Maintaining varying amounts of historical data
+
+Planning for the server resources required to run `rippled` relies on understanding the impact of two factors:
+
+- The [configuration settings](#configuration-settings) that affect resource utilization
+- The commodity [network and hardware](#network-and-hardware) requirements to achieve scalable architecture with consistent performance across the XRP Ledger Network
+
+## Configuration Settings
+
+Ripple recommends the following guidelines to improve performance, based on how our performance engineers evaluate the configuration properties listed. You can set the following parameters in the `rippled.cfg` file to improve performance for your `rippled` server.
+
+### Node Size
+
+The `node_size` parameter determines the size of database caches. For production systems, Ripple recommends that you always set it to `huge`. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance better is that memory requirements increase.
+
+### Node DB Type
+
+The `type` field in the `node_db` section of the `rippled.cfg` file sets the type of key-value store that `rippled` uses to persist the XRP Ledger in the Ledger Store. You can set the value to either `rocksdb` or `nudb`. For setting the store that `rippled` uses to persist history shards, if you are participating in history sharding, see [History Sharding](XREF: concept-history-sharding.md#shard-store-configuration).
+
+#### RocksDB vs NuDB
+RocksDB requires approximately one-third less disk storage than NuDB and provides a corresponding improvement in I/O latency. However, this comes at a cost of increased memory utilization as storage size grows. Nudb, on the other hand, has nearly constant performance and memory footprint regardless of storage.
+
+For `rippled` servers that operate as validators, which keep only a few days' worth of data or less, Ripple recommends using RocksDB. For all other uses, Ripple recommends users configure NuDB for the Ledger Store. Nudb has no performance-related configuration options. But tuning parameters are available for RocksDB that have been used to help achieve maximum tested transaction processing throughput, and are as follows:
+
+```
+[node_db]
+type=rocksdb
+open_files=512
+file_size_mb=64
+file_size_mult=2
+filter_bits=12
+cache_mb=512
+path={path_to_ledger_store}
+```
+
+### Historical Data
+
+The amount of historical data kept online, as set in the `online_delete` and  `advisory_delete` field, is a major contributor to required storage space. Currently, about 12GB of data is stored per day. However, you should expect this amount to grow as transaction volume increases across the XRP Ledger Network.
+
+### Log Level
+
+The default logging verbosity for `rippled` in the `log_level` field is set to `debug` and requires several GB or more per day, depending on transaction volumes and client activity. Setting this to a lower level, such as warning, greatly reduces the space and I/O write requirements. The trade-off to a lower setting is decreased visibility for trouble-shooting problems.
+
+
+## Network and Hardware
+
+Each `rippled` server in the XRP Ledger network performs all of the transaction processing work of the network. It is unknown how soon volumes will approach maximum network capacity. Therefore, the baseline hardware for production `rippled` servers should be similar to that used in Ripple's [performance testing](https://ripple.com/dev-blog/demonstrably-scalable-blockchain/).
+
+### Recommendation
+
+For best performance in enterprise production environments, Ripple recommends running `rippled` on bare metal, with the following characteristics:
+
+- Operating System: Ubuntu 16.04+
+- CPU: Intel Xeon 3+ GHz processor with 4 cores and hyperthreading enabled
+- Disk: SSD
+- RAM: 32 GB RAM
+- Network: Enterprise data center network with a gigabit network interface on the host
+
+#### SSD Storage
+
+SSD Storage should support several thousand both read and write IOPS. Maximum read IOPS come from heavily used servers such as those behind https://s1.ripple.com and https://s2.ripple.com, which service transaction and ledger history retrieval requests. This is sometimes over 10,000 reads per second! Maximum write IOPS have come from performance testing in which up to 7,000 writes/s have been observed.
+
+#### CPU Utilization and Virtualization
+Ripple perfmance engineering finds that bare metal servers acheive maximum throughput. However, it is likely that hypervisors would cause minimal degradation in performance.
+
+#### Network
+
+Any enterprise or carrier-class data center should have plenty of network bandwidth to support running `rippled` servers. The minimum requirements are roughly 2Mbps transmit and 2Mbps receive for current transaction volumes. However, these can burst up to 100MBps transmissions when serving up historical ledger and transaction reports. When a `rippled` server initially starts up, it can burst to well over 20Mbps receive.
+
+#### Storage
+
+Ripple recommends estimating storage sizing at roughly 12GB per day of data kept online with NuDB. RockDB requires around 8GB per day. However, future storage requirements are not known and extra capacity should be available to account for future growth. Currently, a server with all XRP Ledger history requires 6.8TB.
+
+<!-- {# ***TODO: Update the dated storage consideration above, as needed. ***#} -->
+<!-- {# ***TODO: Create historic metrics that a user can use to derive what will be required. For ex, a chart with 1TB in 2014, 3TB in 2015, 7TB in 2018 ***#} -->
+
+#### Memory
+
+Memory requirements are mainly a function of the `node_size` configuration option and the amount of client traffic retrieving historical data. As mentioned, production servers should maximize performance and set this parameter to `huge`. A smaller memory footprint can be achieved by setting the parameter lower, but that should only be used for testing. With a `node_size` of `medium`, a `rippled` server can be reasonably stable in a test Linux system with as little as 8GB of RAM.
+
+#### Amazon Web Servives
+
+Amazon Web Services (AWS) is a popular virtualized hosting environment, and you can run `rippled`  in that environment. However, using EBS storage is not recommended, because the maximum number of IOPS (5,000) may not be able to keep up with the heaviest demands, yet it is very expensive.
+
+AWS instance stores (`ephemeral` storage) do not have these constraints. Therefore, Ripple recommends deploying `rippled` servers with host types such as `M3` that have instance storage. The `database_path` and `node_db` path should each reside on instance storage.
+
+**Caution:** AWS instance storage is not guaranteed to provide durability in the event of hard drive failure. Further, data will be lost when the instance is stopped and restarted (but not when just rebooted).
+

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -1,6 +1,6 @@
 # Capacity Planning
 
-This section describes some of the challenges related to scaling `rippled` servers for testing and production deployments. Additionally, it describes how hardware and configuration settings relate to those challenges. Finally, this section offers recommendations to assist you in properly setting up `rippled` to meet the goals for the use-case of your deployment.
+This section describes some of the challenges related to scaling `rippled` servers for testing and production deployments. Additionally, it describes how hardware and configuration settings relate to those challenges. Finally, this section offers recommendations to assist you in properly setting up `rippled` to meet the goals for the use case of your deployment.
 
 Even the most minimally functional `rippled` server must contain the most recently validated ledger versions to submit transactions to the network and verify the integrity of the XRP Ledger. Beyond these requirements, consider the following possible business needs:
 
@@ -42,7 +42,7 @@ RocksDB requires approximately one-third less disk storage than NuDB and provide
 
 `rippled` servers that operate as validators should keep only a few days' worth of data or less. Ripple recommends using RocksDB for validators. For all other uses, Ripple recommends using NuDB for the ledger store.
 
-RocksDB has performance-related configuration options you can modify to achieve maximum transaction processing throughput. (NuDB does not have performance-related configuration options.) Here is an example of the recommended configuration for a rippled server using RockDB:
+RocksDB has performance-related configuration options you can modify to achieve maximum transaction processing throughput. (NuDB does not have performance-related configuration options.) Here is an example of the recommended configuration for a `rippled` server using RocksDB:
 
 ```
 [node_db]
@@ -59,13 +59,13 @@ path={path_to_ledger_store}
 
 The amount of historical data that a `rippled` server keeps online is a major contributor to required storage space. At the time of writing (2018-03-01), a `rippled` server stores about 12GB of data per day. You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
 
-Online deletion enables pruning of `rippled` ledgers from databases with no disruption of service. Without online deletion, those databases grow without bounds. Freeing disk space requires stopping the process and manually removing database files. Online deletion only removes records that are not part of the current ledgers.
+Online deletion enables pruning of `rippled` ledgers from databases without any disruption of service. It only removes records that are not part of the current ledgers. Without online deletion, those databases grow without bounds. Freeing disk space requires stopping the process and manually removing database files.
 
 <!-- {# ***TODO***: Add link to online_delete section, when complete, per https://ripplelabs.atlassian.net/browse/DOC-1313  #} -->
 
 ### Log Level
 
-The default `rippled.cfg` file sets the logging verbosity to `warning`. This setting greatly reduces disk space and I/O requirements over more verbose logging. However, more verbose logging provides increased visibility when troubleshooting.
+The default `rippled.cfg` file sets the logging verbosity to `warning`. This setting greatly reduces disk space and I/O requirements over more verbose logging. However, more verbose logging provides increased visibility for troubleshooting.
 
 **Note:** If you omit the `log_level` command from the `[rpc_startup]` stanza, `rippled` falls back to `debug` level logging, which requires several more GB of disk space per day, depending on transaction volumes and client activity.
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -18,7 +18,7 @@ Ripple recommends the following guidelines to improve performance. You can set t
 
 ### Node Size
 
-The `node_size` parameter determines the size of database caches. For production systems, Ripple recommends that for production servers, you always set it to `huge`. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance better is that memory requirements increase.
+The `node_size` parameter determines the size of database caches. Ripple recommends you always set it to `huge` for production servers. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance better is that memory requirements increase.
 
 ### Node DB Type
 
@@ -61,7 +61,9 @@ For best performance in enterprise production environments, Ripple recommends ru
 - Operating System: Ubuntu 16.04+
 - CPU: Intel Xeon 3+ GHz processor with 4 cores and hyperthreading enabled
 - Disk: SSD
-- RAM: 32 GB RAM
+- RAM:
+	- For testing: 8GB+
+	- For production: 32GB
 - Network: Enterprise data center network with a gigabit network interface on the host
 
 #### SSD Storage

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -11,7 +11,7 @@ Even the most minimally functional `rippled` server must contain the most recent
 How you meet your `rippled` capacity planning needs depends on how you address these technical factors:
 
 - The [configuration settings](#configuration-settings) that affect resource utilization
-- The [network and hardware] (#network and hardware) requirements to achieve consistent, good performance across the XRP Ledger network
+- The [network and hardware](#network-and-hardware) requirements to achieve consistent, good performance across the XRP Ledger network
 
 ## Configuration Settings
 
@@ -19,16 +19,16 @@ Ripple recommends the following guidelines to improve performance. You can set t
 
 ### Node Size
 
-The `node_size` parameter determines the size of database caches. Ripple recommends you always set it to `huge` for production servers. Increased cache size requires less disk I/O and allows `rippled` to improve performance. The trade-off to improving performance is that memory requirements increase.
-
 The `node_size` parameter determines the size of database caches. Larger database caches decrease disk I/O requirements at a cost of higher memory requirements. Ripple recommends you always use the largest database cache your available memory can support. See the following table for recommended settings.
 
-| Available RAM for `rippled` | Recommended `node_size` value | Notes                              |
-|:----------------------------|:------------------------------|:-----------------------------------|
-| < 8 GB                      | `tiny`                        | Not recommended                    |
-| 8 GB                        | `low`                         |                                    |
-| 16 GB                       | `medium`                      |                                    |
-| 32 GB                       | `huge`                        | Recommended for production servers |
+#### Recommendation
+
+| Available RAM for `rippled` | `node_size` value | Notes                              |
+|:----------------------------|:------------------|:-----------------------------------|
+| < 8GB                       | `tiny`            | Not recommended                    |
+| 8GB                         | `low`             |                                    |
+| 16GB                        | `medium`          |                                    |
+| 32GB                        | `huge`            | Recommended for production servers |
 
 ### Node DB Type
 
@@ -56,7 +56,7 @@ path={path_to_ledger_store}
 
 ### Historical Data
 
-The amount of historical data kept online is a major contributor to required storage space. Currently, about 12GB of data is stored per day. You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
+The amount of historical data that a `rippled` server keeps online is a major contributor to required storage space. Currently, about 12GB of data is stored per day. You can expect this amount to grow as transaction volume increases across the XRP Ledger network. You can control how much data you keep with the `online_delete` and `advisory_delete` fields.
 
 <!-- {# ***TODO***: Add link to online_delete section, when complete, per https://ripplelabs.atlassian.net/browse/DOC-1313  #} -->
 
@@ -84,15 +84,14 @@ For best performance in enterprise production environments, Ripple recommends ru
 
 #### SSD Storage
 
-SSD Storage should support several thousand both read and write IOPS.
-The maximum reads and writes per second that Ripple engineers have observed are over 10,000 reads per second (in heavily-used public server clusters), and over 7,000 writes per second (in dedicated performance testing).
+SSD Storage should support several thousand of both read and write IOPS. The maximum reads and writes per second that Ripple engineers have observed are over 10,000 reads per second (in heavily-used public server clusters), and over 7,000 writes per second (in dedicated performance testing).
 
 #### CPU Utilization and Virtualization
-Ripple performance engineering finds that bare metal servers achieve maximum throughput. However, it is likely that hypervisors cause minimal degradation in performance.
+Ripple performance engineering has determined that bare metal servers achieve maximum throughput. However, it is likely that hypervisors cause minimal degradation in performance.
 
 #### Network
 
-Any enterprise or carrier-class data center should have plenty of network bandwidth to support running `rippled` servers. The minimum requirements are roughly 2Mbps transmit and 2Mbps receive for current transaction volumes. However, these can burst up to 100MBps transmissions when serving up historical ledger and transaction reports. When a `rippled` server initially starts up, it can burst to well over 20Mbps receive.
+Any enterprise or carrier-class data center should have substantial network bandwidth to support running `rippled` servers. The minimum requirements are roughly 2Mbps transmit and 2Mbps receive for current transaction volumes. However, these can burst up to 100MBps transmissions when serving up historical ledger and transaction reports. When a `rippled` server initially starts up, it can burst to well over 20Mbps receive.
 
 #### Storage
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -8,7 +8,7 @@ Even the most minimally functional `rippled` server must contain the most recent
 - Servicing transaction reporting information to clients
 - Maintaining varying amounts of historical data
 
-How you meet your `rippled` capacity planning needs depends on how you address these technical factors:
+To meet your `rippled` capacity requirements, you must address these technical factors:
 
 - The [configuration settings](#configuration-settings) that affect resource utilization
 - The [network and hardware](#network-and-hardware) requirements to achieve consistent, good performance across the XRP Ledger network
@@ -32,16 +32,17 @@ The `node_size` parameter determines the size of database caches. Larger databas
 
 ### Node DB Type
 
-The `type` field in the `node_db` section of the `rippled.cfg` file sets the type of key-value store that `rippled` uses to persist the XRP Ledger in the Ledger Store. You can set the value to either `rocksdb` or `nudb`.
+The `type` field in the `node_db` section of the `rippled.cfg` file sets the type of key-value store that `rippled` uses to persist the XRP Ledger in the ledger store. You can set the value to either `rocksdb` or `nudb`.
 
-`rippled` offers a history sharding feature that allows you to store a randomized range of ledgers in a separate shard store. For more information about how to use this feature, see [History Sharding](XREF: concept-history-sharding.md#shard-store-configuration).
+`rippled` offers a history sharding feature that allows you to store a randomized range of ledgers in a separate shard store. You may want to configure the shard store to use a different type of key-value store than the ledger store. For more information about how to use this feature, see [History Sharding](XREF: concept-history-sharding.md#shard-store-configuration).
+
 
 #### RocksDB vs NuDB
 RocksDB requires approximately one-third less disk storage than NuDB and provides a corresponding improvement in I/O latency. However, this comes at a cost of increased memory utilization as storage size grows. NuDB, on the other hand, has nearly constant performance and memory footprint regardless of [storage](#storage).
 
-`rippled` servers that operate as validators keep only a few days' worth of data or less. Ripple recommends using RocksDB for validators. For all other uses, Ripple recommends using NuDB for the Ledger Store.
+`rippled` servers that operate as validators should keep only a few days' worth of data or less. Ripple recommends using RocksDB for validators. For all other uses, Ripple recommends using NuDB for the ledger store.
 
-NuDB has no performance-related configuration options. RocksDB has performance-related configuration options. You can use these to achieve the maximum tested transaction processing throughput. Here is an example of the recommended configuration:
+RocksDB has performance-related configuration options you can modify to achieve maximum transaction processing throughput. (NuDB does not have performance-related configuration options.) Here is an example of the recommended configuration for a rippled server using RockDB:
 
 ```
 [node_db]

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -34,7 +34,7 @@ The `node_size` parameter determines the size of database caches. Larger databas
 
 The `type` field in the `node_db` section of the `rippled.cfg` file sets the type of key-value store that `rippled` uses to persist the XRP Ledger in the ledger store. You can set the value to either `rocksdb` or `nudb`.
 
-`rippled` offers a history sharding feature that allows you to store a randomized range of ledgers in a separate shard store. You may want to configure the shard store to use a different type of key-value store than the ledger store. For more information about how to use this feature, see [History Sharding](XREF: concept-history-sharding.md#shard-store-configuration).
+`rippled` offers a history sharding feature that allows you to store a randomized range of ledgers in a separate shard store. You may want to configure the shard store to use a different type of key-value store than the ledger store. For more information about how to use this feature, see [History Sharding](https://ripple.com/build/history-sharding/#shard-store-configuration).
 
 
 #### RocksDB vs NuDB

--- a/content/tutorial-build-run-rippled-ubuntu.md
+++ b/content/tutorial-build-run-rippled-ubuntu.md
@@ -17,7 +17,7 @@ You need a **minimum** of 8GB of RAM.
 
 **_To run `rippled`:_**
 
-Meet these [system requirements](tutorial-rippled-setup.html#system-requirements).
+Meet these [system requirements](tutorial-rippled-setup.html#minimum-system-requirements).
 
 
 ## 1. Build `rippled`

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -272,7 +272,7 @@ Network participants are unlikely to trust validators without knowing who is ope
 
 `rippled` should connect to the XRP Ledger with the default configuration. However, you can change your settings by editing the `rippled.cfg` file (located at `/opt/ripple/etc/rippled.cfg` when installing `rippled` with yum). For recommendations about configuration settings, see [Capacity Planning](#capacity-planning).
 
-See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/develop/doc/rippled-example.cfg) for a description of all configuration options.
+See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/develop/cfg/rippled-example.cfg) for a description of all configuration options.
 
 Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path:
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -4,6 +4,7 @@ The core server of the XRP Ledger peer-to-peer network is [`rippled`](reference-
 
 This page contains instructions for:
 
+* [Capacity Planning for `rippled`](#capacity-planning)
 * [Installing `rippled`](#installing-rippled)
 * [Participating in the Consensus Process](#running-a-validator)
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -75,7 +75,9 @@ A `rippled` server should run comfortably on commodity hardware, to make it inex
     - Development: Mac OS X, Windows (64-bit), or most Linux distributions
 - CPU: 64-bit x86_64, 2+ cores
 - Disk: Minimum 50GB SSD recommended (500+ IOPS, more is better) for the database partition
-- RAM: 8GB
+- RAM:
+    - Testing: 8GB+
+    - Production: 32 GB
 
 Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load increases resources needs.
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -75,7 +75,7 @@ A `rippled` server should run comfortably on commodity hardware, to make it inex
     - Development: Mac OS X, Windows (64-bit), or most Linux distributions
 - CPU: 64-bit x86_64, 2+ cores
 - Disk: Minimum 50GB SSD recommended (500+ IOPS, more is better) for the database partition
-- RAM: 4+GB
+- RAM: 8GB
 
 Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load increases resources needs.
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -71,16 +71,15 @@ Production `rippled` instances can [use Ripple's binary executable](#installatio
 A `rippled` server should run comfortably on commodity hardware, to make it inexpensive to participate in the network. At present, we recommend the following mimimum requirements:
 
 - Operating System:
-    - Production: CentOS or RedHat Enterprise Linux (latest release) or Ubuntu (15.04+) supported
+    - Production: CentOS or RedHat Enterprise Linux (latest release) or Ubuntu (16.04+) supported
     - Development: Mac OS X, Windows (64-bit), or most Linux distributions
 - CPU: 64-bit x86_64, 2+ cores
 - Disk: Minimum 50GB SSD recommended (500+ IOPS, more is better) for the database partition
 - RAM: 4+GB
 
-Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load will increase resources needs.
+Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load increases resources needs.
 
-**Tip:** For recommendation beyond the minimum requirements, see [Capacity Planning](#capacity-planning).
-
+**Tip:** For recommendations beyond the minimum requirements, see [Capacity Planning](#capacity-planning).
 
 ## Installation on CentOS/Red Hat with yum
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -57,6 +57,7 @@ There are several properties that define a good validator. The more of these pro
 
 At present, Ripple (the company) cannot recommend any validators aside from those in the default validator list. However, we are collecting data on other validators and building tools to report on their performance. For metrics on validators, see [validators.ripple.com](https://validators.ripple.com).
 
+{% include 'snippets/capacity-planning.md' %}
 
 # Installing rippled
 
@@ -64,9 +65,9 @@ For development, you can [compile `rippled` from source](https://wiki.ripple.com
 
 Production `rippled` instances can [use Ripple's binary executable](#installation-on-centosred-hat-with-yum), available from the Ripple [yum](https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified) repository.
 
-## System Requirements
+## Minimum System Requirements
 
-A `rippled` server should run comfortably on commodity hardware, to make it inexpensive to participate in the network. At present, we recommend the following:
+A `rippled` server should run comfortably on commodity hardware, to make it inexpensive to participate in the network. At present, we recommend the following mimimum requirements:
 
 - Operating System:
     - Production: CentOS or RedHat Enterprise Linux (latest release) or Ubuntu (15.04+) supported
@@ -75,9 +76,9 @@ A `rippled` server should run comfortably on commodity hardware, to make it inex
 - Disk: Minimum 50GB SSD recommended (500+ IOPS, more is better) for the database partition
 - RAM: 4+GB
 
-Amazon EC2's m3.large VM size may be appropriate depending on your workload. (Validating servers need more resources.)
+Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load will increase resources needs.
 
-Naturally, a fast network connection is preferable.
+**Tip:** For recommendation beyond the minimum requirements, see [Capacity Planning](#capacity-planning).
 
 
 ## Installation on CentOS/Red Hat with yum
@@ -267,7 +268,7 @@ Network participants are unlikely to trust validators without knowing who is ope
 
 # Additional Configuration
 
-`rippled` should connect to the XRP Ledger with the default configuration. However, you can change your settings by editing the `rippled.cfg` file (located at `/opt/ripple/etc/rippled.cfg` when installing `rippled` with yum).
+`rippled` should connect to the XRP Ledger with the default configuration. However, you can change your settings by editing the `rippled.cfg` file (located at `/opt/ripple/etc/rippled.cfg` when installing `rippled` with yum). For recommendations about configuration settings, see [Capacity Planning](#capacity-planning).
 
 See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/develop/doc/rippled-example.cfg) for a description of all configuration options.
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -272,7 +272,7 @@ Network participants are unlikely to trust validators without knowing who is ope
 
 `rippled` should connect to the XRP Ledger with the default configuration. However, you can change your settings by editing the `rippled.cfg` file (located at `/opt/ripple/etc/rippled.cfg` when installing `rippled` with yum). For recommendations about configuration settings, see [Capacity Planning](#capacity-planning).
 
-See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/develop/cfg/rippled-example.cfg) for a description of all configuration options.
+See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/release/doc/rippled-example.cfg) for a description of all configuration options.
 
 Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path:
 


### PR DESCRIPTION
This PR adds Mark Travis' [Capacity Planning](https://ripplelabs.atlassian.net/wiki/spaces/~mtravis/pages/205914715/rippled+Capacity+Planning+for+3rd+Parties) documentation to the Dev Portal, which fills the gap left from documenting only the minimum requirements.

As a snippet, this addition will be maintainable for any IA changes during migration to the new Dev Portal.

The PR also changes some other items:
- Changes the *System Requirements* heading to *Minimum System Requirements* and adds a link to the new recommendation. 
- Adds a caveat about sizing for Validators
- Adds links to the new section in the *Additional Configuration* section

For context: https://ripplelabs.atlassian.net/browse/DOC-1262