### PR TITLE
Refactored request example to use ledger_index

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
@@ -16,7 +16,7 @@ An example of the request format:
   "id": 1,
   "command": "account_lines",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-  "ledger": "current"
+  "ledger_index": "current"
 }
 ```
 
@@ -28,7 +28,7 @@ An example of the request format:
     "params": [
         {
             "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-            "ledger": "current"
+            "ledger_index": "current"
         }
     ]
 }


### PR DESCRIPTION
Websocket and JSON-RPC requests had the `ledger` parameter set when it doesn't exist in the parameter list. I vaguely remember that might be a legacy parameter name.

I've updated the parameters to use `ledger_index` instead based on the [Specifying Ledgers](https://developers.ripple.com/basic-data-types.html#specifying-ledgers) documentation.