### PR TITLE
Add --unittest-ipv6 option to CLI ref

### DIFF
--- a/content/references/rippled-api/commandline-usage.md
+++ b/content/references/rippled-api/commandline-usage.md
@@ -116,6 +116,7 @@ While running unit tests, you can specify the [Generic Options](#generic-options
 
 | Option                             | Short Version | Description             |
 |:-----------------------------------|:--------------|:------------------------|
+| `--unittest-ipv6`                  |               | Use [IPv6](https://en.wikipedia.org/wiki/IPv6) to connect to the local server when running unit tests. If not provided, unit tests use IPv4 instead. [New in: rippled 1.1.0][] |
 | `--unittest-jobs {NUMBER_OF_JOBS}` |               | Use the specified number of processes to run unit tests. This can finish running tests faster on multi-core systems. The `{NUMBER_OF_JOBS}` should be a positive integer indicating the number of processes to use. |
 | `--unittest-log`                   |               | Allow unit tests to write to logs even if `--quiet` is specified. (No effect otherwise.) |
 | `--quiet`                          | `-q`          | Print fewer diagnostic messages when running unit tests. |


### PR DESCRIPTION
Documents the new `--unittest-ipv6` option from https://github.com/ripple/rippled/pull/2616 and https://github.com/ripple/rippled/pull/2321

Link checker is expected to fail because the "New in: rippled 1.1.0" link is defined [in another PR](https://github.com/ripple/ripple-dev-portal/pull/438/files#diff-a6e54718e7ae029e780b7647fd07bbc4R35) and the link won't be live until 1.1.0 is released.