### PR TITLE
TOML checker: permit long TLDs

### DIFF
--- a/tool/template-xrp-ledger-toml-checker.html
+++ b/tool/template-xrp-ledger-toml-checker.html
@@ -12,7 +12,7 @@
     <div class="input-group">
       <input id="domain" type="text" class="form-control" required
              placeholder="example.com (Domain name to check)"
-             pattern="^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}$"><br>
+             pattern="^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z][a-zA-Z-]{0,22}[a-zA-Z]$"><br>
       <button class="btn btn-primary form-control">Check toml file</button>
     </div><!--/.input-group-->
   </form>


### PR DESCRIPTION
Longest [top-level domain in use today](https://data.iana.org/TLD/tlds-alpha-by-domain.txt) is 24 characters long (`XN--VERMGENSBERATUNG-PWB`) so I extended the TLD portion of the field validation to that length, with hyphens allowed in the middle but not the beginning or end of the TLD.