### PR TITLE
Fixes to Public Methods landing page

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
+++ b/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
@@ -2,137 +2,87 @@
 
 Communicate directly with a `rippled` server using the following public API methods. Public methods are not necessarily meant for the general public, but they are used by any client attached to the server. Think of public methods as being for members or customers of the organization running the server.
 
-* **[`account_currencies`](account_currencies.html)**
 
-     Get a list of currencies an account can send or receive.
+## [Account Methods](account-methods.html)
 
-* **[`account_channels`](account_channels.html)**
+An account in the XRP Ledger represents a holder of XRP and a sender of transactions. Use these methods to work with account info.
 
-     Get a list of payment channels where the account is the source of the channel.
+* **[`account_channels`](account_channels.html)** - Get a list of payment channels where the account is the source of the channel.
+* **[`account_currencies`](account_currencies.html)** - Get a list of currencies an account can send or receive.
+* **[`account_info`](account_info.html)** - Get basic data about an account.
+* **[`account_lines`](account_lines.html)** - Get info about an account's trust lines.
+* **[`account_objects`](account_objects.html)** - Get all ledger objects owned by an account.
+* **[`account_offers`](account_offers.html)** - Get info about an account's currency exchange offers.
+* **[`account_tx`](account_tx.html)** - Get inf about an account's transactions.
+* **[`gateway_balances`](gateway_balances.html)** - Calculate total amounts issued by an account.
+* **[`noripple_check`](noripple_check.html)** - Get recommended changes to an account's DefaultRipple and NoRipple settings.
 
-* **[`account_info`](account_info.html)**
 
-     Get basic data about an account.
+## [Ledger Methods](ledger-methods.html)
 
-* **[`account_lines`](account_lines.html)**
+A ledger version contains a header, a transaction tree, and a state tree, which contain account settings, trustlines, balances, transactions, and other data. Use these methods to retrieve ledger info.
 
-     Get info about an account's trust lines.
+* **[`ledger`](ledger.html)** - Get info about a ledger version.
+* **[`ledger_closed`](ledger_closed.html)** - Get the latest closed ledger version.
+* **[`ledger_current`](ledger_current.html)** - Get the current working ledger version.
+* **[`ledger_data`](ledger_data.html)** - Get the raw contents of a ledger version.
+* **[`ledger_entry`](ledger_entry.html)** - Get one element from a ledger version.
 
-* **[`account_objects`](account_objects.html)**
 
-     Get all ledger objects owned by an account.
+## [Transaction Methods](transaction-methods.html)
 
-* **[`account_offers`](account_offers.html)**
+Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions. Use these methods to work with transactions.
 
-     Get info about an account's currency exchange offers.
+* **[`sign`](sign.html)** - Cryptographically sign a transaction.
+* **[`sign_for`](sign_for.html)** - Contribute to a multi-signature.
+* **[`submit`](submit.html)** - Send a transaction to the network.
+* **[`submit_multisigned`](submit_multisigned.html)** - Send a multi-signed transaction to the network.
+* **[`transaction_entry`](transaction_entry.html)** - Retrieve info about a transaction from a particular ledger version.
+* **[`tx`](tx.html)** - Retrieve info about a transaction from all the ledgers on hand.
+* **[`tx_history`](tx_history.html)** - Retrieve info about all recent transactions.
 
-* **[`account_tx`](account_tx.html)**
 
-     Get info about an account's transactions.
+## [Path and Order Book Methods](path-and-order-book-methods.html)
 
-* **[`book_offers`](book_offers.html)**
+Paths define a way for payments to flow through intermediary steps on their way from sender to receiver. Paths enable cross-currency payments by connecting sender and receiver through order books. Use these methods to work with paths and other books.
 
-     Get info about offers to exchange two currencies.
+* **[`book_offers`](book_offers.html)** - Get info about offers to exchange two currencies.
+* **[`path_find`](path_find.html)** - Find a path for a payment between two accounts and receive updates.
+* **[`ripple_path_find`](ripple_path_find.html)** - Find a path for payment between two accounts, once.
 
-* **[`channel_authorize`](channel_authorize.html)**
 
