### PR TITLE
fix1571 update to EscrowCreate

### DIFF
--- a/content/_snippets/rippled_versions.md
+++ b/content/_snippets/rippled_versions.md
@@ -31,3 +31,4 @@
 [New in: rippled 0.80.0]: https://github.com/ripple/rippled/releases/tag/0.80.0 "BADGE_BLUE"
 [New in: rippled 0.80.1]: https://github.com/ripple/rippled/releases/tag/0.80.1 "BADGE_BLUE"
 [New in: rippled 0.90.0]: https://github.com/ripple/rippled/releases/tag/0.90.0 "BADGE_BLUE"
+[New in: rippled 1.0.0]: https://github.com/ripple/rippled/releases/tag/1.0.0 "BADGE_BLUE"

--- a/content/references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
@@ -35,7 +35,9 @@ Sequester XRP until the escrow process either finishes or is canceled.
 | `Condition`      | String    | VariableLength    | _(Optional)_ Hex value representing a [PREIMAGE-SHA-256 crypto-condition](https://tools.ietf.org/html/draft-thomas-crypto-conditions-02#section-8.1). The funds can only be delivered to the recipient if this condition is fulfilled. |
 | `DestinationTag` | Number    | UInt32            | _(Optional)_ Arbitrary tag to further specify the destination for this escrowed payment, such as a hosted recipient at the destination address. |
 
-Either `CancelAfter` or `FinishAfter` must be specified. If both are included, the `FinishAfter` time must precede that of `CancelAfter`.
+Either `CancelAfter` or `FinishAfter` must be specified. If both are included, the `FinishAfter` time must be before the `CancelAfter` time.
+
+With the [fix1571 amendment](known-amendments.html#fix1571) enabled, either `FinishAfter` or `Condition` must be specified. [New in: rippled 1.0.0][]
 
 <!--{# common link defs #}-->
 {% include '_snippets/rippled-api-links.md' %}

--- a/content/references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
@@ -37,7 +37,7 @@ Sequester XRP until the escrow process either finishes or is canceled.
 
 Either `CancelAfter` or `FinishAfter` must be specified. If both are included, the `FinishAfter` time must be before the `CancelAfter` time.
 
-With the [fix1571 amendment](known-amendments.html#fix1571) enabled, either `FinishAfter` or `Condition` must be specified. [New in: rippled 1.0.0][]
+With the [fix1571 amendment](known-amendments.html#fix1571) enabled, you must supply `FinishAfter`, `Condition`, or both. [New in: rippled 1.0.0][]
 
 <!--{# common link defs #}-->
 {% include '_snippets/rippled-api-links.md' %}


### PR DESCRIPTION
Of the two changes to EscrowCreate, one fixes EscrowFinish to behave as already documented. The other is described here.