### PR TITLE
Monitor WS: golang example (from @stef-k)

### DIFF
--- a/content/tutorials/get-started/monitor-incoming-payments-with-websocket.md
+++ b/content/tutorials/get-started/monitor-incoming-payments-with-websocket.md
@@ -463,6 +463,118 @@ $("#tx_read").click((event) => {
 - Try monitoring for transactions of advanced types like [Escrows](escrow.html), [Checks](checks.html), or [Payment Channels](payment-channels.html), and responding to incoming notifications.
 <!--{# TODO: uncomment when it's ready. - To more robustly handle internet instability, [Follow a Transaction Chain](follow-a-transaction-chain.html) to detect if you missed a notification. #}-->
 
+## Other Programming Languages
+
+Many programming languages have libraries for sending and receiving data over a WebSocket connection. If you want a head-start on communicating with `rippled`'s WebSocket API in a language other than JavaScript, the following examples demonstrate similar functionality:
+
+<!-- MULTICODE_BLOCK_START -->
+
+*Go*
+
+```go
+package main
+
+// Connect to the XRPL Ledger using websocket and subscribe to an account
+// translation from the JavaScript example to Go
+// https://developers.ripple.com/monitor-incoming-payments-with-websocket.html
+// This example uses the Gorilla websocket library to create a websocket client
+// install: go get github.com/gorilla/websocket
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// websocket address
+var addr = flag.String("addr", "s.altnet.rippletest.net:51233", "http service address")
+
+// Payload object
+type message struct {
+	Command  string   `json:"command"`
+	Accounts []string `json:"accounts"`
+}
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+
+	var m message
+
+	// check for interrupts and cleanly close the connection
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	u := url.URL{Scheme: "ws", Host: *addr, Path: "/"}
+	log.Printf("connecting to %s", u.String())
+
+	// make the connection
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	// on exit close
+	defer c.Close()
+
+	done := make(chan struct{})
+
+	// send a subscribe command and a target XRPL account
+	m.Command = "subscribe"
+	m.Accounts = append(m.Accounts, "rUCzEr6jrEyMpjhs4wSdQdz4g8Y382NxfM")
+
+	// struct to JSON marshalling
+	msg, _ := json.Marshal(m)
+	// write to the websocket
+	err = c.WriteMessage(websocket.TextMessage, []byte(string(msg)))
+	if err != nil {
+		log.Println("write:", err)
+		return
+	}
+
+	// read from the websocket
+	_, message, err := c.ReadMessage()
+	if err != nil {
+		log.Println("read:", err)
+		return
+	}
+	// print the response from the XRP Ledger
+	log.Printf("recv: %s", message)
+
+	// handle interrupt
+	for {
+		select {
+		case <-done:
+			return
+		case <-interrupt:
+			log.Println("interrupt")
+
+			// Cleanly close the connection by sending a close message and then
+			// waiting (with timeout) for the server to close the connection.
+			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			if err != nil {
+				log.Println("write close:", err)
+				return
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+			}
+			return
+		}
+	}
+}
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+**Tip:** Don't see the programming language of your choice? Click the "Edit on GitHub" link at the top of this page and contribute your own sample code!
+
 
 ## Footnotes
 


### PR DESCRIPTION
Fixes #577.

I know it says "examples" (plural) but only has the Go one. Hope to add more in the future.