-     Sign a claim for money from a payment channel.
+## [Payment Channel Methods](payment-channel-methods.html)
 
-* **[`channel_verify`](channel_verify.html)**
+Payment channels are a tool for facilitating repeated, unidirectional payments, or temporary credit between two parties. Use these methods to work with payment channels.
 
-     Check a payment channel claim's signature.
+* **[`channel_authorize`](channel_authorize.html)** - Sign a claim for money from a payment channel.
+* **[`channel_verify`](channel_verify.html)** - Check a payment channel claim's signature.
 
-* **[`fee`](fee.html)**
 
-     Get information about transaction cost.
+## [Subscription Methods](subscription-methods.html)
 
-* **[`gateway_balances`](gateway_balances.html)**
+Use these methods to enable the server to push updates to your client when various events happen, so that you can know and react right away. _WebSocket API only._
 
-     Calculate total amounts issued by an account.
+* **[`subscribe`](subscribe.html)** - Listen for updates about a particular subject.
+* **[`unsubscribe`](unsubscribe.html)** - Stop listening for updates about a particular subject.
 
-* **[`ledger`](ledger.html)**
 
-     Get info about a ledger version.
+## [Server Info Methods](server-info-methods.html)
 
-* **[`ledger_closed`](ledger_closed.html)**
+Use these methods to retrieve information about the current state of the `rippled` server.
 
-     Get the latest closed ledger version.
+* **[`fee`](fee.html)** - Get information about transaction cost.
+* **[`server_info`](server_info.html)** - Retrieve status of the server in human-readable format.
+* **[`server_state`](server_state.html)** - Retrieve status of the server in machine-readable format.
 
-* **[`ledger_current`](ledger_current.html)**
 
-     Get the current working ledger version.
+## [Utility Methods](utility-methods.html)
 
-* **[`ledger_data`](ledger_data.html)**
+Use these methods to perform convenient tasks, such as ping and random number generation.
 
-     Get the raw contents of a ledger version.
-
-* **[`ledger_entry`](ledger_entry.html)**
-
-     Get one element from a ledger version.
-
-* **[`noripple_check`](noripple_check.html)**
-
-     Get recommended changes to an account's DefaultRipple and NoRipple settings.
-
-* **[`path_find`](path_find.html)**
-
-     Find a path for a payment between two accounts and receive updates.
-
-* **[`ping`](ping.html)**
-
-     Confirm connectivity with the server.
-
-* **[`random`](random.html)**
-
-     Generate a random number.
-
-* **[`ripple_path_find`](ripple_path_find.html)**
-
-     Find a path for payment between two accounts, once.
-
-* **[`server_info`](server_info.html)**
-
-     Retrieve status of the server in human-readable format.
-
-* **[`server_state`](server_state.html)**
-
-     Retrieve status of the server in machine-readable format.
-
-* **[`sign`](sign.html)**
-
-     Cryptographically sign a transaction.
-
-* **[`sign_for`](sign_for.html)**
-
-     Contribute to a multi-signature.
-
-* **[`submit`](submit.html)**
-
-     Send a transaction to the network.
-
-* **[`submit_multisigned`](submit_multisigned.html)**
-
-     Send a multi-signed transaction to the network.
-
-* **[`subscribe`](subscribe.html)**
-
-     Listen for updates about a particular subject.
-
-* **[`transaction_entry`](transaction_entry.html)**
-
-     Retrieve info about a transaction from a particular ledger version.
-
-* **[`tx`](tx.html)**
-
-     Retrieve info about a transaction from all the ledgers on hand.
-
-* **[`tx_history`](tx_history.html)**
-
-     Retrieve info about all recent transactions.
-
-* **[`unsubscribe`](unsubscribe.html)**
-
-     Stop listening for updates about a particular subject.
+* **[`json`](json.html)** - Use as a proxy to running other commands. Accepts the parameters for the command as a JSON value. _Commandline only._
+* **[`ping`](ping.html)** - Confirm connectivity with the server.
+* **[`random`](random.html)** - Generate a random number.
 
 
 ## Deprecated Methods

