### PR TITLE
Fix Use Simple XRP Payments landing page

### DIFF
--- a/content/tutorials/use-simple-xrp-payments/use-simple-xrp-payments.md
+++ b/content/tutorials/use-simple-xrp-payments/use-simple-xrp-payments.md
@@ -1,3 +1,0 @@
-# Use Simple XRP Payments
-
-Direct XRP payments from one account to another are the simplest way to transact in the XRP Ledger. This section includes tutorials for how to use simple transactions proficiently and robustly.

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -543,13 +543,13 @@ pages:
 
     # TODO: Get Started with API Tools
 
-    -   md: tutorials/use-simple-xrp-payments/use-simple-xrp-payments.md
+    -   name: Use Simple XRP Payments
         html: use-simple-xrp-payments.html
         funnel: Docs
         doc_type: Tutorials
         category: Use Simple XRP Payments
         template: template-landing-children.html
-        blurb: Send and receive XRP Ledger transactions securely and robustly.
+        blurb: Direct XRP payments from one account to another are the simplest way to transact in the XRP Ledger. This section includes tutorials for how to use simple transactions proficiently and robustly.
         targets:
             - local
 


### PR DESCRIPTION
- Delete use-simple-xrp-payments.md
- Update blurb for Use Simple XRP Payments in dactyl_config
- Check is failing due to broken link: https://github.com/ripple/rippled/blob/master/doc/rippled-example.cfg. Is this a new issue?