### PR TITLE
Transaction Malleability Documentation

### DIFF
--- a/content/concepts/consensus-network/transaction-malleability.md
+++ b/content/concepts/consensus-network/transaction-malleability.md
@@ -12,7 +12,7 @@ There are two circumstances that could lead to transaction malleability:
 
 2. The transaction is [multi-signed](multi-signing.html) and has more signatures than necessary. Even if the transaction originally did not have more signatures than necessary, it could be malleable if one of the authorized signers provides an additional signature.
 
-    There is no solution that prevents all variations of this problem. When using multi-signatures, monitor your account for transactions sent even if they have different hashes, and try not to collect more signatures than necessary.
+    Good operational security can protect against these problems. See [Mitigations for Multi-Signature Malleability](#mitigations-for-multi-signature-malleability) for guidelines.
 
 
 ## Background
@@ -62,6 +62,8 @@ All of the following cases can lead to transaction malleability:
 - If one can replace one signature from a transaction with another valid signature while maintaining a quorum. Only an authorized signer of the sending account could create such a signature.
 
 Even if your authorized signers are not intentionally malicious, confusion or poor coordination could cause several signers to submit different valid versions of the same transaction.
+
+#### Mitigations for Multi-Signature Malleability
 
 **Good operational security can protect against these problems.** Generally, you can avoid transaction malleability problems when multi-signing if you follow good operational security practices, including the following:
 

--- a/content/concepts/consensus-network/transaction-malleability.md
+++ b/content/concepts/consensus-network/transaction-malleability.md
@@ -10,7 +10,7 @@ There are two circumstances that could lead to transaction malleability:
 
     **Use the [tfFullyCanonicalSig flag](transaction-common-fields.html#global-flags)** to guarantee that a transaction is not malleable in this way. Although transactions [signed with Ed25519 keys](cryptographic-keys.html#signing-algorithms) are not vulnerable to this problem, **there is no downside** to using this flag on _all_ transactions.
 
-2. The transaction is [multi-signed](multi-signing.html) and has more signatures than necessary. Even if the transaction originally did not have more signatures than necessary, it could be malleable if one of the authorized signers provides an additional signature.
+2. The transaction is [multi-signed](multi-signing.html) and has more signatures than necessary. Even if the transaction originally did not have more signatures than necessary, it could be malleable if an authorized signer provides an additional signature.
 
     Good operational security can protect against these problems. See [Mitigations for Multi-Signature Malleability](#mitigations-for-multi-signature-malleability) for guidelines.
 

--- a/content/concepts/consensus-network/transaction-malleability.md
+++ b/content/concepts/consensus-network/transaction-malleability.md
@@ -1,0 +1,23 @@
+# Transaction Malleability
+
+A transaction is "malleable" if it can be changed in any way after being signed, without the keys to sign it. In the XRP Ledger, the **functionality** of a signed transaction cannot change, but in some circumstances a third party _could_ change the signature and identifying hash of a transaction.
+
+**Use the [tfFullyCanonicalSig flag](transaction-common-fields.html#global-flags)** to guarantee that a transaction is not malleable in any way. Although transactions [signed with Ed25519 keys](cryptographic-keys.html#signing-algorithms) are not vulnerable to this problem, **there is no downside** to using this flag on _all_ transactions.
+
+## Background
+
+In the XRP Ledger, all [fields of a transaction](transaction-common-fields.html) must be signed, except the signature itself. Any change to the signed fields, no matter how small, would invalidate the signature, so no part of the transaction can be malleable except for the signature itself.
+
+For a transaction to be valid, the signature must be canonical, must match the transaction instructions that were signed, and the key pair used to sign it must be one that is [authorized to send transactions on behalf of that account](transaction-basics.html#authorizing-transactions).
+
+Signatures created with the ECDSA algorithm and secp256k1 curve (the default) must also meet the following requirements:
+
+- The signature must be properly [DER-encoded data](https://en.wikipedia.org/wiki/X.690#DER_encoding).
+- The signature must not have any padding bytes outside the DER-encoded data.
+- The signature's component integers must not be negative, and they must not be larger than the secp256k1 modulus.
+
+Generally speaking, any standard ECDSA implementation handles these requirements automatically. However, with secp256k1, those requirements are insufficient to prevent malleability.
+
+An ECDSA signature consists of two integers, called R and S. The secp256k1 modulus, called N, is a constant value for all secp256k1 signatures. Specifically, N is the value `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`. For any given signature `(R,S)`, the signature `(R, N-S)` (that is, using N minus S in place of S) is also valid. Thus, to have _fully_ canonical signatures, one must choose which of the two possibilities is preferred and declare the other to be invalid. This is what the tfFullyCanonicalSig flag does: without that flag enabled, XRP Ledger transactions are valid with either of the two possible signatures; with it, the signature must use the _smaller_ of the two possible values, `S` or `N-S`.
+
+To calculate a fully-canonical ECDSA signature, one must compare S and N-S 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -474,6 +474,15 @@ pages:
         targets:
             - local
 
+    -   md: concepts/consensus-network/transaction-malleability.md
+        html: transaction-malleability.html
+        funnel: Docs
+        doc_type: Concepts
+        category: Consensus Network
+        blurb: Be aware of ways transactions could be changed have a different hash than expected.
+        targets:
+            - local
+
     -   md: concepts/consensus-network/amendments.md
         html: amendments.html
         funnel: Docs

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -45,6 +45,8 @@ targets:
         github_forkurl: https://github.com/ripple/ripple-dev-portal
         github_branch: master
         recently_updated:
+            - html: transaction-malleability.html
+              date: 2019-01-14
             - html: ledger-history.html
               date: 2019-01-14
             - html: online-deletion.html

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -479,7 +479,7 @@ pages:
         funnel: Docs
         doc_type: Concepts
         category: Consensus Network
-        blurb: Be aware of ways transactions could be changed have a different hash than expected.
+        blurb: Be aware of ways transactions could be changed to have a different hash than expected.
         targets:
             - local
 


### PR DESCRIPTION
Migrates the [old wiki page](https://web.archive.org/web/20170608153028/https://wiki.ripple.com/Transaction_Malleability) on transaction malleability and adds information about a new form of malleability relating to multi-signing.