### PR TITLE
Add dedicated Data API target

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -54,6 +54,15 @@ targets:
             - html: ledger_entry.html
               date: 2018-06-07
 
+    # Data API target for porting changes to the README in the upstream repo
+    # Intended for use in markdown (--md) mode.
+    -   name: data-api-only
+        display_name: XRP Ledger Data API
+        github_forkurl: https://github.com/ripple/ripple-dev-portal
+        github_branch: master
+        link_re_subs:
+           "([\\w-]+\\.html)": https://developers.ripple.com/\1
+
 pages:
 
     -   name: Docs
@@ -2328,6 +2337,7 @@ pages:
               anchor: "#api-conventions"
         targets:
             - local
+            - data-api-only
 
 
 # --------------- end "Docs" section -------------------------------------------

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -60,6 +60,7 @@ targets:
         display_name: XRP Ledger Data API
         github_forkurl: https://github.com/ripple/ripple-dev-portal
         github_branch: master
+        no_cover: True
         link_re_subs:
            "([\\w-]+\\.html)": https://developers.ripple.com/\1
 

--- a/tool/template-base.html
+++ b/tool/template-base.html
@@ -50,7 +50,7 @@
 <body class="xrp-ledger-dev-portal {% if currentpage.sidebar != "disabled" %}sidebar-primary {% endif %}{% block bodyclasses %}{% endblock %}">
 
   <nav class="navbar fixed-top navbar-expand-lg navbar-light bg-white">
-    <a href="index.html" class="navbar-brand"><img src="assets/img/XRPLedger_DevPortal_Gray.svg" class="logo" width="120" height="35" alt="XRP Ledger Dev Portal" /></a>
+    <a href="{% if target.no_cover %}/{% else %}index.html{% endif %}" class="navbar-brand"><img src="assets/img/XRPLedger_DevPortal_Gray.svg" class="logo" width="120" height="35" alt="XRP Ledger Dev Portal" /></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHolder" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/tool/template-breadcrumbs.html
+++ b/tool/template-breadcrumbs.html
@@ -1,6 +1,6 @@
 <nav class="breadcrumbs-wrap {% if currentpage.sidebar == 'disabled' %}p-3 px-sm-4{% else %}p-3{% endif %}" aria-label="breacrumb">
   <ul class="breadcrumb bg-white">
-    <li class="breadcrumb-item"><a href="index.html">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% if target.no_cover %}/{% else %}index.html{% endif %}">Home</a></li>
     {% if currentpage.funnel and currentpage != pages|selectattr('funnel', 'equalto', currentpage.funnel)|first %}
     <li class="active breadcrumb-item"><a href="{{ (pages|selectattr('funnel', 'equalto', currentpage.funnel)|first).html }}">{{ currentpage.funnel }}</a></li>
     {% endif %}


### PR DESCRIPTION
Creates a "data-api-only" target for easier exporting of the Data API
reference to be used in the upstream repository. This target contains
link substitutions so that the links work on an external site (like
GitHub's README view).

I constructed this while testing changes to Dactyl v0.7.3. It would've been pretty handy for the last couple of Data API changes I had to make.