### PR TITLE
RocksDB not supported for history sharding on 1.3

### DIFF
--- a/content/tutorials/manage-the-rippled-server/configuration/configure-history-sharding.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/configure-history-sharding.md
@@ -10,11 +10,11 @@ To configure your `rippled` to store shards of ledger history, complete the foll
 
 Before you configure your `rippled` server to store history shards, you must decide how much disk space to allocate to the history shard store. This also affects how much history you keep in the default ledger store. You should consider the following when deciding what size to configure your shard store:
 
-- The ledger store (defined by the `[node_db]` stanza) is separate from the history shard store. The ledger store is required for all servers and _must_ contain a range of recent history, defined by how many ledgers to keep available in the `online_delete` parameter. (The default configuration stores the most recent 2000 ledgers.)
+- The ledger store (defined by the `[node_db]` stanza) is separate from the history shard store. The ledger store is required for all servers, and always contains a range of recent history, defined by how many ledgers to keep available in the `online_delete` parameter. (The default configuration stores the most recent 2000 ledgers.)
     - If you keep at least 2<sup>15</sup> ledgers (32768) in the ledger store, you can efficiently import chunks of recent history from the ledger store into the shard store.
 - The history shard store (defined by the `[shard_db]` stanza) is only required for storing history shards. The configuration stanza should be omitted from servers that do not store history shards. The size of the history shard store is defined in gigabytes in the `max_size_gb` parameter; the server attempts to use as much of this space as possible to store complete shards. The history shard store _MUST_ be stored on a solid-state disk or similar fast media. Traditional spinning hard disks are insufficient.
 - A shard consists of 2<sup>14</sup> ledgers (16384) and occupies approximately 200 MB to 4 GB based on the age of the shard. Older shards are smaller because there was less activity in the XRP Ledger at the time.
-- The history shard store and the ledger store _must_ be stored at different file paths. You can configure the ledger store and history store to be on different disks or partitions if desired.
+- The history shard store and the ledger store _MUST_ be stored at different file paths. You can configure the ledger store and history store to be on different disks or partitions if desired.
 - It is possible but redundant to hold full ledger history in both the ledger store and the history shard store.
 - The time to acquire a shard, number of file handles needed by the `rippled` server, and memory cache usage is directly affected by the size of the shard.
 
@@ -33,9 +33,9 @@ path=/var/lib/rippled/db/shards/nudb
 max_size_gb=50
 ```
 
-The `type` field **must** be NuDB. [New in: rippled 1.3.0][]
+The `type` field can be omitted. If present, it _MUST_ be `NuDB`. [New in: rippled 1.3.0][]
 
-**Caution:** If you enable history sharding, then later change the database type of your shard store, you must also change the path or delete the existing data from the configured path. If `rippled` detects the wrong type of data in the shard store path, it may [fail to start](server-wont-start.html).
+**Caution:** If `rippled` detects the wrong type of data in the shard store path, it may [fail to start](server-wont-start.html). You should use a new folder for the shard store. If you previously used a RocksDB shard store (`rippled` 1.2.x and lower), use a different path or delete the RocksDB shard data.
 
 For more information, reference the `[shard_db]` example in the [rippled.cfg configuration example](https://github.com/ripple/rippled/blob/master/cfg/rippled-example.cfg).
 
@@ -51,7 +51,7 @@ After your server syncs to the network, it automatically starts downloading hist
 
 This folder should contain a numbered folder for each shard your server has. At any given time, up to one folder may contain a `control.txt` file, indicating it is incomplete.
 
-<!-- TODO: add download_shard and crawl_shards commands when they get added. -->
+<!-- TODO: add download_shard and crawl_shards commands: https://github.com/ripple/ripple-dev-portal/issues/629 -->
 
 
 <!--{# common link defs #}-->

--- a/content/tutorials/manage-the-rippled-server/configuration/configure-history-sharding.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/configure-history-sharding.md
@@ -11,9 +11,9 @@ To configure your `rippled` to store shards of ledger history, complete the foll
 Before you configure your `rippled` server to store history shards, you must decide how much disk space to allocate to the history shard store. This also affects how much history you keep in the default ledger store. You should consider the following when deciding what size to configure your shard store:
 
 - The ledger store (defined by the `[node_db]` stanza) is separate from the history shard store. The ledger store is required for all servers and _must_ contain a range of recent history, defined by how many ledgers to keep available in the `online_delete` parameter. (The default configuration stores the most recent 2000 ledgers.)
-    - If you keep at least 2^15 ledgers (32768) in the ledger store, you can efficiently import chunks of recent history from the ledger store into the shard store.
-- The history shard store (defined by the `[shard_db]` stanza) is only required for storing history shards. The configuration stanza should be omitted from servers that do not store history shards. The size of the history shard store is defined in gigabytes in the `max_size_gb` parameter; the server attempts to use as much of this space as possible to store complete shards.
-- A shard consists of 2^14 ledgers (16384) and occupies approximately 200 MB to 4 GB based on the age of the shard. Older shards are smaller because there was less activity in the XRP Ledger at the time.
+    - If you keep at least 2<sup>15</sup> ledgers (32768) in the ledger store, you can efficiently import chunks of recent history from the ledger store into the shard store.
+- The history shard store (defined by the `[shard_db]` stanza) is only required for storing history shards. The configuration stanza should be omitted from servers that do not store history shards. The size of the history shard store is defined in gigabytes in the `max_size_gb` parameter; the server attempts to use as much of this space as possible to store complete shards. The history shard store _MUST_ be stored on a solid-state disk or similar fast media. Traditional spinning hard disks are insufficient.
+- A shard consists of 2<sup>14</sup> ledgers (16384) and occupies approximately 200 MB to 4 GB based on the age of the shard. Older shards are smaller because there was less activity in the XRP Ledger at the time.
 - The history shard store and the ledger store _must_ be stored at different file paths. You can configure the ledger store and history store to be on different disks or partitions if desired.
 - It is possible but redundant to hold full ledger history in both the ledger store and the history shard store.
 - The time to acquire a shard, number of file handles needed by the `rippled` server, and memory cache usage is directly affected by the size of the shard.
@@ -33,7 +33,7 @@ path=/var/lib/rippled/db/shards/nudb
 max_size_gb=50
 ```
 