--- a/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
+++ b/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
@@ -2,135 +2,135 @@
 
 Communicate directly with a `rippled` server using the following public API methods. Public methods are not necessarily meant for the general public, but they are used by any client attached to the server. Think of public methods as being for members or customers of the organization running the server.
 
-* [`account_currencies`](account_currencies.html)
+* **[`account_currencies`](account_currencies.html)**
 
      Get a list of currencies an account can send or receive.
 
-* [`account_channels`](account_channels.html)
+* **[`account_channels`](account_channels.html)**
 
      Get a list of payment channels where the account is the source of the channel.
 
-* [`account_info`](account_info.html)
+* **[`account_info`](account_info.html)**
 
      Get basic data about an account.
 
-* [`account_lines`](account_lines.html)
+* **[`account_lines`](account_lines.html)**
 
      Get info about an account's trust lines.
 
-* [`account_objects`](account_objects.html)
+* **[`account_objects`](account_objects.html)**
 
      Get all ledger objects owned by an account.
 
-* [`account_offers`](account_offers.html)
+* **[`account_offers`](account_offers.html)**
 
      Get info about an account's currency exchange offers.
 
-* [`account_tx`](account_tx.html)
+* **[`account_tx`](account_tx.html)**
 
      Get info about an account's transactions.
 
-* [`book_offers`](book_offers.html)
+* **[`book_offers`](book_offers.html)**
 
      Get info about offers to exchange two currencies.
 
-* [`channel_authorize`](channel_authorize.html)
+* **[`channel_authorize`](channel_authorize.html)**
 
      Sign a claim for money from a payment channel.
 
-* [`channel_verify`](channel_verify.html)
+* **[`channel_verify`](channel_verify.html)**
 
      Check a payment channel claim's signature.
 
-* [`fee`](fee.html)
+* **[`fee`](fee.html)**
 
      Get information about transaction cost.
 
-* [`gateway_balances`](gateway_balances.html)
+* **[`gateway_balances`](gateway_balances.html)**
 
      Calculate total amounts issued by an account.
 
-* [`ledger`](ledger.html)
+* **[`ledger`](ledger.html)**
 
      Get info about a ledger version.
 
-* [`ledger_closed`](ledger_closed.html)
+* **[`ledger_closed`](ledger_closed.html)**
 
      Get the latest closed ledger version.
 
-* [`ledger_current`](ledger_current.html)
+* **[`ledger_current`](ledger_current.html)**
 
      Get the current working ledger version.
 
-* [`ledger_data`](ledger_data.html)
+* **[`ledger_data`](ledger_data.html)**
 
      Get the raw contents of a ledger version.
 
-* [`ledger_entry`](ledger_entry.html)
+* **[`ledger_entry`](ledger_entry.html)**
 
      Get one element from a ledger version.
 
-* [`noripple_check`](noripple_check.html)
+* **[`noripple_check`](noripple_check.html)**
 
      Get recommended changes to an account's DefaultRipple and NoRipple settings.
 
-* [`path_find`](path_find.html)
+* **[`path_find`](path_find.html)**
 
      Find a path for a payment between two accounts and receive updates.
 
-* [`ping`](ping.html)
+* **[`ping`](ping.html)**
 
      Confirm connectivity with the server.
 
-* [`random`](random.html)
+* **[`random`](random.html)**
 
      Generate a random number.
 
-* [`ripple_path_find`](ripple_path_find.html)
+* **[`ripple_path_find`](ripple_path_find.html)**
 
      Find a path for payment between two accounts, once.
 
-* [`server_info`](server_info.html)
+* **[`server_info`](server_info.html)**
 
      Retrieve status of the server in human-readable format.
 
-* [`server_state`](server_state.html)
+* **[`server_state`](server_state.html)**
 
      Retrieve status of the server in machine-readable format.
 
-* [`sign`](sign.html)
+* **[`sign`](sign.html)**
 
      Cryptographically sign a transaction.
 
-* [`sign_for`](sign_for.html)
+* **[`sign_for`](sign_for.html)**
 
      Contribute to a multi-signature.
 
-* [`submit`](submit.html)
+* **[`submit`](submit.html)**
 
      Send a transaction to the network.
 
