### PR TITLE
Improve table styling slightly

### DIFF
--- a/assets/css/devportal.css
+++ b/assets/css/devportal.css
@@ -183,6 +183,11 @@ th {
 .content table {
   clear: right;
   margin-bottom: 1rem;
+  font-size: 15px;
+}
+
+.content table code {
+  word-break: normal;
 }
 
 /* Big draft warning at top of page so it's hard to mix up with the live site */


### PR DESCRIPTION
- Turns off mid-word line-breaking of code text in table cells (which currently happens in Chrome and not Firefox anyway)
- Slightly reduces font size of table cells to reduce chance of tables spilling into the right column (and therefore under the right nav). Doesn't fix this problem entirely (still visible at, say, 996px wide on accountroot.html)

