### PR TITLE
Update rippled ubuntu tutorial to use cmake, not scons

### DIFF
--- a/content/tutorials/manage-the-rippled-server/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/build-run-rippled-ubuntu.md
@@ -61,55 +61,58 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
     The recommended Boost version is 1.64.0. Because Boost version 1.64.0 isn't available in the Ubuntu 16.04 repos, you must compile it yourself.
 
-      a. Download Boost 1.64.0.
+    If you have previously built Boost 1.64.0 for `rippled` and configured the `BOOST_ROOT` environment variable, you can skip these steps.
 
-          wget https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz
+      1. Download Boost 1.64.0.
 
-      b. Untar `boost_1_64_0.tar.gz`.
+              wget https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz
 
-          tar xvzf boost_1_64_0.tar.gz
+      2. Untar `boost_1_64_0.tar.gz`.
 
-      c. Access the new `boost_1_64_0` directory:
+              tar xvzf boost_1_64_0.tar.gz
 
-          cd boost_1_64_0
+      3. Access the new `boost_1_64_0` directory:
 
-      d. To prepare the Boost.Build system for use, run:
+              cd boost_1_64_0
 
-          ./bootstrap.sh
+      4. To prepare the Boost.Build system for use, run:
 
-      e. To invoke Boost.Build to build the separately-compiled Boost libraries, run the following command. Replace `<number of parallel jobs>` with the number of jobs, or commands, to run in parallel. Choose this value based on the number of cores you want to use for building. This may take about 10 minutes, depending on your hardware specs.
+              ./bootstrap.sh
 
-          ./b2 -j <number of parallel jobs>
+      5. To invoke Boost.Build to build the separately-compiled Boost libraries, run the following command. Replace `<number of parallel jobs>` with the number of jobs to run in parallel. Choose this value based on the number of CPU cores you want to use for building. This may take about 10 minutes, depending on your hardware specs.
 
-      f. Set the environment variable `BOOST_ROOT` to point to the new `boost_1_64_0` directory. It's best to put this environment variable in your `.profile`, or equivalent, file for your shell so it's automatically set when you log in. Add the following line to the file:
+              ./b2 -j <number of parallel jobs>
 
-          export BOOST_ROOT=/home/ubuntu/boost_1_64_0
+      6. Set the environment variable `BOOST_ROOT` to point to the new `boost_1_64_0` directory. It's best to put this environment variable in your `.profile`, or equivalent, file for your shell so it's automatically set when you log in. Add the following line to the file:
 
-      g. Source your updated `.profile` file. For example:
+              export BOOST_ROOT=/home/ubuntu/boost_1_64_0
 
-          source ~/.profile
+      7. Source your updated `.profile` file. For example:
 
-10. Get `rippled` source code.
+              source ~/.profile
 
+10. From a working directory, get the `rippled` source code.
+
+        cd ~
         git clone https://github.com/ripple/rippled.git
         cd rippled
         git checkout master
 
-11. If you previously built, or (more importantly) tried and failed to build `rippled`, you should delete the `build/` directory to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like a `rippled` executable that crashes due to a segmentation fault (segfault).
+11. If you previously built, or (more importantly) tried and failed to build `rippled`, you should delete the `my_build/` directory (or whatever you named it) to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like a `rippled` executable that crashes due to a segmentation fault (segfault).
 
-    If this is your first time building `rippled,` you won't have a `build/` directory and can move on to the next step.
+    If this is your first time building `rippled` 1.0.0 or higher, you won't have a `my_build/` directory and can move on to the next step.
 
 12. Use CMake to build a `rippled` binary executable from source code. The result will be a `rippled` binary executable in the `my_build` directory.
 
-      a. Generate the build system. Builds should be performed in a directory that is separate from the source tree root. In this example, we'll use a `my_build` directory that is a subdirectory of `rippled`.
+      1. Generate the build system. Builds should be performed in a directory that is separate from the source tree root. In this example, we'll use a `my_build` directory that is a subdirectory of `rippled`.
 
