### PR TITLE
Data API v2.4.0 Changes

### DIFF
--- a/assets/css/api-tools.css
+++ b/assets/css/api-tools.css
@@ -1,14 +1,3 @@
-#command_wrapper {
-  display:table;
-  width:100%;
-  padding:0;
-  margin:0;
-  border-spacing:0;
-}
-#command_wrapper > * {
-  vertical-align:top;
-  display:table-cell;
-}
 #command_list {
   list-style-type:none;
   padding:0 0 0 0;

--- a/assets/js/apitool-methods-data_v2.js
+++ b/assets/js/apitool-methods-data_v2.js
@@ -470,16 +470,17 @@ Request('Get Validators', {
     }
 });
 
-Request('Get Validator Validations', {
-    method: GET,
-    path: "/v2/network/validators/{:validation_public_key}/validations?{:query_params}",
-    description: "Get validation votes from a single validator.",
-    link: "#get-validator-validations",
-    params: {
-        "{:validation_public_key}": VALIDATOR_PUBKEY,
-        "{:query_params}": "limit=3"
-    }
-});
+// Removed in v2.4.0
+// Request('Get Validator Validations', {
+//     method: GET,
+//     path: "/v2/network/validators/{:validation_public_key}/validations?{:query_params}",
+//     description: "Get validation votes from a single validator.",
+//     link: "#get-validator-validations",
+//     params: {
+//         "{:validation_public_key}": VALIDATOR_PUBKEY,
+//         "{:query_params}": "limit=3"
+//     }
+// });
 
 Request('Get Single Validator Reports', {
     method: GET,
@@ -498,6 +499,17 @@ Request('Get Daily Validator Reports', {
     description: "Get validation vote stats for all validators for a single day.",
     link: "#get-single-validator-reports",
     params: {
+        "{:query_params}": "format=json"
+    }
+});
+
+Request('Get Validator Manifests', {
+    method: GET,
+    path: "/v2/network/validators/{:validation_public_key}/manifests",
+    description: "Get validation vote stats for all validators for a single day.",
+    link: "#get-validator-manifests",
+    params: {
+        "{:validation_public_key}": VALIDATOR_PUBKEY,
         "{:query_params}": "format=json"
     }
 });

--- a/assets/js/apitool-methods-data_v2.js
+++ b/assets/js/apitool-methods-data_v2.js
@@ -8,7 +8,7 @@ var KRW_TRADER_ADDRESS = "rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw";
 var JPY_TRADER_ADDRESS = "rK5j9n8baXfL4gzUoZsfxBvvsv97P5swaV";
 var DEFAULT_HASH = "9D591B18EDDD34F0B6CF4223A2940AEA2C3CC778925BABF289E0011CD8FA056E";
 var DEFAULT_LEDGER = "3170DA37CE2B7F045F889594CBC323D88686D2E90E8FFD2BBCD9BAD12E416DB5";
-var VALIDATOR_PUBKEY = "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7";
+var VALIDATOR_PUBKEY = "nHUon2tpyJEHHYGmxqeGu37cvPYHzrMtUNQFVdCgGNvEkjmCpTqK";
 var LEDGER_WITH_VALIDATIONS = "A10E9E338BA365D2B768814EC8B0A9A2D8322C0040735E20624AF711C5A593E7";
 
 // general methods -----------------------------------//
@@ -437,15 +437,16 @@ Request('Get Topology Links', {
     }
 });
 
-Request('Get Validations', {
-    method: GET,
-    path: "/v2/network/validations?{:query_params}",
-    description: "Get validation votes.",
-    link: "#get-validations",
-    params: {
-        "{:query_params}": "limit=3&descending=true"
-    }
-});
+// Removed in v2.4.0
+// Request('Get Validations', {
+//     method: GET,
+//     path: "/v2/network/validations?{:query_params}",
+//     description: "Get validation votes.",
+//     link: "#get-validations",
+//     params: {
+//         "{:query_params}": "limit=3&descending=true"
+//     }
+// });
 
 Request('Get Validator', {
     method: GET,

--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -82,10 +82,9 @@ Validation Network Methods:
 * [Get Topology Nodes - `GET /v2/network/topology/nodes`](#get-topology-nodes)
 * [Get Topology Node - `GET /v2/network/topology/nodes/{pubkey}`](#get-topology-node)
 * [Get Topology Links - `GET /v2/network/topology/links`](#get-topology-links)
-* [Get Validations  - `GET /v2/network/validations`](#get-validations)
 * [Get Validator  - `GET /v2/network/validators/{pubkey}`](#get-validator)
 * [Get Validators  - `GET /v2/network/validators`](#get-validators)
-* [Get Validator Validations - `GET /v2/network/validators/{pubkey}/validations`](#get-validator-validations)
+* [Get Validator Manifests - `GET /v2/network/validators/{pubkey}/manifests`](#get-validator-manifests)
 * [Get Single Validator Reports - `GET /v2/network/validators/{pubkey}/reports`](#get-single-validator-reports)
 * [Get Daily Validator Reports - `GET /v2/network/validator_reports`](#get-daily-validator-reports)
 * [Get `rippled` Versions - `GET /v2/network/rippled_versions`](#get-rippled-versions)
@@ -2641,7 +2640,7 @@ Response:
 ## Get Validator
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidators.js "Source")
 
-Get details of a single validator in the [consensus network](consensus.html). _(New in [v2.2.0][])_
+Get details of a single validator in the [consensus network](consensus.html). _(Updated in [v2.4.0][])_
 
 
 #### Request Format
@@ -2675,10 +2674,23 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field                   | Value                           | Description      |
 |:------------------------|:--------------------------------|:-----------------|
 | `result`                | String                          | The value `success` indicates that the body represents a successful response. |
-| `last_datetime`         | Integer                         | The last reported validation vote signed by this validator. |
 | `validation_public_key` | String - Base-58 [Public Key][] | This validator's validator public key. |
 | `domain`                | String                          | (May be omitted) The DNS domain associated with this validator. |
-| `domain_state`          | String                          | The value `verified` indicates that this validator has a [verified domain](run-rippled-as-a-validator.html#domain-verification) controlled by the same operator as the validator. The value `AccountDomainNotFound` indicates that the "Account Domain" part of Domain Verification is not set up properly. The value `RippleTxtNotFound` indicates that the ripple.txt step of Domain Verification is not set up properly. |
+| `chain`                 | String                          | Ledger hash chain which this validator is currently following. The value `main` indicates the main network and `altnet` indicates the XRP Test Network. Other forks are named `chain.{NUMBER}`, where `{NUMBER}` is a unique number for each fork. |
+| `unl`                   | Bool                            | True if the validator is part of the ledger chain's recommended UNL. |
+| `current_index`         | Number                          | Ledger index of most recently validated ledger. |
+| `partial`               | Bool                            | True if the most recent validation was a partial one. |
+| `agreement_1h`          | Agreement Object                | Object containing agreement stats for the most recent hour. |
+| `aggreement_24h`        | Agreement Object                | Object containing agreement stats for the most recent 24 hour period. |
+
+#### Agreement Objects
+
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
+| `score`                 | String                          | Score of agreement with the ledger chain being followed. |
+| `missed`                | Integer                         | Number of ledgers not validated during the time period. |
+| `total`                 | Integer                         | Number of ledgers that could have been validated during the time period. |
+| `incomplete`            | Bool                            | True indicates the data does not cover the entire time period. |
 
 #### Example
 
@@ -2693,10 +2705,24 @@ Response:
 ```
 200 OK
 {
-  "domain": "ripple.com",
-  "domain_state": "verified",
-  "last_datetime": "2016-06-07T01:22:59.929Z",
-  "validation_public_key": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7",
+  "validation_public_key": "nHBidG3pZK11zQD6kpNDoAhDxH6WLGui6ZxSbUx7LSqLHsgzMPec",
+  "domain": "bitso.com",
+  "chain": "main",
+  "current_index": 42279525,
+  "agreement_1h": {
+    "missed": 0,
+    "total": 981,
+    "score": "1.0000",
+    "incomplete": false
+  },
+  "agreement_24h": {
+    "missed": 0,
+    "total": 23519,
+    "score": "1.0000",
+    "incomplete": false
+  },
+  "partial": false,
+  "unl": true,
   "result": "success"
 }
 ```
@@ -2706,7 +2732,7 @@ Response:
 ## Get Validators
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidators.js "Source")
 
-Get a list of known validators. _(New in [v2.2.0][])_
+Get a list of known validators active in the last 24 hours. _(Updated in [v2.4.0][])_
 
 
 #### Request Format
@@ -2736,16 +2762,37 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field                   | Value                           | Description      |
 |:------------------------|:--------------------------------|:-----------------|
 | `result`                | String                          | The value `success` indicates that the body represents a successful response. |
-| `last_datetime`         | Integer                         | Number of links returned. |
-| `validation_public_key` | String - Base-58 [Public Key][] | Validator public key of this validator. |
+| `count`                 | Integer                         | Number of validators returned. |
+| `validators`            | Array of [Validator Objects][]  | List of validators active in the last 24 hours. |
 
+#### Validator Objects
+
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
+| `validation_public_key` | String - Base-58 [Public Key][] | This validator's validator public key. |
+| `domain`                | String                          | (May be omitted) The DNS domain associated with this validator. |
+| `chain`                 | String                          | Ledger hash chain which this validator is currently following. The value `main` indicates the main network and `altnet` indicates the XRP Test Network. Other forks are named `chain.{NUMBER}`, where `{NUMBER}` is a unique number for each fork. |
+| `unl`                   | Bool                            | True if the validator is part of the ledger chain's recommended UNL. |
+| `current_index`         | Number                          | Ledger index of most recently validated ledger. |
+| `partial`               | Bool                            | True if the most recent validation was a partial one. |
+| `agreement_1h`          | Agreement Object                | Object containing agreement stats for the most recent hour. |
+| `aggreement_24h`        | Agreement Object                | Object containing agreement stats for the most recent 24 hour period. |
+
+#### Agreement Objects
+
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
+| `score`                 | String                          | Score of agreement with the ledger chain being followed. |
+| `missed`                | Integer                         | Number of ledgers not validated during the time period. |
+| `total`                 | Integer                         | Number of ledgers that could have been validated during the time period. |
+| `incomplete`            | Bool                            | True indicates the data does not cover the entire time period. |
 
 #### Example
 
 Request:
 
 ```
-GET /v2/network/validators/n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7
+GET /v2/network/validators/
 ```
 
 Response:
@@ -2753,20 +2800,41 @@ Response:
 ```
 200 OK
 {
-  result: "success",
-  last_datetime: "2016-02-11T23:20:41.319Z",
-  validation_public_key: "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7"
+  "result": "success",
+  "count": 141,
+  "validators": [
+    {
+      "validation_public_key": "nHBidG3pZK11zQD6kpNDoAhDxH6WLGui6ZxSbUx7LSqLHsgzMPec",
+      "domain: "bitso.com",
+      "chain": "main",
+      "current_index": 42281151,
+      "agreement_1h": {
+        "missed": 0,
+        "total": 1029,
+        "score": "1.0000",
+        "incomplete": false
+      },
+      "agreement_24h": {
+        "missed": 0,
+        "total": 23585,
+        "score": "1.0000",
+        "incomplete": false
+      },
+      "partial": false,
+      "unl": true
+    }
+  ]
 }
 ```
 
 
 
-## Get Validator Validations
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidations.js "Source")
+## Get Validator Manifests
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getManifests.js "Source")
 
-Retrieve validation votes signed by a specified validator, including votes for ledger versions that are outside the main ledger chain. _(New in [v2.2.0][])_
+Retrieve manifests signed by a specified validator, used to designate ephemeral key to sign proposals and validations. _(New in [v2.3.7][])_
 
-**Note:** The Data API does not have a comprehensive record of all validations. The response only includes data that the Data API has recorded. Some ledger versions, especially older ledgers, may have no validations even if they were validated by consensus.
+**Note:** The Data API does not have a comprehensive record of all manifests. The response only includes data that the Data API has recorded.
 
 #### Request Format
 
@@ -2775,39 +2843,35 @@ Retrieve validation votes signed by a specified validator, including votes for l
 *REST*
 
 ```
-GET /v2/network/validators/{pubkey}/validations
+GET /v2/network/validators/{pubkey}/manifests
 ```
 
 <!-- MULTICODE_BLOCK_END -->
-
-[Try it! >](data-api-v2-tool.html#get-validator-validations)
 
 This method requires the following URL parameters:
 
-| Field    | Value                           | Description           |
-|:---------|:--------------------------------|:----------------------|
-| `pubkey` | String - Base-58 [Public Key][] | Validator public key. |
+| Field     | Value                           | Description           |
+|:----------|:--------------------------------|:----------------------|
+| `pubkey`  | String - Base-58 [Public Key][] | Validator public key. |
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value                  | Description                              |
-|:---------|:-----------------------|:-----------------------------------------|
-| `start`  | String - [Timestamp][] | Filter results to this time and later.   |
-| `end`    | String - [Timestamp][] | Filter results to this time and earlier. |
-| `limit`  | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
-| `marker` | String                 | [Pagination](#pagination) key from previously returned response. |
-| `format` | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
+| Field    | Value   | Description                                             |
+|:---------|:--------|:--------------------------------------------------------|
+| `limit`  | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
+| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
+| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field         | Value                           | Description                |
-|:--------------|:--------------------------------|:---------------------------|
-| `result`      | String                          | The value `success` indicates that the body represents a successful response. |
-| `count`       | Integer                         | Number of validations returned. |
-| `marker`      | String                          | (May be omitted) [Pagination](#pagination) marker. |
-| `validations` | Array of [Validation Objects][] | The requested validations. |
+| Field       | Value                         | Description                    |
+|:------------|:------------------------------|:-------------------------------|
+| `result`    | String                        | The value `success` indicates that the body represents a successful response. |
+| `count`     | Integer                       | Number of manifests returned.  |
+| `marker`    | String                        | (May be omitted) [Pagination](#pagination) marker. |
+| `manifests` | Array of [Manifest Objects][] | The requested manifests.       |
 
 
 #### Example
@@ -2815,7 +2879,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 Request:
 
 ```
-GET /v2/network/validator/n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7/validations?limit=3&descending=true
+GET /v2/network/validator/nHDEmQKb2nbcewdQ1fqCTGcPTcePhJ2Rh6MRftsCaf6UNRQLv7pB/manifests
 ```
 
 Response:
@@ -2824,139 +2888,41 @@ Response:
 200 OK
 {
   "result": "success",
-  "count": 3,
-  "marker": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7|20160608020910|4499E5D60FD4F3F239C5B274E65B9CAE033398BE976E4FB49E9B30508D95F5A5",
-  "validations": [
+  "count": 2,
+  "manifests": [
     {
-      "count": 27,
-      "first_datetime": "2016-06-08T02:09:21.280Z",
-      "last_datetime": "2016-06-08T02:09:21.390Z",
-      "ledger_hash": "246C5142A108C7B64F5D700936D31360B7790FA6349A98A2A1F7A14671D70B48",
-      "reporter_public_key": "n9KKTtooV4h2UsmNEhBqPvMRNj6RAHLPS6Baktf4u1AhgKNbyJAF",
-      "signature": "304402204506DD69B831886C4738F97CEED43AAFDBA67254D3EAF4FB5B3BF167A15B1B690220147E366CA53A3EC8B513978F2BA3A0905DC412CCE553E8ECE544236B097F2C8A",
-      "validation_public_key": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7"
+      "count": 1,
+      "ephemeral_public_key": "nHUvPMeNsrwdJd7d65eaYGkKx6bPEcxJGudjVDqwCybtEfrSUE8w",
+      "first_datetime": "2018-09-06T20:20:08.353Z",
+      "last_datetime": "2018-09-06T20:20:08.353Z",
+      "master_public_key": "nHDEmQKb2nbcewdQ1fqCTGcPTcePhJ2Rh6MRftsCaf6UNRQLv7pB",
+      "master_signature":
+        "D8E78AD2C10ADA5A91D673C2EA66045926D3ED3D4C77DE4350AAA076379F69B8D0EC492A626EA9228964F694EED9EC63394D051001BA432EC57F2B6031204806",
+      "sequence": "1",
+      "signature":
+        "C794C3D1159932FF8EE7360074E7D17CB59F6646B227EF35D439892C00832648C46FD1958714E153AF4BD0540A7B27011B7F58D357B68B87DCBF5CA81874480C"
     },
     {
-      "count": 27,
-      "first_datetime": "2016-06-08T02:09:17.275Z",
-      "last_datetime": "2016-06-08T02:09:17.383Z",
-      "ledger_hash": "1DC9245CDBFE2C640ACD766DB4AF1DE66F6E92A8EE78F628281A6568760DBAB2",
-      "reporter_public_key": "n9JySgyBVcQKvyDoeRKg7s2Mm6ZcFHk22vUZb3o1HSosWxcj9xPt",
-      "signature": "3045022100E07D8CB801EC7AC98DB1DED813D49AE1FFE3C4CB027314EB6ED1BA7796653DE902204E65E96B0961AC09D8D7542EC59B3CE2ECAE6BC02557A4D1C0385DED00445329",
-      "validation_public_key": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7"
-    },
-    {
-      "count": 27,
-      "first_datetime": "2016-06-08T02:09:13.277Z",
-      "last_datetime": "2016-06-08T02:09:13.387Z",
-      "ledger_hash": "0E11FA2052E8D345069CF09F13D76A8EF618C32F2B25A948FF104D59F53371BE",
-      "reporter_public_key": "n9KKTtooV4h2UsmNEhBqPvMRNj6RAHLPS6Baktf4u1AhgKNbyJAF",
-      "signature": "3045022100C1252F3FE8D0683F7FE5261D36876650EE185EEFE558150DEEF67F86E928463F022017237E1D89D5DBD8C4C2CC041C2EA73D96260D44A283D6CFF95359E86008E765",
-      "validation_public_key": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7"
+      "count": 1,
+      "ephemeral_public_key": "n9M7mktkbZCnKWa41LFkZsfXemBGdYsFT6fqJBXa4xupV8X8px7W",
+      "first_datetime": "2018-09-06T20:20:08.357Z",
+      "last_datetime": "2018-09-06T20:20:08.357Z",
+      "master_public_key": "nHDEmQKb2nbcewdQ1fqCTGcPTcePhJ2Rh6MRftsCaf6UNRQLv7pB",
+      "master_signature":
+        "F7ECCB90F84ED3FC5E0DE1A6B0B7E835A8D2A94C8E985A74932DE30CD2EDCB46936FD14C39A5AA1BB3583CF888C869167979FEE068C6C34B9B63AB922850090E",
+      "sequence": "2",
+      "signature":
+        "3044022055ED7EFF1245DE21D3C28C57D19301291F0D617CA3A6D3D4CFDF8692D9E0E68502200276215BA986BA61834E0AC71E8590706C851B8F55F0B80A44EECE868F71415F"
     }
   ]
 }
 ```
-
-
-
-## Get Validations
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidations.js "Source")
-
-Retrieve validation votes, including votes for ledger versions that are outside the main ledger chain. _(New in [v2.2.0][])_
-
-**Note:** The Data API does not have a comprehensive record of all validations. The response only includes data that the Data API has recorded. Some ledger versions, especially older ledgers, may have no validations even if they were validated by consensus.
-
-#### Request Format
-
-<!-- MULTICODE_BLOCK_START -->
-
-*REST*
-
-```
-GET /v2/network/validations
-```
-
-<!-- MULTICODE_BLOCK_END -->
-
-[Try it! >](data-api-v2-tool.html#get-validations)
-
-Optionally, you can provide the following query parameters:
-
-| Field        | Value                  | Description                          |
-|:-------------|:-----------------------|:-------------------------------------|
-| `start`      | String - [Timestamp][] | Filter results to this time and later. |
-| `end`        | String - [Timestamp][] | Filter results to this time and earlier. |
-| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
-| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
-| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
-| `descending` | Boolean                | If `true`, return results sorted with earliest first. Otherwise, return oldest results first. The default is `false`. |
-
-#### Response Format
-
-A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
-
-| Field         | Value                           | Description                |
-|:--------------|:--------------------------------|:---------------------------|
-| `result`      | String                          | The value `success` indicates that the body represents a successful response. |
-| `count`       | Integer                         | Number of validation votes returned. |
-| `marker`      | String                          | (May be omitted) [Pagination](#pagination) marker. |
-| `validations` | Array of [Validation Objects][] | The requested validation votes. |
-
-#### Example
-
-Request:
-
-```
-GET /v2/network/validations?limit=3&descending=true
-```
-
-Response:
-
-```
-200 OK
-{
-  "result": "success",
-  "count": 3,
-  "marker": "20160608005421561|nHUBJUyiW7ePZdjoLYrRvLB6JEytaAiX2NFqcmgNqW3CCFgBV7LZ|ADB496DFDBF27382E4D49F79D7EC5DD15229AF21E664934217A82D404748C994",
-  "validations": [
-    {
-      "count": 7,
-      "first_datetime": "2016-06-08T00:54:21.583Z",
-      "last_datetime": "2016-06-08T00:54:21.583Z",
-      "ledger_hash": "ADB496DFDBF27382E4D49F79D7EC5DD15229AF21E664934217A82D404748C994",
-      "reporter_public_key": "n9MVezjxa3Wk1vsZ8omj7Hga3tEcFiNH3gjWwx2SsQxkiamBwFw5",
-      "signature": "3044022027DCB43438A27F4F51DFD436FC078933524C6D675DBD7E0033C5A33DA3683699022029A5143EE172CA94AAD706454192CC2EC3CC93182697F0B2C00818C1C43ECE27",
-      "validation_public_key": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7"
-    },
-    {
-      "count": 1,
-      "first_datetime": "2016-06-08T00:54:21.574Z",
-      "last_datetime": "2016-06-08T00:54:21.574Z",
-      "ledger_hash": "ADB496DFDBF27382E4D49F79D7EC5DD15229AF21E664934217A82D404748C994",
-      "reporter_public_key": "n9MqZ95ENFuf9yCWjZFsvCuvjNv9K3NpYgE9NYLAgzmCkkFpNs9W",
-      "signature": "3044022054FC074D6AFA022316C24EAEAC70644F3646151C164B72FB3B5A509A692ECAA7022038C93B3E282B5475FC9DC962CA4AD15A28796A1C10A978F66B0C8BBFF42A5782",
-      "validation_public_key": "n9MM9o8j5HmjNF2YFcvNWdKxAsMsMf58Ke6WQvcnn7oHLsuvkAtf"
-    },
-    {
-      "count": 1,
-      "first_datetime": "2016-06-08T00:54:21.574Z",
-      "last_datetime": "2016-06-08T00:54:21.574Z",
-      "ledger_hash": "ADB496DFDBF27382E4D49F79D7EC5DD15229AF21E664934217A82D404748C994",
-      "reporter_public_key": "n9MexcuoJg7KsVnJkvyPuLCtJNx5DSWnZbuWpcdsZ2jeqbU1ghEA",
-      "signature": "3045022100B6CD4FAFF0B699689885D48AB4CA449FA9E4E51832737E36BE5AA6642F88C52C02202297D2F4EFE41F512A4985A571E4D64F8161651DF3FA94561B2F583769305E27",
-      "validation_public_key": "n9KeL6TaqiQoUGndmyYKFDE868bFSAQQJ6XT1LmsuCDCebBdF5BV"
-    }
-  ]
-}
-```
-
 
 
 ## Get Single Validator Reports
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidatorReports.js "Source")
 
-Get a single validator's validation vote stats for 24-hour intervals.
+Get a single validator's validation vote stats for 24-hour intervals. _(Updated in [v2.4.0][])_
 
 #### Request Format
 
@@ -2982,9 +2948,10 @@ Optionally, you can provide the following query parameters:
 
 | Field    | Value                  | Description                              |
 |:---------|:-----------------------|:-----------------------------------------|
-| `start`  | String - [Timestamp][] | Start date and time for historical query. The default is to start 200 days before the current date. |
-| `end`    | String - [Timestamp][] | End date and time for historical query. The default is to end with the most recent data available. |
-| `format` | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
+| `start`      | String - [Timestamp][] | Start date and time for historical query. The default is to start 200 days before the current date. |
+| `end`        | String - [Timestamp][] | End date and time for historical query. The default is to end with the most recent data available. |
+| `descending` | Bool                   | Return results in reverse order. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
@@ -2994,19 +2961,19 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |:-------------|:-----------------------------------------|:-------------------|
 | `result`     | String                                   | The value `success` indicates that the body represents a successful response. |
 | `count`      | Integer                                  | Number of validators returned. |
-| `validators` | Array of Single Validator Report Objects | Daily reports of this validator's validation votes. |
+| `reports`    | Array of Single Validator Report Objects | Daily reports of this validator's validation votes. |
 
-Each member in the `validators` array is a Single Validator Report Object with data on that validator's performance on that day. Each has the following fields:
+Each member in the `reports` array is a Single Validator Report Object with data on that validator's performance on that day. Each has the following fields:
 
-| Field                | Value                  | Description                  |
-|:---------------------|:-----------------------|:-----------------------------|
-| `date`               | String - [Timestamp][] | The start time of the date this object describes. |
-| `total_ledgers`      | Integer                | Number of ledger hashes for which this validator submitted validation votes. If this number is much lower than other validators in the same time period, that could mean the validator had downtime. |
-| `main_net_agreement` | [String - Number][]    | The fraction of consensus-validated production network ledger versions for which this validator voted in this interval. `"1.0"` indicates 100% agreement. |
-| `main_net_ledgers`   | Integer                | Number of consensus-validated [production network](parallel-networks.html) ledger versions this validator voted for. |
-| `alt_net_agreement`  | [String - Number][]    | The fraction of the consensus-validated [Test Network](parallel-networks.html) ledger versions this validator voted for. `"1.0"` indicates 100% agreement. |
-| `alt_net_ledgers`    | Integer                | Number of consensus-validated [Test Network](parallel-networks.html) ledger versions this validator voted for. |
-| `other_ledgers`      | Integer                | Number of other ledger versions this validator voted for. If this number is high, that could indicate that this validator was running non-standard or out-of-date software. |
+| Field                | Value                           | Description                  |
+|:---------------------|:--------------------------------|:-----------------------------|
+| `validation_public_key` | String - Base-58 [Public Key][] | Validator public key. |
+| `date`               | String - [Timestamp][]          | The start time of the date this object describes. |
+| `chain`              | String                          | Ledger hash chain which this validator is currently following. The value `main` indicates the main network and `altnet` indicates the XRP Test Network. Other forks are named `chain.{NUMBER}`, where `{NUMBER}` is a unique number for each fork. |
+| `score`              | String                          | Score of agreement with the ledger chain being followed. |
+| `missed`             | Integer                         | Number of ledgers not validated during the time period. |
+| `total`              | Integer                         | Number of ledgers that could have been validated during the time period. |
+| `incomplete`         | Bool                            | True indicates the data does not cover the entire time period. |
 
 #### Example
 
@@ -3049,7 +3016,6 @@ Response:
 ```
 
 
-
 ## Get Daily Validator Reports
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidatorReports.js "Source")
 
@@ -3088,19 +3054,17 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 Daily Validator Report Object fields:
 
-| Field                   | Value                           | Description      |
-|:------------------------|:--------------------------------|:-----------------|
-| `validation_public_key` | String - Base-58 [Public Key][] | This validator's validator public key. |
-| `date`                  | String - [Timestamp][]          | The start time of the date this object describes. |
-| `total_ledgers`         | Integer                         | Number of ledger indexes for which this validator submitted validation votes. If this number is much lower than other validators in the same time period, that could mean the validator had downtime. |
-| `main_net_agreement`    | [String - Number][]             | The fraction of consensus-validated production network ledger versions for which this validator voted in this interval. `"1.0"` indicates 100% agreement. |
-| `main_net_ledgers`      | Integer                         | Number of consensus-validated [production network](parallel-networks.html) ledger versions this validator voted for. |
-| `alt_net_agreement`     | [String - Number][]             | The fraction of the consensus-validated [Test Network](parallel-networks.html) ledger versions this validator voted for. `"1.0"` indicates 100% agreement. |
-| `alt_net_ledgers`       | Integer                         | Number of consensus-validated [Test Network](parallel-networks.html) ledger versions this validator voted for. |
-| `other_ledgers`         | Integer                         | Number of other ledger versions this validator voted for. If this number is high, that could indicate that this validator was running non-standard or out-of-date software. |
-| `last_datetime`         | Integer                         | The last reported validation vote signed by this validator. |
-| `domain`                | String                          | (May be omitted) The DNS domain associated with this validator. |
-| `domain_state`          | String                          | The value `verified` indicates that this validator has a [verified domain](run-rippled-as-a-validator.html#domain-verification) controlled by the same operator as the validator. The value `AccountDomainNotFound` indicates that the "Account Domain" part of Domain Verification is not set up properly. The value `RippleTxtNotFound` indicates that the ripple.txt step of Domain Verification is not set up properly. |
+Each member in the `reports` array is a Single Validator Report Object with data on that validator's performance on that day. Each has the following fields:
+
+| Field                | Value                           | Description                  |
+|:---------------------|:--------------------------------|:-----------------------------|
+| `validation_public_key` | String - Base-58 [Public Key][] | Validator public key. |
+| `date`               | String - [Timestamp][]          | The start time of the date this object describes. |
+| `chain`              | String                          | Ledger hash chain which this validator is currently following. The value `main` indicates the main network and `altnet` indicates the XRP Test Network. Other forks are named `chain.{NUMBER}`, where `{NUMBER}` is a unique number for each fork. |
+| `score`              | String                          | Score of agreement with the ledger chain being followed. |
+| `missed`             | Integer                         | Number of ledgers not validated during the time period. |
+| `total`              | Integer                         | Number of ledgers that could have been validated during the time period. |
+| `incomplete`         | Bool - Optional                 | True indicates the data does not cover the entire time period. |
 
 #### Example
 
@@ -3119,33 +3083,13 @@ Response:
   "count": 27,
   "reports": [
     {
-      "validation_public_key": "n9KvSsyJiheyFnivzFqChZ58pQgjwWWuc7Tp28WPzXbkdwqL6P5y",
-      "date": "2016-06-07T00:00:00Z",
-      "total_ledgers": 1289,
-      "main_net_agreement": "1.00000",
-      "main_net_ledgers": 1289,
-      "alt_net_agreement": "0.00000",
-      "alt_net_ledgers": 0,
-      "other_ledgers": 0,
-      "domain": "rippled.media.mit.edu",
-      "domain_state": "verified",
-      "last_datetime": "2016-06-07T01:20:20.753Z"
-    },
-    {
-      "validation_public_key": "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7",
-      "date": "2016-06-07T00:00:00Z",
-      "total_ledgers": 1289,
-      "main_net_agreement": "1.00000",
-      "main_net_ledgers": 1289,
-      "alt_net_agreement": "0.00000",
-      "alt_net_ledgers": 0,
-      "other_ledgers": 0,
-      "domain": "ripple.com",
-      "domain_state": "verified",
-      "last_datetime": "2016-06-07T01:20:20.717Z"
-    },
-
-    ...
+      "validation_public_key": "n9J2N3FfiUFC4rBX5UBob8JzgDGsYqUou1cwKdsaymS44mZDfnYe",
+      "date": "2018-10-15T00:00:00Z",
+      "chain": "main",
+      "score": "0.6909",
+      "total": "16127",
+      "missed": "7216"
+    }
   ]
 }
 ```

--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -100,7 +100,7 @@ Health Checks:
 
 
 ## Get Ledger
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getLedger.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
 
 Retrieve a specific Ledger by hash, index, date, or latest validated.
 
@@ -172,7 +172,7 @@ Response:
 
 
 ## Get Ledger Validations
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getLedger.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
 
 Retrieve a any validations recorded for a specific ledger hash.  This dataset includes ledger versions that are outside the validated ledger chain. _(New in [v2.2.0][])_
 
@@ -262,7 +262,7 @@ Response:
 
 
 ## Get Ledger Validation
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getLedger.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
 
 Retrieve a validation vote recorded for a specific ledger hash by a specific validator.  This dataset includes ledger versions that are outside the validated ledger chain. _(New in [v2.2.0][])_
 
@@ -326,7 +326,7 @@ Response:
 
 
 ## Get Transaction
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getTransactions.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getTransactions.js "Source")
 
 Retrieve a specific transaction by its identifying hash.
 
@@ -436,7 +436,7 @@ Response (trimmed for size):
 
 
 ## Get Transactions
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getTransactions.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getTransactions.js "Source")
 
 Retrieve transactions by time
 
@@ -595,7 +595,7 @@ Response:
 
 
 ## Get Payments
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getPayments.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getPayments.js "Source")
 
 Retrieve Payments over time, where Payments are defined as `Payment` type transactions where the sender of the transaction is not also the destination. _(New in [v2.0.4][])_
 
@@ -735,7 +735,7 @@ Response:
 
 
 ## Get Exchanges
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getExchanges.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getExchanges.js "Source")
 
 Retrieve Exchanges for a given currency pair over time.  Results can be returned as individual exchanges or aggregated to a specific list of intervals
 
@@ -867,7 +867,7 @@ Response:
 
 
 ## Get Exchange Rates
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getExchangeRate.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getExchangeRate.js "Source")
 
 Retrieve an exchange rate for a given currency pair at a specific time.
 
@@ -935,7 +935,7 @@ Response:
 
 
 ## Normalize
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/normalize.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/normalize.js "Source")
 
 Convert an amount from one currency and issuer to another, using the network exchange rates.
 
@@ -1002,7 +1002,7 @@ Response:
 
 
 ## Get Daily Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/reports.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/reports.js "Source")
 
 Retrieve per account per day aggregated payment summaries
 
@@ -1166,7 +1166,7 @@ Response (trimmed for size):
 
 
 ## Get Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/stats.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/stats.js "Source")
 
 Retrieve statistics about transaction activity in the XRP Ledger, divided into intervals of time.
 
@@ -1270,7 +1270,7 @@ Response:
 
 
 ## Get Active Accounts
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/activeAccounts.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/activeAccounts.js "Source")
 
 Get information on which accounts are actively trading in a specific currency pair. _(New in [v2.0.4][])_
 
@@ -1422,7 +1422,7 @@ Response:
 
 
 ## Get Exchange Volume
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getMetric.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getMetric.js "Source")
 
 Get aggregated exchange volume for a given time period. _(New in [v2.0.4][])_
 
@@ -1569,7 +1569,7 @@ Response:
 
 
 ## Get Payment Volume
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getMetric.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getMetric.js "Source")
 
 Get aggregated payment volume for a given time period. _(New in [v2.0.4][])_
 
@@ -1697,7 +1697,7 @@ Response:
 
 
 ## Get External Markets
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/externalMarkets.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/externalMarkets.js "Source")
 
 Get aggregated exchange volume from a list of off ledger exchanges for a specified rolling interval.
 
@@ -1820,7 +1820,7 @@ Response:
 
 
 ## Get XRP Distribution
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/xrpDistribution.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/xrpDistribution.js "Source")
 
 Get information on the total amount of XRP in existence and in circulation, by weekly intervals. _(New in [v2.2.0][])_
 
@@ -1898,7 +1898,7 @@ Response:
 
 
 ## Get Top Currencies
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/topCurrencies.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/topCurrencies.js "Source")
 
 Returns the top currencies on the XRP Ledger, ordered from highest rank to lowest. The ranking is determined by the volume and count of transactions and the number of unique counterparties. By default, returns results for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. _(New in [v2.1.0][])_
 
@@ -2001,7 +2001,7 @@ Response:
 
 
 ## Get Top Markets
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/topMarkets.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/topMarkets.js "Source")
 
 Returns the top exchange markets on the XRP Ledger, ordered from highest rank to lowest. The rank is determined by the number and volume of exchanges and the number of counterparties participating. By default, returns top markets for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. _(New in [v2.1.0][])_
 
@@ -2105,7 +2105,7 @@ Response:
 
 
 ## Get Transaction Costs
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getFees.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getFees.js "Source")
 
 Returns [transaction cost](transaction-cost.html) stats per ledger, hour, or day.  The data shows the average, minimum, maximum, and total transaction costs paid for the given interval or ledger. _(New in [v2.2.0][])_
 
@@ -2207,7 +2207,7 @@ Response:
 
 
 ## Get Fee Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getFeeStats.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getFeeStats.js "Source")
 
 Returns snapshots of the metrics derived from `rippled`'s [`fee` command](fee.html). _(New in [v2.3.2][])_
 
@@ -2307,7 +2307,7 @@ Response:
 
 
 ## Get Topology
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getTopology.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getTopology.js "Source")
 
 Get known `rippled` servers and peer-to-peer connections between them. _(New in [v2.2.0][])_
 
@@ -2412,7 +2412,7 @@ Response:
 
 
 ## Get Topology Nodes
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getNodes.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getNodes.js "Source")
 
 Get known `rippled` nodes. (This is a subset of the data returned by the [Get Topology method](#get-topology).) _(New in [v2.2.0][])_
 
@@ -2503,7 +2503,7 @@ Response:
 
 
 ## Get Topology Node
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getNodes.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getNodes.js "Source")
 
 Get information about a single `rippled` server by its [node public key](#public-keys) (not validator public key). _(New in [v2.2.0][])_
 
@@ -2575,7 +2575,7 @@ Response:
 
 
 ## Get Topology Links
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getLinks.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getLinks.js "Source")
 
 Get information on peer-to-peer connections between `rippled` servers. (This is a subset of the data returned by the [Get Topology method](#get-topology).) _(New in [v2.2.0][])_
 
@@ -2640,7 +2640,7 @@ Response:
 
 
 ## Get Validator
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidators.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidators.js "Source")
 
 Get details of a single validator in the [consensus network](consensus.html). _(Updated in [v2.4.0][])_
 
@@ -2734,7 +2734,7 @@ Response:
 
 
 ## Get Validators
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidators.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidators.js "Source")
 
 Get a list of known validators active in the last 24 hours. _(Updated in [v2.4.0][])_
 
@@ -2857,7 +2857,7 @@ Response:
 
 
 ## Get Validator Manifests
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getManifests.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getManifests.js "Source")
 
 Retrieve manifests signed by a specified validator. (Manifests, also called _subkey authorizations_, designate the ephemeral key a validator uses to sign proposals and validations.) _(New in [v2.3.7][])_
 
@@ -2964,7 +2964,7 @@ Response:
 
 
 ## Get Single Validator Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidatorReports.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidatorReports.js "Source")
 
 Get a single validator's validation vote stats for 24-hour intervals. _(Updated in [v2.4.0][])_
 
@@ -3064,7 +3064,7 @@ Response:
 
 
 ## Get Daily Validator Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getValidatorReports.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidatorReports.js "Source")
 
 Get validation vote stats and validator information for all known validators in a 24-hour period.
 
@@ -3144,7 +3144,7 @@ Response:
 
 
 ## Get rippled Versions
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getVersions.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getVersions.js "Source")
 
 Reports the latest versions of `rippled` available from the official Ripple Yum repositories. _(New in [v2.3.0][].)_
 
@@ -3219,7 +3219,7 @@ Response:
 
 
 ## Get All Gateways
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/gateways.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js "Source")
 
 Get information about [known gateways](https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json). _(New in [v2.0.4][])_
 
@@ -3315,7 +3315,7 @@ Response:
 
 
 ## Get Gateway
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/gateways.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js "Source")
 
 <!-- STYLE_OVERRIDE: gateway, gateways -->
 Get information about a specific gateway from [the Data API's list of known gateways](https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json). _(New in [v2.0.4][])_
@@ -3408,7 +3408,7 @@ Response:
 
 ## Get Currency Image
 
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/gateways.js#L199 "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js#L199 "Source")
 
 Retrieve vector icons for various currencies. _(New in [v2.0.4][])_
 
@@ -3469,7 +3469,7 @@ Content-Type: image/svg+xml
 
 
 ## Get Accounts
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accounts.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accounts.js "Source")
 
 Retrieve information about the creation of new accounts in the XRP Ledger.
 
@@ -3557,7 +3557,7 @@ Response:
 
 
 ## Get Account
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/getAccount.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getAccount.js "Source")
 
 Get creation info for a specific ripple account
 
@@ -3619,7 +3619,7 @@ Response:
 
 
 ## Get Account Balances
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountBalances.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountBalances.js "Source")
 
 Get all balances held or owed by a specific XRP Ledger account.
 
@@ -3704,7 +3704,7 @@ Response:
 
 
 ## Get Account Orders
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountOrders.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountOrders.js "Source")
 
 Get orders in the order books, placed by a specific account. This does not return orders that have already been filled.
 
@@ -3830,7 +3830,7 @@ Response:
 
 
 ## Get Account Transaction History
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountTransactions.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountTransactions.js "Source")
 
 Retrieve a history of transactions that affected a specific account. This includes all transactions the account sent, payments the account received, and payments that rippled through the account.
 
@@ -3962,7 +3962,7 @@ Response:
 
 
 ## Get Transaction By Account And Sequence
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountTxSeq.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountTxSeq.js "Source")
 
 Retrieve a specifc transaction originating from a specified account
 
@@ -4031,7 +4031,7 @@ Response:
 
 
 ## Get Account Payments
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountPayments.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountPayments.js "Source")
 
 Retrieve a payments for a specified account
 
@@ -4136,7 +4136,7 @@ Response:
 
 
 ## Get Account Exchanges
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountExchanges.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountExchanges.js "Source")
 
 Retrieve Exchanges for a given account over time.
 
@@ -4256,7 +4256,7 @@ Response:
 
 
 ## Get Account Balance Changes
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountBalanceChanges.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountBalanceChanges.js "Source")
 
 Retrieve Balance changes for a given account over time.
 
@@ -4361,7 +4361,7 @@ Response:
 
 
 ## Get Account Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountReports.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountReports.js "Source")
 
 Retrieve daily summaries of payment activity for an account.
 
@@ -4474,7 +4474,7 @@ Response:
 
 
 ## Get Account Transaction Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountStats.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountStats.js "Source")
 
 Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.0][].)_
 
@@ -4573,7 +4573,7 @@ Response:
 
 
 ## Get Account Value Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountStats.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountStats.js "Source")
 
 Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.0][].)_
 
@@ -4660,7 +4660,7 @@ Response:
 
 
 ## Health Check - API
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/checkHealth.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the API service.
 
@@ -4723,7 +4723,7 @@ Response:
 
 
 ## Health Check - Ledger Importer
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/checkHealth.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the Ledger Importer Service.
 
@@ -4795,7 +4795,7 @@ Response:
 
 
 ## Health Check - Nodes ETL
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/checkHealth.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the Topology Nodes Extract, Transform, Load (ETL) Service.
 
@@ -4861,7 +4861,7 @@ Response:
 
 
 ## Health Check - Validations ETL
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/checkHealth.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the Validations Extract, Transform, Load (ETL) Service.
 
@@ -5332,7 +5332,7 @@ To install the Data API v2:
 
 4. Change the config files as needed. Remove the `postgres` section from `api.config.json`.
 
-Reports, stats, and aggregated exchange data needs more processing before the API can make it available. This processing uses Apache Storm as well as some custom scripts. See [Storm Setup](https://github.com/ripple/rippled-historical-database/blob/develop/storm/README.md) for more information.
+Reports, stats, and aggregated exchange data needs more processing before the API can make it available. This processing uses Apache Storm as well as some custom scripts. See [Storm Setup](https://github.com/ripple/rippled-historical-database/blob/master/storm/README.md) for more information.
 
 At this point, the Data API is installed. See [Services](#services) for the different components that you can run.
 

--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -26,6 +26,7 @@ The Ripple Data API v2 replaces the Historical Database v1 and the [Charts API](
 [v2.3.0]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.3.0
 [v2.3.2]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.3.2
 [v2.3.5]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.3.5
+[v2.4.0]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.4.0
 
 
 # API Method Reference

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2665,7 +2665,7 @@ pages:
         funnel: Dev Tools
         html: data-api-v2-tool.html
         methods_js: js/apitool-methods-data_v2.js
-        rest_host: https://data-staging.ripple.com
+        rest_host: https://data.ripple.com
         doc_page: data-api.html
         sidebar: custom
         targets:

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2665,7 +2665,7 @@ pages:
         funnel: Dev Tools
         html: data-api-v2-tool.html
         methods_js: js/apitool-methods-data_v2.js
-        rest_host: https://data.ripple.com
+        rest_host: https://data-staging.ripple.com
         doc_page: data-api.html
         sidebar: custom
         targets:


### PR DESCRIPTION
This updates the dev portal Data API docs with the changes from https://github.com/ripple/rippled-historical-database/pull/183 and adds some more changes (which will hopefully get incorporated into that PR).

Also:

- Updates the Data API v2 tool to add the "Get Validator Manifests" method (added in v2.3.7) and remove the two methods removed in v2.4.0
- Changes the default validator key in the API tool to one that reports recent data
- Fixes a CSS problem that was causing API tool responses to overlap the right column.

This should not be merged until after the Data API PR is merged.