### PR TITLE
Fix duplicate key in dactyl-config

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -1849,7 +1849,6 @@ pages:
 
     -   md: references/rippled-api/admin-rippled-methods/admin-rippled-methods.md
         html: admin-rippled-methods.html
-        blurb: Admin methods are meant only for trusted personnel in charge of keeping the server operational. Admin methods include commands for managing, monitoring, and debugging the server.
         funnel: Docs
         doc_type: References
         supercategory: rippled API

--- a/tool/phrase_substitutions.yaml
+++ b/tool/phrase_substitutions.yaml
@@ -57,7 +57,6 @@ it is essential: must, need to
 it is requested: please, we request, I request
 limited number: limits
 not later than: by, before
-not later than: by
 pertaining to: about, of, on
 prior to: before
 provided that: if


### PR DESCRIPTION
The blurb is defined again on line 1857. (It uses the last instance.)

This particular blurb shows up in the "Admin rippled methods" box of https://developers.ripple.com/references.html

In the forthcoming Dactyl version, duplicate keys like this will be an error.