### PR TITLE
Fix transaction results landing page

### DIFF
--- a/content/references/rippled-api/transaction-formats/transaction-results/transaction-results-overview.md
+++ b/content/references/rippled-api/transaction-formats/transaction-results/transaction-results-overview.md
@@ -1,4 +1,4 @@
-# Transaction Results
+# Transaction Results Overview
 
 [[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/TER.h "Source")
 
@@ -6,12 +6,12 @@ The `rippled` server summarizes transaction results with result codes, which app
 
 | Category              | Prefix                  | Description                |
 |:----------------------|:------------------------|:---------------------------|
+| Claimed cost only     | [tec](tec-codes.html)   | The transaction did not achieve its intended purpose, but the [transaction cost](transaction-cost.html) was destroyed. This result is only final in a validated ledger. |
+| Failure               | [tef](tef-codes.html)   | The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future. |
 | Local error           | [tel](tel-codes.html)   | The `rippled` server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time. |
 | Malformed transaction | [tem](tem-codes.html)   | The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else. |
-| Failure               | [tef](tef-codes.html)   | The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future. |
 | Retry                 | [ter](ter-codes.html)   | The transaction could not be applied, but it might be possible to apply later. |
 | Success               | [tes](tes-success.html) | (Not an error) The transaction succeeded. This result only final in a validated ledger. |
-| Claimed cost only     | [tec](tec-codes.html)   | The transaction did not achieve its intended purpose, but the [transaction cost](transaction-cost.html) was destroyed. This result is only final in a validated ledger. |
 
 **Warning:** Transactions' provisional result codes may differ than their final result. Transactions that provisionally succeeded may eventually fail and transactions that provisionally failed may eventually succeed. Transactions that provisionally failed may also eventually fail with a different code. See [finality of results](finality-of-results.html) for how to know when a transaction's result is final.
 

--- a/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
+++ b/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
@@ -1,4 +1,4 @@
-# Transaction Results Overview
+# Transaction Results
 
 [[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/TER.h "Source")
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2151,14 +2151,26 @@ pages:
         targets:
             - local
 
-    -   md: references/rippled-api/transaction-formats/transaction-results/transaction-results.md
+    -   name: Transaction Results
         html: transaction-results.html
         funnel: Docs
         doc_type: References
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
-        blurb: All possible transaction result codes and their meanings.
+        blurb: Learn how to interpret rippled server transaction results.
+        template: template-landing-children.html
+        targets:
+            - local
+
+    -   md: references/rippled-api/transaction-formats/transaction-results/transaction-results-overview.md
+        html: transaction-results-overview.html
+        funnel: Docs
+        doc_type: References
+        supercategory: rippled API
+        category: Transaction Formats
+        subcategory: Transaction Results
+        blurb: Understand the difference between provisional and final results. Get an introduction to transaction result codes.
         targets:
             - local
 
@@ -2169,6 +2181,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
+        blurb: tec codes indicate that the transaction failed, but it was applied to a ledger to apply the transaction cost.
         targets:
             - local
 
@@ -2179,6 +2192,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
+        blurb: tef codes indicate that the transaction failed and was not included in a ledger, but the transaction could have succeeded in some theoretical ledger.
         targets:
             - local
 
@@ -2189,6 +2203,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
+        blurb: tel codes indicate an error in the local server processing the transaction.
         targets:
             - local
 
@@ -2199,6 +2214,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
+        blurb: tem codes indicate that the transaction was malformed, and cannot succeed according to the XRP Ledger protocol.
         targets:
             - local
 
@@ -2209,6 +2225,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
+        blurb: ter codes indicate that the transaction failed, but it could apply successfully in the future, usually if some other hypothetical transaction applies first.
         targets:
             - local
 
@@ -2219,6 +2236,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
+        blurb: tesSUCCESS is the only code that indicates a transaction succeeded. This does not always mean it accomplished what you expected it to do.
         targets:
             - local
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2151,7 +2151,7 @@ pages:
         targets:
             - local
 
-    -   name: Transaction Results
+    -   md: references/rippled-api/transaction-formats/transaction-results/transaction-results.md
         html: transaction-results.html
         funnel: Docs
         doc_type: References
@@ -2159,18 +2159,6 @@ pages:
         category: Transaction Formats
         subcategory: Transaction Results
         blurb: Learn how to interpret rippled server transaction results.
-        template: template-landing-children.html
-        targets:
-            - local
-
-    -   md: references/rippled-api/transaction-formats/transaction-results/transaction-results-overview.md
-        html: transaction-results-overview.html
-        funnel: Docs
-        doc_type: References
-        supercategory: rippled API
-        category: Transaction Formats
-        subcategory: Transaction Results
-        blurb: Understand the difference between provisional and final results. Get an introduction to transaction result codes.
         targets:
             - local
 
@@ -2246,6 +2234,7 @@ pages:
         doc_type: References
         supercategory: rippled API
         category: Transaction Formats
+        blurb: Transaction metadata describes the outcome of the transaction in detail, regardless of whether the transaction is successful.
         targets:
             - local
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2169,7 +2169,7 @@ pages:
         supercategory: rippled API
         category: Transaction Formats
         subcategory: Transaction Results
-        blurb: tec codes indicate that the transaction failed, but it was applied to a ledger to apply the transaction cost.
+        blurb: tec codes indicate that the transaction failed, but it was applied to a ledger to deduct the transaction cost.
         targets:
             - local
 


### PR DESCRIPTION
- Adjusted order of transaction codes in table at top of transaction-results.md
- Added blurbs for child pages in dactyl_config - even if not being used now, may be useful in the future
- Added blurb for transaction-metadata.md to display on transaction-formats.md