### PR TITLE
Closes #639

### DIFF
--- a/tool/template-home.html
+++ b/tool/template-home.html
@@ -181,7 +181,7 @@
 
   <section class="container-fluid card-grid card-grid-2x2">
     <div class="section-hero card pl-0">
-      <h2>Start BUIDLing</h2>
+      <h2>Start Building</h2>
       <div class="blurb">
         <p>Use these tutorials to get step-by-step guidance to perform common tasks with the XRP Ledger.</p>
       </div>


### PR DESCRIPTION
Typo "BUIDLing" in Start Building section header.

Corrected spelling and capitalization to Building.