### PR TITLE
Move Dev Blog links

### DIFF
--- a/content/news/news.md
+++ b/content/news/news.md
@@ -12,7 +12,7 @@ Get the latest XRP Ledger news and release information.
 
       Amendments provide a way to introduce breaking changes to the decentralized XRP Ledger network without causing disruptions. Get the comprehensive list of [all known amendments](known-amendments.html) and their statuses on the production XRP Ledger.
 
-* **[Ripple Dev Blog](https://ripple.com/category/dev-blog/)**
+* **[Ripple Dev Blog](/blog/)**
 
       Visit the Dev Blog for the latest news and stories about the XRP Ledger and `rippled`.
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2950,6 +2950,8 @@ known_broken_links:
     # These PDFs download OK in a browser
     - http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX%3A32015R0847
     - http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:L:2006:345:0001:0009:EN:PDF
+    # Dev blog link assumes relationship with developers.ripple.com
+    - /blog/
 
 # Style Checker Config ------------------------------------------------------ #
 

--- a/tool/template-base.html
+++ b/tool/template-base.html
@@ -46,9 +46,6 @@
       gtag('config', 'UA-45576805-2');
     </script>
 
-    <!-- Crazy Egg -->
-    <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0070/6316.js" async="async"></script>
-
     {% block head %}
 
     {% endblock %}

--- a/tool/template-footer.html
+++ b/tool/template-footer.html
@@ -50,5 +50,5 @@
 </footer>
 
 <!-- Jump to top button -->
-<a href="#main_content_wrapper" class="jump-to-top btn btn-primary btn-lg" role="button" title="Jump to top of page">Top</span></a>
+<a href="#main_content_wrapper" class="jump-to-top btn btn-primary btn-lg" role="button" title="Jump to top of page">Top</a>
 <script type="text/javascript" src="assets/js/jump-to-top.js"></script>

--- a/tool/template-page-children.html
+++ b/tool/template-page-children.html
@@ -99,6 +99,11 @@
       {% endif %}
     {% endif %}
   {% endfor %}
+
+  {# Special case to add Dev Blog to things #}
+  {% if parent.name == "News" %}
+  <li class="level-{{indent_level}}"><a href="/blog/">Ripple Dev Blog</a></li>
+  {% endif %}
 {% endmacro %}
 
 <div class="children-display">

--- a/tool/template-sidebar_nav.html
+++ b/tool/template-sidebar_nav.html
@@ -44,6 +44,9 @@
             <li><a class="nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
             {% endif %}
           {% endfor %}
+          {% if currentpage.funnel == "News" %}
+          <li><a class="nosubcat-page" href="/blog/">Ripple Dev Blog</a></li>
+          {% endif %}
           </ul>
         </div><!-- /.card-body -->
       </div><!-- /.card -->


### PR DESCRIPTION
Updates template links for the new dev blog location at https://developers.ripple.com/blog/