### PR TITLE
Clarify that terQUEUED can change ledger state

### DIFF
--- a/content/references/rippled-api/transaction-formats/transaction-results/ter-codes.md
+++ b/content/references/rippled-api/transaction-formats/transaction-results/ter-codes.md
@@ -2,7 +2,7 @@
 
 These codes indicate that the transaction failed, but it could apply successfully in the future, usually if some other hypothetical transaction applies first. They have numerical values in the range -99 to -1. The exact code for any given error is subject to change, so don't rely on it.
 
-**Caution:** Transactions with `ter` codes are not applied to ledgers and cannot cause any changes to the XRP Ledger state. However, a transaction that provisionally failed may still succeed or fail with a different code after being reapplied. For more information, see [Finality of Results](finality-of-results.html) and [Reliable Transaction Submission](reliable-transaction-submission.html).
+**Caution:** Transactions with `ter` codes are not applied the current ledger and cannot cause any changes to the XRP Ledger state. However, a transaction that provisionally failed may still succeed or fail with a different code after being automatically reapplied. For more information, see [Finality of Results](finality-of-results.html) and [Reliable Transaction Submission](reliable-transaction-submission.html).
 
 | Code             | Explanation                                               |
 |:-----------------|:----------------------------------------------------------|

--- a/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
+++ b/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
@@ -10,7 +10,7 @@ The `rippled` server summarizes transaction results with result codes, which app
 | Failure               | [tef](tef-codes.html)   | The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future. |
 | Local error           | [tel](tel-codes.html)   | The `rippled` server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time. |
 | Malformed transaction | [tem](tem-codes.html)   | The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else. |
-| Retry                 | [ter](ter-codes.html)   | The transaction could not be applied, but it might be possible to apply later. |
+| Retry                 | [ter](ter-codes.html)   | The transaction could not be applied, but attempts will be made automatically to apply to a future ledger. |
 | Success               | [tes](tes-success.html) | (Not an error) The transaction succeeded. This result only final in a validated ledger. |
 
 **Warning:** Transactions' provisional result codes may differ than their final result. Transactions that provisionally succeeded may eventually fail and transactions that provisionally failed may eventually succeed. Transactions that provisionally failed may also eventually fail with a different code. See [finality of results](finality-of-results.html) for how to know when a transaction's result is final.

--- a/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
+++ b/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
@@ -10,8 +10,10 @@ The `rippled` server summarizes transaction results with result codes, which app
 | Failure               | [tef](tef-codes.html)   | The transaction cannot be applied to the server's current (in-progress) ledger or any later one. It may have already been applied, or the condition of the ledger makes it impossible to apply in the future. |
 | Local error           | [tel](tel-codes.html)   | The `rippled` server had an error due to local conditions, such as high load. You may get a different response if you resubmit to a different server or at a different time. |
 | Malformed transaction | [tem](tem-codes.html)   | The transaction was not valid, due to improper syntax, conflicting options, a bad signature, or something else. |
-| Retry                 | [ter](ter-codes.html)   | The transaction could not be applied, but attempts will be made automatically to apply to a future ledger. |
+| Retry                 | [ter](ter-codes.html)   | The transaction could not be applied, but it could apply successfully in a future ledger. |
 | Success               | [tes](tes-success.html) | (Not an error) The transaction succeeded. This result only final in a validated ledger. |
+
+The `rippled` server automatically retries failed transactions. It is important not to assume that a transaction has completely failed based on a tentative failure result. A transaction may later succeed unless its success or failure is [final](finality-of-results.html).
 
 **Warning:** Transactions' provisional result codes may differ than their final result. Transactions that provisionally succeeded may eventually fail and transactions that provisionally failed may eventually succeed. Transactions that provisionally failed may also eventually fail with a different code. See [finality of results](finality-of-results.html) for how to know when a transaction's result is final.
 


### PR DESCRIPTION
The ter-codes document previously states that transaction responses with terCodes can't affect the state of the ledger. This is misleading, as terQUEUED does, normally in the next ledger, without any further action from the caller. It seems from the description that all other ter codes won't modify the ledger without resubmission.