-          mkdir my_build
-          cd my_build
-          cmake -Dtarget=gcc.debug.unity ..
+              mkdir my_build
+              cd my_build
+              cmake -Dtarget=gcc.debug.unity ..
 
-      b. Build the `rippled` binary executable.
+      2. Build the `rippled` binary executable. Replace `<number of parallel jobs>` with the number of jobs to run in parallel. Choose this value based on the number of CPU cores you want to use for building.
 
-          cmake --build . -- -j <number of parallel jobs>
+              cmake --build . -- -j <number of parallel jobs>
 
 13. _(Optional)_ Run `rippled` unit tests. If there are no test failures, you can be fairly certain that your `rippled` executable compiled correctly.
 
@@ -127,11 +130,11 @@ Complete the following configurations that are required for `rippled` to start u
 
 2. Edit the config file to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here.
 
-      a. Set the `[node_db]`'s path to the location where you want to store the ledger database.
+      1. Set the `[node_db]`'s path to the location where you want to store the ledger database.
 
-      b. Set the `[database_path]` to the location where you want to store other database data. (This includes an SQLite database with configuration data, and is typically one level above the `[node_db]` path field.)
+      2. Set the `[database_path]` to the location where you want to store other database data. (This includes an SQLite database with configuration data, and is typically one level above the `[node_db]` path field.)
 
-      c. Set the `[debug_logfile]` to a path where `rippled` can write logging information.
+      3. Set the `[debug_logfile]` to a path where `rippled` can write logging information.
 
 3. Copy the example `validators.txt` file to the same folder as `rippled.cfg`:
 

--- a/content/tutorials/manage-the-rippled-server/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/build-run-rippled-ubuntu.md
@@ -91,18 +91,28 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
               source ~/.profile
 
-10. From a working directory, get the `rippled` source code.
+10. From a working directory, get the `rippled` source code. The `master` branch has the latest released version.
 
         cd ~
         git clone https://github.com/ripple/rippled.git
         cd rippled
         git checkout master
 
-11. If you previously built, or (more importantly) tried and failed to build `rippled`, you should delete the `my_build/` directory (or whatever you named it) to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like a `rippled` executable that crashes due to a segmentation fault (segfault).
+11. Check the commit log to be sure you're compiling the version you intend to. The most recent commit should be signed by a well-known Ripple developer and should set the version number to the latest released version. For example:
+
+        $ git log
+
+        commit f31ca2860fb5f045b618aa05d1e76c7e2e9494ec (HEAD, tag: 1.0.0, origin/release, origin/master, master)
+        Author: Nikolaos D. Bougalis <nikb@bougalis.net>
+        Date:   Fri May 11 10:29:41 2018 -0700
+
+            Set version to 1.0.0
+
+12. If you previously built, or (more importantly) tried and failed to build `rippled`, you should delete the `my_build/` directory (or whatever you named it) to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like a `rippled` executable that crashes due to a segmentation fault (segfault).
 
     If this is your first time building `rippled` 1.0.0 or higher, you won't have a `my_build/` directory and can move on to the next step.
 
-12. Use CMake to build a `rippled` binary executable from source code. The result will be a `rippled` binary executable in the `my_build` directory.
+13. Use CMake to build a `rippled` binary executable from source code. The result will be a `rippled` binary executable in the `my_build` directory.
 
       1. Generate the build system. Builds should be performed in a directory that is separate from the source tree root. In this example, we'll use a `my_build` directory that is a subdirectory of `rippled`.
 
@@ -114,7 +124,7 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
               cmake --build . -- -j <number of parallel jobs>
 
-13. _(Optional)_ Run `rippled` unit tests. If there are no test failures, you can be fairly certain that your `rippled` executable compiled correctly.
+14. _(Optional)_ Run `rippled` unit tests. If there are no test failures, you can be fairly certain that your `rippled` executable compiled correctly.
 
         ./rippled -u
 

