### PR TITLE
fix issued currencies landing

### DIFF
--- a/content/concepts/issued-currencies/issued-currencies-overview.md
+++ b/content/concepts/issued-currencies/issued-currencies-overview.md
@@ -1,4 +1,4 @@
-# Issued Currencies
+# Issued Currencies Overview
 
 All currencies other than XRP can be represented in the XRP Ledger as **issued currencies**. These digital assets (sometimes called "issuances" or "IOUs") are tracked in accounting relationships, called "trust lines," between addresses. Issued currencies are typically considered as liabilities from one perspective and assets from the other, so the balance of a trust line is negative or positive depending on which side you view it from. Any address may freely issue (non-XRP) currencies, limited only by how much other addresses are willing to hold.
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -276,13 +276,22 @@ pages:
         targets:
             - local
 
-    -   md: concepts/issued-currencies/issued-currencies.md
+    -   name: Issued Currencies
         html: issued-currencies.html
         funnel: Docs
         doc_type: Concepts
         category: Issued Currencies
         template: template-landing-children.html
         blurb: All currencies other than XRP can be represented in the XRP Ledger as issued currencies. Learn more about how issued currencies function in the XRP Ledger.
+        targets:
+            - local
+
+    -   md: concepts/issued-currencies/issued-currencies-overview.md
+        html: issued-currencies-overview.html
+        funnel: Docs
+        doc_type: Concepts
+        category: Issued Currencies
+        blurb: Get an overview of issued currencies and their properties in the XRP Ledger.
         targets:
             - local
 
@@ -300,6 +309,7 @@ pages:
         funnel: Docs
         doc_type: Concepts
         category: Issued Currencies
+        blurb: Learn about authorized trust lines, which enable a currency issuer to limit who can hold its issued (non-XRP) currencies.
         targets:
             - local
 


### PR DESCRIPTION
- Moved content on issued-currencies.md to child page: issued-currencies-overview.md
- Removed issued-currencies.md file to be able to autogen landing page content from dactyl_config blurbs
- Check is failing due to broken link: https://github.com/ripple/rippled/blob/master/doc/rippled-example.cfg. Is this a new issue?