### PR TITLE
removed verb "use" when talking about open source licenses limitation

### DIFF
--- a/content/concepts/introduction/technical-faq.md
+++ b/content/concepts/introduction/technical-faq.md
@@ -87,7 +87,7 @@ No, Ripple does not own or control the XRP Ledger or XRP Ledger network.
 
 Ripple does publish a reference implementation of the core XRP Ledger server ([`rippled`](https://github.com/ripple/rippled)) and employs a team of engineers who contribute to the open-source codebase. Ripple also periodically publishes precompiled binary packages of the software as a convenience. Anyone is free to [download and compile the software from source](install-rippled.html), if they prefer.  
 
-You don't need to use Ripple’s version of the XRP Ledger software to interact with the XRP Ledger. `rippled` is open-source software and Ripple grants anyone the ability to use, extend, and modify it as long as they follow the terms of the [ISC license](https://github.com/ripple/rippled/blob/develop/LICENSE). The ISC License is very permissive compared to some other open-source licenses that strictly limit how you can extend, and adapt the software.
+You don't need to use Ripple’s version of the XRP Ledger software to interact with the XRP Ledger. `rippled` is open-source software and Ripple grants anyone the ability to use, extend, and modify it as long as they follow the terms of the [ISC license](https://github.com/ripple/rippled/blob/develop/LICENSE). The ISC License is very permissive compared to some other open-source licenses that strictly limit how you can extend and adapt the software.
 
 #### Does Ripple offer a secure method to download their software?
 

--- a/content/concepts/introduction/technical-faq.md
+++ b/content/concepts/introduction/technical-faq.md
@@ -87,7 +87,7 @@ No, Ripple does not own or control the XRP Ledger or XRP Ledger network.
 
 Ripple does publish a reference implementation of the core XRP Ledger server ([`rippled`](https://github.com/ripple/rippled)) and employs a team of engineers who contribute to the open-source codebase. Ripple also periodically publishes precompiled binary packages of the software as a convenience. Anyone is free to [download and compile the software from source](install-rippled.html), if they prefer.  
 
-You don't need to use Ripple’s version of the XRP Ledger software to interact with the XRP Ledger. `rippled` is open-source software and Ripple grants anyone the ability to use, extend, and modify it as long as they follow the terms of the [ISC license](https://github.com/ripple/rippled/blob/develop/LICENSE). The ISC License is very permissive compared to some other open-source licenses that strictly limit how you can use, extend, and adapt the software.
+You don't need to use Ripple’s version of the XRP Ledger software to interact with the XRP Ledger. `rippled` is open-source software and Ripple grants anyone the ability to use, extend, and modify it as long as they follow the terms of the [ISC license](https://github.com/ripple/rippled/blob/develop/LICENSE). The ISC License is very permissive compared to some other open-source licenses that strictly limit how you can extend, and adapt the software.
 
 #### Does Ripple offer a secure method to download their software?
 


### PR DESCRIPTION
No proper open source license can limit how you can *use* software. See point 6 of the [Open Source Definition](https://opensource.org/osd)