-* [`submit_multisigned`](submit_multisigned.html)
+* **[`submit_multisigned`](submit_multisigned.html)**
 
      Send a multi-signed transaction to the network.
 
-* [`subscribe`](subscribe.html)
+* **[`subscribe`](subscribe.html)**
 
      Listen for updates about a particular subject.
 
-* [`transaction_entry`](transaction_entry.html)
+* **[`transaction_entry`](transaction_entry.html)**
 
      Retrieve info about a transaction from a particular ledger version.
 
-* [`tx`](tx.html)
+* **[`tx`](tx.html)**
 
      Retrieve info about a transaction from all the ledgers on hand.
 
-* [`tx_history`](tx_history.html)
+* **[`tx_history`](tx_history.html)**
 
      Retrieve info about all recent transactions.
 
-* [`unsubscribe`](unsubscribe.html)
+* **[`unsubscribe`](unsubscribe.html)**
 
      Stop listening for updates about a particular subject.
 

--- a/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
+++ b/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
@@ -1,47 +1,138 @@
 # Public rippled Methods
 
-Communicate directly with a `rippled` server using these public API methods.
+Communicate directly with a `rippled` server using the following public API methods. Public methods are not necessarily meant for the general public, but they are used by any client attached to the server. Think of public methods as being for members or customers of the organization running the server.
 
-Public methods are not necessarily meant for the general public, but they are used by any client attached to the server. Think of public methods as being for members or customers of the organization running the server.
+* [`account_currencies`](account_currencies.html)
 
-Public methods include operations such as checking the state of the ledger, finding a path to connecting users, and submitting a transaction, among others.
+     Get a list of currencies an account can send or receive.
 
-## List of Methods
+* [`account_channels`](account_channels.html)
 
+     Get a list of payment channels where the account is the source of the channel.
 
