### PR TITLE
Validation stream messages are from all validators

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
+++ b/content/references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
@@ -169,7 +169,7 @@ The fields from a ledger stream message are as follows:
 
 [New in: rippled 0.29.0][]
 
-The validations stream sends messages whenever it receives validation messages, also called validation votes, from validators it trusts. The message looks like the following:
+The validations stream sends messages whenever it receives validation messages, also called validation votes, regardless of whether or not the validation message is from a trusted validator. The message looks like the following:
 
 ```
 {


### PR DESCRIPTION
Edited the description of the validation stream. This resolves issue [https://github.com/ripple/ripple-dev-portal/issues/670](https://github.com/ripple/ripple-dev-portal/issues/670).