### PR TITLE
Delete downloaded RPM after installation on Ubuntu

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
@@ -28,6 +28,8 @@ To update manually, complete the following steps:
 
         $ sudo service rippled restart
 
-7. Remove the downloaded `rippled` package
+7. Delete the downloaded `rippled` package file:
         
         $ rm rippled*.rpm
+        
+    (This does not affect the installation, but prevents later updates from trying to re-install the old version.)

--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
@@ -27,3 +27,7 @@ To update manually, complete the following steps:
 6. Restart the `rippled` service:
 
         $ sudo service rippled restart
+
+7. Remove the downloaded `rippled` package
+        
+        $ rm rippled*.rpm


### PR DESCRIPTION
The downloaded RPM should be deleted before the next update. To ensure that `sudo alien -i --scripts rippled*.rpm` doesn't accidentally install an earlier version of `rippled` that has already been downloaded.