### PR TITLE
Update link to IL-RFC 0016 (PSK)'s new location

### DIFF
--- a/content/tutorials/use-complex-payment-types/use-escrows/send-a-conditionally-held-escrow.md
+++ b/content/tutorials/use-complex-payment-types/use-escrows/send-a-conditionally-held-escrow.md
@@ -5,7 +5,7 @@
 XRP Ledger escrows require PREIMAGE-SHA-256 [Crypto-Conditions](https://tools.ietf.org/html/draft-thomas-crypto-conditions-03). To calculate a condition and fulfillment in the proper format, you should use a Crypto-Conditions library such as [five-bells-condition](https://github.com/interledgerjs/five-bells-condition). For fulfillments, Ripple recommends using one of the following methods to generate the fulfillment:
 
 - Use a cryptographically secure source of randomness to generate at least 32 random bytes.
-- Follow Interledger Protocol's [PSK specification](https://github.com/interledger/rfcs/blob/master/0016-pre-shared-key/0016-pre-shared-key.md) and use an HMAC-SHA-256 of the ILP packet as the fulfillment.
+- Follow Interledger Protocol's [PSK specification](https://github.com/interledger/rfcs/blob/master/deprecated/0016-pre-shared-key/0016-pre-shared-key.md) and use an HMAC-SHA-256 of the ILP packet as the fulfillment.
 
 Example JavaScript code for a random fulfillment and condition:
 


### PR DESCRIPTION
Interledger no longer uses PSK, so they moved it to a "deprecated" folder. However, the recommendations for sending a conditionally held escrow in the XRP Ledger haven't really changed (I think?) so we'll just have to link to the deprecated spec.