### PR TITLE
Removed deprecated legacy param from account_offers

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
@@ -15,8 +15,7 @@ An example of the request format:
 {
   "id": 2,
   "command": "account_offers",
-  "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
-  "ledger": "current"
+  "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM"
 }
 ```
 
@@ -27,8 +26,7 @@ An example of the request format:
     "method": "account_offers",
     "params": [
         {
-            "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
-            "ledger_index": "current"
+            "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM"
         }
     ]
 }
@@ -52,7 +50,7 @@ A request can include the following parameters:
 | `account`      | String                                     | A unique identifier for the account, most commonly the account's [Address][]. |
 | `ledger`       | Unsigned integer, or String                | (Deprecated, Optional) A unique identifier for the ledger version to use, such as a ledger sequence number, a hash, or a shortcut such as "validated". |
 | `ledger_hash`  | String                                     | _(Optional)_ A 20-byte hex string identifying the ledger version to use. |
-| `ledger_index` | _(Optional)_ [Ledger Index][]              | (Optional, defaults to `current`) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See [Specifying Ledgers][]) |
+| `ledger_index` | [Ledger Index][]                           | (Optional, defaults to `current`) The sequence number of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See [Specifying Ledgers][]) |
 | `limit`        | Integer                                    | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Must be within the inclusive range 10 to 400. [New in: rippled 0.26.4][] |
 | `marker`       | [Marker][] | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. [New in: rippled 0.26.4][] |
 


### PR DESCRIPTION
Sorry for all the PRs, I'm editing directly in github's UI. I checked ahead and this is the last one of this type in the Account API section. I'm writing a wrapper for the API so the changes are trickling in as I get through each method document.

This PR includes the same changes reported in #410, except its for `account_offers` this time.
- Removed deprecated `ledger` parameter is used in the websocket request
- Removed `ledger_index` parameter from the json request since it includes the default value (for consistency)
- Removed the word `Optional` from the Type column since the convention seems to be to indicate that in the Description area.