### PR TITLE
Missing install keyword

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
@@ -18,7 +18,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 2. Install utilities:
 
-        $ sudo apt -y apt-transport-https ca-certificates wget gnupg
+        $ sudo apt -y install apt-transport-https ca-certificates wget gnupg
 
 3. Add Ripple's package-signing GPG key to your list of trusted keys:
 


### PR DESCRIPTION
`apt -y apt-transport-https ca-certificates wget gnupg` changed to `apt -y install apt-transport-https ca-certificates wget gnupg`