### PR TITLE
Consistent use of terminology in admin method blurbs

### DIFF
--- a/content/references/rippled-api/admin-rippled-methods/key-generation-methods/wallet_propose.md
+++ b/content/references/rippled-api/admin-rippled-methods/key-generation-methods/wallet_propose.md
@@ -3,7 +3,7 @@
 
 Use the `wallet_propose` method to generate a key pair and XRP Ledger address. This command only generates key and address values, and does not affect the XRP Ledger itself in any way. To become a funded address stored in the ledger, the address must [receive a Payment transaction](accounts.html#creating-accounts) that provides enough XRP to meet the [reserve requirement](reserves.html).
 
-*The `wallet_propose` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!* (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)
+*The `wallet_propose` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!* (This command is restricted to protect against people sniffing network traffic for account secrets, since admin commands are not usually transmitted over the outside network.)
 
 [Updated in: rippled 0.31.0][New in: rippled 0.31.0]
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_request.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_request.md
@@ -3,7 +3,7 @@
 
 The `ledger_request` command tells server to fetch a specific ledger version from its connected peers. This only works if one of the server's immediately-connected peers has that ledger. You may need to run the command several times to completely fetch a ledger.
 
-*The `ledger_request` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `ledger_request` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/connect.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/connect.md
@@ -3,7 +3,7 @@
 
 The `connect` command forces the `rippled` server to connect to a specific peer `rippled` server.
 
-*The `connect` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `connect` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/stop.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/stop.md
@@ -3,7 +3,7 @@
 
 Gracefully shuts down the server.
 
-*The `stop` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `stop` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/validation_seed.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/validation_seed.md
@@ -3,7 +3,7 @@
 
 The `validation_seed` command temporarily sets the secret value that rippled uses to sign validations. This value resets based on the config file when you restart the server. [Disabled since: rippled 0.29.1](https://github.com/ripple/rippled/releases/tag/0.29.1-rc1 "BADGE_RED")
 
-*The `validation_seed` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `validation_seed` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/peers.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/peers.md
@@ -3,7 +3,7 @@
 
 The `peers` command returns a list of all other `rippled` servers currently connected to this one over the [Peer Protocol](peer-protocol.html), including information on their connection and sync status.
 
-*The `peers` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `peers` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/print.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/print.md
@@ -3,7 +3,7 @@
 
 The `print` command returns the current status of various internal subsystems, including peers, the ledger cleaner, and the resource manager.
 
-*The `print` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `print` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validator_list_sites.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validator_list_sites.md
@@ -3,7 +3,7 @@
 
 The `validator_list_sites` command returns status information of sites serving validator lists. [New in: rippled 0.80.1][]
 
-*The `validator_list_sites` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `validator_list_sites` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validators.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validators.md
@@ -3,7 +3,7 @@
 
 The `validators` command returns human readable information about the current list of published and trusted validators used by the server. [New in: rippled 0.80.1][]
 
-*The `validators` request is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
+*The `validators` method is an [admin method](admin-rippled-methods.html) that cannot be run by unprivileged users!*
 
 ### Request Format
 An example of the request format:


### PR DESCRIPTION
The inconsistency was pointed out by translators. This takes the more common phrasing and applies it to the other methods.