### PR TITLE
Fix invalid message key

### DIFF
--- a/content/references/rippled-api/transaction-formats/transaction-types/accountset.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/accountset.md
@@ -14,7 +14,7 @@ An AccountSet transaction modifies the properties of an [account in the XRP Ledg
     "Sequence": 5,
     "Domain": "6578616D706C652E636F6D",
     "SetFlag": 5,
-    "MessageKey": "rQD4SqHJtDxn5DDL7xNnojNa3vxS1Jx5gv"
+    "MessageKey": "03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB"
 }
 ```
 


### PR DESCRIPTION
The current message key example uses an account address, which is incorrect and can never be used to prepare a valid transaction. 