### PR TITLE
Removed ledger parameter from request in account_lines

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
@@ -15,8 +15,7 @@ An example of the request format:
 {
   "id": 1,
   "command": "account_lines",
-  "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-  "ledger": "current"
+  "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
 }
 ```
 
@@ -27,8 +26,7 @@ An example of the request format:
     "method": "account_lines",
     "params": [
         {
-            "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-            "ledger": "current"
+            "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
         }
     ]
 }


### PR DESCRIPTION
The `ledger` parameter is now `ledger_index`, which is optional and defaults to current. This PR removes the `ledger` param from the example requests.

I had opened a PR to simply change `ledger` to `ledger_index`, however the conventions of the API docs seem to only use required parameters when they are not set to the default value, so I closed that PR and created this one instead.