### PR TITLE
Update devblog links

### DIFF
--- a/content/concepts/decentralized-exchange/autobridging.md
+++ b/content/concepts/decentralized-exchange/autobridging.md
@@ -8,6 +8,6 @@ Auto-bridging happens automatically on any OfferCreate transaction. [Payment tra
 
 ## See Also
 
-- [Dev Blog: Introducing Autobridging](https://ripple.com/dev-blog/introducing-offer-autobridging/)
+- [Dev Blog: Introducing Autobridging](https://developers.ripple.com/blog/2014/introducing-offer-autobridging.html)
 
 - [Offer Preference](offers.html#offer-preference)

--- a/content/concepts/decentralized-exchange/ticksize.md
+++ b/content/concepts/decentralized-exchange/ticksize.md
@@ -12,7 +12,7 @@ When an issuer enables, disables, or changes the `TickSize`, Offers that were pl
 
 ## See Also
 
-- [Dev Blog: Introducing the TickSize Amendment](https://ripple.com/dev-blog/ticksize-amendment-open-voting/#ticksize-amendment-overview)
+- [Dev Blog: Introducing the TickSize Amendment](https://developers.ripple.com/blog/2017/ticksize-voting.html#ticksize-amendment-overview)
 
 - [AccountSet transaction][]
 

--- a/content/concepts/introduction/intro-to-consensus.md
+++ b/content/concepts/introduction/intro-to-consensus.md
@@ -55,7 +55,7 @@ For a longer exploration of how the XRP Ledger Consensus Protocol responds to va
 
 - [Consensus Network Concepts](consensus-network.html) for several articles describing the mechanics of the XRP Ledger Consensus Protocol in greater depth.
 - [Run `rippled` as a Validator](run-rippled-as-a-validator.html) for instructions on running your own validator.
-- [Decentralization Strategy Update (Ripple Dev Blog)](https://ripple.com/dev-blog/decentralization-strategy-update/) for a description of Ripple's goals and plans for decentralizing the XRP Ledger.
+- [Decentralization Strategy Update (Ripple Dev Blog)](https://developers.ripple.com/blog/2017/decent-strategy-update.html) for a description of Ripple's goals and plans for decentralizing the XRP Ledger.
 
 <!--{# TODO: Replace the Decent Strategy Update w/ a newer article when we have one #}-->
 

--- a/content/concepts/introduction/xrp-ledger-overview.md
+++ b/content/concepts/introduction/xrp-ledger-overview.md
@@ -28,7 +28,7 @@ This combines qualities of physical and centralized digital money. Prior to the 
 
 **Note:** Users of the XRP Ledger _can_ freeze non-XRP currencies issued in the XRP Ledger. For more information, see the [Freeze documentation](freezes.html).
 
-The XRP Ledger's system of trusted validators uses a small amount of human interaction to achieve better distribution of authority than other decentralized systems. Fully-automated systems for reaching consensus from an unknown set of participants are vulnerable to concentrations of voting power. For example, Bitcoin mining is disproportionately concentrated in places with cheap electricity. As Ripple curates a list of distinct validators operated by different entities in different jurisdictions, the XRP Ledger can become more resistant to censorship and outside pressures than proof-of-work mining. For more information on Ripple's plan to decentralize the recommended set of validators, see the  [Decentralization Strategy Update](https://ripple.com/dev-blog/decentralization-strategy-update/).
+The XRP Ledger's system of trusted validators uses a small amount of human interaction to achieve better distribution of authority than other decentralized systems. Fully-automated systems for reaching consensus from an unknown set of participants are vulnerable to concentrations of voting power. For example, Bitcoin mining is disproportionately concentrated in places with cheap electricity. As Ripple curates a list of distinct validators operated by different entities in different jurisdictions, the XRP Ledger can become more resistant to censorship and outside pressures than proof-of-work mining. For more information on Ripple's plan to decentralize the recommended set of validators, see the  [Decentralization Strategy Update](https://developers.ripple.com/blog/2017/decent-strategy-update.html).
 
 For more information about the XRP Ledger's ability to detect censorship, see [Transaction Censorship Detection](transaction-censorship-detection.html).
 
@@ -87,7 +87,7 @@ A sample of advanced features in the XRP Ledger:
 - [Escrow](escrow.html) locks up XRP until a declared time passes or cryptographic condition is met.
 - [DepositAuth](depositauth.html) lets users decide who can send them money and who can't.
 - A [Decentralized Exchange](#on-ledger-decentralized-exchange) lets users trade obligations and XRP on-ledger.
-- [Invariant Checking](https://ripple.com/dev-blog/protecting-ledger-invariant-checking/) provides an independent layer of protections against bugs in transaction execution.
+- [Invariant Checking](https://developers.ripple.com/blog/2017/invariant-checking.html) provides an independent layer of protections against bugs in transaction execution.
 - [Amendments](amendments.html) provide smooth upgrades to the existing feature set, so the technology can continue to evolve without fracturing the ecosystem or causing uncertainty around times of transition.
 
 

--- a/content/concepts/introduction/xrp.md
+++ b/content/concepts/introduction/xrp.md
@@ -2,7 +2,7 @@
 
 **XRP** is the native cryptocurrency of the XRP Ledger. All [accounts](accounts.html) in the XRP Ledger can send XRP among one another and must hold a minimum amount of XRP as a [reserve](reserves.html). XRP can be sent directly from any XRP Ledger address to any other, without needing a gateway or liquidity provider. This helps make XRP a convenient bridge currency.
 
-Some advanced features of the XRP Ledger, such as [Escrow](escrow.html) and [Payment Channels](use-payment-channels.html), only work with XRP. Order book [autobridging](https://ripple.com/dev-blog/introducing-offer-autobridging/) uses XRP to deepen liquidity in the decentralized exchange by merging order books of two issued currencies with XRP order books to create synthetic combined order books. (For example, autobridging matches USD:XRP and XRP:EUR orders to augment USD:EUR order books.)
+Some advanced features of the XRP Ledger, such as [Escrow](escrow.html) and [Payment Channels](use-payment-channels.html), only work with XRP. Order book [autobridging](https://developers.ripple.com/blog/2014/introducing-offer-autobridging.html) uses XRP to deepen liquidity in the decentralized exchange by merging order books of two issued currencies with XRP order books to create synthetic combined order books. (For example, autobridging matches USD:XRP and XRP:EUR orders to augment USD:EUR order books.)
 
 XRP also serves as a protective measure against spamming the network. All XRP Ledger addresses need a small amount of XRP to pay the costs of maintaining the XRP Ledger. The [transaction cost](transaction-cost.html) and [reserve](reserves.html) are neutral fees denominated in XRP and not paid to any party. In the ledger's data format, XRP is stored in [AccountRoot objects](accountroot.html).
 

--- a/content/news/known-amendments.md
+++ b/content/news/known-amendments.md
@@ -37,8 +37,8 @@ The following is a comprehensive list of all known amendments and their status o
 | [TrustSetAuth][]            | v0.30.0    | [Enabled: 2016-07-19](https://xrpcharts.ripple.com/#/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF "BADGE_GREEN") |
 | [MultiSign][]               | v0.31.0    | [Enabled: 2016-06-27](https://xrpcharts.ripple.com/#/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7 "BADGE_GREEN") |
 | [FeeEscalation][]           | v0.31.0    | [Enabled: 2016-05-19](https://xrpcharts.ripple.com/#/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3 "BADGE_GREEN") |
-| [FlowV2][]                  | v0.32.1    | [Vetoed: Removed in v0.33.0](https://ripple.com/dev-blog/flowv2-amendment-vetoed/ "BADGE_RED") |
-| [SusPay][]                  | v0.31.0    | [Vetoed: Removed in v0.60.0](https://ripple.com/dev-blog/ticksize-amendment-open-voting/#upcoming-features "BADGE_RED") |
+| [FlowV2][]                  | v0.32.1    | [Vetoed: Removed in v0.33.0](https://developers.ripple.com/blog/2016/flowv2-vetoed.html "BADGE_RED") |
+| [SusPay][]                  | v0.31.0    | [Vetoed: Removed in v0.60.0](https://developers.ripple.com/blog/2017/ticksize-voting.html#upcoming-features "BADGE_RED") |
 
 **Note:** In many cases, an incomplete version of the code for an amendment is present in previous versions of the software. The "Introduced" version in the table above is the first stable version. The value "TBD" indicates that the amendment is not yet considered stable.
 
@@ -340,7 +340,7 @@ With this amendment enabled, the XRP Ledger removes these dry offers when they'r
 |:-----------------------------------------------------------------|:----------|
 | 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 | Enabled   |
 
-Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment supersedes the [FlowV2](https://ripple.com/dev-blog/flowv2-amendment-vetoed/) amendment.
+Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment supersedes the [FlowV2](https://developers.ripple.com/blog/2016/flowv2-vetoed.html) amendment.
 
 The Flow Engine also makes it easier to improve and expand the payment engine with further Amendments.
 
@@ -366,7 +366,7 @@ Streamlines the offer crossing logic in the XRP Ledger's decentralized exchange.
 |:-----------------------------------------------------------------|:----------|
 | 5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26 | Vetoed    |
 
-This is a previous version of the [Flow](#flow) amendment. It was [rejected due to a bug](https://ripple.com/dev-blog/flowv2-amendment-vetoed/) and removed in version 0.33.0.
+This is a previous version of the [Flow](#flow) amendment. It was [rejected due to a bug](https://developers.ripple.com/blog/2016/flowv2-vetoed.html) and removed in version 0.33.0.
 
 
 ## MultiSign

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
@@ -138,7 +138,7 @@ Complete the following configurations that are required for `rippled` to start u
 
         cp cfg/validators-example.txt ~/.config/ripple/validators.txt
 
-    **Warning:** Ripple has designed a [decentralization plan](https://ripple.com/dev-blog/decentralization-strategy-update/) with maximum safety in mind. During the transition, you *should not* modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
+    **Warning:** Ripple has designed a [decentralization plan](https://developers.ripple.com/blog/2017/decent-strategy-update.html) with maximum safety in mind. During the transition, you *should not* modify the `validators.txt` file except as recommended by Ripple. Even minor modifications to your validator settings could cause your server to diverge from the rest of the network and report out of date, incomplete, or inaccurate data. Acting on such data can cause you to lose money.
 
 
 ## 3. Run `rippled`

--- a/content/tutorials/manage-the-rippled-server/installation/capacity-planning.md
+++ b/content/tutorials/manage-the-rippled-server/installation/capacity-planning.md
@@ -108,7 +108,7 @@ The example `rippled-example.cfg` file sets the logging verbosity to `warning` i
 
 ## Network and Hardware
 
-Each `rippled` server in the XRP Ledger network performs all of the transaction processing work of the network. Therefore, the baseline hardware for production `rippled` servers should be similar to that used in Ripple's [performance testing](https://ripple.com/dev-blog/demonstrably-scalable-blockchain/).
+Each `rippled` server in the XRP Ledger network performs all of the transaction processing work of the network. Therefore, the baseline hardware for production `rippled` servers should be similar to that used in Ripple's [performance testing](https://developers.ripple.com/blog/2017/high-scalability-xrp-ledger.html).
 
 Ensuring that your `rippled` server meets these network and hardware requirements helps achieve consistent, good performance across the XRP Ledger network.
 


### PR DESCRIPTION
Replaces all old dev portal links in the dev portal to go to their new locations at developers.ripple.com/blog