### PR TITLE
Add Crazy Egg script to Dev Portal

### DIFF
--- a/tool/template-base.html
+++ b/tool/template-base.html
@@ -40,6 +40,8 @@
       gtag('config', 'UA-45576805-2');
     </script>
 
+    <!-- Crazy Egg -->
+    <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0070/6316.js" async="async"></script>
 
     {% block head %}
 


### PR DESCRIPTION
Adding a Crazy Egg script to Dev Portal to enable us to improve the Dev Portal and its content by understanding how users are interacting with the Dev Portal and its content. Crazy Egg provides reporting in the form of heatmaps and scrollmaps per page tracked.

- Crazy Egg does not run on the entire site. We select a few strategic pages that we want to track usage on.

- Crazy Egg does not run forever. Crazy Egg tracks usage (called a snapshot) until a selected page receives 25,000 visits or a snapshot runs for 60 days.

- To see what and how Crazy Egg tracks usage data, see the “Information Collected from Crazy Egg Visitors” section on [Crazy Egg Privacy Policy](https://www.crazyegg.com/privacy).