### PR TITLE
Transaction Queue Reserve Changes for 1.2.0

### DIFF
--- a/content/concepts/consensus-network/transaction-queue.md
+++ b/content/concepts/consensus-network/transaction-queue.md
@@ -30,7 +30,10 @@ The `rippled` server uses a variety of heuristics to estimate which transactions
 
 * Transactions must be properly-formed and [authorized](transaction-basics.html#authorizing-transactions) with valid signatures.
 * Transactions with an `AccountTxnID` field cannot be queued.
-* A single sending address can have at most 10 transactions queued at the same time. In order for a transaction to be queued, the sender must have enough XRP to pay all the XRP costs of all the sender's queued transactions including both the `Fee` fields and the sum of the XRP that each transaction could send. [New in: rippled 0.32.0][]
+* A single sending address can have at most 10 transactions queued at the same time. In order for a transaction to be queued, the sender must have enough XRP to pay all the XRP costs of all the sender's queued transactions, including all of the following:
+    - The `Fee` fields of all queued transactions.
+    - The sum amount the XRP that each transaction could send.
+    - The amount of XRP the account must keep in [reserve](reserves.html). [Updated in: rippled 1.2.0][New in: rippled 1.2.0]
 * If a transaction affects how the sending address authorizes transactions, no other transactions from the same address can be queued behind it. [New in: rippled 0.32.0][]
 * If a transaction includes a `LastLedgerSequence` field, the value of that field must be at least **the current ledger index + 2**.
 

--- a/content/concepts/consensus-network/transaction-queue.md
+++ b/content/concepts/consensus-network/transaction-queue.md
@@ -32,7 +32,7 @@ The `rippled` server uses a variety of heuristics to estimate which transactions
 * Transactions with an `AccountTxnID` field cannot be queued.
 * A single sending address can have at most 10 transactions queued at the same time. In order for a transaction to be queued, the sender must have enough XRP to pay all the XRP costs of all the sender's queued transactions, including all of the following:
     - The `Fee` fields of all queued transactions.
-    - The sum amount the XRP that each transaction could send.
+    - The sum amount of XRP that all queued transactions could send.
     - The amount of XRP the account must keep in [reserve](reserves.html). [Updated in: rippled 1.2.0][New in: rippled 1.2.0]
 * If a transaction affects how the sending address authorizes transactions, no other transactions from the same address can be queued behind it. [New in: rippled 0.32.0][]
 * If a transaction includes a `LastLedgerSequence` field, the value of that field must be at least **the current ledger index + 2**.

--- a/content/concepts/consensus-network/transaction-queue.md
+++ b/content/concepts/consensus-network/transaction-queue.md
@@ -32,7 +32,7 @@ The `rippled` server uses a variety of heuristics to estimate which transactions
 - Transactions with an `AccountTxnID` field cannot be queued.
 - A single sending address can have at most 10 transactions queued at the same time.
 - To queue a transaction, the sender must have enough XRP for all of the following: [Updated in: rippled 1.2.0][New in: rippled 1.2.0]
-    - Destroying the XRP [transaction cost](transaction-cost.html) as specified in the `Fee` fields of all the sender's queued transactions. This amount cannot be more than the base account reserve (currently 20 XRP). (Transactions paying significantly more than the minimum transaction cost of 0.00001 XRP typically skip the queue and go straight into the open ledger.)
+    - Destroying the XRP [transaction cost](transaction-cost.html) as specified in the `Fee` fields of all the sender's queued transactions. The total amount among queued transactions cannot be more than the base account reserve (currently 20 XRP). (Transactions paying significantly more than the minimum transaction cost of 0.00001 XRP typically skip the queue and go straight into the open ledger.)
     - Sending the maximum sum of XRP that all the sender's queued transactions could send.
     - Keeping enough XRP to meet the account's [reserve requirements](reserves.html).
 - If a transaction affects how the sending address authorizes transactions, no other transactions from the same address can be queued behind it. [New in: rippled 0.32.0][]

--- a/content/concepts/consensus-network/transaction-queue.md
+++ b/content/concepts/consensus-network/transaction-queue.md
@@ -28,14 +28,15 @@ The transaction queue plays an important role in selecting the transactions that
 
 The `rippled` server uses a variety of heuristics to estimate which transactions are "likely to be included in a ledger." The current implementation uses the following rules to decide which transactions to queue:
 
-* Transactions must be properly-formed and [authorized](transaction-basics.html#authorizing-transactions) with valid signatures.
-* Transactions with an `AccountTxnID` field cannot be queued.
-* A single sending address can have at most 10 transactions queued at the same time. In order for a transaction to be queued, the sender must have enough XRP to pay all the XRP costs of all the sender's queued transactions, including all of the following:
-    - The `Fee` fields of all queued transactions.
-    - The sum amount of XRP that all queued transactions could send.
-    - The amount of XRP the account must keep in [reserve](reserves.html). [Updated in: rippled 1.2.0][New in: rippled 1.2.0]
-* If a transaction affects how the sending address authorizes transactions, no other transactions from the same address can be queued behind it. [New in: rippled 0.32.0][]
-* If a transaction includes a `LastLedgerSequence` field, the value of that field must be at least **the current ledger index + 2**.
+- Transactions must be properly-formed and [authorized](transaction-basics.html#authorizing-transactions) with valid signatures.
+- Transactions with an `AccountTxnID` field cannot be queued.
+- A single sending address can have at most 10 transactions queued at the same time.
+- To queue a transaction, the sender must have enough XRP for all of the following: [Updated in: rippled 1.2.0][New in: rippled 1.2.0]
+    - Destroying the XRP [transaction cost](transaction-cost.html) as specified in the `Fee` fields of all the sender's queued transactions. This amount cannot be more than the base account reserve (currently 20 XRP). (Transactions paying significantly more than the minimum transaction cost of 0.00001 XRP typically skip the queue and go straight into the open ledger.)
+    - Sending the maximum sum of XRP that all the sender's queued transactions could send.
+    - Keeping enough XRP to meet the account's [reserve requirements](reserves.html).
+- If a transaction affects how the sending address authorizes transactions, no other transactions from the same address can be queued behind it. [New in: rippled 0.32.0][]
+- If a transaction includes a `LastLedgerSequence` field, the value of that field must be at least **the current ledger index + 2**.
 
 ### Fee Averaging
 


### PR DESCRIPTION
Updates the guidance in the transaction queue page based on the changes from https://github.com/ripple/rippled/pull/2750.

Fixes DOC-2094.