### PR TITLE
Updates rippled Ubuntu tutorial with updated log signature

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
@@ -24,7 +24,7 @@ For development purposes Ripple recommends running `rippled` as your own user, n
 
         $ brew install git cmake pkg-config protobuf openssl ninja
 
-0. Install Boost 1.67.0. `rippled` 1.2.x is compatible with Boost 1.67. <!--#{ no boost@1.67 formula, so must manually compile and install. will eventually upgrade to boost 1.68, but needs testing first }# -->
+0. Install Boost 1.67.0. `rippled` 1.2.0 is compatible with Boost 1.67. <!--#{ no boost@1.67 formula, so must manually compile and install. will eventually upgrade to boost 1.68, but needs testing first }# -->
 
       1. Download [Boost 1.67.0](https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2).
 

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
@@ -88,11 +88,11 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
         $ git log -1
 
-        commit 4f3a76dec00c0c7ea28e78e625c68499debbbbf3
-        Author: Nik Bougalis <nikb@bougalis.net>
-        Date:   Thu Nov 29 21:49:10 2018 -0800
+        commit 7779dcdda00ea61a976cf5f387bc1f3bb4ebbfdd
+        Author: Mike Ellery <mellery451@gmail.com>
+        Date:   Tue Feb 12 16:41:03 2019 -0800
 
-            Set version to 1.1.2
+            Set version to 1.2.0
 
 8. If you previously built, or (more importantly) tried and failed to build `rippled`, you should delete the `my_build/` directory (or whatever you named it) to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like a `rippled` executable that crashes due to a segmentation fault (segfault).
 


### PR DESCRIPTION
- Updates the `git log -1` response in the tutorial to reflect the 1.2.0 release and signature
- Fixes imprecise `rippled` version number in macOS build tutorial