### PR TITLE
Update rippled.cfg links for 1.0 release

### DIFF
--- a/content/concepts/the-rippled-server/history-sharding.md
+++ b/content/concepts/the-rippled-server/history-sharding.md
@@ -40,7 +40,7 @@ max_size_gb=50
 
 **Tip:** While both validator and tracking (or stock) `rippled` servers can be configured to use history shard stores, Ripple recommends adding history sharding only for non-validator `rippled` servers to reduce overhead for validators. If you run a validator and want to manage ledger history using sharding, run a separate `rippled` server with sharding enabled.
 
-For more information, reference the `[shard_db]` example in the [rippled.cfg configuration example](https://github.com/ripple/rippled/blob/master/doc/rippled-example.cfg).
+For more information, reference the `[shard_db]` example in the [rippled.cfg configuration example](https://github.com/ripple/rippled/blob/master/cfg/rippled-example.cfg).
 
 ### Sizing the Shard Store
 Determining a suitable size for the shard store involves careful consideration. You should consider the following when deciding what size your shard store should be:

--- a/content/concepts/the-rippled-server/peer-protocol.md
+++ b/content/concepts/the-rippled-server/peer-protocol.md
@@ -6,7 +6,7 @@ Servers in the XRP Ledger communicate to each other using the XRP Ledger peer pr
 
 To participate in the XRP Ledger, `rippled` servers connects to arbitrary peers using the peer protocol. (All such peers are treated as untrusted, unless they are [clustered](clustering.html) with the current server.)
 
-Ideally, the server should be able to send _and_ receive connections on the peer port. You should forward the port used for the peer protocol through your firewall to the `rippled` server. The [default `rippled` configuration file](https://github.com/ripple/rippled/blob/master/doc/rippled-example.cfg) listens for incoming peer protocol connections on port 51235 on all network interfaces. You can change the port used by editing the appropriate stanza in your `rippled.cfg` file.
+Ideally, the server should be able to send _and_ receive connections on the peer port. You should forward the port used for the peer protocol through your firewall to the `rippled` server. The [default `rippled` configuration file](https://github.com/ripple/rippled/blob/master/cfg/rippled-example.cfg) listens for incoming peer protocol connections on port 51235 on all network interfaces. You can change the port used by editing the appropriate stanza in your `rippled.cfg` file.
 
 Example:
 

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -93,7 +93,7 @@ For a full list of available methods, see the [rippled API reference](rippled-ap
 
 `rippled` should connect to the XRP Ledger with the default configuration. However, you can change your settings by editing the `rippled.cfg` file (located at `/opt/ripple/etc/rippled.cfg` when installing `rippled` with yum). For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
 
-See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/master/doc/rippled-example.cfg) for a description of all configuration options.
+See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/master/cfg/rippled-example.cfg) for a description of all configuration options.
 
 Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path:
 


### PR DESCRIPTION
Assuming this works, we can rebase the other PRs after this gets merged to master and that should stop them from failing on these broken links.