--- a/content/tutorials/manage-the-rippled-server/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/build-run-rippled-ubuntu.md
@@ -4,7 +4,7 @@
 
 For an overview of `rippled`, see [Operating rippled Servers](install-rippled.html).
 
-Use these instructions to build a `rippled` executable from source version 0.90.0 or higher on Ubuntu Linux 16.04 or higher. These instructions were tested on Ubuntu 16.04 LTS.
+Use these instructions to build a `rippled` executable from source version 1.0.0 or higher on Ubuntu Linux 16.04 or higher. These instructions were tested on Ubuntu 16.04 LTS.
 
 For information about building `rippled` for other platforms, see [Builds](https://github.com/ripple/rippled/tree/develop/Builds) in the `rippled` GitHub repository.
 
@@ -36,9 +36,9 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
         sudo apt-get -y install git
 
-4. Install SCons.
+4. Install CMake.
 
-        sudo apt-get -y install scons
+        sudo apt-get -y install cmake
 
 5. Install `pkg-config`.
 
@@ -59,7 +59,7 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
 9. Compile Boost.
 
-    Starting in `rippled` 0.90.0, the recommended Boost version is 1.64.0. Because Boost version 1.64.0 isn't available in the Ubuntu 16.04 repos, you must compile it yourself.
+    The recommended Boost version is 1.64.0. Because Boost version 1.64.0 isn't available in the Ubuntu 16.04 repos, you must compile it yourself.
 
       a. Download Boost 1.64.0.
 
@@ -77,9 +77,9 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
           ./bootstrap.sh
 
-      e. To invoke Boost.Build to build the separately-compiled Boost libraries, run the following command. Replace `<number of jobs>` with the number of job, or commands, to run in parallel. This may take about 15 minutes, depending on your hardware specs.
+      e. To invoke Boost.Build to build the separately-compiled Boost libraries, run the following command. Replace `<number of parallel jobs>` with the number of jobs, or commands, to run in parallel. Choose this value based on the number of cores you want to use for building. This may take about 10 minutes, depending on your hardware specs.
 
-          ./b2 -j <number of jobs>
+          ./b2 -j <number of parallel jobs>
 
       f. Set the environment variable `BOOST_ROOT` to point to the new `boost_1_64_0` directory. It's best to put this environment variable in your `.profile`, or equivalent, file for your shell so it's automatically set when you log in. Add the following line to the file:
 
@@ -99,11 +99,17 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
     If this is your first time building `rippled,` you won't have a `build/` directory and can move on to the next step.
 
-12. Build a `rippled` binary executable from source code. This may take about 20 minutes, depending on your hardware specs.
+12. Use CMake to build a `rippled` binary executable from source code. The result will be a `rippled` binary executable in the `my_build` directory.
 
-        scons
+      a. Generate the build system. Builds should be performed in a directory that is separate from the source tree root. In this example, we'll use a `my_build` directory that is a subdirectory of `rippled`.
 
-    SCons saves the built executable in `rippled/build`.
+          mkdir my_build
+          cd my_build
+          cmake -Dtarget=gcc.debug.unity ..
+
+      b. Build the `rippled` binary executable.
+
+          cmake --build . -- -j <number of parallel jobs>
 
 13. _(Optional)_ Run `rippled` unit tests. If there are no test failures, you can be fairly certain that your `rippled` executable compiled correctly.
 
@@ -117,27 +123,28 @@ Complete the following configurations that are required for `rippled` to start u
 1. Create a copy of the example config file (assumes you're in the `rippled` folder already). Saving the config file to this location enables you to run `rippled` as a non-root user (recommended).
 
         mkdir -p ~/.config/ripple
-        cp doc/rippled-example.cfg ~/.config/ripple/rippled.cfg
+        cp cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
 
 2. Edit the config file to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here.
 
-    1. Set the `[node_db]`'s path to the location where you want to store the ledger database.
+      a. Set the `[node_db]`'s path to the location where you want to store the ledger database.
 
-    2. Set the `[database_path]` to the location where you want to store other database data. (This includes an SQLite database with configuration data, and is typically one level above the `[node_db]` path field.)
+      b. Set the `[database_path]` to the location where you want to store other database data. (This includes an SQLite database with configuration data, and is typically one level above the `[node_db]` path field.)
 
-    3. Set the `[debug_logfile]` to a path where `rippled` can write logging information.
+      c. Set the `[debug_logfile]` to a path where `rippled` can write logging information.
 
 3. Copy the example `validators.txt` file to the same folder as `rippled.cfg`:
 
-        cp doc/validators-example.txt ~/.config/ripple/validators.txt
+        cp cfg/validators-example.txt ~/.config/ripple/validators.txt
 
     **Warning:** Ripple has designed a [decentralization plan](https://ripple.com/dev-blog/decentralization-strategy-update/) with maximum safety in mind. During the transition, you *should not* modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
+
 
 ## 3. Run `rippled`
 
 To run your stock `rippled` server from the executable you built, using the configurations you defined:
 ```
-cd build
+cd my_build
 ./rippled
 ```
 
@@ -149,34 +156,47 @@ Once you've run `rippled`, here are excerpts of what you can expect to see in yo
 ```
 Loading: "/home/ubuntu/.config/ripple/rippled.cfg"
 Watchdog: Launching child 1
-2018-Jan-31 20:19:40 JobQueue:NFO Auto-tuning to 4 validation/transaction/proposal threads.
-2018-Jan-31 20:19:40 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
-2018-Jan-31 20:19:40 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
+2018-Jun-06 00:51:35.094331139 JobQueue:NFO Auto-tuning to 4 validation/transaction/proposal threads.
+2018-Jun-06 00:51:35.100607625 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
+2018-Jun-06 00:51:35.101226904 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
+2018-Jun-06 00:51:35.101354503 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
+2018-Jun-06 00:51:35.101503304 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
+2018-Jun-06 00:51:35.101624717 Amendments:DBG Amendment 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 is supported.
 ...
-2018-Jan-31 20:19:40 OrderBookDB:DBG Advancing from 0 to 3
-2018-Jan-31 20:19:40 OrderBookDB:DBG OrderBookDB::update>
-2018-Jan-31 20:19:40 OrderBookDB:DBG OrderBookDB::update< 0 books found
-2018-Jan-31 20:19:40 ValidatorList:DBG Loading configured trusted validator list publisher keys
-2018-Jan-31 20:19:40 ValidatorList:DBG Loaded 1 keys
-2018-Jan-31 20:19:40 ValidatorList:DBG Loading configured validator keys
+2018-Jun-06 00:51:35.106970906 OrderBookDB:DBG Advancing from 0 to 3
+2018-Jun-06 00:51:35.107158071 OrderBookDB:DBG OrderBookDB::update>
+2018-Jun-06 00:51:35.107380722 OrderBookDB:DBG OrderBookDB::update< 0 books found
+2018-Jun-06 00:51:35.168875072 ManifestCache:NFO Manifest: AcceptedNew;Pk: nHBARBMi2MC3LJYuvs9Rhp94WcfbxoQD5BGhwN3jaHBsPkbNpoZq;Seq: 1;
+2018-Jun-06 00:51:35.172099325 ManifestCache:NFO Manifest: AcceptedNew;Pk: nHB57Sey9QgaB8CubTPvMZLkLAzfJzNMWBCCiDRgazWJujRdnz13;Seq: 1;
+2018-Jun-06 00:51:35.175302816 ManifestCache:NFO Manifest: AcceptedNew;Pk: nHDsPCxoBHZS9KNNfsd7iVaQXBSitNtbqXfB6BS1iEmJwwEKLhhQ;Seq: 1;
+2018-Jun-06 00:51:35.178486951 ManifestCache:NFO Manifest: AcceptedNew;Pk: nHBQ3CT3EWYZ4uzbnL3k6TRf9bBPhWRFVcK1F5NjtwCBksMEt5yy;Seq: 2;
+2018-Jun-06 00:51:35.181681868 ManifestCache:NFO Manifest: AcceptedNew;Pk: nHU5egMCYs1g7YRVKrKjEqVYFL12mFWwkqVFTiz2Zi4Z8jppPgxU;Seq: 2;
+2018-Jun-06 00:51:35.184864291 ManifestCache:NFO Manifest: AcceptedNew;Pk: nHBbiP5ua5dUqCTz5i5vd3ia9jg3KJthohDjgKxnc7LxtmnauW7Z;Seq: 2;
 ...
-2018-Jan-31 20:19:40 LedgerConsensus:NFO Entering consensus process, watching, synced=no
-2018-Jan-31 20:19:40 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
-...
-2018-Jan-31 20:19:40 Application:FTL Startup RPC:
+2018-Jun-06 00:51:35.317972033 LedgerConsensus:NFO Entering consensus process, watching, synced=no
+2018-Jun-06 00:51:35.318155351 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
+2018-Jun-06 00:51:35.318360468 NetworkOPs:DBG Initiating consensus engine
+2018-Jun-06 00:51:35.358673488 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
+2018-Jun-06 00:51:35.359296222 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
+2018-Jun-06 00:51:35.359778994 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
+2018-Jun-06 00:51:35.360240190 Application:FTL Startup RPC:
 {
 	"command" : "log_level",
 	"severity" : "warning"
 }
 ...
-2018-Jan-31 20:20:32 NetworkOPs:WRN We are not running on the consensus ledger
-2018-Jan-31 20:20:32 LedgerConsensus:WRN Need consensus ledger 17F251A5AD7120BD0D3ED9EB1B45598AACA1D76EA67C7FFC3384E629C25E198B
-2018-Jan-31 20:20:35 NetworkOPs:WRN We are not running on the consensus ledger
-2018-Jan-31 20:20:35 LedgerConsensus:WRN Need consensus ledger 0EAEFBC6C63DE7CEA32415336C7524D50E2531781704CE86895EAF84A63477D7
+2018-Jun-06 00:52:32.385295633 NetworkOPs:WRN We are not running on the consensus ledger
+2018-Jun-06 00:52:32.388552023 LedgerConsensus:WRN Need consensus ledger 84726E8C5B346E28C21ADE6AAD703E65F802322EDAA5B76446A4D0C5206AB2DB
+2018-Jun-06 00:52:33.379448561 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
+2018-Jun-06 00:52:33.379541915 LedgerConsensus:WRN 84726E8C5B346E28C21ADE6AAD703E65F802322EDAA5B76446A4D0C5206AB2DB to 1720162AE3BA8CD953BFB40EB746D7B78D13E1C97905E8C553E0B573F1B6A517
+2018-Jun-06 00:52:33.379747629 LedgerConsensus:WRN {"accepted":true,"account_hash":"CC1F1EC08E76BC9FE843BBF9C6068C5B73192E6957B9CC1174DCB2B94DD2025A","close_flags":0,"close_time":581561550,"close_time_human":"2018-Jun-06 00:52:30.000000000","close_time_resolution":30,"closed":true,"hash":"94354A7FECAB638C29BBC79B18CFDBDC05E4FF72647AD62F072DB4D23A5E0317","ledger_hash":"94354A7FECAB638C29BBC79B18CFDBDC05E4FF72647AD62F072DB4D23A5E0317","ledger_index":"3","parent_close_time":581561490,"parent_hash":"80BF92A69F65F5C543E962DF4B41715546FDD97FC6988028E5ACBB46654756CA","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
 ...
-2018-Jan-31 20:20:53 LedgerConsensus:WRN View of consensus changed during establish status=establish,  mode=wrongLedger
-2018-Jan-31 20:20:53 LedgerConsensus:WRN E5C6EF6AB5C1DB0EA5EF1C43C2EDC1179459FBAC5ABDF6523F488DEE276FA9E6 to 7F0E5EE15F8FC41776BA230094C364DE045C35A15073C9E057407506A9E53892
-2018-Jan-31 20:20:53 LedgerConsensus:WRN {"accepted":true,"account_hash":"8EE80E7E8ADCE2AB550611752BC4EC748D9DFEBB4B4B98F05BD5F6147CF61ED5","close_flags":0,"close_time":570745240,"close_time_human":"2018-Jan-31 20:20:40","close_time_resolution":20,"closed":true,"hash":"9FA1BAF2A4F6A908B10303E6624E175CCD53D1E87E6B44D09FC28E8FCC63D3C3","ledger_hash":"9FA1BAF2A4F6A908B10303E6624E175CCD53D1E87E6B44D09FC28E8FCC63D3C3","ledger_index":"8","parent_close_time":570745234,"parent_hash":"9AF26062D241A16EDD8436EB1A9B533281D43949A7DA2E4F35A50110537BD596","seqNum":"8","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
+2018-Jun-06 00:53:50.568965045 LedgerConsensus:WRN {"accepted":true,"account_hash":"A79E6754544F9C8FC74870C95A39CED1D45CC1206DDA4C113E51F9DB6DDB0E76","close_flags":0,"close_time":581561630,"close_time_human":"2018-Jun-06 00:53:50.000000000","close_time_resolution":10,"closed":true,"hash":"6294118F39F5F2B8349E7CC6D4D5931011622E78DD4E34D91372651E9F453E2F","ledger_hash":"6294118F39F5F2B8349E7CC6D4D5931011622E78DD4E34D91372651E9F453E2F","ledger_index":"29","parent_close_time":581561623,"parent_hash":"5F57870CE5160D6B53271955F26E3BE63696D1127B91BC7943F9A199B313CB85","seqNum":"29","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
+2018-Jun-06 00:53:50.569776678 LedgerConsensus:WRN Need consensus ledger 6A0DE66550B6BA9636E3F8FDB71C2E924D182A1835E4143B2170DAA1D33CAE8D
+2018-Jun-06 00:53:51.576778862 NetworkOPs:WRN We are not running on the consensus ledger
+2018-Jun-06 00:53:53.576524564 LedgerConsensus:WRN View of consensus changed during establish status=establish,  mode=wrongLedger
+2018-Jun-06 00:53:53.576783663 LedgerConsensus:WRN 6A0DE66550B6BA9636E3F8FDB71C2E924D182A1835E4143B2170DAA1D33CAE8D to 1CB9C9A1C27403CBAB9DFCFA61E1F915059DFE4FA93524537B885CC190DB5C6B
+2018-Jun-06 00:53:53.577079124 LedgerConsensus:WRN {"accepted":true,"account_hash":"5CAB3E4F5F2AC1A764106D7CC0729E6E7D1F7F93C65B7D8CB04C8DE2FC2C1305","close_flags":0,"close_time":581561631,"close_time_human":"2018-Jun-06 00:53:51.000000000","close_time_resolution":10,"closed":true,"hash":"201E147BD195CE3C56B0C0B8DF58386FC7BFF450E1E5B286A29AB856926D5F79","ledger_hash":"201E147BD195CE3C56B0C0B8DF58386FC7BFF450E1E5B286A29AB856926D5F79","ledger_index":"30","parent_close_time":581561630,"parent_hash":"6294118F39F5F2B8349E7CC6D4D5931011622E78DD4E34D91372651E9F453E2F","seqNum":"30","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
 ```
 
 


### PR DESCRIPTION
Tested the updated steps using my existing ubuntu 16.04 environment (which I've used to install 0.90.0), but hoped to test on a clean environment. 

@mDuo13, would you mind testing out the updated instructions, please? And, thank you again for such a thorough and helpful JIRA ticket for this update!