### PR TITLE
Replace ECDSA link

### DIFF
--- a/content/concepts/payment-system-basics/accounts/cryptographic-keys.md
+++ b/content/concepts/payment-system-basics/accounts/cryptographic-keys.md
@@ -102,7 +102,7 @@ The XRP Ledger supports the following cryptographic signing algorithms:
 
 | Key Type    | Algorithm | Description |
 |-------------|-----------|---|
-| `secp256k1` | [ECDSA](https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss2/ecdsa2vs.pdf) using the elliptic curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1) | This is the scheme used in Bitcoin. The XRP Ledger uses these key types by default. |
+| `secp256k1` | [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm) using the elliptic curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1) | This is the scheme used in Bitcoin. The XRP Ledger uses these key types by default. |
 | `ed25519` | [EdDSA](https://tools.ietf.org/html/rfc8032) using the elliptic curve [Ed25519](https://ed25519.cr.yp.to/) | This is a newer algorithm which has better performance and other convenient properties. Since Ed25519 public keys are one byte shorter than secp256k1 keys, `rippled` prefixes Ed25519 public keys with the byte `0xED` so both types of public key are 33 bytes. |
 
 When you generate a key pair with the [wallet_propose method][], you can specify the `key_type` to choose which cryptographic signing algorithm to use to derive the keys. If you generated a key type other than the default, you must also specify the `key_type` when signing transactions.


### PR DESCRIPTION
Since the NIST article it previously linked is down for an unclear
amount of time as a result of the government shutdown, I replaced it
with a link to the Wikipedia ECDSA article (which is fairly complete).

Assuming this passes, then after merging this, we can rebase the other open PRs onto master to get those much-coveted :heavy_check_mark: s.