### PR TITLE
"Can't Freeze XRP" callout

### DIFF
--- a/content/concept-freeze.md
+++ b/content/concept-freeze.md
@@ -1,6 +1,6 @@
 # Freezing Issued Currencies
 
-The XRP Ledger gives addresses the ability to freeze non-XRP balances, which can be useful to meet regulatory requirements, or while investigating suspicious activity. There are three settings related to freezes:
+The XRP Ledger gives issuers the ability to freeze non-XRP balances they have issued. This feature can be useful to meet regulatory requirements, or while investigating suspicious activity. There are three settings related to freezes:
 
 * [**Individual Freeze**](#individual-freeze) - Freeze one counterparty.
 * [**Global Freeze**](#global-freeze) - Freeze all counterparties.

--- a/content/concept-freeze.md
+++ b/content/concept-freeze.md
@@ -6,7 +6,9 @@ The XRP Ledger gives addresses the ability to freeze non-XRP balances, which can
 * [**Global Freeze**](#global-freeze) - Freeze all counterparties.
 * [**No Freeze**](#no-freeze) - Permanently give up the ability to freeze individual counterparties, as well as the ability to end a global freeze.
 
-Because no party has a privileged place in the XRP Ledger, the freeze feature cannot prevent a counterparty from conducting transactions in XRP or funds issued by other counterparties. No one can freeze XRP.
+Because no party has a privileged place in the XRP Ledger, the freeze feature cannot prevent a counterparty from conducting transactions in XRP or funds issued by other counterparties.
+
+**Tip:** The freeze feature only applies to issued currencies. No one can freeze XRP.
 
 All freeze settings can be enacted regardless of whether the balance(s) to be frozen are positive or negative. Either the currency issuer or the currency holder can freeze a trust line; however, the effect of a currency holder freezing an issuer is minimal.
 


### PR DESCRIPTION
This simple change attempts to combat FUD by highlighting the part of the article that says you can't freeze XRP.

Resolves DOC-1255