### PR TITLE
Edits capacity planning doc from rippled team feedback

### DIFF
--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -67,7 +67,7 @@ Online deletion enables pruning of `rippled` ledgers from databases without any 
 
 The default `rippled.cfg` file sets the logging verbosity to `warning`. This setting greatly reduces disk space and I/O requirements over more verbose logging. However, more verbose logging provides increased visibility for troubleshooting.
 
-**Note:** If you omit the `log_level` command from the `[rpc_startup]` stanza, `rippled` falls back to `warning` level logging, which requires several more GB of disk space per day, depending on transaction volumes and client activity.
+**Caution:** If you omit the `log_level` command from the `[rpc_startup]` stanza, `rippled` writes logs to disk at the `debug` level and outputs `warning` level  logs to the console. `debug` level logging requires several more GB of disk space per day than `warning` level, depending on transaction volumes and client activity.
 
 ## Network and Hardware
 

--- a/content/snippets/capacity-planning.md
+++ b/content/snippets/capacity-planning.md
@@ -67,7 +67,7 @@ Online deletion enables pruning of `rippled` ledgers from databases without any 
 
 The default `rippled.cfg` file sets the logging verbosity to `warning`. This setting greatly reduces disk space and I/O requirements over more verbose logging. However, more verbose logging provides increased visibility for troubleshooting.
 
-**Note:** If you omit the `log_level` command from the `[rpc_startup]` stanza, `rippled` falls back to `debug` level logging, which requires several more GB of disk space per day, depending on transaction volumes and client activity.
+**Note:** If you omit the `log_level` command from the `[rpc_startup]` stanza, `rippled` falls back to `warning` level logging, which requires several more GB of disk space per day, depending on transaction volumes and client activity.
 
 ## Network and Hardware
 

--- a/content/tutorial-rippled-setup.md
+++ b/content/tutorial-rippled-setup.md
@@ -74,7 +74,7 @@ A `rippled` server should run comfortably on commodity hardware, to make it inex
     - Production: CentOS or RedHat Enterprise Linux (latest release) or Ubuntu (16.04+) supported
     - Development: Mac OS X, Windows (64-bit), or most Linux distributions
 - CPU: 64-bit x86_64, 2+ cores
-- Disk: Minimum 50GB SSD recommended (500+ IOPS, more is better) for the database partition
+- Disk: Minimum 50GB SSD recommended (1000 IOPS, more is better) for the database partition
 - RAM:
     - Testing: 8GB+
     - Production: 32 GB


### PR DESCRIPTION
After publishing the Capacity Planning section of the `rippled` setup page, some of the `rippled` team spotted a couple of areas that could be improved:

* 500+ IOPS `=>` 1000 IOPS 
* an unset `log_level` defaults to `warning`, not `debug`, as we had documented