### PR TITLE
Make 404 page path-independent

### DIFF
--- a/tool/template-404.html
+++ b/tool/template-404.html
@@ -1,23 +1,125 @@
-{% extends "template-base.html" %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width">
 
-{% block left_sidebar %}
-{% set use_page = pages|selectattr("html", 'defined_and_equalto', "docs.html")|first %}
-{% include 'template-sidebar_nav.html' %}
-{% endblock %}
+    <title>404 Not Found - XRP Ledger Dev Portal</title>
 
-{% block main %}
-  <article class="pt-3 p-md-3">
-    <h1>Not Found</h1>
-    <div class="content">
-        <p>Sorry, this page does not exist. Try looking in the <a href="/docs.html#full-doc-index">Full Documentation Index</a>, or you can search the site with Google:</p>
-        <form role="search" method="get" action="https://www.google.com/search">
-          <div class="form-inline">
-            <label class="sr-only" for="centersearch">Search site with Google...</label>
-            <input name="q" value="site:xrpl.org" type="hidden">
-            <input id="centersearch" name="q" type="text" class="form-control" placeholder="Search site with Google...">
-            <button type="submit" class="btn btn-default fa fa-search">&nbsp;</button>
-          </div>
-        </form>
+    <!-- favicon -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicons/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicons/favicon-32x32.png">
+    <link rel="manifest" href="/assets/favicons/site.webmanifest">
+    <link rel="shortcut icon" href="/favicon.ico">
+    <meta name="msapplication-TileColor" content="#25A768">
+    <meta name="msapplication-config" content="/assets/favicons/browserconfig.xml">
+    <meta name="theme-color" content="#25A768">
+
+    <!-- jQuery -->
+    <script src="/assets/vendor/jquery-1.11.1.min.js"></script>
+
+    <!-- Custom Stylesheets. -->
+    <link href="/assets/vendor/bootstrap.css" rel="stylesheet" />
+    <link href="/assets/css/devportal.css" rel="stylesheet" />
+
+    <!-- Bootstrap JS -->
+    <script src="/assets/vendor/bootstrap.min.js"></script>
+
+    <!-- fontawesome icons -->
+    <link rel="stylesheet" href="/assets/vendor/fontawesome/css/font-awesome.min.css" />
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-45576805-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-45576805-2');
+    </script>
+
+</head>
+
+<body class="xrp-ledger-dev-portal {% if currentpage.sidebar is undefined or currentpage.sidebar != "disabled" %}sidebar-primary {% endif %}{% block bodyclasses %}{% endblock %}">
+
+  <nav class="navbar fixed-top navbar-expand-lg navbar-light bg-white">
+    <a href="/index.html" class="navbar-brand"><img src="/assets/img/XRPLedger_DevPortal-black.svg" class="logo"  height="44" alt="XRP Ledger Dev Portal" /></a>
+    <button class="navbar-toggler" type="button" data-toggle="slide-collapse" data-target="#navbarHolder" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse justify-content-end" id="navbarHolder">
+      <ul class="nav navbar-nav">
+        {% set funnels = [] %}
+        {% for page in pages %}
+          {% if page.funnel is defined and page.funnel not in funnels %}
+            {% set thisfunneltop = pages|selectattr('funnel', 'defined_and_equalto', page.funnel)|first %}
+            <li class="nav-item{% if currentpage == thisfunneltop %} active{% elif currentpage.funnel is defined and currentpage.funnel == thisfunneltop.name %} active-parent{% endif %}">
+              <a class="nav-link" href="/{{ thisfunneltop.html }}">{{ thisfunneltop.name }}</a>
+            </li>
+            {% set _ = funnels.append(page.funnel) %}
+          {% endif %}
+        {% endfor %}
+        <li class="nav-item">
+          <a class="nav-link" href="/blog/">Blog</a>
+        </li>
+      </ul><!-- /.navbar-nav -->
+      {% include 'template-github-edit.html' %}
+      <form class="navbar-form navbar-right" id="navbar-search" role="search" method="get" action="https://www.google.com/search">
+        <div class="form-inline">
+          <label class="sr-only" for="topsearchbar">Search site with Google...</label>
+          <input name="q" value="site:xrpl.org" type="hidden">
+          <input id="topsearchbar" name="q" type="text" class="form-control" class="top-search" placeholder="Search site with Google...">
+          <button type="submit" class="btn btn-default fa fa-search">&nbsp;</button>
+        </div>
+      </form>
     </div>
-  </article>
-{% endblock %}
+    <div class="menu-overlay"></div>
+  </nav>
+
+  <div class="container-fluid" role="document" id="main_content_wrapper">
+    <div class="row">
+      <!-- Right sidebar first so it's at the beginning for mobile layouts -->
+      {% if currentpage.sidebar is undefined or (currentpage.sidebar != "disabled" and currentpage.sidebar != "left_only") %}
+      <aside class="right-sidebar col-lg-3 order-lg-4 p-0" role="complementary">
+          {% block right_sidebar %}{% endblock %}
+      </aside>
+      {% endif %}
+
+      <!-- main column -->
+      <main class="main {% if currentpage.sidebar is defined and currentpage.sidebar == "disabled" %}col-md-12{% else %}col-md-7 col-lg-6{% endif %} order-md-3  {% block mainclasses %}{% endblock %}" role="main" id="main_content_body">
+          {% block breadcrumbs %}
+            {% include 'template-breadcrumbs.html' %}
+          {% endblock %}
+          <article class="pt-3 p-md-3">
+            <h1>Not Found</h1>
+            <div class="content">
+                <p>Sorry, this page does not exist. Try looking in the <a href="/docs.html#full-doc-index">Full Documentation Index</a>, or you can search the site with Google:</p>
+                <form role="search" method="get" action="https://www.google.com/search">
+                  <div class="form-inline">
+                    <label class="sr-only" for="centersearch">Search site with Google...</label>
+                    <input name="q" value="site:xrpl.org" type="hidden">
+                    <input id="centersearch" name="q" type="text" class="form-control" placeholder="Search site with Google...">
+                    <button type="submit" class="btn btn-default fa fa-search">&nbsp;</button>
+                  </div>
+                </form>
+            </div>
+          </article>
+      </main>
+      {% if currentpage.sidebar is undefined or currentpage.sidebar != "disabled" %}
+      <!-- Left sidebar last so it's at the end for mobile -->
+      <aside class="sidebar col-md-5 col-lg-3 p-0 order-md-1" role="complementary">
+          {% block left_sidebar %}
+            {% set use_page = pages|selectattr("html", 'defined_and_equalto', "docs.html")|first %}
+            {% set link_prefix = "/" %}{# Links need to be absolute so they work no matter what URL the 404 page is served from #}
+            {% include "template-sidebar_nav.html" %}
+          {% endblock %}
+      </aside>
+      {% endif %}
+    </div><!--/.row (main layout)-->
+  </div>
+
+{% include 'template-footer.html' %}
+
+</body>
+</html>

--- a/tool/template-sidebar_nav.html
+++ b/tool/template-sidebar_nav.html
@@ -1,31 +1,34 @@
 {% if use_page is undefined %}
   {% set use_page = currentpage %}
 {% endif %}
+{% if link_prefix is undefined %}
+  {% set link_prefix = "" %}
+{% endif %}
 <div class="tree_nav">
 
   <!--{############# Parent page link ###############################}-->
   {% if use_page.supercategory is defined %}
     <div class="sidenav_parent">
       {% if use_page == (pages|selectattr('supercategory', 'defined_and_equalto', use_page.supercategory)|first) %}
-      <a  href="{{ use_page.html }}">{{ use_page.supercategory }}</a>
+      <a  href="{{ link_prefix}}{{ use_page.html }}">{{ use_page.supercategory }}</a>
       {% else %}
-      <a href="{{ (pages|selectattr('supercategory', 'defined_and_equalto', use_page.supercategory)|first).html }}"> {{ use_page.supercategory }}</a>
+      <a href="{{ link_prefix}}{{ (pages|selectattr('supercategory', 'defined_and_equalto', use_page.supercategory)|first).html }}"> {{ use_page.supercategory }}</a>
       {% endif %}
     </div>
   {% elif use_page.doc_type is defined %}
     <div class="sidenav_parent">
       {% if use_page == (pages|selectattr('doc_type', 'defined_and_equalto', use_page.doc_type)|first) %}
-      <a  href="{{ use_page.html }}">{{ use_page.doc_type }}</a>
+      <a  href="{{ link_prefix}}{{ use_page.html }}">{{ use_page.doc_type }}</a>
       {% else %}
-      <a href="{{ (pages|selectattr('doc_type', 'defined_and_equalto', use_page.doc_type)|first).html }}"> {{ use_page.doc_type }}</a>
+      <a href="{{ link_prefix}}{{ (pages|selectattr('doc_type', 'defined_and_equalto', use_page.doc_type)|first).html }}"> {{ use_page.doc_type }}</a>
       {% endif %}
     </div>
   {% elif use_page.funnel is defined %}
     <div class="sidenav_parent">
       {% if use_page == (pages|selectattr('funnel', 'defined_and_equalto', use_page.funnel)|first) %}
-      <a  href="{{ use_page.html }}">{{ use_page.funnel }}</a>
+      <a  href="{{ link_prefix}}{{ use_page.html }}">{{ use_page.funnel }}</a>
       {% else %}
-      <a href="{{ (pages|selectattr('funnel', 'defined_and_equalto', use_page.funnel)|first).html }}"> {{ use_page.funnel }}</a>
+      <a href="{{ link_prefix}}{{ (pages|selectattr('funnel', 'defined_and_equalto', use_page.funnel)|first).html }}"> {{ use_page.funnel }}</a>
       {% endif %}
     </div>
   {% endif %}
@@ -43,9 +46,9 @@
             {% if loop.index == 1 %}{# Skip the first element since it's linked by the funnel header #}
             {% elif page.template == "template-redirect.html" %}{# skip redirects #}
             {% elif page == use_page %}
-            <li><a class="active nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+            <li><a class="active nosubcat-page" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
             {% else %}
-            <li><a class="nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+            <li><a class="nosubcat-page" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
             {% endif %}
           {% endfor %}
           {% if use_page.funnel == "News" %}
@@ -76,7 +79,7 @@
                 <a class="{% if use_page.category is undefined or use_page.category != cat %}collapsed {% endif %}sidenav_cat_toggler" role="button" data-toggle="collapse" href="#sidenav_collapse_{{loop.index}}" aria-expanded="true" aria-controls="sidenav_collapse_{{loop.index}}"></a>
                 {% endif %}
                 <h5 class="card-title">
-                    <a class="sidenav_cat_title{% if use_page == (cat_parent) %} active{% elif use_page.category is defined and use_page.category == cat %} active-parent{% endif %}" href="{{ cat_parent.html }}">{{ cat }}</a>
+                    <a class="sidenav_cat_title{% if use_page == (cat_parent) %} active{% elif use_page.category is defined and use_page.category == cat %} active-parent{% endif %}" href="{{ link_prefix}}{{ cat_parent.html }}">{{ cat }}</a>
                 </h5>
               </div><!-- /.card-header -->
 
@@ -89,17 +92,17 @@
                       {% if page.template == "template-redirect.html" %}{# skip redirects #}
                       {% elif page.subcategory is undefined %}
                         {% if page == use_page %}
-                          <li><a class="active nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                          <li><a class="active nosubcat-page" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                         {% else %}
-                        <li><a class="nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                        <li><a class="nosubcat-page" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                         {% endif %}
                       {% elif page.subcategory not in printed_subcategories %}
                         {% if page == use_page %}
                         <li><a class="subcat-title active" href="#main_content_body">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                         {% elif use_page.subcategory is defined and page.subcategory == use_page.subcategory %}
-                        <li><a class="subcat-title active-parent" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                        <li><a class="subcat-title active-parent" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                         {% else %}
-                        <li><a class="subcat-title" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                        <li><a class="subcat-title" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                         {% endif %}
 
                         {% for subpage in catpages|selectattr('subcategory', 'defined_and_equalto', page.subcategory) %}
@@ -107,7 +110,7 @@
                             {% if subpage == use_page %}
                             <li><a class="active subpage" href="#main_content_body">{{ subpage.name }}{% if subpage.status is defined and subpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                             {% else %}
-                            <li><a class="subpage" href="{{ subpage.html }}">{{ subpage.name }}{% if subpage.status is defined and subpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                            <li><a class="subpage" href="{{ link_prefix}}{{ subpage.html }}">{{ subpage.name }}{% if subpage.status is defined and subpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                             {% endif %}
                           {% endif %}
                         {% endfor %}
@@ -149,7 +152,7 @@
                   <a class="collapsed sidenav_cat_toggler" role="button" data-toggle="collapse" href="#sidenav_collapse_{{loop.index}}" aria-expanded="true" aria-controls="sidenav_collapse_{{loop.index}}"></a>
                 {% endif %}
                 <h5 class="card-title">
-                  <a class="sidenav_cat_title" href="{{ supercat_parent.html }}">{{ supercat }}</a>
+                  <a class="sidenav_cat_title" href="{{ link_prefix}}{{ supercat_parent.html }}">{{ supercat }}</a>
                 </h5>
               </div><!-- /.card-header -->
 
@@ -161,14 +164,14 @@
                     {% if loop.index != 1 %}{# Skip the first element since it's linked by the supercategory header #}
                       {% if subpage.template == "template-redirect.html" %}{# skip redirects #}
                       {% elif subpage.category not in printed_categories %}
-                        <li><a class="subcat-title" href="{{ subpage.html }}">{{ subpage.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                        <li><a class="subcat-title" href="{{ link_prefix}}{{ subpage.html }}">{{ subpage.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
 
                         {% set category_members = supercatpages|selectattr('category', 'defined_and_equalto', subpage.category)|list %}
                         <!-- DEBUG: category_members is {{ category_members }} -->
                         {% for subsubpage in category_members %}
                           {% if subsubpage != subpage and (subsubpage.subcategory is undefined or
                               subsubpage == category_members|selectattr('subcategory', 'defined_and_equalto', subsubpage.subcategory)|first) and subsubpage.template != "template-redirect.html" %}
-                            <li><a class="subpage" href="{{ subsubpage.html }}">{{ subsubpage.name }}{% if subsubpage.status is defined and subsubpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                            <li><a class="subpage" href="{{ link_prefix}}{{ subsubpage.html }}">{{ subsubpage.name }}{% if subsubpage.status is defined and subsubpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                           {% endif %}
                         {% endfor %}
                         {% set _ = printed_categories.append(subpage.category) %}
@@ -200,8 +203,8 @@
                 <a class="{% if use_page.category is undefined or use_page.category != cat %}collapsed {% endif %}sidenav_cat_toggler" role="button" data-toggle="collapse" href="#sidenav_collapse_{{loop.index}}" aria-expanded="true" aria-controls="sidenav_collapse_{{loop.index}}"></a>
               {% endif %}
               <h5 class="card-title">
-                  <a class="sidenav_cat_title{% if use_page == (cat_parent) %} active{% elif use_page.category is defined and use_page.category == cat %} active-parent{% endif %}" href="{{ cat_parent.html }}">{{ cat }}</a>
-                <!-- <a class="sidenav_cat_title" href="{{ cat_parent.html }}">{{ cat }}</a> -->
+                  <a class="sidenav_cat_title{% if use_page == (cat_parent) %} active{% elif use_page.category is defined and use_page.category == cat %} active-parent{% endif %}" href="{{ link_prefix}}{{ cat_parent.html }}">{{ cat }}</a>
+                <!-- <a class="sidenav_cat_title" href="{{ link_prefix}}{{ cat_parent.html }}">{{ cat }}</a> -->
               </h5>
             </div><!-- /.card-header -->
 
@@ -214,17 +217,17 @@
                     {% if page.template == "template-redirect.html" %}{# skip redirects #}
                     {% elif page.subcategory is undefined %}
                       {% if page == use_page %}
-                      <li><a class="active nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                      <li><a class="active nosubcat-page" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                       {% else %}
-                      <li><a class="nosubcat-page" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                      <li><a class="nosubcat-page" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                       {% endif %}
                     {% elif page.subcategory not in printed_subcategories %}
                       {% if page == use_page %}
                       <li><a class="subcat-title active" href="#main_content_body">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                       {% elif page.subcategory is defined and use_page.subcategory is defined and page.subcategory == use_page.subcategory %}
-                      <li><a class="subcat-title active-parent" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                      <li><a class="subcat-title active-parent" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                       {% else %}
-                      <li><a class="subcat-title" href="{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                      <li><a class="subcat-title" href="{{ link_prefix}}{{ page.html }}">{{ page.name }}{% if page.status is defined and page.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                       {% endif %}
 
                       {% for subpage in catpages|selectattr('subcategory', 'defined_and_equalto', page.subcategory) %}
@@ -232,7 +235,7 @@
                           {% if subpage == use_page %}
                           <li><a class="active subpage" href="#main_content_body">{{ subpage.name }}{% if subpage.status is defined and subpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                           {% elif subpage.template != "template-redirect.html" %}
-                          <li><a class="subpage" href="{{ subpage.html }}">{{ subpage.name }}{% if subpage.status is defined and subpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
+                          <li><a class="subpage" href="{{ link_prefix}}{{ subpage.html }}">{{ subpage.name }}{% if subpage.status is defined and subpage.status == "not_enabled" %} {% include 'template-status_not_enabled.html' %}{% endif %}</a></li>
                           {% endif %}
                         {% endif %}
                       {% endfor %}


### PR DESCRIPTION
When the 404 page is served from a path that includes slashes for
subfolders (for example, /transactions/ or /some/404/page), any relative
links and content references it has won't work. This change converts all
relative references to absolute references instead.