### PR TITLE
account_objects - consistent description for `validated`

### DIFF
--- a/content/rippled-api-methods/account_objects.md
+++ b/content/rippled-api-methods/account_objects.md
@@ -608,7 +608,7 @@ The response follows the [standard format](#response-formatting), with a success
 | `ledger_current_index` | Number                                     | (May be omitted) The sequence number of the current in-progress ledger version that was used to generate this response. |
 | `limit`                | Number                                     | (May be omitted) The limit that was used in this request, if any. |
 | `marker`               | [(Not Specified)](#markers-and-pagination) | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. |
-| `validated`            | Boolean                                    | If `true`, this information comes from ledger version that has been validated by consensus. |
+| `validated`            | Boolean                                    | If included and set to `true`, the information in this request comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 #### Possible Errors
 

--- a/content/rippled-api-methods/account_objects.md
+++ b/content/rippled-api-methods/account_objects.md
@@ -608,7 +608,7 @@ The response follows the [standard format](#response-formatting), with a success
 | `ledger_current_index` | Number                                     | (May be omitted) The sequence number of the current in-progress ledger version that was used to generate this response. |
 | `limit`                | Number                                     | (May be omitted) The limit that was used in this request, if any. |
 | `marker`               | [(Not Specified)](#markers-and-pagination) | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. |
-| `validated`            | Boolean                                    | If included and set to `true`, the information in this request comes from a validated ledger version. Otherwise, the information is subject to change. |
+| `validated`            | Boolean                                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 #### Possible Errors
 

--- a/content/rippled-api-methods/account_tx.md
+++ b/content/rippled-api-methods/account_tx.md
@@ -568,7 +568,7 @@ The response follows the [standard format](#response-formatting), with a success
 | `limit`            | Integer                                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [(Not Specified)](#markers-and-pagination) | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
 | `transactions`     | Array                                      | Array of transactions matching the request's criteria, as explained below. |
-| `validated`        | Boolean                                    | If included and set to `true`, the information in this request comes from a validated ledger version. Otherwise, the information is subject to change. |
+| `validated`        | Boolean                                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 **Note:** The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.
 
@@ -581,7 +581,7 @@ Each transaction object includes the following fields, depending on whether it w
 | `tx`           | Object                           | (JSON mode only) JSON object defining the transaction |
 | `tx_blob`      | String                           | (Binary mode only) Unique hashed String representing the transaction. |
 | `validated`    | Boolean                          | Whether or not the transaction is included in a validated ledger. Any transaction not yet in a validated ledger is subject to change. |
-
+ 
 #### Possible Errors
 
 * Any of the [universal error types](#universal-errors).


### PR DESCRIPTION
The sentence seemed to be missing the word `a` so I just replaced it with the exact same description we use for `account_tx`'s `validated` response field.

https://ripple.com/build/rippled-apis/#account-tx