### PR TITLE
Tutorials: Add macOS install and Test Net connect to Install rippled

### DIFF
--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -96,7 +96,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
 {{n.next()}}. Install [Xcode](https://developer.apple.com/download/).
 
-{{n.next()}}. Install Xcode command line tools. ***TODO: Comment from Daniel: Installing homebrew removes the need to install xcode command line tools separately. JHA: homebrew lists xcode command line tools as a requirement: https://docs.brew.sh/Installation#requirements. Do we keep or remove this step?***
+{{n.next()}}. Install Xcode command line tools. ***TODO: Comment from PM: Installing homebrew removes the need to install xcode command line tools separately. JHA: homebrew lists xcode command line tools as a requirement: https://docs.brew.sh/Installation#requirements. Do we keep or remove this step?***
 
         xcode-select --install
 
@@ -108,11 +108,11 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         brew update
 
-{{n.next()}}. Use Homebrew to install dependencies. ***TODO: Added boost per Daniel's request: Installing Boost directly is going to frustrate people - brew can do it in one command. I ended up installing Boost with Brew with no issues. Which release to choose? JHA: I did `brew install boost` and brew installs 1.67.0 in /usr/local/Cellar/boost/1.67.0_1 -- is this okay? If we install Boost via brew, do we no longer have to compile boost: ./bootstrap.sh and ./b2 cxxflags="-std=c++14"? Comment from Daniel: Build issues with Boost not finding lib (boost-context) in my case. JHA: when does this issue come up? How can we help the user avoid or address this issue?***
+{{n.next()}}. Use Homebrew to install dependencies. ***TODO: Added boost per PM's request: Installing Boost directly is going to frustrate people - brew can do it in one command. I ended up installing Boost with Brew with no issues. Which release to choose? JHA: I did `brew install boost` and brew installs 1.67.0 in /usr/local/Cellar/boost/1.67.0_1 -- is this okay? If we install Boost via brew, do we no longer have to compile boost: ./bootstrap.sh and ./b2 cxxflags="-std=c++14"? Comment from PM: Build issues with Boost not finding lib (boost-context) in my case. JHA: when does this issue come up? How can we help the user avoid or address this issue?***
 
         brew install git cmake pkg-config protobuf openssl ninja boost
 
-{{n.next()}}. Set the `BOOST_ROOT` environment variable to point to the new directory created by the Homebrew installation of Boost. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, add the following line to the file. To find your Boost install directory, use `brew info boost`. ***TODO: Feedback from Daniel: Have to deal with environment variables. “rc” files is a vague statement. JHA: If you do brew install boost - you still have to set env variables, correct? I did it using .bash_profile and removed references to "rc files" - is this okay? Or do we want to tell users that they can choose to put the env var in the .bashrc file instead of .bash_profile - is there any benefit to saying this?***
+{{n.next()}}. Set the `BOOST_ROOT` environment variable to point to the new directory created by the Homebrew installation of Boost. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, add the following line to the file. To find your Boost install directory, use `brew info boost`. ***TODO: Feedback from PM: Have to deal with environment variables. “rc” files is a vague statement. JHA: If you do brew install boost - you still have to set env variables, correct? I did it using .bash_profile and removed references to "rc files" - is this okay? Or do we want to tell users that they can choose to put the env var in the .bashrc file instead of .bash_profile - is there any benefit to saying this?***
 
         export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
 
@@ -120,7 +120,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         source .bashrc
 
-{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory.  ***TODO: Note from Daniel: Cloning github repo is going to require proper github setup. Should we provide some guidance or references? JHA: What is the proper github setup? I may have set this up a whlie ago and I can't remember the steps that may have been required.***
+{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory.  ***TODO: Note from PM: Cloning github repo is going to require proper github setup. Should we provide some guidance or references? JHA: What is the proper github setup? I may have set this up a whlie ago and I can't remember the steps that may have been required.***
 
         git clone git@github.com:ripple/rippled.git
         cd rippled

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -98,82 +98,80 @@ At this time, we don't recommend using the macOS platform for `rippled` producti
 
 That said, macOS is suitable for many development and testing tasks. `rippled` has been tested for use with macOS High Sierra up to 10.13.
 
-{% set n = cycler(* range(1,99)) %}
+1. Install [Xcode](https://developer.apple.com/download/).
 
-{{n.next()}}. Install [Xcode](https://developer.apple.com/download/).
+0. Install Xcode command line tools.
 
-{{n.next()}}. Install Xcode command line tools.
+        $ xcode-select --install
 
-        xcode-select --install
+0. Install [Homebrew](https://brew.sh/).
 
-{{n.next()}}. Install [Homebrew](https://brew.sh/).
+        $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-        ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+0. Update Homebrew.
 
-{{n.next()}}. Update Homebrew.
+        $ brew update
 
-        brew update
+0. Use Homebrew to install dependencies.
 
-{{n.next()}}. Use Homebrew to install dependencies.
+        $ brew install git cmake pkg-config protobuf openssl ninja
 
-        brew install git cmake pkg-config protobuf openssl ninja
+0. Install Boost 1.67.0. `rippled` 1.1.x is compatible with Boost 1.67.
 
-{{n.next()}}. Install Boost 1.67.0. Currently, we support Boost 1.67 only.
+        $ brew install boost@1.67
 
-        brew install boost@1.67
-
-{{n.next()}}. Ensure that your `BOOST_ROOT` environment variable points to the directory created by the Boost installation. To find your Boost install directory, use `brew info boost`. Put this environment variable in your `.bash_profile` file so it's automatically set when you log in. For example:
+0. Ensure that your `BOOST_ROOT` environment variable points to the directory created by the Boost installation. To find your Boost install directory, use `brew info boost`. Put this environment variable in your `.bash_profile` file so it's automatically set when you log in. For example:
 
         export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
 
-{{n.next()}}. If you updated your `.bash_profile` file in the previous step, be sure to source it. For example:
+0. If you updated your `.bash_profile` file in the previous step, be sure to source it. For example:
 
-        source .bash_profile
+        $ source .bash_profile
 
-{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/).
+0. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/).
 
-        git clone git@github.com:ripple/rippled.git
-        cd rippled
+        $ git clone git@github.com:ripple/rippled.git
+        $ cd rippled
 
-{{n.next()}}. By default, cloning puts you on the `develop` branch. Use this branch if you are doing development work and want the latest set of untested features.
+0. By default, cloning puts you on the `develop` branch. Use this branch if you are doing development work and want the latest set of untested features.
 
       If you want the latest stable release, checkout the `master` branch.
 
-        git checkout master
+        $ git checkout master
 
       If you want to test out the latest release candidate, checkout the `release` branch:
 
-        git checkout release
+        $ git checkout release
 
       Or, you can checkout one of the tagged releases listed on [GitHub](https://github.com/ripple/rippled/releases).
 
-{{n.next()}}. In the `rippled` directory you just cloned, create your build directory and access it. For example:
+0. In the `rippled` directory you just cloned, create your build directory and access it. For example:
 
-        mkdir my_build
-        cd my_build
+        $ mkdir my_build
+        $ cd my_build
 
-{{n.next()}}. Build `rippled`. This could take about 5 minutes, depending on your hardware specs.
+0. Build `rippled`. This could take about 5 minutes, depending on your hardware specs.
 
-        cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+        $ cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
 
       You can set `CMAKE_BUILD_TYPE` to the `Debug` or `Release` build type. All four standard [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html) values are supported.
 
-{{n.next()}}. Run the build using CMake. This could take about 10 minutes, depending on your hardware specs.
+0. Run the build using CMake. This could take about 10 minutes, depending on your hardware specs.
 
-        cmake --build . -- -j 4
+        $ cmake --build . -- -j 4
 
       **Tip:** This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -n hw.ncpu` to get your CPU core count.
 
-{{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) <!--{# ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.*** #}-->
+0. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) <!--{# ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.*** #}-->
 
-        ./rippled --unittest
+        $ ./rippled --unittest
 
-{{n.next()}}. `rippled` requires the `rippled.cfg` configuration file to run. You can find an example config file, `rippled-example.cfg` in `rippled/cfg`. Make a copy and save it as `rippled.cfg` in a location that enables you to run `rippled` as a non-root user. Access the `rippled` directory and run:
+0. `rippled` requires the `rippled.cfg` configuration file to run. You can find an example config file, `rippled-example.cfg` in `rippled/cfg`. Make a copy and save it as `rippled.cfg` in a location that enables you to run `rippled` as a non-root user. Access the `rippled` directory and run:
 
-        mkdir -p /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
-        cp cfg/rippled-example.cfg /etc/opt/ripple/rippled.cfg
+        $ mkdir -p /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
+        $ cp cfg/rippled-example.cfg /etc/opt/ripple/rippled.cfg
 
-{{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: We need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually checked/updated to ensure that there are no permission issues, correct?***
+0. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: We need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually checked/updated to ensure that there are no permission issues, correct?***
 
       * Set the `[node_db]` path to the location where you want to store the ledger database.
 
@@ -183,15 +181,15 @@ That said, macOS is suitable for many development and testing tasks. `rippled` h
 
       These are the only configurations required for `rippled` to start up successfully. All other configuration is optional and can be tweaked after you have a working server. For more information, see [Additional Configurations](#additional-configuration).
 
-{{n.next()}}. `rippled` requires the `validators.txt` file to run. You can find an example validators file, `validators-example.txt`, in `rippled/cfg/`. Make a copy and save it as `validators.txt` in the same folder as your `rippled.cfg` file. Access the `rippled` directory and run:
+0. `rippled` requires the `validators.txt` file to run. You can find an example validators file, `validators-example.txt`, in `rippled/cfg/`. Make a copy and save it as `validators.txt` in the same folder as your `rippled.cfg` file. Access the `rippled` directory and run:
 
-        cp cfg/validators-example.txt /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
+        $ cp cfg/validators-example.txt /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
 
       **Warning:** Ripple has designed a decentralization plan with maximum safety in mind. During the transition, you should not modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
 
-{{n.next()}}. Access your build directory, `my_build` for example, and start the `rippled` service.
+0. Access your build directory, `my_build` for example, and start the `rippled` service.
 
-        sudo ./rippled
+        $ sudo ./rippled
 
       Here's an excerpt of what you can expect to see in your terminal:
 

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -27,6 +27,8 @@ Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A
 
 ## Installation on Ubuntu with alien
 
+<!--{# ***TODO: this doc states that ubuntu has received the highest level of QA and testing - so I moved it above centos and macOS install sections. Okay?*** #}-->
+
 This section assumes that you are using Ubuntu 15.04 or later.
 
 1. Install yum-utils and alien:
@@ -108,11 +110,31 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         brew update
 
-{{n.next()}}. Use Homebrew to install dependencies. ***TODO: Added boost to the brew installs per PM's request: Installing Boost directly is going to frustrate people - brew can do it in one command.*** Boost 1.67.x to 1.68.x are supported. To view the Boost version that will be installed by `brew install boost`, use `brew info boost`. ***TODO: added this text to ensure that users don't install unsupported versions of Boost. For example, what if the brew install boost starts installing 1.69, but we haven't tested and verified yet? Are the supported versions correct? Do we need to list supported version for any of the other dependencies as well?***
+{{n.next()}}. Use Homebrew to install dependencies.
 
-        brew install git cmake pkg-config protobuf openssl ninja boost
+        brew install git cmake pkg-config protobuf openssl ninja
 
-{{n.next()}}. Ensure that the `BOOST_ROOT` environment variable points to the directory created by the Homebrew installation of Boost. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, ensure that the following line is in the file. To find your Boost install directory, use `brew info boost`. ***TODO: Feedback from PM: Have to deal with environment variables. JHA: When I did a brew install boost, I had to set the env variable -- but I think it may be because I had an existing BOOST_ROOT env var set to a location I created when I previously did a manual boost install. Maybe the brew install doesn't overwrite/update an existing BOOST_ROOT value? Changed the wording a bit to address this - so it is not that you'll always need to add the env var - just make sure it is there and up to date?***
+{{n.next()}}. Install a supported version of Boost. Supported versions include Boost 1.67.x - 1.68.x. ***TODO: correctly stated supported versions? Doc will need to keep an eye on these supported versions. In the rippled repo, we say "Boost 1.67 or later is required." <-- Based on our discussion in this doc, I don't think this is true.*** Installation using Homebrew is faster and requires fewer manual steps, but you must ensure that Homebrew installs a supported version of Boost.
+
+    Pick one of the following options to install Boost:
+
+    * To ensure that Homebrew installs a supported version of Boost, use `brew install boost@1.67` to install Boost 1.67.0. ***TODO: When the supported versions change above, we can also change this, if needed. There is no brew command to install 1.68 right now. brew install boost is still installing 1.67 and there is no brew formula boost@1.68.***
+
+    * To use Homebrew to install a different supported version of Boost, check [Homebrew Formulae - boost](https://formulae.brew.sh/formula/boost) to see if there is a formula for the version you want to install. To verify the Boost version a Homebrew formula will install, use `brew info <formula>`. For example, `brew info boost` or `brew info boost@1.67`.
+
+    * To install a supported version of Boost that does not have a defined Homebrew formula, compile Boost yourself. These compile instructions are for Boost 1.68.0.
+
+        1. Download [Boost 1.68.0](https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2). ***TODO: do we want to give them CLI instructions? If yes, then we need to have them use brew install wget.***
+
+        2. Extract it to a folder. Be sure to note the location. ***TODO: provide CLI instructions?***
+
+        3. In a terminal, run:
+
+              `./bootstrap.sh`
+
+              `./b2 cxxflags="-std=c++14"`
+
+{{n.next()}}. Ensure that the `BOOST_ROOT` environment variable points to the directory created by your Boost installation. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, ensure that the following line is in the file. To find your Boost install directory, use `brew info boost`. ***TODO: JHA clean out boost env vars and uninstall boost - then try again and see what gets populated in bash_profile....***
 
         export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
 
@@ -152,9 +174,9 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         cmake --build . -- -j 4
 
-      This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -a | grep machdep.cpu | grep core_count` to get your CPU core count. ***TODO: the mac build page in the github repo goes much more in-depth about cmake build options - should we include these here? https://github.com/ripple/rippled/tree/develop/Builds/macos#generate-and-build***
+      This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -a | grep machdep.cpu | grep core_count` to get your CPU core count. ***TODO: the mac build page in the github repo (https://github.com/ripple/rippled/tree/develop/Builds/macos#generate-and-build) goes much more in-depth about cmake build options - should we include these here, just to bring a parity between what we say in the rippled repo and what we say here? That said -- do we want to eventually just have one doc on how to do the mac install -- meaning the macos doc content in the rippled repo would go away and just link to this article in the Dev Portal? We also probably want to take a look at what to do with the Linux and Visual Studio install in the rippled repo.***
 
-{{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.***
+{{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) <!--{# ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.*** #}-->
 
         ./rippled --unittest
 
@@ -164,7 +186,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
         cd rippled
         cp cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
 
-{{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: this is required at this point in the install b/c if you don't have the permissions set correctly, rippled won't run, correct? It is not that the default values in rippled.cfg are incorrect--there may just be permission issues, is that right? what is the equivalent command in macOS for `chown -R rippled:rippled <configured path>`? I think we need to add this step to the centos and ubuntu tasks. The config files are placed in the correct directory automatically -- but these values still need to be manually updated, yes?***
+{{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: I think we need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually updated to avoid permission issues, correct?***
 
       * Set the `[node_db]` path to the location where you want to store the ledger database.
 
@@ -191,7 +213,7 @@ For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#
 
 It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers.
 
-Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'll see this for the macOS install, but not for centos and ubuntu. For centos and ubuntu - is there any benefit to giving the user a command that will display this view? Does such a command exist? Alternatively, for centos and ubuntu - we need to give the user some other way to tell that the service is running - refer them to server states?***
+Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'll see this in the CLI for the macOS install, but not for centos and ubuntu using the instructions provided in this doc. For centos and ubuntu - is there a benefit to giving the user a command that will display this view? Does such a command exist? If not, for centos and ubuntu - we need to give the user some other way to tell that the service is running correctly - refer them to server states?***
 
         2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
         2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
@@ -243,7 +265,7 @@ Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'l
         2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
         2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
 
-***TODO: for the future, provide a reference for what the most common and unintuitive messages mean -- esp when signalling possible errors.***
+<!--{# ***TODO: for the future, provide a reference for what the most common and unintuitive messages mean -- esp when signaling possible errors.*** #}-->
 
 Once your `rippled` has synchronized with the rest of the network, you have a fully functional stock `rippled` server that you can use for local signing and API access to the XRP Ledger. Use [`rippled` server states](rippled-server-states.html) to tell whether your `rippled` server has synchronized with the network.
 
@@ -262,12 +284,12 @@ The default locations for `rippled.cfg` are as follows:
 
 * Ubuntu with alien: `~/.config/ripple/`
 
-* macOS: `~/.config/ripple/` ***TODO: Info in rippled-example.cfg points to the wiki to tell folks where to put this file -- need to update rippled-example.cfg to address. Specifically, the section explaining the --conf command line option: https://ripple.com/wiki/Rippled#--conf.3Dpath - the content doesn't exist on the wiki page and we are retiring the wiki.***
+* macOS: `~/.config/ripple/`
 
-Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: Per notes above, I think we need to add the "Edit `rippled.cfg` to set necessary file paths." step to centos and ubuntu tasks. Once we do that, we can put this command info in the context of each task.***
+Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: [node_db] as well? When I try this for a [node_db] value of /var/lib/rippled/db/rocksdb: chown -R rippled:rippled /var/lib/rippled/db/rocksdb, I get -- chown: rippled: illegal group name. Is rippled:rippled just an example below? Or should there be a rippled group?***
 
     $ chown -R rippled:rippled <configured path>
 
-Restart `rippled` for any configuration changes to take effect: ***TODO: what is the macOS command for this?***
+Restart `rippled` for any configuration changes to take effect: ***TODO: does this command work for centos, ubuntu, and macOS? JHA verify.***
 
     $ sudo service rippled restart

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -80,7 +80,7 @@ This section assumes that you are using Ubuntu 15.04 or later.
         $ sudo systemctl start rippled.service
 
 
-## Installation on macOS with homebrew
+## Installation on macOS with Homebrew
 
 We don't recommend macOS for `rippled` production use at this time. Currently, the [Ubuntu platform](#installation-on-ubuntu-with-alien) has received the highest level of quality assurance and testing. That said, macOS is suitable for many development/test tasks.
 
@@ -88,15 +88,31 @@ https://github.com/ripple/rippled/tree/develop/Builds/macos
 
 This section assumes that you are using macOS X 10.0 or higher. ***TODO: correct?***
 
-1. Download Xcode: https://developer.apple.com/download/
+1. Install [Xcode](https://developer.apple.com/download/). ***TODO: min and max version? If you try to install Xcode today, you'll need at least macOS 10.13.6.***
 
-2. Install home brew: ruby -e “$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)
+Installing homebrew removes the need to install xcode command line tools separately
+  homebrew install lists xcode commend line tools as a requirement: https://docs.brew.sh/Installation#requirements. What does this comment mean?
 
-3. brew update
+2. Install Homebrew.
 
-4. brew install git cmake pkg-config protobuf openssl ninja
+        ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-5. Download boost: https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
+3. Update Homebrew.
+
+        brew update
+
+4. Use Homebrew to install git, cmake, pkg-config, protobuf, openssl, and ninja.
+
+        brew install git cmake pkg-config protobuf openssl ninja
+
+5. Download [boost](https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2):
+
+Installing Boost directly is going to frustrate people - brew can do it in one command
+  Which release to choose?
+  Have to deal with environment variables
+  “rc” files is a vague statement
+  Build issues with Boost not finding lib (boost-context) in my case
+  I ended up installing Boost with Brew with no issues
 
 6. build boost: ./bootstrap.sh
 
@@ -105,6 +121,9 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: correct
 8. create boost_root variable: export BOOST_ROOT=/Users/manojdoshi/rippled/boost_1_67_0
 
 9. Clone the ripple repo: git clone https://github.com/ripple/rippled.git
+
+Cloning github repo is going to require proper github setup
+  Should we provide some guidance or references?
 
 10. switch the branch: git checkout develop
 
@@ -122,22 +141,10 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: correct
 
 Daniel: Compiling from source (OSX)
 
-Installing homebrew removes the need to install xcode command line tools separately
-  homebrew install lists xcode commend line tools as a requirement: https://docs.brew.sh/Installation#requirements. What does this comment mean?
-
-Installing Boost directly is going to frustrate people - brew can do it in one command
-  Which release to choose?
-  Have to deal with environment variables
-  “rc” files is a vague statement
-  Build issues with Boost not finding lib (boost-context) in my case
-  I ended up installing Boost with Brew with no issues
-
-Cloning github repo is going to require proper github setup
-  Should we provide some guidance or references?
-
 Update rippled
   No instructions on github or dev docs on how to do this for OSX, Windows, or other Linux distros
 
+Is this about how to run rippled too? How to do that...and how to tell if what you are running is working correctly?
 
 ## Postinstall
 

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -1,16 +1,15 @@
 # Install rippled
 
-Production `rippled` instances can [use Ripple's binary executable](#installation-on-centosred-hat-with-yum), available from the Ripple [yum](https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified) repository.
+For production, you can install a `rippled` instance using Ripple's binary executable for [Ubuntu](#installation-on-ubuntu-with-alien) or [CentOS/Red Hat](#installation-on-centosred-hat-with-yum).
 
-For development, you can compile `rippled` from source:
+For development, you can install a `rippled` instance using Ripple's binary executable for [macOS](#installation-on-macos), or you can build and run `rippled` from source for [Ubuntu](build-run-rippled-ubuntu.html).
 
-- See [Build and Run `rippled` on Ubuntu](build-run-rippled-ubuntu.html) for Ubuntu Linux 16.04 and higher.
-- For other platforms, see the [rippled repository](https://github.com/ripple/rippled/tree/develop/Builds) for instructions.
+For installation information for other platforms, see the [rippled repository](https://github.com/ripple/rippled/tree/develop/Builds).
 
 
 ## Minimum System Requirements
 
-A `rippled` server should run comfortably on commodity hardware, to make it inexpensive to participate in the network. At present, we recommend the following mimimum requirements:
+A `rippled` server should run comfortably on commodity hardware, to make it inexpensive to participate in the network. At present, we recommend the following minimum requirements:
 
 - Operating System:
     - Production: CentOS or RedHat Enterprise Linux (latest release) or Ubuntu (16.04+) supported
@@ -25,26 +24,6 @@ Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A
 
 **Tip:** For recommendations beyond the minimum requirements, see [Capacity Planning](capacity-planning.html).
 
-
-## Installation on CentOS/Red Hat with yum
-
-This section assumes that you are using CentOS 7 or Red Hat Enterprise Linux 7.
-
-1. Install the Ripple RPM repository:
-
-        $ sudo rpm -Uvh https://mirrors.ripple.com/ripple-repo-el7.rpm
-
-2. Install the `rippled` software package:
-
-        $ sudo yum install --enablerepo=ripple-stable rippled
-
-3. Configure the `rippled` service to start on system boot:
-
-        $ sudo systemctl enable rippled.service
-
-4. Start the `rippled` service
-
-        $ sudo systemctl start rippled.service
 
 ## Installation on Ubuntu with alien
 
@@ -79,93 +58,216 @@ This section assumes that you are using Ubuntu 15.04 or later.
 
         $ sudo systemctl start rippled.service
 
+For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
 
-## Installation on macOS with Homebrew
 
-We don't recommend macOS for `rippled` production use at this time. Currently, the [Ubuntu platform](#installation-on-ubuntu-with-alien) has received the highest level of quality assurance and testing. That said, macOS is suitable for many development/test tasks.
+## Installation on CentOS/Red Hat with yum
 
-https://github.com/ripple/rippled/tree/develop/Builds/macos
+This section assumes that you are using CentOS 7 or Red Hat Enterprise Linux 7.
 
-This section assumes that you are using macOS X 10.0 or higher. ***TODO: correct?***
+1. Install the Ripple RPM repository:
 
-1. Install [Xcode](https://developer.apple.com/download/). ***TODO: min and max version? If you try to install Xcode today, you'll need at least macOS 10.13.6.***
+        $ sudo rpm -Uvh https://mirrors.ripple.com/ripple-repo-el7.rpm
 
-Installing homebrew removes the need to install xcode command line tools separately
-  homebrew install lists xcode commend line tools as a requirement: https://docs.brew.sh/Installation#requirements. What does this comment mean?
+2. Install the `rippled` software package:
 
-2. Install Homebrew.
+        $ sudo yum install --enablerepo=ripple-stable rippled
+
+3. Configure the `rippled` service to start on system boot:
+
+        $ sudo systemctl enable rippled.service
+
+4. Start the `rippled` service
+
+        $ sudo systemctl start rippled.service
+
+For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
+
+
+## Installation on macOS
+
+At this time, we don't recommend using the macOS platform for `rippled` production use. For production, consider using the [Ubuntu platform](#installation-on-ubuntu-with-alien), which has received the highest level of quality assurance and testing.
+
+That said, macOS is suitable for many development and testing tasks.
+
+This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?***
+
+{% set n = cycler(* range(1,99)) %}
+
+{{n.next()}}. Install [Xcode](https://developer.apple.com/download/).
+
+{{n.next()}}. Install Xcode command line tools. ***TODO: Comment from Daniel: Installing homebrew removes the need to install xcode command line tools separately. JHA: homebrew lists xcode command line tools as a requirement: https://docs.brew.sh/Installation#requirements. Do we keep or remove this step?***
+
+        xcode-select --install
+
+{{n.next()}}. Install [Homebrew](https://brew.sh/).
 
         ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-3. Update Homebrew.
+{{n.next()}}. Update Homebrew.
 
         brew update
 
-4. Use Homebrew to install git, cmake, pkg-config, protobuf, openssl, and ninja.
+{{n.next()}}. Use Homebrew to install dependencies. ***TODO: Added boost per Daniel's request: Installing Boost directly is going to frustrate people - brew can do it in one command. I ended up installing Boost with Brew with no issues. Which release to choose? JHA: I did `brew install boost` and brew installs 1.67.0 in /usr/local/Cellar/boost/1.67.0_1 -- is this okay? If we install Boost via brew, do we no longer have to compile boost: ./bootstrap.sh and ./b2 cxxflags="-std=c++14"? Comment from Daniel: Build issues with Boost not finding lib (boost-context) in my case. JHA: when does this issue come up? How can we help the user avoid or address this issue?***
 
-        brew install git cmake pkg-config protobuf openssl ninja
+        brew install git cmake pkg-config protobuf openssl ninja boost
 
-5. Download [boost](https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2):
+{{n.next()}}. Set the `BOOST_ROOT` environment variable to point to the new directory created by the Homebrew installation of Boost. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, add the following line to the file. To find your Boost install directory, use `brew info boost`. ***TODO: Feedback from Daniel: Have to deal with environment variables. “rc” files is a vague statement. JHA: If you do brew install boost - you still have to set env variables, correct? I did it using .bash_profile and removed references to "rc files" - is this okay? Or do we want to tell users that they can choose to put the env var in the .bashrc file instead of .bash_profile - is there any benefit to saying this?***
 
-Installing Boost directly is going to frustrate people - brew can do it in one command
-  Which release to choose?
-  Have to deal with environment variables
-  “rc” files is a vague statement
-  Build issues with Boost not finding lib (boost-context) in my case
-  I ended up installing Boost with Brew with no issues
+        export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
 
-6. build boost: ./bootstrap.sh
+{{n.next()}}. Source the file you added the `BOOST_ROOT` environment variable to. For example:
 
-7. build boost: ./b2 cxxflags=“-std=c++14”
+        source .bashrc
 
-8. create boost_root variable: export BOOST_ROOT=/Users/manojdoshi/rippled/boost_1_67_0
+{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory.  ***TODO: Note from Daniel: Cloning github repo is going to require proper github setup. Should we provide some guidance or references? JHA: What is the proper github setup? I may have set this up a whlie ago and I can't remember the steps that may have been required.***
 
-9. Clone the ripple repo: git clone https://github.com/ripple/rippled.git
+        git clone git@github.com:ripple/rippled.git
+        cd rippled
 
-Cloning github repo is going to require proper github setup
-  Should we provide some guidance or references?
+{{n.next()}}. By default, cloning puts you on the `develop` branch. Use this branch if you are doing development work and want the latest set of untested features.
 
-10. switch the branch: git checkout develop
+      If you want the latest stable release, checkout the `master` branch.
 
-11. Create build folder: mkdir my_build
+        git checkout master
 
-12. cd my_build
+      Or, you can checkout one of the tagged releases listed on [GitHub](https://github.com/ripple/rippled/releases GitHub).
 
-13. Build rippled:
+      If you want to test out the latest release candidate, checkout the `release` branch:
 
-14. cmake -G “Unix Makefiles” -DCMAKE_BUILD_TYPE=Debug ../rippled/
+        git checkout release
 
-15. cmake --build . -- -j 4
+{{n.next()}}. Create your `rippled` build directory and access it. For example:
 
-16. Run unit tests: ./rippled --unittest
+        mkdir my_build
+        cd my_build
 
-Daniel: Compiling from source (OSX)
+{{n.next()}}. Build `rippled`. This could take about 5 minutes, depending on your hardware specs.
 
-Update rippled
-  No instructions on github or dev docs on how to do this for OSX, Windows, or other Linux distros
+        cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
 
-Is this about how to run rippled too? How to do that...and how to tell if what you are running is working correctly?
+      You can set `CMAKE_BUILD_TYPE` to the `Debug` or `Release` build type. All four standard [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html) values are supported.
+
+{{n.next()}}. Run the build using CMake. This could take about 10 minutes, depending on your hardware specs.
+
+        cmake --build . -- -j 4
+
+      This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -a | grep machdep.cpu | grep core_count` to get your CPU core count. ***TODO: the mac build page in the github repo goes much more in-depth about cmake build options - should we include these here? https://github.com/ripple/rippled/tree/develop/Builds/macos#generate-and-build***
+
+{{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) ***TODO: We should provide info about what to do if you get failures. What should the user do?***
+
+        ./rippled --unittest
+
+{{n.next()}}. Create a copy of the example config file and save it to a location that enables you to run `rippled` as a non-root user (recommended). ***TODO: unlike the centos and ubuntu installs on this page, the macos install requires that you manually put rippled.cfg and validator.txt in place. At least that is what I experienced - true?***
+
+        mkdir -p ~/.config/ripple
+        cd rippled
+        cp cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
+
+{{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: this is required at this point in the install b/c if you don't have the permissions set correctly, rippled won't run, correct? It is not that the default values in rippled.cfg are incorrect--there may just be permission issues, is that right? what is the equivalent command in macOS for `chown -R rippled:rippled <configured path>`? I think we need to add this step to the centos and ubuntu tasks. The config files are placed in the correct directory automatically -- but these values still need to be manually updated, yes?***
+
+      * Set the `[node_db]` path to the location where you want to store the ledger database.
+
+      * Set the `[database_path]` to the location where you want to store other database data. (This includes an SQLite database with configuration data, and is typically one level above the `[node_db]` path field.)
+
+      * Set the `[debug_logfile]` to a path where `rippled` can write logging information.
+
+      These are the only configurations required for `rippled` to start up successfully. All other configuration is optional and can be tweaked after you have a working server. For more information, see [Additional Configurations](#additional-configurations).
+
+{{n.next()}}. Copy the example `validators.txt` file to the same folder as `rippled.cfg`:
+
+        cp cfg/validators-example.txt ~/.config/ripple/validators.txt
+
+      **Warning:** Ripple has designed a decentralization plan with maximum safety in mind. During the transition, you should not modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
+
+{{n.next()}}. Start the `rippled` service.
+
+        sudo ./rippled
+
+For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
+
 
 ## Postinstall
 
-It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers. After that, you have a fully functional stock `rippled` server that you can use for local signing and API access to the XRP Ledger.
+It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers.
 
-You can use the [rippled commandline interface](get-started-with-the-rippled-api.html#commandline) as follows:
+Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'll see this for the macOS install, but not for centos and ubuntu. For centos and ubuntu - is there any benefit to giving the user a command that will display this view? Does such a command exist? Alternatively, for centos and ubuntu - we need to give the user some other way to tell that the service is running - refer them to server states?***
 
-    $ /opt/ripple/bin/rippled <METHOD>
+        2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
+        2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
+        2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
+        2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
+        2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
+        ...
+        2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
+        2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
+        2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
+        2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
+        2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
+        2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
+        2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
+        2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
+        2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
+        2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
+        2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
+        2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
+        2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
+        2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
+        2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
+        2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
+        2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
+        2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
+        2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
+        2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
+        2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
+        2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
+        2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
+        2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
+        2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
+        {
+        	"command" : "log_level",
+        	"severity" : "warning"
+        }
 
-For a full list of available methods, see the [rippled API reference](rippled-api.html).
 
-### Additional Configuration
+        2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
 
-`rippled` should connect to the XRP Ledger with the default configuration. However, you can change your settings by editing the `rippled.cfg` file (located at `/opt/ripple/etc/rippled.cfg` when installing `rippled` with yum). For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
 
-See [the `rippled` GitHub repository](https://github.com/ripple/rippled/blob/master/cfg/rippled-example.cfg) for a description of all configuration options.
+        2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
+        2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
+        2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
+        2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
+        2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
+        2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
+        2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
+        2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
+        2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
 
-Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path:
+***TODO: for the future, provide a reference for what the most common and unintuitive messages mean -- esp when signalling possible errors.***
 
-        $ chown -R rippled:rippled <configured path>
+Once your `rippled` has synchronized with the rest of the network, you have a fully functional stock `rippled` server that you can use for local signing and API access to the XRP Ledger. Use [`rippled` server states](rippled-server-states.html) to tell whether your `rippled` server has synchronized with the network.
 
-Restart `rippled` for any configuration changes to take effect:
+For information about communicating with your `rippled` server using the rippled API, see the [rippled API reference](rippled-api.html).
 
-        $ sudo service rippled restart
+Once you have your stock `rippled` server running, you may want to consider running it as a validating server. For information about validating servers and why you might want to run one, see [Run rippled as a Validator](run-rippled-as-a-validator.html).
+
+
+## Additional Configuration
+
+`rippled` should connect to the XRP Ledger with the default configurations. However, you can change your settings by editing the `rippled.cfg` file. For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
+
+The default locations for `rippled.cfg` are as follows:
+
+* CentOS/Red Hat with yum: `/opt/ripple/etc/`
+
+* Ubuntu with alien: `~/.config/ripple/`
+
+* macOS: `~/.config/ripple/` ***TODO: Info in rippled-example.cfg points to the wiki to tell folks where to put this file -- need to update rippled-example.cfg to address. Specifically, the section explaining the --conf command line option: https://ripple.com/wiki/Rippled#--conf.3Dpath - the content doesn't exist on the wiki page and we are retiring the wiki.***
+
+Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: Per notes above, I think we need to add the "Edit `rippled.cfg` to set necessary file paths." step to centos and ubuntu tasks. Once we do that, we can put this command info in the context of each task.***
+
+    $ chown -R rippled:rippled <configured path>
+
+Restart `rippled` for any configuration changes to take effect: ***TODO: what is the macOS command for this?***
+
+    $ sudo service rippled restart

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -96,7 +96,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
 {{n.next()}}. Install [Xcode](https://developer.apple.com/download/).
 
-{{n.next()}}. Install Xcode command line tools. ***TODO: Comment from PM: Installing homebrew removes the need to install xcode command line tools separately. JHA: homebrew lists xcode command line tools as a requirement: https://docs.brew.sh/Installation#requirements. Do we keep or remove this step?***
+{{n.next()}}. Install Xcode command line tools.
 
         xcode-select --install
 
@@ -108,19 +108,19 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         brew update
 
-{{n.next()}}. Use Homebrew to install dependencies. ***TODO: Added boost per PM's request: Installing Boost directly is going to frustrate people - brew can do it in one command. I ended up installing Boost with Brew with no issues. Which release to choose? JHA: I did `brew install boost` and brew installs 1.67.0 in /usr/local/Cellar/boost/1.67.0_1 -- is this okay? If we install Boost via brew, do we no longer have to compile boost: ./bootstrap.sh and ./b2 cxxflags="-std=c++14"? Comment from PM: Build issues with Boost not finding lib (boost-context) in my case. JHA: when does this issue come up? How can we help the user avoid or address this issue?***
+{{n.next()}}. Use Homebrew to install dependencies. ***TODO: Added boost to the brew installs per PM's request: Installing Boost directly is going to frustrate people - brew can do it in one command.*** Boost 1.67.x to 1.68.x are supported. To view the Boost version that will be installed by `brew install boost`, use `brew info boost`. ***TODO: added this text to ensure that users don't install unsupported versions of Boost. For example, what if the brew install boost starts installing 1.69, but we haven't tested and verified yet? Are the supported versions correct? Do we need to list supported version for any of the other dependencies as well?***
 
         brew install git cmake pkg-config protobuf openssl ninja boost
 
-{{n.next()}}. Set the `BOOST_ROOT` environment variable to point to the new directory created by the Homebrew installation of Boost. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, add the following line to the file. To find your Boost install directory, use `brew info boost`. ***TODO: Feedback from PM: Have to deal with environment variables. “rc” files is a vague statement. JHA: If you do brew install boost - you still have to set env variables, correct? I did it using .bash_profile and removed references to "rc files" - is this okay? Or do we want to tell users that they can choose to put the env var in the .bashrc file instead of .bash_profile - is there any benefit to saying this?***
+{{n.next()}}. Ensure that the `BOOST_ROOT` environment variable points to the directory created by the Homebrew installation of Boost. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, ensure that the following line is in the file. To find your Boost install directory, use `brew info boost`. ***TODO: Feedback from PM: Have to deal with environment variables. JHA: When I did a brew install boost, I had to set the env variable -- but I think it may be because I had an existing BOOST_ROOT env var set to a location I created when I previously did a manual boost install. Maybe the brew install doesn't overwrite/update an existing BOOST_ROOT value? Changed the wording a bit to address this - so it is not that you'll always need to add the env var - just make sure it is there and up to date?***
 
         export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
 
-{{n.next()}}. Source the file you added the `BOOST_ROOT` environment variable to. For example:
+{{n.next()}}. If you updated your `.bash_profile` file in the previous step, be sure to source the file. For example:
 
-        source .bashrc
+        source .bash_profile
 
-{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory.  ***TODO: Note from PM: Cloning github repo is going to require proper github setup. Should we provide some guidance or references? JHA: What is the proper github setup? I may have set this up a whlie ago and I can't remember the steps that may have been required.***
+{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/).
 
         git clone git@github.com:ripple/rippled.git
         cd rippled
@@ -154,11 +154,11 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
       This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -a | grep machdep.cpu | grep core_count` to get your CPU core count. ***TODO: the mac build page in the github repo goes much more in-depth about cmake build options - should we include these here? https://github.com/ripple/rippled/tree/develop/Builds/macos#generate-and-build***
 
-{{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) ***TODO: We should provide info about what to do if you get failures. What should the user do?***
+{{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.***
 
         ./rippled --unittest
 
-{{n.next()}}. Create a copy of the example config file and save it to a location that enables you to run `rippled` as a non-root user (recommended). ***TODO: unlike the centos and ubuntu installs on this page, the macos install requires that you manually put rippled.cfg and validator.txt in place. At least that is what I experienced - true?***
+{{n.next()}}. Create a copy of the example config file and save it to a location that enables you to run `rippled` as a non-root user (recommended).
 
         mkdir -p ~/.config/ripple
         cd rippled

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -114,35 +114,51 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         brew install git cmake pkg-config protobuf openssl ninja
 
-{{n.next()}}. Install a supported version of Boost. Supported versions include Boost 1.67.x - 1.68.x. ***TODO: correctly stated supported versions? Doc will need to keep an eye on these supported versions. In the rippled repo, we say "Boost 1.67 or later is required." <-- Based on our discussion in this doc, I don't think this is true.*** Installation using Homebrew is faster and requires fewer manual steps, but you must ensure that Homebrew installs a supported version of Boost.
+{{n.next()}}. Install a supported version of Boost. Supported versions include Boost 1.67.x - 1.68.x. ***TODO: correctly stated supported versions? In the rippled repo, we say "Boost 1.67 or later is required." <-- Based on our discussion in this doc, I don't think this open-ended "later" part is true, is it?***
 
-    Pick one of the following options to install Boost:
+    Pick one of the following Boost installation methods: ***TODO: I provided the two options below because these are the most straightforward ways for a user to install one of the two supported versions of Boost. In the future, if there are more supported versions or more brew boost formalae, there may be more options to document.***
 
-    * To ensure that Homebrew installs a supported version of Boost, use `brew install boost@1.67` to install Boost 1.67.0. ***TODO: When the supported versions change above, we can also change this, if needed. There is no brew command to install 1.68 right now. brew install boost is still installing 1.67 and there is no brew formula boost@1.68.***
+    * To install Boost 1.67.0, use `brew install boost@1.67`. ***TODO: When Boost 1.67.0 is no longer supported, we'll need to change this formula. Until then, the user will be able to use this command to get a supported version of Boost. `brew install boost` also installs 1.67.0, but as discussed, we don't want to provide the command because it won't always install 1.67.0 and may cause the user to install an unsupported version. There is no brew command to install 1.68 right now.***
 
-    * To use Homebrew to install a different supported version of Boost, check [Homebrew Formulae - boost](https://formulae.brew.sh/formula/boost) to see if there is a formula for the version you want to install. To verify the Boost version a Homebrew formula will install, use `brew info <formula>`. For example, `brew info boost` or `brew info boost@1.67`.
+    * To install Boost 1.68.0, compile Boost yourself. ***TODO: When the supported versions change above, we can also change these instructions, if needed. It would be great to genericize - but the way that the Boost brew and compiles are working right now - being version-specific seems necessary to keep folks from inadvertently installing an unsupported version.***
 
-    * To install a supported version of Boost that does not have a defined Homebrew formula, compile Boost yourself. These compile instructions are for Boost 1.68.0.
+        1. Download [Boost 1.68.0](https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2) to an appropriate directory. ***TODO: okay to do it outside of CLI? If we want to give them CLI instructions, need to have them run `brew install wget` and then `wget https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2`.***
 
-        1. Download [Boost 1.68.0](https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2). ***TODO: do we want to give them CLI instructions? If yes, then we need to have them use brew install wget.***
+        2. Extract `boost_1_68_0.tar.bz2`.
 
-        2. Extract it to a folder. Be sure to note the location. ***TODO: provide CLI instructions?***
+              `tar xvzf boost_1_68_0.tar.bz2`
 
-        3. In a terminal, run:
+        3. Change to the newly created `boost_1_68_0` directory.
+
+              `cd boost_1_68_0`
+
+        4. Prepare the Boost.Build system for use.
 
               `./bootstrap.sh`
 
-              `./b2 cxxflags="-std=c++14"`
+        5. Build the separately-compiled Boost libraries. This may take about 10 minutes, depending on your hardware specs. 11:14
 
-{{n.next()}}. Ensure that the `BOOST_ROOT` environment variable points to the directory created by your Boost installation. Put this environment variable in your `.bash_profile` so it's automatically set when you log in. For example, ensure that the following line is in the file. To find your Boost install directory, use `brew info boost`. ***TODO: JHA clean out boost env vars and uninstall boost - then try again and see what gets populated in bash_profile....***
+              `./b2 cxxflags="-std=c++14" -j 4`
 
-        export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
+            **Tip:** This example uses 4 processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -n hw.ncpu` to get your CPU core count.
 
-{{n.next()}}. If you updated your `.bash_profile` file in the previous step, be sure to source the file. For example:
+{{n.next()}}. Ensure that the `BOOST_ROOT` environment variable points to the directory created by your Boost installation. Put this environment variable in your `.bash_profile` file so it's automatically set when you log in.
+
+    * If you used Homebrew to install Boost, ensure that `BOOST_ROOT` is set to the location where Homebrew installed Boost. For example:
+
+        `export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1`
+
+        To find your Boost install directory, use `brew info boost`.
+
+    * If you manually compiled and installed Boost, ensure that `BOOST_ROOT` is set to the location where you installed Boost. For example:
+
+        `export BOOST_ROOT=/Users/tblee/boost/boost_1_68_0`
+
+{{n.next()}}. If you updated your `.bash_profile` file in the previous step, be sure to source it. For example:
 
         source .bash_profile
 
-{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/).
+{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/). ***TODO: does this sound okay for introducing what a user may have to do to set up git and GitHub?***
 
         git clone git@github.com:ripple/rippled.git
         cd rippled
@@ -159,7 +175,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         git checkout release
 
-{{n.next()}}. Create your `rippled` build directory and access it. For example:
+{{n.next()}}. In the `rippled` directory you just cloned, create your build directory and access it. ***TODO: Does this "In the rippled directory you just cloned" language make sense? I just want to tell the user where to create the build directory.*** For example:
 
         mkdir my_build
         cd my_build
@@ -174,17 +190,16 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         cmake --build . -- -j 4
 
-      This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -a | grep machdep.cpu | grep core_count` to get your CPU core count. ***TODO: the mac build page in the github repo (https://github.com/ripple/rippled/tree/develop/Builds/macos#generate-and-build) goes much more in-depth about cmake build options - should we include these here, just to bring a parity between what we say in the rippled repo and what we say here? That said -- do we want to eventually just have one doc on how to do the mac install -- meaning the macos doc content in the rippled repo would go away and just link to this article in the Dev Portal? We also probably want to take a look at what to do with the Linux and Visual Studio install in the rippled repo.***
+      This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -n hw.ncpu` to get your CPU core count.
 
 {{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) <!--{# ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.*** #}-->
 
         ./rippled --unittest
 
-{{n.next()}}. Create a copy of the example config file and save it to a location that enables you to run `rippled` as a non-root user (recommended).
+{{n.next()}}. `rippled` requires the `rippled.cfg` configuration file to run. You can find an example config file, `rippled-example.cfg` in `rippled/cfg`. Make a copy and save it as `rippled.cfg` in a location that enables you to run `rippled` as a non-root user. Access the `rippled` directory and run:
 
-        mkdir -p ~/.config/ripple
-        cd rippled
-        cp cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
+        mkdir -p /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
+        cp cfg/rippled-example.cfg /etc/opt/ripple/rippled.cfg
 
 {{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: I think we need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually updated to avoid permission issues, correct?***
 
@@ -196,13 +211,13 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
       These are the only configurations required for `rippled` to start up successfully. All other configuration is optional and can be tweaked after you have a working server. For more information, see [Additional Configurations](#additional-configuration).
 
-{{n.next()}}. Copy the example `validators.txt` file to the same folder as `rippled.cfg`:
+{{n.next()}}. `rippled` requires the `validators.txt` file to run. You can find an example validators file, `validators-example.txt`, in `rippled/cfg/`. Make a copy and save it as `validators.txt` in the same folder as your `rippled.cfg` file. Access the `rippled` directory and run:
 
-        cp cfg/validators-example.txt ~/.config/ripple/validators.txt
+        cp cfg/validators-example.txt /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
 
       **Warning:** Ripple has designed a decentralization plan with maximum safety in mind. During the transition, you should not modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
 
-{{n.next()}}. Start the `rippled` service.
+{{n.next()}}. Access your build directory, `my_build` for example, and start the `rippled` service.
 
         sudo ./rippled
 
@@ -213,7 +228,7 @@ For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#
 
 It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers.
 
-Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'll see this in the CLI for the macOS install, but not for centos and ubuntu using the instructions provided in this doc. For centos and ubuntu - is there a benefit to giving the user a command that will display this view? Does such a command exist? If not, for centos and ubuntu - we need to give the user some other way to tell that the service is running correctly - refer them to server states?***
+Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'll see this in the CLI for the macOS install because we tell them to start the service using `sudo ./rippled`, but not for centos and ubuntu. For centos and ubuntu, we tell the user to start the service using `sudo systemctl start rippled.service`, which starts the service, but doesn't display a log of the service starting up. At least for first-time start up - would it make sense to give the user this start up command (sudo ./rippled) instead so that they can see it running? Perhaps in Postinstall we can give them the `sudo systemctl start rippled.service` command for when they want to start the service, but don't need to see the running log?***
 
         2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
         2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
@@ -276,20 +291,14 @@ Once you have your stock `rippled` server running, you may want to consider runn
 
 ## Additional Configuration
 
+<!--{# TODO: Once post-rippled-install.md PR is merged, include it here to get latest, consistent info. #}-->
+
 `rippled` should connect to the XRP Ledger with the default configurations. However, you can change your settings by editing the `rippled.cfg` file. For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
 
-The default locations for `rippled.cfg` are as follows:
-
-* CentOS/Red Hat with yum: `/opt/ripple/etc/`
-
-* Ubuntu with alien: `~/.config/ripple/`
-
-* macOS: `~/.config/ripple/`
-
-Changes to the `[debug_logfile]` or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: [node_db] as well? When I try this for a [node_db] value of /var/lib/rippled/db/rocksdb: chown -R rippled:rippled /var/lib/rippled/db/rocksdb, I get -- chown: rippled: illegal group name. Is rippled:rippled just an example below? Or should there be a rippled group?***
+Changes to the `[node_db]`, `[debug_logfile]`, or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: I added [node_db] to this list - okay? When I try the following command, `chown -R rippled:rippled /var/lib/rippled/db/rocksdb`, I get `chown: rippled: illegal group name.` Is `rippled:rippled` just an example below -- or should there be a `rippled` group that is created by the build/install process?***
 
     $ chown -R rippled:rippled <configured path>
 
-Restart `rippled` for any configuration changes to take effect: ***TODO: does this command work for centos, ubuntu, and macOS? JHA verify.***
+Restart `rippled` for any configuration changes to take effect: ***TODO: when I try this on macOS, I get `sudo: service: command not found`. I don't think the `service` command exists for macOS. For macOS, can the user just stop (ctrl+c? Not sure if that is the proper way to stop the service) and start rippled (sudo ./rippled) instead? For centos and ubuntu, we use `sudo systemctl start rippled.service` to start the service - below should we use `sudo systemctl restart rippled.service` - just to be consistent?***
 
     $ sudo service rippled restart

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -131,7 +131,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         git checkout master
 
-      Or, you can checkout one of the tagged releases listed on [GitHub](https://github.com/ripple/rippled/releases GitHub).
+      Or, you can checkout one of the tagged releases listed on [GitHub](https://github.com/ripple/rippled/releases).
 
       If you want to test out the latest release candidate, checkout the `release` branch:
 
@@ -172,7 +172,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
       * Set the `[debug_logfile]` to a path where `rippled` can write logging information.
 
-      These are the only configurations required for `rippled` to start up successfully. All other configuration is optional and can be tweaked after you have a working server. For more information, see [Additional Configurations](#additional-configurations).
+      These are the only configurations required for `rippled` to start up successfully. All other configuration is optional and can be tweaked after you have a working server. For more information, see [Additional Configurations](#additional-configuration).
 
 {{n.next()}}. Copy the example `validators.txt` file to the same folder as `rippled.cfg`:
 

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -272,3 +272,47 @@ Changes to the `[node_db]`, `[debug_logfile]`, or `[database_path]` sections may
 Restart `rippled` for any configuration changes to take effect: ***TODO: when I try this on macOS, I get `sudo: service: command not found`. I don't think the `service` command exists for macOS. For macOS, can the user just stop (ctrl+c? Not sure if that is the proper way to stop the service) and start rippled (sudo ./rippled) instead? For centos and ubuntu, we use `sudo systemctl start rippled.service` to start the service - below should we use `sudo systemctl restart rippled.service` - just to be consistent?***
 
     $ sudo service rippled restart
+
+### Connect Your `rippled` to the XRP Test Net
+
+Ripple has created the [XRP Test Network](https://ripple.com/build/xrp-test-net/) to provide a testing platform for the XRP Ledger. XRP Test Net funds are not real funds and are intended for testing only. You may want to connect your `rippled` server to the XRP Test Net to test out and understand `rippled` functionality before connecting to the production XRP Ledger Network. ***TODO: stated correctly?***
+
+**Note:** The XRP Test Net ledger and balances are reset on a regular basis.
+
+_**To connect your `rippled` server to the XRP Test Net, set the following configurations:**_
+
+1. In your `rippled.cfg` file:
+
+      a. Uncomment the following section, as follows:
+
+        [ips]
+        r.altnet.rippletest.net 51235
+
+      b. Comment out the following section, as follows:
+
+        # [ips]
+        # r.ripple.com 51235
+
+2. In your `validators.txt` file:
+
+      a. Uncomment the following sections, as follows:
+
+        [validator_list_sites]
+        https://vl.altnet.rippletest.net
+
+        [validator_list_keys]
+        ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
+
+      b. Comment out the following sections, as follows:
+
+        # [validator_list_sites]
+        # https://vl.ripple.com
+        #
+        # [validator_list_keys]
+        # ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+
+3. Restart `rippled`.
+
+4. To verify that your `rippled` is connected to the XRP Test Net, go to the [XRP Test Net Faucet](https://developers.ripple.com/xrp-test-net-faucet.html) and click **Generate credentials**. Make a note of the **Address** value. Make the [`account_info`](https://developers.ripple.com/account_info.html) request to your `rippled` server. ***TODO: Any ideas for a better way to this check?***
+
+      If the request returns account information, your `rippled` is connected to the XRP Test Net. If the request cannot find the account, your `rippled` is not connected to the XRP Test Net. Check your `rippled.cfg` and `validators.txt` configurations.

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -94,9 +94,11 @@ For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#
 
 ## Installation on macOS
 
-At this time, we don't recommend using the macOS platform for `rippled` production use. For production, consider using the [Ubuntu platform](#installation-on-ubuntu-with-alien), which has received the highest level of quality assurance and testing.
+At this time, Ripple doesn't recommend using the macOS platform for `rippled` production use. For production, consider using the [Ubuntu platform](#installation-on-ubuntu-with-alien), which has received the highest level of quality assurance and testing.
 
 That said, macOS is suitable for many development and testing tasks. `rippled` has been tested for use with macOS High Sierra up to 10.13.
+
+Ripple recommends running `rippled` as your own user.
 
 1. Install [Xcode](https://developer.apple.com/download/).
 
@@ -168,10 +170,10 @@ That said, macOS is suitable for many development and testing tasks. `rippled` h
 
 0. `rippled` requires the `rippled.cfg` configuration file to run. You can find an example config file, `rippled-example.cfg` in `rippled/cfg`. Make a copy and save it as `rippled.cfg` in a location that enables you to run `rippled` as a non-root user. Access the `rippled` directory and run:
 
-        $ mkdir -p /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
-        $ cp cfg/rippled-example.cfg /etc/opt/ripple/rippled.cfg
+        $ mkdir -p $HOME/.config/ripple
+        $ cp cfg/rippled-example.cfg $HOME/.config/ripple/rippled.cfg
 
-0. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: We need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually checked/updated to ensure that there are no permission issues, correct?***
+0. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here.
 
       * Set the `[node_db]` path to the location where you want to store the ledger database.
 
@@ -183,13 +185,13 @@ That said, macOS is suitable for many development and testing tasks. `rippled` h
 
 0. `rippled` requires the `validators.txt` file to run. You can find an example validators file, `validators-example.txt`, in `rippled/cfg/`. Make a copy and save it as `validators.txt` in the same folder as your `rippled.cfg` file. Access the `rippled` directory and run:
 
-        $ cp cfg/validators-example.txt /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
+        $ cp cfg/validators-example.txt $HOME/.config/ripple/validators.txt
 
       **Warning:** Ripple has designed a decentralization plan with maximum safety in mind. During the transition, you should not modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
 
 0. Access your build directory, `my_build` for example, and start the `rippled` service.
 
-        $ sudo ./rippled
+        $ ./rippled
 
       Here's an excerpt of what you can expect to see in your terminal:
 
@@ -241,6 +243,8 @@ That said, macOS is suitable for many development and testing tasks. `rippled` h
       2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
 ```
 
+For information about `rippled` log messages, see [Understanding Log Messages](understanding-log-messages.html).
+
 For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
 
 
@@ -248,7 +252,7 @@ For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#
 
 It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers.
 
-<!--{# ***TODO: for the future, provide a reference for what the most common and unintuitive messages mean -- esp when signaling possible errors.*** #}-->
+For information about `rippled` log messages, see [Understanding Log Messages](understanding-log-messages.html).
 
 Once your `rippled` has synchronized with the rest of the network, you have a fully functional stock `rippled` server that you can use for local signing and API access to the XRP Ledger. Use [`rippled` server states](rippled-server-states.html) to tell whether your `rippled` server has synchronized with the network.
 
@@ -256,24 +260,31 @@ For information about communicating with your `rippled` server using the rippled
 
 Once you have your stock `rippled` server running, you may want to consider running it as a validating server. For information about validating servers and why you might want to run one, see [Run rippled as a Validator](run-rippled-as-a-validator.html).
 
+Having trouble getting your `rippled` server started? See [rippled Server Won't Start](server-wont-start.html).
+
 
 ## Additional Configuration
 
 <!--{# TODO: Once post-rippled-install.md PR is merged, include it here to get latest, consistent info. #}-->
 
-`rippled` should connect to the XRP Ledger with the default configurations. However, you can change your settings by editing the `rippled.cfg` file. For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
+`rippled` should connect to the XRP Ledger with the default configurations. However, you can change your settings by editing the `rippled.cfg` file.
 
-Changes to the `[node_db]`, `[debug_logfile]`, or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: I added [node_db] to this list - okay?***
+For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
 
-    $ chown -R rippled:rippled <configured path> ***TODO: Is `rippled:rippled` just an example value? When I run this command on macOS, I get `chown: rippled: illegal group name.` When I run it on centos, I get chown: changing ownership of ... : Operation not permitted***
+You must restart `rippled` for any configuration changes to take effect:
 
-Restart `rippled` for any configuration changes to take effect: ***TODO: when I try this on macOS, I get `sudo: service: command not found`. I don't think the `service` command exists for macOS. For macOS, can the user just stop (ctrl+c? Not sure if that is the proper way to stop the service) and start rippled (sudo ./rippled) instead? For centos and ubuntu, we use `sudo systemctl start rippled.service` to start the service - below should we use `sudo systemctl restart rippled.service` - just to be consistent?***
+  * For Ubuntu and CentOS/Red Hat:
 
-    $ sudo service rippled restart
+        $ sudo systemctl restart rippled.service
+
+  * For macOS, use Ctrl-C to stop `rippled` and then start it again:
+
+        $ ./rippled
+
 
 ### Connect Your `rippled` to the XRP Test Net
 
-Ripple has created the [XRP Test Network](https://ripple.com/build/xrp-test-net/) to provide a testing platform for the XRP Ledger. XRP Test Net funds are not real funds and are intended for testing only. You may want to connect your `rippled` server to the XRP Test Net to test out and understand `rippled` functionality before connecting to the production XRP Ledger Network. ***TODO: stated correctly?***
+Ripple has created the [XRP Test Network](https://ripple.com/build/xrp-test-net/) to provide a testing platform for the XRP Ledger. XRP Test Net funds are not real funds and are intended for testing only. You can connect your `rippled` server to the XRP Test Net to test out and understand `rippled` functionality before connecting to the production XRP Ledger Network. You can also use the XRP Test Net to verify that your own code interacts correctly with `rippled`.
 
 **Note:** The XRP Test Net ledger and balances are reset on a regular basis.
 
@@ -281,19 +292,19 @@ _**To connect your `rippled` server to the XRP Test Net, set the following confi
 
 1. In your `rippled.cfg` file:
 
-      a. Uncomment the following section, as follows:
+    a. Uncomment the following section, as follows:
 
         [ips]
         r.altnet.rippletest.net 51235
 
-      b. Comment out the following section, as follows:
+    b. Comment out the following section, as follows:
 
         # [ips]
         # r.ripple.com 51235
 
 2. In your `validators.txt` file:
 
-      a. Uncomment the following sections, as follows:
+    a. Uncomment the following sections, as follows:
 
         [validator_list_sites]
         https://vl.altnet.rippletest.net
@@ -301,7 +312,7 @@ _**To connect your `rippled` server to the XRP Test Net, set the following confi
         [validator_list_keys]
         ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
 
-      b. Comment out the following sections, as follows:
+    b. Comment out the following sections, as follows:
 
         # [validator_list_sites]
         # https://vl.ripple.com
@@ -311,6 +322,8 @@ _**To connect your `rippled` server to the XRP Test Net, set the following confi
 
 3. Restart `rippled`.
 
-4. To verify that your `rippled` is connected to the XRP Test Net, go to the [XRP Test Net Faucet](https://developers.ripple.com/xrp-test-net-faucet.html) and click **Generate credentials**. Make a note of the **Address** value. Make the [`account_info`](https://developers.ripple.com/account_info.html) request to your `rippled` server. ***TODO: Any ideas for a better way to this check?***
+4. To verify that your `rippled` is connected to the XRP Test Net, go to the [XRP Test Net Faucet](https://developers.ripple.com/xrp-test-net-faucet.html) and click **Generate credentials**. Make a note of the **Address** value. Make the [`account_info`](https://developers.ripple.com/account_info.html) request to your `rippled` server.
 
       If the request returns account information, your `rippled` is connected to the XRP Test Net. If the request cannot find the account, your `rippled` is not connected to the XRP Test Net. Check your `rippled.cfg` and `validators.txt` configurations.
+
+      Ripple recommends that you generate new test credentials each time you want to perform this verification. Using an old XRP Test Net **Address** value may not provide accurate results.

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -27,8 +27,6 @@ Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A
 
 ## Installation on Ubuntu with alien
 
-<!--{# ***TODO: this doc states that ubuntu has received the highest level of QA and testing - so I moved it above centos and macOS install sections. Okay?*** #}-->
-
 This section assumes that you are using Ubuntu 15.04 or later.
 
 1. Install yum-utils and alien:
@@ -60,6 +58,10 @@ This section assumes that you are using Ubuntu 15.04 or later.
 
         $ sudo systemctl start rippled.service
 
+8. Verify that `rippled` has started.
+
+        $ sudo systemctl status rippled
+
 For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
 
 
@@ -83,6 +85,10 @@ This section assumes that you are using CentOS 7 or Red Hat Enterprise Linux 7.
 
         $ sudo systemctl start rippled.service
 
+5. Verify that `rippled` has started.
+
+        $ sudo systemctl status rippled
+
 For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
 
 
@@ -90,9 +96,7 @@ For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#
 
 At this time, we don't recommend using the macOS platform for `rippled` production use. For production, consider using the [Ubuntu platform](#installation-on-ubuntu-with-alien), which has received the highest level of quality assurance and testing.
 
-That said, macOS is suitable for many development and testing tasks.
-
-This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?***
+That said, macOS is suitable for many development and testing tasks. `rippled` has been tested for use with macOS High Sierra up to 10.13.
 
 {% set n = cycler(* range(1,99)) %}
 
@@ -114,51 +118,19 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         brew install git cmake pkg-config protobuf openssl ninja
 
-{{n.next()}}. Install a supported version of Boost. Supported versions include Boost 1.67.x - 1.68.x. ***TODO: correctly stated supported versions? In the rippled repo, we say "Boost 1.67 or later is required." <-- Based on our discussion in this doc, I don't think this open-ended "later" part is true, is it?***
+{{n.next()}}. Install Boost 1.67.0. Currently, we support Boost 1.67 only.
 
-    Pick one of the following Boost installation methods: ***TODO: I provided the two options below because these are the most straightforward ways for a user to install one of the two supported versions of Boost. In the future, if there are more supported versions or more brew boost formalae, there may be more options to document.***
+        brew install boost@1.67
 
-    * To install Boost 1.67.0, use `brew install boost@1.67`. ***TODO: When Boost 1.67.0 is no longer supported, we'll need to change this formula. Until then, the user will be able to use this command to get a supported version of Boost. `brew install boost` also installs 1.67.0, but as discussed, we don't want to provide the command because it won't always install 1.67.0 and may cause the user to install an unsupported version. There is no brew command to install 1.68 right now.***
+{{n.next()}}. Ensure that your `BOOST_ROOT` environment variable points to the directory created by the Boost installation. To find your Boost install directory, use `brew info boost`. Put this environment variable in your `.bash_profile` file so it's automatically set when you log in. For example:
 
-    * To install Boost 1.68.0, compile Boost yourself. ***TODO: When the supported versions change above, we can also change these instructions, if needed. It would be great to genericize - but the way that the Boost brew and compiles are working right now - being version-specific seems necessary to keep folks from inadvertently installing an unsupported version.***
-
-        1. Download [Boost 1.68.0](https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2) to an appropriate directory. ***TODO: okay to do it outside of CLI? If we want to give them CLI instructions, need to have them run `brew install wget` and then `wget https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2`.***
-
-        2. Extract `boost_1_68_0.tar.bz2`.
-
-              `tar xvzf boost_1_68_0.tar.bz2`
-
-        3. Change to the newly created `boost_1_68_0` directory.
-
-              `cd boost_1_68_0`
-
-        4. Prepare the Boost.Build system for use.
-
-              `./bootstrap.sh`
-
-        5. Build the separately-compiled Boost libraries. This may take about 10 minutes, depending on your hardware specs. 11:14
-
-              `./b2 cxxflags="-std=c++14" -j 4`
-
-            **Tip:** This example uses 4 processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -n hw.ncpu` to get your CPU core count.
-
-{{n.next()}}. Ensure that the `BOOST_ROOT` environment variable points to the directory created by your Boost installation. Put this environment variable in your `.bash_profile` file so it's automatically set when you log in.
-
-    * If you used Homebrew to install Boost, ensure that `BOOST_ROOT` is set to the location where Homebrew installed Boost. For example:
-
-        `export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1`
-
-        To find your Boost install directory, use `brew info boost`.
-
-    * If you manually compiled and installed Boost, ensure that `BOOST_ROOT` is set to the location where you installed Boost. For example:
-
-        `export BOOST_ROOT=/Users/tblee/boost/boost_1_68_0`
+        export BOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1
 
 {{n.next()}}. If you updated your `.bash_profile` file in the previous step, be sure to source it. For example:
 
         source .bash_profile
 
-{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/). ***TODO: does this sound okay for introducing what a user may have to do to set up git and GitHub?***
+{{n.next()}}. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/).
 
         git clone git@github.com:ripple/rippled.git
         cd rippled
@@ -169,13 +141,13 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         git checkout master
 
-      Or, you can checkout one of the tagged releases listed on [GitHub](https://github.com/ripple/rippled/releases).
-
       If you want to test out the latest release candidate, checkout the `release` branch:
 
         git checkout release
 
-{{n.next()}}. In the `rippled` directory you just cloned, create your build directory and access it. ***TODO: Does this "In the rippled directory you just cloned" language make sense? I just want to tell the user where to create the build directory.*** For example:
+      Or, you can checkout one of the tagged releases listed on [GitHub](https://github.com/ripple/rippled/releases).
+
+{{n.next()}}. In the `rippled` directory you just cloned, create your build directory and access it. For example:
 
         mkdir my_build
         cd my_build
@@ -190,7 +162,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         cmake --build . -- -j 4
 
-      This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -n hw.ncpu` to get your CPU core count.
+      **Tip:** This example uses a `-j` parameter set to `4`, which uses four processes to build in parallel. The best number of processes to use depends on how many CPU cores your hardware has available. Use `sysctl -n hw.ncpu` to get your CPU core count.
 
 {{n.next()}}. Run unit tests built into the server executable. This could take about 5 minutes, depending on your hardware specs. (optional, but recommended) <!--{# ***TODO: We should provide info about what to do if you get failures. What should the user do? PM looking into this.*** #}-->
 
@@ -201,7 +173,7 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
         mkdir -p /etc/opt/ripple ***TODO: changed this from ~/.config/ripple to match guidance coming in conf-file-location.md PR -- okay?***
         cp cfg/rippled-example.cfg /etc/opt/ripple/rippled.cfg
 
-{{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: I think we need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually updated to avoid permission issues, correct?***
+{{n.next()}}. Edit `rippled.cfg` to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here. ***TODO: We need to add this step to the centos and ubuntu tasks, correct? For centos and ubuntu, the config files are automatically placed in the correct directories, but the following paths still need to be manually checked/updated to ensure that there are no permission issues, correct?***
 
       * Set the `[node_db]` path to the location where you want to store the ledger database.
 
@@ -221,64 +193,62 @@ This section assumes that you are using macOS X 10.0 or higher. ***TODO: okay?**
 
         sudo ./rippled
 
+      Here's an excerpt of what you can expect to see in your terminal:
+
+```
+      2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
+      2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
+      2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
+      2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
+      2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
+      ...
+      2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
+      2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
+      2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
+      2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
+      2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
+      2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
+      2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
+      2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
+      2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
+      2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
+      2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
+      2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
+      2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
+      2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
+      2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
+      2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
+      2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
+      2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
+      2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
+      2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
+      2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
+      2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
+      2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
+      2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
+      2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
+      {
+      	"command" : "log_level",
+      	"severity" : "warning"
+      }
+      2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
+      2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
+      2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
+      2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
+      2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
+      2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
+      2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
+      2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
+      2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
+      2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
+```
+
 For next steps, see [Postinstall](#postinstall) and [Additional Configuration](#additional-configuration).
 
 
 ## Postinstall
 
 It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers.
-
-Here's an excerpt of what you can expect to see in your terminal: ***TODO: you'll see this in the CLI for the macOS install because we tell them to start the service using `sudo ./rippled`, but not for centos and ubuntu. For centos and ubuntu, we tell the user to start the service using `sudo systemctl start rippled.service`, which starts the service, but doesn't display a log of the service starting up. At least for first-time start up - would it make sense to give the user this start up command (sudo ./rippled) instead so that they can see it running? Perhaps in Postinstall we can give them the `sudo systemctl start rippled.service` command for when they want to start the service, but don't need to see the running log?***
-
-        2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
-        2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
-        2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
-        2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
-        2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
-        ...
-        2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
-        2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
-        2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
-        2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
-        2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
-        2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
-        2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
-        2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
-        2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
-        2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
-        2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
-        2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
-        2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
-        2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
-        2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
-        2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
-        2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
-        2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
-        2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
-        2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
-        2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
-        2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
-        2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
-        2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
-        2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
-        {
-        	"command" : "log_level",
-        	"severity" : "warning"
-        }
-
-
-        2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
-
-
-        2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
-        2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
-        2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
-        2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
-        2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
-        2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
-        2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
-        2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
-        2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
 
 <!--{# ***TODO: for the future, provide a reference for what the most common and unintuitive messages mean -- esp when signaling possible errors.*** #}-->
 
@@ -295,9 +265,9 @@ Once you have your stock `rippled` server running, you may want to consider runn
 
 `rippled` should connect to the XRP Ledger with the default configurations. However, you can change your settings by editing the `rippled.cfg` file. For recommendations about configuration settings, see [Capacity Planning](capacity-planning.html).
 
-Changes to the `[node_db]`, `[debug_logfile]`, or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: I added [node_db] to this list - okay? When I try the following command, `chown -R rippled:rippled /var/lib/rippled/db/rocksdb`, I get `chown: rippled: illegal group name.` Is `rippled:rippled` just an example below -- or should there be a `rippled` group that is created by the build/install process?***
+Changes to the `[node_db]`, `[debug_logfile]`, or `[database_path]` sections may require you to give the `rippled` user and group ownership to your new configured path: ***TODO: I added [node_db] to this list - okay?***
 
-    $ chown -R rippled:rippled <configured path>
+    $ chown -R rippled:rippled <configured path> ***TODO: Is `rippled:rippled` just an example value? When I run this command on macOS, I get `chown: rippled: illegal group name.` When I run it on centos, I get chown: changing ownership of ... : Operation not permitted***
 
 Restart `rippled` for any configuration changes to take effect: ***TODO: when I try this on macOS, I get `sudo: service: command not found`. I don't think the `service` command exists for macOS. For macOS, can the user just stop (ctrl+c? Not sure if that is the proper way to stop the service) and start rippled (sudo ./rippled) instead? For centos and ubuntu, we use `sudo systemctl start rippled.service` to start the service - below should we use `sudo systemctl restart rippled.service` - just to be consistent?***
 

--- a/content/tutorials/manage-the-rippled-server/install-rippled.md
+++ b/content/tutorials/manage-the-rippled-server/install-rippled.md
@@ -79,6 +79,66 @@ This section assumes that you are using Ubuntu 15.04 or later.
 
         $ sudo systemctl start rippled.service
 
+
+## Installation on macOS with homebrew
+
+We don't recommend macOS for `rippled` production use at this time. Currently, the [Ubuntu platform](#installation-on-ubuntu-with-alien) has received the highest level of quality assurance and testing. That said, macOS is suitable for many development/test tasks.
+
+https://github.com/ripple/rippled/tree/develop/Builds/macos
+
+This section assumes that you are using macOS X 10.0 or higher. ***TODO: correct?***
+
+1. Download Xcode: https://developer.apple.com/download/
+
+2. Install home brew: ruby -e “$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)
+
+3. brew update
+
+4. brew install git cmake pkg-config protobuf openssl ninja
+
+5. Download boost: https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
+
+6. build boost: ./bootstrap.sh
+
+7. build boost: ./b2 cxxflags=“-std=c++14”
+
+8. create boost_root variable: export BOOST_ROOT=/Users/manojdoshi/rippled/boost_1_67_0
+
+9. Clone the ripple repo: git clone https://github.com/ripple/rippled.git
+
+10. switch the branch: git checkout develop
+
+11. Create build folder: mkdir my_build
+
+12. cd my_build
+
+13. Build rippled:
+
+14. cmake -G “Unix Makefiles” -DCMAKE_BUILD_TYPE=Debug ../rippled/
+
+15. cmake --build . -- -j 4
+
+16. Run unit tests: ./rippled --unittest
+
+Daniel: Compiling from source (OSX)
+
+Installing homebrew removes the need to install xcode command line tools separately
+  homebrew install lists xcode commend line tools as a requirement: https://docs.brew.sh/Installation#requirements. What does this comment mean?
+
+Installing Boost directly is going to frustrate people - brew can do it in one command
+  Which release to choose?
+  Have to deal with environment variables
+  “rc” files is a vague statement
+  Build issues with Boost not finding lib (boost-context) in my case
+  I ended up installing Boost with Brew with no issues
+
+Cloning github repo is going to require proper github setup
+  Should we provide some guidance or references?
+
+Update rippled
+  No instructions on github or dev docs on how to do this for OSX, Windows, or other Linux distros
+
+
 ## Postinstall
 
 It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers. After that, you have a fully functional stock `rippled` server that you can use for local signing and API access to the XRP Ledger.


### PR DESCRIPTION
- Update Install `rippled` tutorial to include steps for installing `rippled` on macOS
- Add info about how to connect `rippled` to the XRP Test Net
- Incorporate feedback from PM
- Base on install steps from QA
- Base on https://github.com/ripple/rippled/tree/develop/Builds/macos
