### PR TITLE
chore: update capacity-planning.md

### DIFF
--- a/content/tutorials/manage-the-rippled-server/capacity-planning.md
+++ b/content/tutorials/manage-the-rippled-server/capacity-planning.md
@@ -26,7 +26,7 @@ The `node_size` parameter determines the size of database caches. Larger databas
 | Available RAM for `rippled` | `node_size` value | Notes                              |
 |:----------------------------|:------------------|:-----------------------------------|
 | < 8GB                       | `tiny`            | Not recommended                    |
-| 8GB                         | `low`             |                                    |
+| 8GB                         | `small`           |                                    |
 | 16GB                        | `medium`          |                                    |
 | 32GB                        | `huge`            | Recommended for production servers |
 


### PR DESCRIPTION
`low` seems to be an invalid value causing an unhandled exception:

    Terminating thread rippled: main: unhandled N5beast14BadLexicalCastE 'std::bad_cast'

It appears correct value is `small`...