### PR TITLE
Fixed invalid JSON response in noripple_check

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/noripple_check.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/noripple_check.md
@@ -122,7 +122,7 @@ An example of a successful response:
         "problems": [
             "You should immediately set your default ripple flag",
             "You should clear the no ripple flag on your XAU line to r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z",
-            "You should clear the no ripple flag on your USD line to rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            "You should clear the no ripple flag on your USD line to rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
         ],
         "status": "success",
         "transactions": [


### PR DESCRIPTION
A trailing comma was left in the last item of the `result.problems` array in the JSON-RPC example response of noripple_check.

I'm actually creating json files with the examples to mock responses in unit tests for the library I'm writing, so my tests found it. I wouldn't have noticed otherwise. I'm grateful we have example responses to review and copy!