### PR TITLE
Clarify flag ranges

### DIFF
--- a/content/references/rippled-api/transaction-formats/transaction-common-fields.md
+++ b/content/references/rippled-api/transaction-formats/transaction-common-fields.md
@@ -74,11 +74,11 @@ When using the [sign method][] (or [submit method][] in "sign-and-submit" mode),
 
 The `Flags` field can contain flags that apply at different levels or contexts. Flags for each context are limited to the following ranges:
 
-| Range Name | Bit Mask | Description |
-|--|---|---|
-| Universal Flags | `0xff000000` | Flags that apply equally to all transaction types. |
+| Range Name       | Bit Mask     | Description                                |
+|:-----------------|:-------------|:-------------------------------------------|
+| Universal Flags  | `0xff000000` | Flags that apply equally to all transaction types. |
 | Type-based Flags | `0x00ff0000` | Flags with different meanings depending on the [transaction type](transaction-types.html) that uses them. |
-| Reserved Flags | `0x0000ffff` | Flags that are not currently defined. A transaction is only valid if these flags are disabled. |
+| Reserved Flags   | `0x0000ffff` | Flags that are not currently defined. A transaction is only valid if these flags are disabled. |
 
 **Note:** The [AccountSet transaction][] type has [its own non-bitwise flags](accountset.html#accountset-flags), which serve a similar purpose to type-based flags.
 

--- a/content/references/rippled-api/transaction-formats/transaction-common-fields.md
+++ b/content/references/rippled-api/transaction-formats/transaction-common-fields.md
@@ -52,7 +52,7 @@ The [`Paths` field](payment.html#paths) of the [Payment transaction][] type can 
 
 The `Flags` field can contain various options that affect how a transaction should behave. The options are represented as binary values that can be combined with bitwise-or operations to set multiple flags at once.
 
-To check whether a transaction has a given flag enabled, use a bitwise-and operation comparing the flag's value to the `Flags` field; result of zero indicates the flag is disabled, and a result equal to the flag value indicates the flag is enabled. (Any other result indicates you performed the wrong operation.)
+To check whether a transaction has a given flag enabled, use the bitwise-and operator on the flag's value and the `Flags` field. A result of zero indicates the flag is disabled, and a result equal to the flag value indicates the flag is enabled. (Any other result indicates you performed the wrong operation.)
 
 Most flags only have meaning for a specific transaction type. The same bitwise value may be reused for flags on different transaction types, so it is important to pay attention to the `TransactionType` field when setting and reading flags.
 
@@ -72,7 +72,7 @@ When using the [sign method][] (or [submit method][] in "sign-and-submit" mode),
 
 ### Flag Ranges
 
-The `Flags` field can contain flags that apply at different levels or contexts. Flags for each context are limited to the following ranges:
+A transaction's `Flags` field can contain flags that apply at different levels or contexts. Flags for each context are limited to the following ranges:
 
 | Range Name       | Bit Mask     | Description                                |
 |:-----------------|:-------------|:-------------------------------------------|
@@ -80,7 +80,7 @@ The `Flags` field can contain flags that apply at different levels or contexts. 
 | Type-based Flags | `0x00ff0000` | Flags with different meanings depending on the [transaction type](transaction-types.html) that uses them. |
 | Reserved Flags   | `0x0000ffff` | Flags that are not currently defined. A transaction is only valid if these flags are disabled. |
 
-**Note:** The [AccountSet transaction][] type has [its own non-bitwise flags](accountset.html#accountset-flags), which serve a similar purpose to type-based flags.
+**Note:** The [AccountSet transaction][] type has [its own non-bitwise flags](accountset.html#accountset-flags), which serve a similar purpose to type-based flags. [Ledger objects](ledger-object-types.html) also have a `Flags` field with different bitwise flag definitions.
 
 
 ## Memos Field

--- a/content/references/rippled-api/transaction-formats/transaction-common-fields.md
+++ b/content/references/rippled-api/transaction-formats/transaction-common-fields.md
@@ -52,7 +52,13 @@ The [`Paths` field](payment.html#paths) of the [Payment transaction][] type can 
 
 The `Flags` field can contain various options that affect how a transaction should behave. The options are represented as binary values that can be combined with bitwise-or operations to set multiple flags at once.
 
+To check whether a transaction has a given flag enabled, use a bitwise-and operation comparing the flag's value to the `Flags` field; result of zero indicates the flag is disabled, and a result equal to the flag value indicates the flag is enabled. (Any other result indicates you performed the wrong operation.)
+
 Most flags only have meaning for a specific transaction type. The same bitwise value may be reused for flags on different transaction types, so it is important to pay attention to the `TransactionType` field when setting and reading flags.
+
+Bits that are not defined as flags MUST be 0. (The [fix1543 amendment](known-amendments.html#fix1543) enforces this rule on some transaction types. Most transaction types enforce this rule by default.)
+
+### Global Flags
 
 The only flag that applies globally to all transactions is as follows:
 
@@ -63,6 +69,18 @@ The only flag that applies globally to all transactions is as follows:
 When using the [sign method][] (or [submit method][] in "sign-and-submit" mode), `rippled` adds a `Flags` field with `tfFullyCanonicalSig` enabled unless the `Flags` field is already present. The `tfFullyCanonicalSig` flag ***is not*** automatically enabled if `Flags` is explicitly specified. The flag ***is not*** automatically enabled when using the [sign_for method][] to add a signature to a multi-signed transaction.
 
 **Warning:** If you do not enable `tfFullyCanonicalSig`, it is theoretically possible for a malicious actor to modify your transaction signature so that the transaction may succeed with a different hash than expected. In the worst case, this could trick your integration into submitting the same payment multiple times. To avoid this problem, enable the `tfFullyCanonicalSig` flag on all transactions you sign.
+
+### Flag Ranges
+
+The `Flags` field can contain flags that apply at different levels or contexts. Flags for each context are limited to the following ranges:
+
+| Range Name | Bit Mask | Description |
+|--|---|---|
+| Universal Flags | `0xff000000` | Flags that apply equally to all transaction types. |
+| Type-based Flags | `0x00ff0000` | Flags with different meanings depending on the [transaction type](transaction-types.html) that uses them. |
+| Reserved Flags | `0x0000ffff` | Flags that are not currently defined. A transaction is only valid if these flags are disabled. |
+
+**Note:** The [AccountSet transaction][] type has [its own non-bitwise flags](accountset.html#accountset-flags), which serve a similar purpose to type-based flags.
 
 
 ## Memos Field


### PR DESCRIPTION
Prompted by the fix1543 amendment, this clarifies the defined flags, brings back the [bitmask table](https://wiki.ripple.com/index.php?title=Transaction_Format&oldid=8602#Flags) (without the typo this time), and adds a little more beginner-level info on how to check bitwise flags.