### PR TITLE
base58 Encodings page

### DIFF
--- a/content/_snippets/data_types/address.md
+++ b/content/_snippets/data_types/address.md
@@ -7,5 +7,5 @@ Accounts in the XRP Ledger are identified by a base58 XRP Ledger Address. The ad
 * Includes a 4-byte checksum so that the probability of generating a valid address from random characters is approximately 1 in 2^32
 
 {% if currentpage.md != "concept-accounts.md" %}
-For more information, see [Accounts](accounts.html).
+For more information, see [Accounts](accounts.html) and [base58 Encodings](base58-encodings.html).
 {% endif %}

--- a/content/references/rippled-api/api-conventions/base58-encodings.md
+++ b/content/references/rippled-api/api-conventions/base58-encodings.md
@@ -1,0 +1,31 @@
+# base58 Encodings
+
+The `rippled` APIs often use a [base58](https://en.wikipedia.org/wiki/Base58) encoding with a checksum (sometimes called "Base58Check") to represent [account addresses](accounts.html#addresses) and other types of values related to cryptographic keys. This encoding is the same as the one used for Bitcoin addresses, except that the XRP Ledger uses the following dictionary: `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`.
+
+The XRP Ledger prefixes different types of values with a specific 8-bit number before encoding them to distinguish between different data types. Combined with the arrangement of characters in the XRP Ledger's base58 dictionary, the result is that the base58 representations for different types of encoded values start with specific letters by type.
+
+The following table lists all the encodings the XRP Ledger uses:
+
+| Data Type                    | Starts With | Type Prefix | Content size¹ | Maximum characters |
+|:-----------------------------|:------------|:---------------|:--------------|:--|
+| [Account][] address          | r           | `0x00`         | 20 bytes      | 35 |
+| Account public key           | a           | `0x23`         | 33 bytes      | 53 |
+| Seed value (for secret keys) | s           | `0x21`         | 16 bytes      | 29 |
+| Validation public key        | n           | `0x1C`         | 33 bytes      | 53 |
+
+¹ Content size excludes the 1-byte type prefix.
+
+[Account]: accounts.html
+
+## See Also
+
+- [Address Encoding](accounts.html#address-encoding) - detailed information on address encoding
+- [Cryptographic Keys](cryptographic-keys.html) - types of cryptographic keys in the XRP Ledger and how they're used
+- [wallet_propose Reference][wallet_propose method] - API method for generating account keys
+- [validation_create Reference][validation_create method] - API method for generating validator keys
+
+
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}			
+{% include '_snippets/tx-type-links.md' %}			
+{% include '_snippets/rippled_versions.md' %}

--- a/content/references/rippled-api/public-rippled-methods/payment-channel-methods/channel_verify.md
+++ b/content/references/rippled-api/public-rippled-methods/payment-channel-methods/channel_verify.md
@@ -115,7 +115,7 @@ The response follows the [standard format][], with a successful result containin
 
 * Any of the [universal error types][].
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
-* `publicMalformed` - The `public_key` field of the request is not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58 or hexadecimal. The base58 representation of account public keys starts with the letter `a`. The hexadecimal representation is 66 characters long.
+* `publicMalformed` - The `public_key` field of the request is not a valid public key in the correct format. Public keys are 33 bytes and must be represented in base58 or hexadecimal. The [base58 representation of account public keys starts with the letter `a`](base58-encodings.html). The hexadecimal representation is 66 characters long.
 * `channelMalformed` - The `channel_id` field of the request is not a valid Channel ID. The Channel ID must be a 256-bit (64-character) hexadecimal string.
 * `channelAmtMalformed` - The value specified in the `amount` field was not a valid [XRP amount][XRP, in drops].
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -1179,6 +1179,16 @@ pages:
         targets:
             - local
 
+    -   md: references/rippled-api/api-conventions/base58-encodings.md
+        html: base58-encodings.html
+        funnel: Docs
+        doc_type: References
+        supercategory: rippled API
+        category: API Conventions
+        blurb: Formats for representing cryptographic keys and related data in base58 format.
+        targets:
+            - local
+
     -   md: references/rippled-api/api-conventions/currency-formats.md
         html: currency-formats.html
         funnel: Docs


### PR DESCRIPTION
Migrates this old wiki page: https://web.archive.org/web/20150422095115/https://wiki.ripple.com/Encodings

I did not copy over the encodings for validation_private_key,
account_private_key, or family_public_generator since as far as I know
those are unused.