### PR TITLE
Update channel API methods with 0.90.0 fixes

### DIFF
--- a/content/rippled-api-methods/account_channels.md
+++ b/content/rippled-api-methods/account_channels.md
@@ -83,7 +83,10 @@ An example of a successful response:
         "public_key_hex": "023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6",
         "settle_delay": 86400
       }
-    ]
+    ],
+    "ledger_hash": "F168208EECDAA57DDAC32780CDD8330FA3E89F0E84D27A9052AA2F88681EBD08",
+    "ledger_index": 37230642,
+    "validated": true
   }
 }
 ```
@@ -107,7 +110,10 @@ An example of a successful response:
             "public_key_hex": "023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6",
             "settle_delay": 86400
         }],
-        "status": "success"
+        "ledger_hash": "B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D",
+        "ledger_index": 37230600,
+        "status": "success",
+        "validated": true
     }
 }
 ```
@@ -131,7 +137,10 @@ An example of a successful response:
             "public_key_hex": "023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6",
             "settle_delay": 86400
         }],
-        "status": "success"
+        "ledger_hash": "B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D",
+        "ledger_index": 37230600,
+        "status": "success",
+        "validated": true
     }
 }
 ```
@@ -144,6 +153,9 @@ The response follows the [standard format](#response-formatting), with a success
 |:-----------|:-------------------------------------------|:-------------------|
 | `account`  | String                                     | The address of the source/owner of the payment channels. This corresponds to the `account` field of the request. |
 | `channels` | Array of Channel Objects                   | Payment channels owned by this `account`. |
+| `ledger_hash` | String                                  | The identifying [Hash][] of the ledger version used to generate this response. [New in: rippled 0.90.0][] |
+| `ledger_index` | Number                                 | The [Ledger Index][] of the ledger version used to generate this response. [New in: rippled 0.90.0][] |
+| `validated` | Boolean                                   | _(May be omitted)_ If `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. [New in: rippled 0.90.0][] |
 | `limit`    | Number                                     | _(May be omitted)_ The limit to how many channel objects were actually returned by this request. |
 | `marker`   | [(Not Specified)](#markers-and-pagination) | _(May be omitted)_ Server-defined value for pagination. Pass this to the next call to resume getting results where this call left off. Omitted when there are no additional pages after this one. |
 

--- a/content/rippled-api-methods/channel_authorize.md
+++ b/content/rippled-api-methods/channel_authorize.md
@@ -55,7 +55,7 @@ The request includes the following parameters:
 | `secret` | String | The secret key to use to sign the claim. This must be the same key pair as the public key specified in the channel. |
 | `amount` | String | Cumulative amount of XRP, in drops, to authorize. If the destination has already received a lesser amount of XRP from this channel, the signature created by this method can be redeemed for the difference. |
 
-**Note:** You cannot use Ed25519 keys to sign claims with this method. This is a known bug.
+**Note:** You cannot use Ed25519 keys to sign claims with this method. This is a known bug (RIPD-1474).
 
 #### Response Format
 

--- a/content/rippled-api-methods/channel_verify.md
+++ b/content/rippled-api-methods/channel_verify.md
@@ -55,7 +55,7 @@ The request includes the following parameters:
 |-------|------|-------------|
 | `amount` | String | The amount of [XRP, in drops][], the provided `signature` authorizes. |
 | `channel_id` | String | The Channel ID of the channel that provides the XRP. This is a 64-character hexadecimal string. |
-| `public_key` | String | The public key of the channel and the key pair that was used to create the signature, in base58 format. (One way to get the public key in base58 format is to use the [`wallet_propose` command](#wallet-propose).) |
+| `public_key` | String | The public key of the channel and the key pair that was used to create the signature, in hexadecimal or base58 format. [Updated in: rippled 0.90.0][New in: rippled 0.90.0] |
 | `signature` | String | The signature to verify, in hexadecimal. |
 
 #### Response Format
@@ -115,6 +115,6 @@ The response follows the [standard format](#response-formatting), with a success
 
 * Any of the [universal error types](#universal-errors).
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
-* `publicMalformed` - The `public_key` field of the request is not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58. The base58 representation of account public keys starts with the letter `a`.
+* `publicMalformed` - The `public_key` field of the request is not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58 or hexadecimal. The base58 representation of account public keys starts with the letter `a`. The hexadecimal representation is 66 characters long.
 * `channelMalformed` - The `channel_id` field of the request is not a valid Channel ID. The Channel ID must be a 256-bit (64-character) hexadecimal string.
 * `channelAmtMalformed` - The value specified in the `amount` field was not a valid [XRP amount](#specifying-currency-amounts).


### PR DESCRIPTION
account_channels validated and ledger_* fields (RIPD-1466)
channel_verify public_key in hex format (RIPD-1467)

(Both addressed by https://github.com/ripple/rippled/pull/2192 )

Resolves DOC-1277