### PR TITLE
Missing Optional flag for hotwallet param

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/gateway_balances.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/gateway_balances.md
@@ -48,7 +48,7 @@ The request includes the following parameters:
 |:---------------|:---------------------------|:-------------------------------|
 | `account`      | String                     | The [Address][] to check. This should be the [issuing address](issuing-and-operational-addresses.html) |
 | `strict`       | Boolean                    | _(Optional)_ If true, only accept an address or public key for the account parameter. Defaults to false. |
-| `hotwallet`    | String or Array            | An [operational address](issuing-and-operational-addresses.html) to exclude from the balances issued, or an array of such addresses. |
+| `hotwallet`    | String or Array            | _(Optional)_ An [operational address](issuing-and-operational-addresses.html) to exclude from the balances issued, or an array of such addresses. |
 | `ledger_hash`  | String                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Unsigned Integer | _(Optional)_ The sequence number of the ledger version to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 


### PR DESCRIPTION
The `hotwallet` parameter of `gateway-balances()` didn't seem like the type of parameter that needs to be required. I tested the API w/o it and it returned successfully.