### PR TITLE
External links: work around type inconsistency of link class

### DIFF
--- a/tool/filter_external_links.py
+++ b/tool/filter_external_links.py
@@ -28,4 +28,7 @@ def filter_soup(soup, **kwargs):
                     "aria-hidden": "true"})
             link.append(" ")
             link.append(ex_link_marker)
-            link['class'] = link.get('class',[]) + ['external-link']
+            oldclass = link.get('class',[])
+            if type(oldclass) == str:
+                oldclass = [oldclass]
+            link['class'] = oldclass + ['external-link']


### PR DESCRIPTION
This change should avoid the build errors that are sporadically occurring in the `data-api-only` target. (I have a feeling that [the buttonize filter](https://github.com/ripple/dactyl/blob/62f0dde413ca7261eaf78f3e10340aabf92b6800/dactyl/filter_buttonize.py#L19) is to blame.)