-* [`account_currencies` - Get a list of currencies an account can send or receive](account_currencies.html)
-* [`account_channels` - Get a list of payment channels where the account is the source of the channel](account_channels.html)
-* [`account_info` - Get basic data about an account](account_info.html)
-* [`account_lines` - Get info about an account's trust lines](account_lines.html)
-* [`account_objects` - Get all ledger objects owned by an account](account_objects.html)
-* [`account_offers` - Get info about an account's currency exchange offers](account_offers.html)
-* [`account_tx` - Get info about an account's transactions](account_tx.html)
-* [`book_offers` - Get info about offers to exchange two currencies](book_offers.html)
-* [`channel_authorize` - Sign a claim for money from a payment channel](channel_authorize.html)
-* [`channel_verify` - Check a payment channel claim's signature](channel_verify.html)
-* [`fee` - Get information about transaction cost](fee.html)
-* [`gateway_balances` - Calculate total amounts issued by an account](gateway_balances.html)
-* [`ledger` - Get info about a ledger version](ledger.html)
-* [`ledger_closed` - Get the latest closed ledger version](ledger_closed.html)
-* [`ledger_current` - Get the current working ledger version](ledger_current.html)
-* [`ledger_data` - Get the raw contents of a ledger version](ledger_data.html)
-* [`ledger_entry` - Get one element from a ledger version](ledger_entry.html)
-* [`noripple_check` - Get recommended changes to an account's DefaultRipple and NoRipple settings](noripple_check.html)
-* [`path_find` - Find a path for a payment between two accounts and receive updates](path_find.html)
-* [`ping` - Confirm connectivity with the server](ping.html)
-* [`random` - Generate a random number](random.html)
-* [`ripple_path_find` - Find a path for payment between two accounts, once](ripple_path_find.html)
-* [`server_info` - Retrieve status of the server in human-readable format](server_info.html)
-* [`server_state` - Retrieve status of the server in machine-readable format](server_state.html)
-* [`sign` - Cryptographically sign a transaction](sign.html)
-* [`sign_for` - Contribute to a multi-signature](sign_for.html)
-* [`submit` - Send a transaction to the network](submit.html)
-* [`submit_multisigned` - Send a multi-signed transaction to the network](submit_multisigned.html)
-* [`subscribe` - Listen for updates about a particular subject](subscribe.html)
-* [`transaction_entry` - Retrieve info about a transaction from a particular ledger version](transaction_entry.html)
-* [`tx` - Retrieve info about a transaction from all the ledgers on hand](tx.html)
-* [`tx_history` - Retrieve info about all recent transactions](tx_history.html)
-* [`unsubscribe` - Stop listening for updates about a particular subject](unsubscribe.html)
+* [`account_info`](account_info.html)
+
+     Get basic data about an account.
+
+* [`account_lines`](account_lines.html)
+
+     Get info about an account's trust lines.
+
+* [`account_objects`](account_objects.html)
+
+     Get all ledger objects owned by an account.
+
+* [`account_offers`](account_offers.html)
+
+     Get info about an account's currency exchange offers.
+
+* [`account_tx`](account_tx.html)
+
+     Get info about an account's transactions.
+
+* [`book_offers`](book_offers.html)
+
+     Get info about offers to exchange two currencies.
+
+* [`channel_authorize`](channel_authorize.html)
+
+     Sign a claim for money from a payment channel.
+
+* [`channel_verify`](channel_verify.html)
+
+     Check a payment channel claim's signature.
+
+* [`fee`](fee.html)
+
+     Get information about transaction cost.
+
+* [`gateway_balances`](gateway_balances.html)
+
+     Calculate total amounts issued by an account.
+
+* [`ledger`](ledger.html)
+
+     Get info about a ledger version.
+
+* [`ledger_closed`](ledger_closed.html)
+
+     Get the latest closed ledger version.
+
+* [`ledger_current`](ledger_current.html)
+
+     Get the current working ledger version.
+
+* [`ledger_data`](ledger_data.html)
+
+     Get the raw contents of a ledger version.
+
+* [`ledger_entry`](ledger_entry.html)
+
+     Get one element from a ledger version.
+
+* [`noripple_check`](noripple_check.html)
+
+     Get recommended changes to an account's DefaultRipple and NoRipple settings.
+
+* [`path_find`](path_find.html)
+
+     Find a path for a payment between two accounts and receive updates.
+
+* [`ping`](ping.html)
+
+     Confirm connectivity with the server.
+
+* [`random`](random.html)
+
+     Generate a random number.
+
+* [`ripple_path_find`](ripple_path_find.html)
+
+     Find a path for payment between two accounts, once.
+
+* [`server_info`](server_info.html)
+
+     Retrieve status of the server in human-readable format.
+
+* [`server_state`](server_state.html)
+
+     Retrieve status of the server in machine-readable format.
+
+* [`sign`](sign.html)
+
+     Cryptographically sign a transaction.
+
+* [`sign_for`](sign_for.html)
+
+     Contribute to a multi-signature.
+
+* [`submit`](submit.html)
+
+     Send a transaction to the network.
+
+* [`submit_multisigned`](submit_multisigned.html)
+
+     Send a multi-signed transaction to the network.
+
+* [`subscribe`](subscribe.html)
+
+     Listen for updates about a particular subject.
+
+* [`transaction_entry`](transaction_entry.html)
+
+     Retrieve info about a transaction from a particular ledger version.
+
+* [`tx`](tx.html)
+
+     Retrieve info about a transaction from all the ledgers on hand.
+
+* [`tx_history`](tx_history.html)
+
+     Retrieve info about all recent transactions.
+
+* [`unsubscribe`](unsubscribe.html)
+
+     Stop listening for updates about a particular subject.
 
 
 ## Deprecated Methods

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -1025,7 +1025,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         blurb: Get data from the XRP Ledger and submit transactions using these public API methods.
-        template: template-landing-children.html
+        # template: template-landing-children.html
         targets:
             - local
 
@@ -1036,8 +1036,8 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Account Methods
-        # blurb: An Account in the XRP Ledger represents a holder of XRP and a sender of transactions. Accounts can send and receive XRP and issued assets, participate in the decentralized exchange, and change their own settings. Creating an account involves generating keys and then receiving XRP from another account.
         template: template-landing-children.html
+        blurb: An account in the XRP Ledger represents a holder of XRP and a sender of transactions. Use these methods to work with account info.
         targets:
             - local
 
@@ -1147,7 +1147,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Ledger Methods
-        # blurb: Each rippled server keeps a complete copy of the XRP Ledger's current state, which contains all the accounts, transactions, offers, and other data in the network in an optimized tree format. As transactions and offers are proposed, each server incorporates them into its current copy of the ledger, closes it periodically, and (if configured) participates in advancing the globally-validated version. After the network reaches consensus, that ledger version is validated and becomes permanently immutable. Any transactions that were not included in one ledger version become candidates to be included in the next validated version.
+        blurb: A ledger version contains a header, a transaction tree, and a state tree, which contain account settings, trustlines, balances, transactions, and other data. Use these methods to retrieve ledger info.
         template: template-landing-children.html
         targets:
             - local
@@ -1215,7 +1215,7 @@ pages:
         category: Public rippled Methods
         subcategory: Transaction Methods
         template: template-landing-children.html
-        # blurb: Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions, which include not only payments, but also currency-exchange offers, account settings, and changes to the properties of the ledger itself (like adopting new features).
+        blurb: Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions. Use these methods to work with transactions.
         targets:
             - local
 
@@ -1303,7 +1303,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Path and Order Book Methods
-        # blurb: In the XRP Ledger, paths define a way for payments to flow through intermediary steps on their way from sender to receiver. Paths enable cross-currency payments by connecting sender and receiver through order books.
+        blurb: Paths define a way for payments to flow through intermediary steps on their way from sender to receiver. Paths enable cross-currency payments by connecting sender and receiver through order books. Use these methods to work with paths and other books.
         template: template-landing-children.html
         targets:
             - local
@@ -1348,7 +1348,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Payment Channel Methods
-        # blurb: Payment channels are a tool for facilitating repeated, unidirectional payments, or temporary credit between two parties. Learn about methods that work on payment channels.
+        blurb: Payment channels are a tool for facilitating repeated, unidirectional payments, or temporary credit between two parties. Use these methods to work with payment channels.
         template: template-landing-children.html
         targets:
             - local
@@ -1382,7 +1382,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Subscription Methods
-        # blurb: Using subscriptions, you can have the server push updates to your client when various events happen, so that you can know and react right away. Subscriptions are only supported in the WebSocket API, where you can receive additional responses in the same channel. JSON-RPC support for subscription callbacks is deprecated and may not work as expected.
+        blurb: Use these methods to enable the server to push updates to your client when various events happen, so that you can know and react right away. WebSocket API only.
         template: template-landing-children.html
         targets:
             - local
@@ -1416,7 +1416,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Server Info Methods
-        # blurb: Learn about methods that enable you to retrieve information about the current state of the rippled server. These may be useful for monitoring the health of the server, or in preparing to make requests to other API methods.
+        blurb: Use these methods to retrieve information about the current state of the rippled server.
         template: template-landing-children.html
         targets:
             - local
@@ -1461,7 +1461,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Utility Methods
-        # blurb: Learn about methods that provide convenient functions, such as ping and a random number generator.
+        blurb: Use these methods to perform convenient tasks, such as ping and random number generation.
         template: template-landing-children.html
         targets:
             - local

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -1036,7 +1036,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Account Methods
-        blurb: An Account in the XRP Ledger represents a holder of XRP and a sender of transactions. Accounts can send and receive XRP and issued assets, participate in the decentralized exchange, and change their own settings. Creating an account involves generating keys and then receiving XRP from another account.
+        # blurb: An Account in the XRP Ledger represents a holder of XRP and a sender of transactions. Accounts can send and receive XRP and issued assets, participate in the decentralized exchange, and change their own settings. Creating an account involves generating keys and then receiving XRP from another account.
         template: template-landing-children.html
         targets:
             - local
@@ -1147,7 +1147,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Ledger Methods
-        blurb: Each rippled server keeps a complete copy of the XRP Ledger's current state, which contains all the accounts, transactions, offers, and other data in the network in an optimized tree format. As transactions and offers are proposed, each server incorporates them into its current copy of the ledger, closes it periodically, and (if configured) participates in advancing the globally-validated version. After the network reaches consensus, that ledger version is validated and becomes permanently immutable. Any transactions that were not included in one ledger version become candidates to be included in the next validated version.
+        # blurb: Each rippled server keeps a complete copy of the XRP Ledger's current state, which contains all the accounts, transactions, offers, and other data in the network in an optimized tree format. As transactions and offers are proposed, each server incorporates them into its current copy of the ledger, closes it periodically, and (if configured) participates in advancing the globally-validated version. After the network reaches consensus, that ledger version is validated and becomes permanently immutable. Any transactions that were not included in one ledger version become candidates to be included in the next validated version.
         template: template-landing-children.html
         targets:
             - local
@@ -1215,7 +1215,7 @@ pages:
         category: Public rippled Methods
         subcategory: Transaction Methods
         template: template-landing-children.html
-        blurb: Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions, which include not only payments, but also currency-exchange offers, account settings, and changes to the properties of the ledger itself (like adopting new features).
+        # blurb: Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions, which include not only payments, but also currency-exchange offers, account settings, and changes to the properties of the ledger itself (like adopting new features).
         targets:
             - local
 
@@ -1303,7 +1303,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Path and Order Book Methods
-        blurb: In the XRP Ledger, paths define a way for payments to flow through intermediary steps on their way from sender to receiver. Paths enable cross-currency payments by connecting sender and receiver through order books.
+        # blurb: In the XRP Ledger, paths define a way for payments to flow through intermediary steps on their way from sender to receiver. Paths enable cross-currency payments by connecting sender and receiver through order books.
         template: template-landing-children.html
         targets:
             - local
@@ -1348,7 +1348,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Payment Channel Methods
-        blurb: Payment channels are a tool for facilitating repeated, unidirectional payments, or temporary credit between two parties. Learn about methods that work on payment channels.
+        # blurb: Payment channels are a tool for facilitating repeated, unidirectional payments, or temporary credit between two parties. Learn about methods that work on payment channels.
         template: template-landing-children.html
         targets:
             - local
@@ -1382,7 +1382,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Subscription Methods
-        blurb: Using subscriptions, you can have the server push updates to your client when various events happen, so that you can know and react right away. Subscriptions are only supported in the WebSocket API, where you can receive additional responses in the same channel. JSON-RPC support for subscription callbacks is deprecated and may not work as expected.
+        # blurb: Using subscriptions, you can have the server push updates to your client when various events happen, so that you can know and react right away. Subscriptions are only supported in the WebSocket API, where you can receive additional responses in the same channel. JSON-RPC support for subscription callbacks is deprecated and may not work as expected.
         template: template-landing-children.html
         targets:
             - local
@@ -1416,7 +1416,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Server Info Methods
-        blurb: Learn about methods that enable you to retrieve information about the current state of the rippled server. These may be useful for monitoring the health of the server, or in preparing to make requests to other API methods.
+        # blurb: Learn about methods that enable you to retrieve information about the current state of the rippled server. These may be useful for monitoring the health of the server, or in preparing to make requests to other API methods.
         template: template-landing-children.html
         targets:
             - local
@@ -1461,7 +1461,7 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         subcategory: Utility Methods
-        blurb: Learn about methods that provide convenient functions, such as ping and a random number generator.
+        # blurb: Learn about methods that provide convenient functions, such as ping and a random number generator.
         template: template-landing-children.html
         targets:
             - local

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -1025,7 +1025,6 @@ pages:
         supercategory: rippled API
         category: Public rippled Methods
         blurb: Get data from the XRP Ledger and submit transactions using these public API methods.
-        # template: template-landing-children.html
         targets:
             - local
 


### PR DESCRIPTION
- Added method category headings and overviews to public-rippled-methods.html.
- Moved method descriptions out of links for readability - I think it makes it easier to read?
- Shortened overview text for method categories. In particular, please take a look at the overview for Ledger Methods.

At first, I was going to update the page to include the method subcategories and their overviews only, but saw that we'd then lose the single-page view of all public methods and what they do. Decided to provide both. Overkill? This is basically the left nav, but with more context -- which I have to admit, I like.

Open to feedback. Whatever structure we use for this page, I'll replicate for the Admin Methods category.

How do these landing pages impact search results? If they're having a negative impact, perhaps we can remove them from search? They are provided primarily to help folks who are manually navigating the site.