### PR TITLE
Adds missing info to Boost install

### DIFF
--- a/content/references/xrp-ledger-toml.md
+++ b/content/references/xrp-ledger-toml.md
@@ -261,7 +261,7 @@ For other web servers, see [I want to add CORS support to my server](https://ena
 
 ## Domain Verification
 
-One use for the `xrp-ledger.toml` file is verifying that the same entity that operates a particular domain also operates a particular validator, as identified by the validator's public key. Verifying that a domain and a validator are owned by the same entity provides greater assurances of the identity of the validator operator and is a recommended step for becoming a trusted validator. (For other recommendations, see [Properties of a Good Validator](run-rippled-as-a-validator.html#understand-the-traits-of-a-good-validator).)
+One use for the `xrp-ledger.toml` file is verifying that the same entity that operates a particular domain also operates a particular validator, as identified by the validator's public key. Verifying that a domain and a validator are owned by the same entity provides greater assurances of the identity of the validator operator and is a recommended step for becoming a trusted validator. (For other recommendations, see [Properties of a Good Validator](run-rippled-as-a-validator.html#1-understand-the-traits-of-a-good-validator).)
 
 Domain verification requires establishing a two-way link between the domain operator and the validator:
 

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
@@ -32,6 +32,7 @@ For development purposes Ripple recommends running `rippled` as your own user, n
 
       3. In a terminal, run:
 
+            cd /LOCATION/OF/YOUR/BOOST/DIRECTORY
             ./bootstrap.sh
             ./b2 cxxflags="-std=c++14"
 


### PR DESCRIPTION
- Addresses a missing step in the Boost install instructions in the macOS tutorial. Fixes #533. 🙌 
- Fixes broken link
