### PR TITLE
Remove instructions on how to run a historical database

### DIFF
--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -6,7 +6,7 @@ Ripple provides a live instance of the Data API with as complete a transaction r
 
 [**https://data.ripple.com**](https://data.ripple.com)
 
-You can run a historical database yourself, but we don’t recommend it because of the complexity involved. If your use case requires that you run a historical database, [contact us](mailto:docs@ripple.com) for information about how to set it up.
+You can run a historical database yourself, but we don’t recommend it because of the complexity involved. If your use case requires that you run a historical database, contact [Ripple Technical Services](mailto:support@ripple.com) for information about how to set it up.
 
 
 


### PR DESCRIPTION
- Removes the "Running a Historical Database" section from https://developers.ripple.com/data-api.html. The section was removed due to complexity of the task.
- Adds a note stating that users can run a historical database on their own, while also acknowledging that the task is complex. The note asks users to contact `docs@ripple.com` if they want to do it anyway and need the instructions.
- Is docs@ripple.com the best email to provide? Or should they open an issue in the `rippled` repo?