-**Tip:** Ripple recommends using NuDB for the shard store (`type=NuDB`). NuDB uses fewer file handles per shard than RocksDB. RocksDB uses memory that scales with the size of data it stores, which may require excessive memory overhead. However, NuDB is designed to be used with SSD drives and does not work with rotational disks.
+The `type` field **must** be NuDB. [New in: rippled 1.3.0][]
 
 **Caution:** If you enable history sharding, then later change the database type of your shard store, you must also change the path or delete the existing data from the configured path. If `rippled` detects the wrong type of data in the shard store path, it may [fail to start](server-wont-start.html).
 
@@ -52,3 +52,9 @@ After your server syncs to the network, it automatically starts downloading hist
 This folder should contain a numbered folder for each shard your server has. At any given time, up to one folder may contain a `control.txt` file, indicating it is incomplete.
 
 <!-- TODO: add download_shard and crawl_shards commands when they get added. -->
+
+
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}
+{% include '_snippets/tx-type-links.md' %}
+{% include '_snippets/rippled_versions.md' %}

--- a/content/tutorials/manage-the-rippled-server/troubleshooting/server-wont-start.md
+++ b/content/tutorials/manage-the-rippled-server/troubleshooting/server-wont-start.md
@@ -94,7 +94,7 @@ Terminating thread rippled: main: unhandled St13runtime_error 'Can not create "/
 Aborted (core dumped)
 ```
 
-The paths to the config file (`/home/rippled/.config/ripple/rippled.cfg`) and the database path (`/var/lib/rippled/db`) may vary depending on your system.
+The paths to the configuration file (`/home/rippled/.config/ripple/rippled.cfg`) and the database path (`/var/lib/rippled/db`) may vary depending on your system.
 
 Possible solutions:
 
@@ -179,17 +179,24 @@ Terminating thread rippled: main: unhandled St13runtime_error 'shard path missin
 
 If your config includes a `[shard_db]` stanza, it must contain a `path` field, which points to a directory where `rippled` can write the data for the shard store. This error means the `path` field is missing or located in the wrong place. Check for extra whitespace or typos in your config file, and compare against the [Shard Configuration Example](configure-history-sharding.html#2-edit-rippledcfg).
 
+## Unsupported shard store type: RocksDB
 
-## ShardStore unable to open/create RocksDB
+RocksDB is no longer supported as a backend for [history sharding](history-sharding.html). If you have an existing configuration that defines a RocksDB shard store, the server fails to start. [New in: rippled 1.3.0][]
 
-If you enable [history sharding](history-sharding.html), then later change the configuration to use RocksDB instead of NuDB, the server may try to read the existing NuDB data as RocksDB data and fail to start. In this case, the server writes an error such as the following:
+In this case, the process dies shortly after the log startup command, with a message such as the following appearing earlier in the output log:
 
 ```text
-ShardStore:ERR shard 504 error: Unable to open/create RocksDB: Invalid argument: /var/lib/rippled/db/shards/504: does not exist (create_if_missing is false)
+ShardStore:ERR Unsupported shard store type: RocksDB
 ```
 
-To fix this problem, do one of the following:
 
-- Move or delete the existing shard data from the configured folder
-- Change where the shard store is located on disk by changing the `path` of the `[shard_db]` stanza in the `rippled.cfg` file.
-- Change the shard store back to using NuDB.
+To fix this problem, do one of the following, then restart the server:
+
+- Change your shard store to use NuDB instead.
+- Disable history sharding.
+
+
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}
+{% include '_snippets/tx-type-links.md' %}
+{% include '_snippets/rippled_versions.md' %}


### PR DESCRIPTION
- Updated troubleshooting with example error
- Removed stale RocksDB-on-shards error from troubleshooting
- Updating configuration tutorial to mention that NuDB & SSD are
  required for shards