### PR TITLE
xrp-ledger.toml file - proper syntax for enabling CORS w/ .htaccess 

### DIFF
--- a/assets/css/devportal.css
+++ b/assets/css/devportal.css
@@ -1,5 +1,21 @@
 /* Generic styles and colors not in the bootstrap files --------------------- */
 
+
+body {
+  font-feature-settings: "liga", "kern";
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  font-size: 0.9375rem;
+}
+
+pre, code {
+  /* Disable ligatures on code-font, so, for example,
+  </ doesn't become a diagonal arrow. */
+  font-feature-settings: "liga" 0;
+  font-variant-ligatures: none;
+}
+
+
 th, td {
   padding: 0.2em;
   vertical-align: text-top;
@@ -149,14 +165,6 @@ td:nth-child(1) {
 
 }
 
-
-
-body {
-  font-feature-settings: "liga", "kern";
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  font-size: 0.9375rem;
-}
 .row {
   margin: 0 -1px;
 }

--- a/content/references/xrp-ledger-toml.md
+++ b/content/references/xrp-ledger-toml.md
@@ -238,13 +238,22 @@ When creating custom fields, be mindful of the field name you choose. If you use
 
 You MUST configure your web server to allow Cross-Origin Resource Sharing ([CORS][]) for the `xrp-ledger.toml` file. This configuration depends on your web server.
 
-If you use Apache HTTP Server, add the following to your config file or a `.htaccess` file:
+If you run an Apache HTTP Server, add the following to your config file:
 
 ```
 <Location "/.well-known/xrp-ledger.toml">
     Header set Access-Control-Allow-Origin "*"
 </Location>
 ```
+
+Alternatively, you can add the following to a `.htaccess` file in the `/.well-known/` directory of your server:
+
+```
+<Files "xrp-ledger.toml">
+    Header set Access-Control-Allow-Origin "*"
+</Files>
+```
+
 
 If you use nginx, add the following to your config file:
 


### PR DESCRIPTION
also disables a ligature in the code font that's causing `</` to look like a diagonal arrow in this example and the Apache settings sample