### PR TITLE
Closes #609

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
@@ -37,7 +37,7 @@ An example of the request format:
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#account_currencies)
+[Try it! >](websocket-api-tool.html#account-currencies)
 
 The request includes the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_info.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_info.md
@@ -47,7 +47,7 @@ rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#account_info)
+[Try it! >](websocket-api-tool.html#account-info)
 
 The request contains the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
@@ -34,7 +34,7 @@ An example of the request format:
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#account_lines)
+[Try it! >](websocket-api-tool.html#account-lines)
 
 The request accepts the following paramters:
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
@@ -41,7 +41,7 @@ rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#account_offers)
+[Try it! >](websocket-api-tool.html#account-offers)
 
 A request can include the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
@@ -51,7 +51,7 @@ rippled -- account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 5 1 0 1
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#account_tx)
+[Try it! >](websocket-api-tool.html#account-tx)
 
 The request includes the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_closed.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_closed.md
@@ -37,7 +37,7 @@ rippled ledger_closed
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_closed)
+[Try it! >](websocket-api-tool.html#ledger-closed)
 
 This method accepts no parameters.
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_current.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_current.md
@@ -38,7 +38,7 @@ rippled ledger_current
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_current)
+[Try it! >](websocket-api-tool.html#ledger-current)
 
 The request contains no parameters.
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
@@ -40,7 +40,7 @@ An example of the request format:
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger-entry)
 
 This method can retrieve several different types of data. You can select which type of item to retrieve by passing the appropriate parameters. Specifically, you should provide exactly one of the following fields:
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
@@ -56,7 +56,7 @@ rippled book_offers 'USD/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B' 'EUR/rvYAfWj5gh67oV6
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#book_offers)
+[Try it! >](websocket-api-tool.html#book-offers)
 
 The request includes the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/ripple_path_find.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/ripple_path_find.md
@@ -72,7 +72,7 @@ rippled ripple_path_find '{"source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ripple_path_find)
+[Try it! >](websocket-api-tool.html#ripple-path-find)
 
 The request includes the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
+++ b/content/references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
@@ -37,7 +37,7 @@ rippled server_info
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#server_info)
+[Try it! >](websocket-api-tool.html#server-info)
 
 The request does not take any parameters.
 

--- a/content/references/rippled-api/public-rippled-methods/server-info-methods/server_state.md
+++ b/content/references/rippled-api/public-rippled-methods/server-info-methods/server_state.md
@@ -37,7 +37,7 @@ rippled server_state
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#server_state)
+[Try it! >](websocket-api-tool.html#server-state)
 
 The request does not takes any parameters.
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/transaction_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/transaction_entry.md
@@ -43,7 +43,7 @@ rippled transaction_entry E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDA
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#transaction_entry)
+[Try it! >](websocket-api-tool.html#transaction-entry)
 
 The request includes the following parameters:
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/tx_history.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/tx_history.md
@@ -42,7 +42,7 @@ rippled tx_history 0
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#tx_history)
+[Try it! >](websocket-api-tool.html#tx-history)
 
 The request includes the following parameters:
 


### PR DESCRIPTION
Links on "Try It!" button were incorrect leading to raw WebSocket API Tool
template being served.

- replaced _ with - to fix "Try It!" links.

Does not fix link for 'sign' method.