### PR TITLE
rippled book_offers returns offers formatted as ledger entries 

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
@@ -161,7 +161,7 @@ The response follows the [standard format][], with a successful result containin
 | `ledger_index`         | Integer                                    | (Omitted if ledger\_current\_index provided instead) Sequence number, provided in the request, of the ledger version that was used when retrieving this data. |
 | `ledger_hash`          | String                                     | (May be omitted) Hex hash, provided in the request, of the ledger version that was used when retrieving this data. |
 | `marker`               | [Marker][] | (May be omitted) Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no pages of information after this one. |
-| `offers`               | Array                                      | Array of offer objects, each of which has the fields of an [OfferCreate transaction][] |
+| `offers`               | Array                                      | Array of offer objects, each of which has the fields of an [Offer object](offer.html) |
 
 In addition to the standard Offer fields, the following fields may be included in members of the `offers` array:
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
@@ -170,7 +170,7 @@ In addition to the standard Offer fields, the following fields may be included i
 | `owner_funds`       | String                           | Amount of the TakerGets currency the side placing the offer has available to be traded. (XRP is represented as drops; any other currency is represented as a decimal value.) If a trader has multiple offers in the same book, only the highest-ranked offer includes this field. |
 | `taker_gets_funded` | String (XRP) or Object (non-XRP) | (Only included in partially-funded offers) The maximum amount of currency that the taker can get, given the funding status of the offer. |
 | `taker_pays_funded` | String (XRP) or Object (non-XRP) | (Only included in partially-funded offers) The maximum amount of currency that the taker would pay, given the funding status of the offer. |
-| `quality`           | Number                           | The exchange rate, as the ratio `taker_pays` divided by `taker_gets`. For fairness, offers that have the same quality are automatically taken first-in, first-out. (In other words, if multiple people offer to exchange currency at the same rate, the oldest offer is taken first.) |
+| `quality`           | String                           | The exchange rate, as the ratio `taker_pays` divided by `taker_gets`. For fairness, offers that have the same quality are automatically taken first-in, first-out. (In other words, if multiple people offer to exchange currency at the same rate, the oldest offer is taken first.) |
 
 ## Possible Errors
 


### PR DESCRIPTION
The current documentation claims that the rippled-api book_offers function returns an array of offers with the fields of a CreateOffer object, but when looking at the actual fields returned by the function, the format matches the format of the offer ledger entry.

[Original Documentation](https://developers.ripple.com/offer.html) - actual response below
```
{
  "id": 11,
  "status": "success",
  "type": "response",
  "result": {
    "ledger_current_index": 7035305,
    "offers": [
      {
        "Account": "rM3X3QSr8icjTGpaF52dozhbT2BZSXJQYM",
        "BookDirectory": "7E5F614417C2D0A7CEFEB73C4AA773ED5B078DE2B5771F6D55055E4C405218EB",
        "BookNode": "0000000000000000",
        "Flags": 0,
        "LedgerEntryType": "Offer",
        "OwnerNode": "0000000000000AE0",
        "PreviousTxnID": "6956221794397C25A53647182E5C78A439766D600724074C99D78982E37599F1",
        "PreviousTxnLgrSeq": 7022646,
        "Sequence": 264542,
        "TakerGets": {
          "currency": "EUR",
          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
          "value": "17.90363633316433"
        },
        "TakerPays": {
          "currency": "USD",
          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
          "value": "27.05340557506234"
        },
        "index": "96A9104BF3137131FF8310B9174F3B37170E2144C813CA2A1695DF2C5677E811",
        "quality": "1.511056473200875"
      },
      {
        "Account": "rhsxKNyN99q6vyYCTHNTC1TqWCeHr7PNgp",
        "BookDirectory": "7E5F614417C2D0A7CEFEB73C4AA773ED5B078DE2B5771F6D5505DCAA8FE12000",
        "BookNode": "0000000000000000",
        "Flags": 131072,
        "LedgerEntryType": "Offer",
        "OwnerNode": "0000000000000001",
        "PreviousTxnID": "8AD748CD489F7FF34FCD4FB73F77F1901E27A6EFA52CCBB0CCDAAB934E5E754D",
        "PreviousTxnLgrSeq": 7007546,
        "Sequence": 265,
        "TakerGets": {
          "currency": "EUR",
          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
          "value": "2.542743233917848"
        },
        "TakerPays": {
          "currency": "USD",
          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
          "value": "4.19552633596446"
        },
        "index": "7001797678E886E22D6DE11AF90DF1E08F4ADC21D763FAFB36AF66894D695235",
        "quality": "1.65"
      }
    ]
  }
}
```
[Offer Ledger Entry Fields](https://developers.ripple.com/offer.html) - 
```Account, BookDirectory, BookNode, Flags, LedgerEntryType, OwnerNode, PreviousTxnID, PreviousTxnLgrSeq, Sequence, TakerGets, TakerPays, index```

[OfferCreate Transaction Fields](https://developers.ripple.com/offercreate.html) - 
```TransactionType, Account, Fee, Flags, LastLedgerSequence, Sequence, TakerGets, TakerPays, etc.```

I chose to capitalize the 'O' in offer an not in object to match https://developers.ripple.com/account_objects.html and https://developers.ripple.com/account_objects.html