### PR TITLE
Removed duplicate message from checkcash.md

### DIFF
--- a/content/references/rippled-api/transaction-formats/transaction-types/checkcash.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/checkcash.md
@@ -22,9 +22,6 @@ Since the funds for a check are not guaranteed, redeeming a Check can fail becau
 {% include '_snippets/tx-fields-intro.md' %}
 <!--{# fix md highlighting_ #}-->
 
-
-In addition to the [common fields](transaction-common-fields.html), a CheckCash transaction has the following:
-
 | Field       | JSON Type | [Internal Type][] | Description                    |
 |:------------|:----------|:------------------|:-------------------------------|
 | `CheckID`   | String    | Hash256           | The ID of the [Check ledger object](check.html) to cash, as a 64-character hexadecimal string. |


### PR DESCRIPTION
It looks like the field intro was optimized to use a snippet, but the original intro text was left in, duplicating the field intro message.