### PR TITLE
Rename 'local' target to 'en'

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -44,7 +44,7 @@ cover_page:
 
 targets:
     # First member is the default that gets built when target not specified
-    -   name: local
+    -   name: en
         display_name: XRP Ledger Dev Portal
         # These github_ fields are used by the template's "Edit on GitHub" link.
         #  Override them with --vars to change which fork/branch to edit.
@@ -75,7 +75,7 @@ pages:
         html: docs.html
         sidebar: disabled
         targets:
-            - local
+            - en
 
 # Concepts ---------------------------------------------------------------------
 
@@ -86,7 +86,7 @@ pages:
         template: template-landing-children.html
         blurb: Learn the "what" and "why" behind fundamental aspects of the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   name: Introduction
         funnel: Docs
@@ -96,7 +96,7 @@ pages:
         template: template-landing-children.html
         blurb: The XRP Ledger is a decentralized cryptographic ledger powered by a network of peer-to-peer rippled servers. This section covers basic concepts that help you learn the "what" and "why" behind fundamental aspects of the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: concepts/introduction/xrp-ledger-overview.md
         html: xrp-ledger-overview.html
@@ -105,7 +105,7 @@ pages:
         category: Introduction
         blurb: Get a quick and concise introduction to key features of the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: concepts/introduction/intro-to-consensus.md
         html: intro-to-consensus.html
@@ -114,7 +114,7 @@ pages:
         category: Introduction
         blurb: Develop a basic understanding of the XRP Ledger's consensus mechanism.
         targets:
-            - local
+            - en
 
     -   md: concepts/introduction/xrp.md
         html: xrp.html
@@ -123,7 +123,7 @@ pages:
         category: Introduction
         blurb: Learn about the uses and properties of XRP, the digital asset for payments.
         targets:
-            - local
+            - en
 
     -   md: concepts/introduction/software-ecosystem.md
         html: software-ecosystem.html
@@ -132,7 +132,7 @@ pages:
         category: Introduction
         blurb: Get an overview of what XRP Ledger software is out there and how it fits together.
         targets:
-            - local
+            - en
 
     -   md: concepts/introduction/technical-faq.md
         html: technical-faq.html
@@ -141,7 +141,7 @@ pages:
         category: Introduction
         blurb: Get answers to frequently asked questions, covering topics such as validators, unique node lists, the role of XRP, and security.
         targets:
-            - local
+            - en
 
     -   name: Payment System Basics
         html: payment-system-basics.html
@@ -151,7 +151,7 @@ pages:
         template: template-landing-children.html
         blurb: One of the primary purposes of the XRP Ledger is payment processing. Learn more about key concepts that will help you understand the XRP Ledger payment system.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/accounts/accounts.md
         html: accounts.html
@@ -161,7 +161,7 @@ pages:
         subcategory: Accounts
         blurb: Learn about accounts in the XRP Ledger. Accounts can send transactions and hold XRP.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/accounts/cryptographic-keys.md
         html: cryptographic-keys.html
@@ -171,7 +171,7 @@ pages:
         subcategory: Accounts
         blurb: Use cryptographic keys to approve transactions so the XRP Ledger can execute them.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/accounts/multi-signing.md
         html: multi-signing.html
@@ -181,7 +181,7 @@ pages:
         subcategory: Accounts
         blurb: Use multi-signing for greater security sending transactions.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/accounts/reserves.md
         html: reserves.html
@@ -191,7 +191,7 @@ pages:
         subcategory: Accounts
         blurb: XRP Ledger accounts require a reserve of XRP to reduce spam in ledger data.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/accounts/depositauth.md
         html: depositauth.html
@@ -201,7 +201,7 @@ pages:
         subcategory: Accounts
         blurb: The DepositAuth setting lets an account block incoming payments by default.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/fees.md
         html: fees.html
@@ -210,7 +210,7 @@ pages:
         category: Payment System Basics
         blurb: Learn about the types of fees allowed by the XRP Ledger, including neutral fees (payable to no one) that protect the ledger against abuse, as well as fees that users can collect from each other.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/ledgers.md
         html: ledgers.html
@@ -219,7 +219,7 @@ pages:
         category: Payment System Basics
         blurb: The XRP Ledger is composed of a series of individual ledgers, or ledger versions, which rippled keeps in its internal database. Learn about the structure and contents of these ledgers.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/transaction-basics/transaction-basics.md
         html: transaction-basics.html
@@ -229,7 +229,7 @@ pages:
         subcategory: Transaction Basics
         blurb: Transactions are the only way to change the XRP Ledger. Understand what forms they take and how to use them.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/transaction-basics/transaction-cost.md
         html: transaction-cost.html
@@ -239,7 +239,7 @@ pages:
         subcategory: Transaction Basics
         blurb: The transaction cost is a small amount of XRP destroyed to send a transaction, which protects the ledger from spam. Learn how the transaction cost applies.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/transaction-basics/finality-of-results.md
         html: finality-of-results.html
@@ -249,7 +249,7 @@ pages:
         subcategory: Transaction Basics
         blurb: Transactions are the only way to change the XRP Ledger. Understand what forms they take and how to use them.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-system-basics/transaction-basics/source-and-destination-tags.md
         html: source-and-destination-tags.html
@@ -259,7 +259,7 @@ pages:
         subcategory: Transaction Basics
         blurb: Use source and destination tags to indicate specific purposes for payments from and to multi-purpose addresses
         targets:
-            - local
+            - en
 
     -   name: Payment Types
         html: payment-types.html
@@ -269,7 +269,7 @@ pages:
         template: template-landing-children.html
         blurb: The XRP Ledger supports point-to-point XRP payments alongside other, more specialized payment types.
         targets:
-            - local
+            - en
 
         # Redirect from the old landing name/URL
     -   name: Complex Payment Types
@@ -280,7 +280,7 @@ pages:
         template: template-redirect.html
         redirect_url: payment-types.html
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-types/direct-xrp-payments.md
         html: direct-xrp-payments.html
@@ -289,7 +289,7 @@ pages:
         category: Payment Types
         blurb: Direct XRP payments are the simplest way to send value in the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-types/cross-currency-payments.md
         html: cross-currency-payments.html
@@ -298,7 +298,7 @@ pages:
         category: Payment Types
         blurb: Cross-currency payments atomically deliver a different currency than they send by converting through paths and order books.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-types/checks.md
         html: checks.html
@@ -308,7 +308,7 @@ pages:
         blurb: Checks let users create deferred payments that can be canceled or cashed by the intended recipients.
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-types/escrow.md
         html: escrow.html
@@ -317,7 +317,7 @@ pages:
         category: Payment Types
         blurb: Escrows set aside XRP and deliver it later when certain conditions are met. Escrows can depend on time limits, cryptographic conditions, or both.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-types/partial-payments.md
         html: partial-payments.html
@@ -326,7 +326,7 @@ pages:
         category: Payment Types
         blurb: Partial payments subtract fees from the amount sent, delivering a flexible amount. Partial payments are useful for returning unwanted payments without incurring additional costs.
         targets:
-            - local
+            - en
 
     -   md: concepts/payment-types/payment-channels.md
         html: payment-channels.html
@@ -335,7 +335,7 @@ pages:
         category: Payment Types
         blurb: Payment Channels enable fast, asynchronous XRP payments that can be divided into very small increments and settled later.
         targets:
-            - local
+            - en
 
     -   name: Issued Currencies
         html: issued-currencies.html
@@ -345,7 +345,7 @@ pages:
         template: template-landing-children.html
         blurb: All currencies other than XRP can be represented in the XRP Ledger as issued currencies. Learn more about how issued currencies function in the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/issued-currencies-overview.md
         html: issued-currencies-overview.html
@@ -354,7 +354,7 @@ pages:
         category: Issued Currencies
         blurb: Get an overview of issued currencies and their properties in the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/trust-lines-and-issuing.md
         html: trust-lines-and-issuing.html
@@ -363,7 +363,7 @@ pages:
         category: Issued Currencies
         blurb: Learn about the properties and rationale of trust lines.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/authorized-trust-lines.md
         html: authorized-trust-lines.html
@@ -372,7 +372,7 @@ pages:
         category: Issued Currencies
         blurb: Learn about authorized trust lines, which enable a currency issuer to limit who can hold its issued (non-XRP) currencies.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/freezes.md
         html: freezes.html
@@ -381,7 +381,7 @@ pages:
         category: Issued Currencies
         blurb: Freezes can suspend trading of issued currencies for compliance purposes.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/rippling.md
         html: rippling.html
@@ -390,7 +390,7 @@ pages:
         category: Issued Currencies
         blurb: Rippling is automatic multi-party net settlement of issued currency balances.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/transfer-fees.md
         html: transfer-fees.html
@@ -399,7 +399,7 @@ pages:
         category: Issued Currencies
         blurb: Currency issuers can charge a fee for transferring their issued currencies.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/issuing-and-operational-addresses.md
         html: issuing-and-operational-addresses.html
@@ -408,7 +408,7 @@ pages:
         category: Issued Currencies
         blurb: Businesses sending transactions on the XRP Ledger automatically should set up separate addresses for different purposes to minimize risk.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/paths.md
         html: paths.html
@@ -417,7 +417,7 @@ pages:
         category: Issued Currencies
         blurb: Payments of issued currencies must traverse paths of connected users and order books.
         targets:
-            - local
+            - en
 
     -   md: concepts/issued-currencies/demurrage.md
         html: demurrage.html
@@ -426,7 +426,7 @@ pages:
         category: Issued Currencies
         blurb: (Obsolete) Some older XRP Ledger tools used to support currency codes with built-in interest and negative interest rates.
         targets:
-            - local
+            - en
 
     -   name: Decentralized Exchange
         html: decentralized-exchange.html
@@ -436,7 +436,7 @@ pages:
         template: template-landing-children.html
         blurb: The XRP Ledger contains a fully-functional exchange where users can trade issued currencies for XRP or each other.
         targets:
-            - local
+            - en
 
     -   md: concepts/decentralized-exchange/offers.md
         html: offers.html
@@ -445,7 +445,7 @@ pages:
         category: Decentralized Exchange
         blurb: Offers are the XRP Ledger's form of currency trading orders. Understand their lifecycle and properties.
         targets:
-            - local
+            - en
 
     -   md: concepts/decentralized-exchange/autobridging.md
         html: autobridging.html
@@ -454,7 +454,7 @@ pages:
         category: Decentralized Exchange
         blurb: Autobriding automatically connects order books using XRP as an intermediary when it reduces costs.
         targets:
-            - local
+            - en
 
     -   md: concepts/decentralized-exchange/ticksize.md
         html: ticksize.html
@@ -463,7 +463,7 @@ pages:
         category: Decentralized Exchange
         blurb: Issuers can set custom tick sizes for currencies to reduce churn in order books over miniscule differences in exchange rates.
         targets:
-            - local
+            - en
 
     -   name: Consensus Network
         html: consensus-network.html
@@ -473,7 +473,7 @@ pages:
         template: template-landing-children.html
         blurb: The XRP Ledger uses a consensus algorithm to resolve the double spend problem and choose which transactions to execute in which order. Consensus also governs rules of transaction processing.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/consensus.md
         html: consensus.html
@@ -482,7 +482,7 @@ pages:
         category: Consensus Network
         blurb: Understand the role of consensus in the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/consensus-principles-and-rules.md
         html: consensus-principles-and-rules.html
@@ -491,7 +491,7 @@ pages:
         category: Consensus Network
         blurb: The rules and principles of the consensus algorithm that allow users to transfer funds (including fiat currencies, digital currencies and other forms of value) across national boundaries as seamlessly as sending an email.
         targets:
-          - local
+          - en
 
     -   md: concepts/consensus-network/consensus-protections.md
         html: consensus-protections.html
@@ -500,7 +500,7 @@ pages:
         category: Consensus Network
         blurb: Learn how the XRP Ledger Consensus Protocol is protected against various problems and attacks that may occur in a decentralized financial system.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/transaction-queue.md
         html: transaction-queue.html
@@ -509,7 +509,7 @@ pages:
         category: Consensus Network
         blurb: Understand how transactions can be queued before reaching consensus.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/about-canceling-a-transaction.md
         html: about-canceling-a-transaction.html
@@ -518,7 +518,7 @@ pages:
         category: Consensus Network
         blurb: Understand when and how it's possible to cancel a transaction that has already been sent.
         targets:
-          - local
+          - en
 
     -   md: concepts/consensus-network/transaction-malleability.md
         html: transaction-malleability.html
@@ -527,7 +527,7 @@ pages:
         category: Consensus Network
         blurb: Be aware of ways transactions could be changed to have a different hash than expected.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/amendments/amendments.md
         html: amendments.html
@@ -537,7 +537,7 @@ pages:
         subcategory: Amendments
         blurb: Amendments represent new features or other changes to transaction processing. Validators coordinate through consensus to apply these upgrades to the XRP Ledger in an orderly fashion.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/amendments/known-amendments.md
         html: known-amendments.html
@@ -547,7 +547,7 @@ pages:
         subcategory: Amendments
         blurb: List of all known amendments to the XRP Ledger protocol and their status.
         targets:
-            - local
+            - en
 
     -   md: concepts/consensus-network/fee-voting.md
         html: fee-voting.html
@@ -556,7 +556,7 @@ pages:
         category: Consensus Network
         blurb: How validators vote on fees (transaction cost and reserve requirements).
         targets:
-          - local
+          - en
 
     -   md: concepts/consensus-network/consensus-research.md
         html: consensus-research.html
@@ -565,7 +565,7 @@ pages:
         category: Consensus Network
         blurb: Scholarly articles on consensus algorithms and related research.
         targets:
-          - local
+          - en
 
     # TODO: add pseudo-transactions concept page
 
@@ -576,7 +576,7 @@ pages:
         category: Consensus Network
         blurb: Understand how test networks and alternate ledger chains relate to the production XRP Ledger.
         targets:
-          - local
+          - en
 
     -   name: The rippled Server
         html: the-rippled-server.html
@@ -586,7 +586,7 @@ pages:
         template: template-landing-children.html
         blurb: rippled is the core peer-to-peer server that manages the XRP Ledger. This section covers concepts that help you learn the "what" and "why" behind fundamental aspects of the rippled server.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/rippled-server-modes.md
         html: rippled-server-modes.html
@@ -595,7 +595,7 @@ pages:
         category: The rippled Server
         blurb: Learn about rippled server modes, including stock servers, validator servers, and rippled servers run in stand-alone mode.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/clustering.md
         html: clustering.html
@@ -604,7 +604,7 @@ pages:
         category: The rippled Server
         blurb: Run rippled servers in a cluster to share the load of cryptography between them.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/ledger-history/ledger-history.md
         html: ledger-history.html
@@ -614,7 +614,7 @@ pages:
         subcategory: Ledger History
         blurb: rippled servers store a variable amount of transaction and state history locally.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/ledger-history/online-deletion.md
         html: online-deletion.html
@@ -624,7 +624,7 @@ pages:
         subcategory: Ledger History
         blurb: Online deletion purges outdated transaction and state history.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/ledger-history/history-sharding.md
         html: history-sharding.html
@@ -634,7 +634,7 @@ pages:
         subcategory: Ledger History
         blurb: History sharding divides the work of keeping historical ledger data among rippled servers.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/peer-protocol.md
         html: peer-protocol.html
@@ -643,7 +643,7 @@ pages:
         category: The rippled Server
         blurb: The peer protocol specifies the language rippled servers speak to each other.
         targets:
-            - local
+            - en
 
     -   md: concepts/the-rippled-server/transaction-censorship-detection.md
         html: transaction-censorship-detection.html
@@ -652,7 +652,7 @@ pages:
         category: The rippled Server
         blurb: XRP Ledger provides an automated transaction censorship detector that is available on all rippled servers.
         targets:
-            - local
+            - en
 
 # Tutorials --------------------------------------------------------------------
 
@@ -663,7 +663,7 @@ pages:
         template: template-landing-children.html
         blurb: Get step-by-step guidance to perform common tasks with the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   name: Get Started
         html: get-started.html
@@ -673,7 +673,7 @@ pages:
         template: template-landing-children.html
         blurb: Get up and running with some of the resources you'll use to work with the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: tutorials/get-started/get-started-with-the-rippled-api.md
         html: get-started-with-the-rippled-api.html
@@ -682,7 +682,7 @@ pages:
         category: Get Started
         blurb: Connect to the rippled API and get data about the shared ledger state.
         targets:
-            - local
+            - en
 
     -   md: tutorials/get-started/set-up-secure-signing.md
         html: set-up-secure-signing.html
@@ -691,7 +691,7 @@ pages:
         category: Get Started
         blurb: Set up an environment where you can submit transactions securely.
         targets:
-            - local
+            - en
 
     # TODO: Send a Transaction with the rippled API
 
@@ -702,7 +702,7 @@ pages:
         category: Get Started
         blurb: Build an entry-level JavaScript application for querying the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: tutorials/get-started/look-up-transaction-results.md
         html: look-up-transaction-results.html
@@ -711,7 +711,7 @@ pages:
         category: Get Started
         blurb: Find the results of previously-submitted transactions.
         targets:
-          - local
+          - en
 
     -   md: tutorials/get-started/monitor-incoming-payments-with-websocket.md
         html: monitor-incoming-payments-with-websocket.html
@@ -722,7 +722,7 @@ pages:
         filters:
             - interactive_steps
         targets:
-            - local
+            - en
 
     # TODO: Get Started with API Tools
 
@@ -734,7 +734,7 @@ pages:
         template: template-landing-children.html
         blurb: Direct XRP payments from one account to another are the simplest way to transact in the XRP Ledger. This section includes tutorials for how to use simple transactions proficiently and robustly.
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-simple-xrp-payments/send-xrp.md
         html: send-xrp.html
@@ -745,7 +745,7 @@ pages:
         filters:
             - interactive_steps
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-simple-xrp-payments/reliable-transaction-submission.md
         html: reliable-transaction-submission.html
@@ -754,7 +754,7 @@ pages:
         category: Use Simple XRP Payments
         blurb: Build a system that can submit transactions to the XRP Ledger and get their final results safely and quickly.
         targets:
-            - local
+            - en
 
         # Redirect for this page's new home outside of tutorials
     -   name: Cancel or Skip a Transaction
@@ -766,7 +766,7 @@ pages:
         redirect_url: about-canceling-a-transaction.html
         blurb: Replace a pending transaction if it gets stuck from paying too low a transaction cost.
         targets:
-          - local
+          - en
 
     -   name: Manage Account Settings
         html: manage-account-settings.html
@@ -776,7 +776,7 @@ pages:
         template: template-landing-children.html
         blurb: Set up your XRP Ledger account to send and receive payments the way you want it to.
         targets:
-            - local
+            - en
 
     # TODO: "Get an Account" (DOC-1554)
     # blurb: Learn how to generate and fund an XRP Ledger address to create an XRP Ledger account.
@@ -788,7 +788,7 @@ pages:
         category: Manage Account Settings
         blurb: Authorize a second key pair to sign transactions from your account. This key pair can be changed or removed later.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-account-settings/change-or-remove-a-regular-key-pair.md
         html: change-or-remove-a-regular-key-pair.html
@@ -797,7 +797,7 @@ pages:
         category: Manage Account Settings
         blurb: Remove or update a regular key pair already authorized by your account.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-account-settings/set-up-multi-signing.md
         html: set-up-multi-signing.html
@@ -806,7 +806,7 @@ pages:
         category: Manage Account Settings
         blurb: Add a signer list to your account to enable multi-signing.
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-simple-xrp-payments/send-a-multi-signed-transaction.md
         html: send-a-multi-signed-transaction.html
@@ -815,7 +815,7 @@ pages:
         category: Manage Account Settings
         blurb: Send a transaction authorized with multiple signatures.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-account-settings/require-destination-tags.md
         html: require-destination-tags.html
@@ -824,7 +824,7 @@ pages:
         category: Manage Account Settings
         blurb: Require users to specify a destination tag when sending to your address.
         targets:
-            - local
+            - en
 
     # TODO: "Use Deposit Authorization to Block Unwanted Payments" (DOC-1555)
 
@@ -836,7 +836,7 @@ pages:
         template: template-landing-children.html
         blurb: Use advanced features like Escrow and Payment Channels to build smart applications on the XRP Ledger.
         targets:
-            - local
+            - en
 
         # Redirect from old "complex" payment types URL
     -   name: Use Complex Payment Types
@@ -847,7 +847,7 @@ pages:
         template: template-redirect.html
         redirect_url: use-specialized-payment-types.html
         targets:
-            - local
+            - en
 
     -   name: Use Escrows
         html: use-escrows.html
@@ -858,7 +858,7 @@ pages:
         blurb: The XRP Ledger supports held payments, or escrows, that can be executed only after a certain time has passed or a cryptographic condition has been fulfilled. Escrows can only send XRP, not issued currencies. You can use these features to build publicly-provable smart contracts. This sections explains basic tasks relating to held payments.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-escrows/send-a-time-held-escrow.md
         html: send-a-time-held-escrow.html
@@ -868,7 +868,7 @@ pages:
         subcategory: Use Escrows
         blurb: Create an escrow whose only condition for release is that a specific time has passed.
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-escrows/send-a-conditionally-held-escrow.md
         html: send-a-conditionally-held-escrow.html
@@ -878,7 +878,7 @@ pages:
         subcategory: Use Escrows
         blurb: Create an escrow whose release is based on a condition being fulfilled.
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-escrows/cancel-an-expired-escrow.md
         html: cancel-an-expired-escrow.html
@@ -888,7 +888,7 @@ pages:
         subcategory: Use Escrows
         blurb: Cancel an expired escrow.
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-escrows/look-up-escrows.md
         html: look-up-escrows.html
@@ -898,7 +898,7 @@ pages:
         subcategory: Use Escrows
         blurb: Look up pending escrows by sender or destination address.
         targets:
-            - local
+            - en
 
     #TODO: split concept info off of the paychan tutorial
     -   md: tutorials/use-complex-payment-types/use-payment-channels.md
@@ -908,7 +908,7 @@ pages:
         category: Use Specialized Payment Types
         blurb: Payment Channels are an advanced feature for sending "asynchronous" XRP payments that can be divided into very small increments and settled later. This tutorial walks through the entire process of using a payment channel, with examples using the JSON-RPC API of a local rippled server.
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/use-checks.md
         html: use-checks.html
@@ -920,7 +920,7 @@ pages:
         status: not_enabled
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/send-a-check.md
         html: send-a-check.html
@@ -930,7 +930,7 @@ pages:
         subcategory: Use Checks
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/cash-a-check-for-an-exact-amount.md
         html: cash-a-check-for-an-exact-amount.html
@@ -940,7 +940,7 @@ pages:
         subcategory: Use Checks
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/cash-a-check-for-a-flexible-amount.md
         html: cash-a-check-for-a-flexible-amount.html
@@ -950,7 +950,7 @@ pages:
         subcategory: Use Checks
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/cancel-a-check.md
         html: cancel-a-check.html
@@ -960,7 +960,7 @@ pages:
         subcategory: Use Checks
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/look-up-checks-by-sender.md
         html: look-up-checks-by-sender.html
@@ -970,7 +970,7 @@ pages:
         subcategory: Use Checks
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: tutorials/use-complex-payment-types/use-checks/look-up-checks-by-recipient.md
         html: look-up-checks-by-recipient.html
@@ -980,7 +980,7 @@ pages:
         subcategory: Use Checks
         status: not_enabled
         targets:
-            - local
+            - en
 
     # TODO: "Send a Cross-Currency Payment"
 
@@ -993,7 +993,7 @@ pages:
     #     blurb: Use issued currencies for cross-currency payments, trading in the decentralized exchange, or as natively digital tokens.
     #     template: template-landing-children.html
     #     targets:
-    #         - local
+    #         - en
 
     # TODO: Set up issuing/operational addresses, monitor changes to balances,
     # freeze, enable/disable rippling, set transfer fees, use auth'd trust lines
@@ -1006,7 +1006,7 @@ pages:
         blurb: This section demonstrates how to follow various best practices for running businesses that interface with the XRP Ledger, such as exchanges listing XRP and gateways issuing currency in the XRP Ledger.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: tutorials/xrp-ledger-businesses/list-xrp-as-an-exchange.md
         html: list-xrp-as-an-exchange.html
@@ -1015,7 +1015,7 @@ pages:
         category: XRP Ledger Businesses
         blurb: Using a fictitious business called Alpha Exchange, this tutorial demonstrates the high-level steps required to list XRP.
         targets:
-            - local
+            - en
 
     -   md: tutorials/xrp-ledger-businesses/list-your-exchange-on-xrp-charts.md
         html: list-your-exchange-on-xrp-charts.html
@@ -1024,7 +1024,7 @@ pages:
         category: XRP Ledger Businesses
         blurb: This tutorial describes how to have your exchange and its XRP trade and order book data listed on XRP Charts.
         targets:
-            - local
+            - en
 
     -   md: tutorials/xrp-ledger-businesses/become-an-xrp-ledger-gateway.md
         html: become-an-xrp-ledger-gateway.html
@@ -1033,7 +1033,7 @@ pages:
         category: XRP Ledger Businesses
         blurb: Gateways are the businesses that link the XRP Ledger to the rest of the world. This tutorial demonstrates how an existing online financial institution can expand to act as a gateway in the the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   name: Manage the rippled Server
         html: manage-the-rippled-server.html
@@ -1043,7 +1043,7 @@ pages:
         blurb: A system admin's guide to setting up and maintaining the rippled server.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   name: Install rippled
         html: install-rippled.html
@@ -1054,7 +1054,7 @@ pages:
         blurb: Set up and update the rippled server.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/system-requirements.md
         html: system-requirements.html
@@ -1064,7 +1064,7 @@ pages:
         subcategory: Installation
         blurb: Hardware and software requirements for running rippled.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
         html: install-rippled-on-centos-rhel-with-yum.html
@@ -1074,7 +1074,7 @@ pages:
         subcategory: Installation
         blurb: Install a precompiled rippled binary on CentOS or Red Hat Enterprise Linux.
         targets:
-            - local
+            - en
 
     # Redirect old Alien-based install
     -   name: Install rippled on Ubuntu with Alien
@@ -1086,7 +1086,7 @@ pages:
         category: Manage the rippled Server
         subcategory: Installation
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
         html: install-rippled-on-ubuntu.html
@@ -1096,7 +1096,7 @@ pages:
         subcategory: Installation
         blurb: Install a precompiled rippled binary on Ubuntu Linux.
         targets:
-            - local
+            - en
 
     -   name: Update rippled Automatically on CentOS/RHEL
         html: update-rippled-automatically-on-centos-rhel.html
@@ -1107,7 +1107,7 @@ pages:
         category: Manage the rippled Server
         subcategory: Installation
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/update-rippled-automatically-on-linux.md
         html: update-rippled-automatically-on-linux.html
@@ -1117,7 +1117,7 @@ pages:
         subcategory: Installation
         blurb: Set up automatic updates for rippled on Linux.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
         html: update-rippled-manually-on-centos-rhel.html
@@ -1127,7 +1127,7 @@ pages:
         subcategory: Installation
         blurb: Manually update rippled on CentOS or Red Hat Enterprise Linux.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
         html: update-rippled-manually-on-ubuntu.html
@@ -1137,7 +1137,7 @@ pages:
         subcategory: Installation
         blurb: Manually update rippled on Ubuntu Linux.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
         html: build-run-rippled-ubuntu.html
@@ -1147,7 +1147,7 @@ pages:
         subcategory: Installation
         blurb: Compile rippled yourself on Ubuntu Linux.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
         html: build-run-rippled-macos.html
@@ -1157,7 +1157,7 @@ pages:
         subcategory: Installation
         blurb: Compile rippled yourself on macOS.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/capacity-planning.md
         html: capacity-planning.html
@@ -1167,7 +1167,7 @@ pages:
         subcategory: Installation
         blurb: Plan system specs and tune configuration for rippled in production environments.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/installation/rippled-1-3-migration-instructions.md
         html: rippled-1-3-migration-instructions.html
@@ -1177,7 +1177,7 @@ pages:
         subcategory: Installation
         blurb: Use these instructions to upgrade rippled packages from 1.2.x or below to 1.3.x or higher.
         targets:
-            - local
+            - en
 
     -   name: Configure rippled
         html: configure-rippled.html
@@ -1188,7 +1188,7 @@ pages:
         blurb: Customize your rippled server configuration.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
         html: run-rippled-as-a-validator.html
@@ -1198,7 +1198,7 @@ pages:
         subcategory: Configuration
         blurb: Have your server vote on the consensus ledger.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
         html: connect-your-rippled-to-the-xrp-test-net.html
@@ -1208,7 +1208,7 @@ pages:
         subcategory: Configuration
         blurb: Connect your rippled server to the test net to try out new features or test functionality with fake money.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/cluster-rippled-servers.md
         html: cluster-rippled-servers.html
@@ -1218,7 +1218,7 @@ pages:
         subcategory: Configuration
         blurb: Set up a group of servers that share work for higher efficiency.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/configure-online-deletion.md
         html: configure-online-deletion.html
@@ -1228,7 +1228,7 @@ pages:
         subcategory: Configuration
         blurb: Configure how far back your server should store transaction history.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/configure-advisory-deletion.md
         html: configure-advisory-deletion.html
@@ -1238,7 +1238,7 @@ pages:
         subcategory: Configuration
         blurb: Use advisory deletion to delete older ledger history on a schedule rather than as new history becomes available.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/configure-history-sharding.md
         html: configure-history-sharding.html
@@ -1248,7 +1248,7 @@ pages:
         subcategory: Configuration
         blurb: Set up a server to contribute to preserving shards of historical XRP Ledger data.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/configure-full-history.md
         html: configure-full-history.html
@@ -1258,7 +1258,7 @@ pages:
         subcategory: Configuration
         blurb: Full history servers provide a record of every transaction ever to occur in the XRP Ledger, although they are expensive to run.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/configure-the-peer-crawler.md
         html: configure-the-peer-crawler.html
@@ -1268,7 +1268,7 @@ pages:
         subcategory: Configuration
         blurb: Configure how much information your server reports publicly about its status and peers.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/configuration/enable-public-signing.md
         html: enable-public-signing.html
@@ -1278,7 +1278,7 @@ pages:
         subcategory: Configuration
         blurb: Allow others to use your server to sign transactions. (Not recommended)
         targets:
-            - local
+            - en
 
     -   name: Test rippled Functionality in Stand-Alone Mode
         html: use-stand-alone-mode.html
@@ -1289,7 +1289,7 @@ pages:
         blurb: For new features and experiments, you can use Stand-Alone Mode to test features with a full network.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
 
     -   md: tutorials/manage-the-rippled-server/stand-alone-mode/start-a-new-genesis-ledger-in-stand-alone-mode.md
@@ -1300,7 +1300,7 @@ pages:
         subcategory: Stand-Alone Mode
         blurb: Start from a fresh genesis ledger in stand-alone mode.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/stand-alone-mode/load-a-saved-ledger-in-stand-alone-mode.md
         html: load-a-saved-ledger-in-stand-alone-mode.html
@@ -1310,7 +1310,7 @@ pages:
         subcategory: Stand-Alone Mode
         blurb: Start in stand-alone mode from a specific saved ledger to test or replay transactions.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/stand-alone-mode/advance-the-ledger-in-stand-alone-mode.md
         html: advance-the-ledger-in-stand-alone-mode.html
@@ -1320,7 +1320,7 @@ pages:
         subcategory: Stand-Alone Mode
         blurb: Make progress in stand-alone mode by manually closing the ledger.
         targets:
-            - local
+            - en
 
 
     -   name: Troubleshooting rippled
@@ -1332,7 +1332,7 @@ pages:
         blurb: Troubleshoot all kinds of problems with the rippled server.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/troubleshooting/diagnosing-problems.md
         html: diagnosing-problems.html
@@ -1342,7 +1342,7 @@ pages:
         subcategory: Troubleshooting rippled
         blurb: Collect information to identify the cause of problems.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/troubleshooting/understanding-log-messages.md
         html: understanding-log-messages.html
@@ -1352,7 +1352,7 @@ pages:
         subcategory: Troubleshooting rippled
         blurb: Interpret and respond to warning and error messages in the debug log.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/troubleshooting/server-wont-start.md
         html: server-wont-start.html
@@ -1362,7 +1362,7 @@ pages:
         subcategory: Troubleshooting rippled
         blurb: A collection of problems that would cause a rippled server not to start, and how to fix them.
         targets:
-            - local
+            - en
 
     -   md: tutorials/manage-the-rippled-server/troubleshooting/fix-sqlite-tx-db-page-size-issue.md
         html: fix-sqlite-tx-db-page-size-issue.html
@@ -1371,7 +1371,7 @@ pages:
         category: Manage the rippled Server
         subcategory: Troubleshooting rippled
         targets:
-            - local
+            - en
 
 # References -------------------------------------------------------------------
 
@@ -1383,7 +1383,7 @@ pages:
         sidebar: disabled
         blurb: Complete references for different interfaces to the XRP Ledger.
         targets:
-            - local
+            - en
 
     # rippled API --------------------------------------------------------------
 
@@ -1395,7 +1395,7 @@ pages:
         template: template-landing-children.html
         blurb: Communicate directly with rippled, the core peer-to-peer server that manages the XRP Ledger.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/api-conventions.md
         html: api-conventions.html
@@ -1406,7 +1406,7 @@ pages:
         category: API Conventions
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/basic-data-types.md
         html: basic-data-types.html
@@ -1416,7 +1416,7 @@ pages:
         category: API Conventions
         blurb: Format and meaning of fundamental data types like addresses, ledger index, and currency codes.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/base58-encodings.md
         html: base58-encodings.html
@@ -1426,7 +1426,7 @@ pages:
         category: API Conventions
         blurb: Formats for representing cryptographic keys and related data in base58 format.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/currency-formats.md
         html: currency-formats.html
@@ -1436,7 +1436,7 @@ pages:
         category: API Conventions
         blurb: Precision and range for currency numbers, plus formats of custom currency codes.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/error-formatting.md
         html: error-formatting.html
@@ -1446,7 +1446,7 @@ pages:
         category: API Conventions
         blurb: Error formats and common error codes for WebSocket, JSON-RPC, and Commandline interfaces.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/markers-and-pagination.md
         html: markers-and-pagination.html
@@ -1456,7 +1456,7 @@ pages:
         category: API Conventions
         blurb: Convention for paginating large queries into multiple responses.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/modifying-the-ledger.md
         html: modifying-the-ledger.html
@@ -1466,7 +1466,7 @@ pages:
         category: API Conventions
         blurb: Why and how only transactions can modify the ledger.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/request-formatting.md
         html: request-formatting.html
@@ -1476,7 +1476,7 @@ pages:
         category: API Conventions
         blurb: Standard request format, with examples, for the WebSocket, JSON-RPC, and Commandline interfaces.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/response-formatting.md
         html: response-formatting.html
@@ -1486,7 +1486,7 @@ pages:
         category: API Conventions
         blurb: Standard response format, with examples, for the WebSocket, JSON-RPC, and Commandline interfaces.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/rippled-server-states.md
         html: rippled-server-states.html
@@ -1496,7 +1496,7 @@ pages:
         category: API Conventions
         blurb: Definitions of state information reported in some API methods.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/api-conventions/serialization.md
         html: serialization.html
@@ -1506,7 +1506,7 @@ pages:
         category: API Conventions
         blurb: Conversion between JSON and canonical binary format for XRP Ledger transactions and other objects.
         targets:
-            - local
+            - en
 
 # rippled Public Methods
 
@@ -1518,7 +1518,7 @@ pages:
         category: Public rippled Methods
         blurb: Get data from the XRP Ledger and submit transactions using these public API methods.
         targets:
-            - local
+            - en
 
     -   name: Account Methods
         html: account-methods.html
@@ -1530,7 +1530,7 @@ pages:
         template: template-landing-children.html
         blurb: An account in the XRP Ledger represents a holder of XRP and a sender of transactions. Use these methods to work with account info.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_channels.md
         html: account_channels.html
@@ -1541,7 +1541,7 @@ pages:
         subcategory: Account Methods
         blurb: Get a list of payment channels where the account is the source of the channel.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
         html: account_currencies.html
@@ -1552,7 +1552,7 @@ pages:
         subcategory: Account Methods
         blurb: Get a list of currencies an account can send or receive.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_info.md
         html: account_info.html
@@ -1563,7 +1563,7 @@ pages:
         subcategory: Account Methods
         blurb: Get basic data about an account.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_lines.md
         html: account_lines.html
@@ -1574,7 +1574,7 @@ pages:
         subcategory: Account Methods
         blurb: Get info about an account's trust lines.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_objects.md
         html: account_objects.html
@@ -1585,7 +1585,7 @@ pages:
         subcategory: Account Methods
         blurb: Get all ledger objects owned by an account.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_offers.md
         html: account_offers.html
@@ -1596,7 +1596,7 @@ pages:
         subcategory: Account Methods
         blurb: Get info about an account's currency exchange offers.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/account_tx.md
         html: account_tx.html
@@ -1607,7 +1607,7 @@ pages:
         subcategory: Account Methods
         blurb: Get info about an account's transactions.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/gateway_balances.md
         html: gateway_balances.html
@@ -1618,7 +1618,7 @@ pages:
         subcategory: Account Methods
         blurb: Calculate total amounts issued by an account.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/account-methods/noripple_check.md
         html: noripple_check.html
@@ -1629,7 +1629,7 @@ pages:
         subcategory: Account Methods
         blurb: Get recommended changes to an account's DefaultRipple and NoRipple settings.
         targets:
-            - local
+            - en
 
     -   name: Ledger Methods
         html: ledger-methods.html
@@ -1641,7 +1641,7 @@ pages:
         blurb: A ledger version contains a header, a transaction tree, and a state tree, which contain account settings, trustlines, balances, transactions, and other data. Use these methods to retrieve ledger info.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/ledger-methods/ledger.md
         html: ledger.html # Watch carefully for clashes w/ this filename
@@ -1652,7 +1652,7 @@ pages:
         subcategory: Ledger Methods
         blurb: Get info about a ledger version.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/ledger-methods/ledger_closed.md
         html: ledger_closed.html
@@ -1663,7 +1663,7 @@ pages:
         subcategory: Ledger Methods
         blurb: Get the latest closed ledger version.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/ledger-methods/ledger_current.md
         html: ledger_current.html
@@ -1674,7 +1674,7 @@ pages:
         subcategory: Ledger Methods
         blurb: Get the current working ledger version.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/ledger-methods/ledger_data.md
         html: ledger_data.html
@@ -1685,7 +1685,7 @@ pages:
         subcategory: Ledger Methods
         blurb: Get the raw contents of a ledger version.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
         html: ledger_entry.html
@@ -1696,7 +1696,7 @@ pages:
         subcategory: Ledger Methods
         blurb: Get one element from a ledger version.
         targets:
-            - local
+            - en
 
     -   name: Transaction Methods
         html: transaction-methods.html # watch for clashes w/ this filename
@@ -1708,7 +1708,7 @@ pages:
         template: template-landing-children.html
         blurb: Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions. Use these methods to work with transactions.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign.md
         html: sign.html # watch for clashes w/ this filename
@@ -1719,7 +1719,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Cryptographically sign a transaction.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign_for.md
         html: sign_for.html
@@ -1730,7 +1730,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Contribute to a multi-signature.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/submit.md
         html: submit.html
@@ -1741,7 +1741,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Send a transaction to the network.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/submit_multisigned.md
         html: submit_multisigned.html
@@ -1752,7 +1752,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Send a multi-signed transaction to the network.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/transaction_entry.md
         html: transaction_entry.html
@@ -1763,7 +1763,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Retrieve info about a transaction from a particular ledger version.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/tx.md
         html: tx.html
@@ -1774,7 +1774,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Retrieve info about a transaction from all the ledgers on hand.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/tx_history.md
         html: tx_history.html
@@ -1785,7 +1785,7 @@ pages:
         subcategory: Transaction Methods
         blurb: Retrieve info about all recent transactions.
         targets:
-            - local
+            - en
 
     -   name: Path and Order Book Methods
         html: path-and-order-book-methods.html
@@ -1797,7 +1797,7 @@ pages:
         blurb: Paths define a way for payments to flow through intermediary steps on their way from sender to receiver. Paths enable cross-currency payments by connecting sender and receiver through order books. Use these methods to work with paths and other books.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
         html: book_offers.html
@@ -1808,7 +1808,7 @@ pages:
         subcategory: Path and Order Book Methods
         blurb: Get info about offers to exchange two currencies.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/path-and-order-book-methods/deposit_authorized.md
         html: deposit_authorized.html
@@ -1819,7 +1819,7 @@ pages:
         subcategory: Path and Order Book Methods
         blurb: Check whether an account is authorized to send money directly to another.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/path-and-order-book-methods/path_find.md
         html: path_find.html
@@ -1830,7 +1830,7 @@ pages:
         subcategory: Path and Order Book Methods
         blurb: Find a path for a payment between two accounts and receive updates.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/path-and-order-book-methods/ripple_path_find.md
         html: ripple_path_find.html
@@ -1841,7 +1841,7 @@ pages:
         subcategory: Path and Order Book Methods
         blurb: Find a path for payment between two accounts, once.
         targets:
-            - local
+            - en
 
     -   name: Payment Channel Methods
         html: payment-channel-methods.html
@@ -1853,7 +1853,7 @@ pages:
         blurb: Payment channels are a tool for facilitating repeated, unidirectional payments, or temporary credit between two parties. Use these methods to work with payment channels.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/payment-channel-methods/channel_authorize.md
         html: channel_authorize.html
@@ -1864,7 +1864,7 @@ pages:
         subcategory: Payment Channel Methods
         blurb: Sign a claim for money from a payment channel.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/payment-channel-methods/channel_verify.md
         html: channel_verify.html
@@ -1875,7 +1875,7 @@ pages:
         subcategory: Payment Channel Methods
         blurb: Check a payment channel claim's signature.
         targets:
-            - local
+            - en
 
     -   name: Subscription Methods
         html: subscription-methods.html
@@ -1887,7 +1887,7 @@ pages:
         blurb: Use these methods to enable the server to push updates to your client when various events happen, so that you can know and react right away. WebSocket API only.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
         html: subscribe.html
@@ -1898,7 +1898,7 @@ pages:
         subcategory: Subscription Methods
         blurb: Listen for updates about a particular subject.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/subscription-methods/unsubscribe.md
         html: unsubscribe.html
@@ -1909,7 +1909,7 @@ pages:
         subcategory: Subscription Methods
         blurb: Stop listening for updates about a particular subject.
         targets:
-            - local
+            - en
 
     -   name: Server Info Methods
         html: server-info-methods.html
@@ -1921,7 +1921,7 @@ pages:
         blurb: Use these methods to retrieve information about the current state of the rippled server.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/server-info-methods/fee.md
         html: fee.html
@@ -1932,7 +1932,7 @@ pages:
         subcategory: Server Info Methods
         blurb: Get information about transaction cost.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
         html: server_info.html
@@ -1943,7 +1943,7 @@ pages:
         subcategory: Server Info Methods
         blurb: Retrieve status of the server in human-readable format.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/server-info-methods/server_state.md
         html: server_state.html
@@ -1954,7 +1954,7 @@ pages:
         subcategory: Server Info Methods
         blurb: Retrieve status of the server in machine-readable format.
         targets:
-            - local
+            - en
 
     -   name: Utility Methods
         html: utility-methods.html
@@ -1966,7 +1966,7 @@ pages:
         blurb: Use these methods to perform convenient tasks, such as ping and random number generation.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/utility-methods/json.md
         html: json.html
@@ -1977,7 +1977,7 @@ pages:
         subcategory: Utility Methods
         blurb: Pass JSON through the commandline.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/utility-methods/ping.md
         html: ping.html
@@ -1988,7 +1988,7 @@ pages:
         subcategory: Utility Methods
         blurb: Confirm connectivity with the server.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/public-rippled-methods/utility-methods/random.md
         html: random.html
@@ -1999,7 +1999,7 @@ pages:
         subcategory: Utility Methods
         blurb: Generate a random number.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/admin-rippled-methods/admin-rippled-methods.md
         html: admin-rippled-methods.html
@@ -2009,7 +2009,7 @@ pages:
         category: Admin rippled Methods
         blurb: Administer a rippled server with these admin API methods.
         targets:
-            - local
+            - en
 
     -   name: Key Generation Methods
         html: key-generation-methods.html
@@ -2021,7 +2021,7 @@ pages:
         subcategory: Key Generation Methods
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/admin-rippled-methods/key-generation-methods/validation_create.md
         html: validation_create.html
@@ -2032,7 +2032,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Key Generation Methods
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/admin-rippled-methods/key-generation-methods/wallet_propose.md
         html: wallet_propose.html
@@ -2043,7 +2043,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Key Generation Methods
         targets:
-          - local
+          - en
 
     -   name: Logging and Data Management Methods
         html: logging-and-data-management-methods.html
@@ -2055,7 +2055,7 @@ pages:
         subcategory: Logging and Data Management Methods
         template: template-landing-children.html
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/can_delete.md
         html: can_delete.html
@@ -2066,7 +2066,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/crawl_shards.md
         html: crawl_shards.html
@@ -2077,7 +2077,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/download_shard.md
         html: download_shard.html
@@ -2088,7 +2088,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_cleaner.md
         html: ledger_cleaner.html
@@ -2099,7 +2099,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_request.md
         html: ledger_request.html
@@ -2110,7 +2110,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/log_level.md
         html: log_level.html
@@ -2121,7 +2121,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/logrotate.md
         html: logrotate.html
@@ -2132,7 +2132,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Logging and Data Management Methods
         targets:
-          - local
+          - en
 
     -   name: Server Control Methods
         html: server-control-methods.html
@@ -2144,7 +2144,7 @@ pages:
         subcategory: Server Control Methods
         template: template-landing-children.html
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/server-control-methods/connect.md
         html: connect.html
@@ -2155,7 +2155,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Server Control Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/server-control-methods/ledger_accept.md
         html: ledger_accept.html
@@ -2166,7 +2166,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Server Control Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/server-control-methods/stop.md
         html: stop.html
@@ -2177,7 +2177,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Server Control Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/server-control-methods/validation_seed.md
         html: validation_seed.html
@@ -2188,7 +2188,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Server Control Methods
         targets:
-          - local
+          - en
 
     -   name: Status and Debugging Methods
         html: status-and-debugging-methods.html
@@ -2200,7 +2200,7 @@ pages:
         subcategory: Status and Debugging Methods
         template: template-landing-children.html
         targets:
-          - local
+          - en
 
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/consensus_info.md
@@ -2212,7 +2212,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/feature.md
         html: feature.html
@@ -2223,7 +2223,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/fetch_info.md
         html: fetch_info.html
@@ -2234,7 +2234,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/get_counts.md
         html: get_counts.html
@@ -2245,7 +2245,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/peers.md
         html: peers.html
@@ -2256,7 +2256,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/print.md
         html: print.html
@@ -2267,7 +2267,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validator_list_sites.md
         html: validator_list_sites.html
@@ -2278,7 +2278,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   md: references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validators.md
         html: validators.html
@@ -2289,7 +2289,7 @@ pages:
         category: Admin rippled Methods
         subcategory: Status and Debugging Methods
         targets:
-          - local
+          - en
 
     -   name: Ledger Data Formats
         html: ledger-data-formats.html
@@ -2300,7 +2300,7 @@ pages:
         blurb: Learn about individual data objects that comprise the XRP Ledger's shared state.
         template: template-landing-children.html #TODO: consider using the default template instead for page sidebar?
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-header.md
         html: ledger-header.html
@@ -2310,7 +2310,7 @@ pages:
         category: Ledger Data Formats
         blurb: A unique header that describes the contents of a ledger version.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-ids.md
         html: ledger-object-ids.html
@@ -2320,7 +2320,7 @@ pages:
         category: Ledger Data Formats
         blurb: All objects in a ledger's state tree have a unique ID.
         targets:
-            - local
+            - en
 
     -   name: Ledger Object Types
         html: ledger-object-types.html
@@ -2332,7 +2332,7 @@ pages:
         template: template-landing-children.html
         blurb: Each ledger's state tree consists of a set of ledger objects, which collectively represent all settings, balances, and relationships in the shared ledger. In the peer protocol that rippled servers use to communicate with each other, ledger objects are represented in their raw binary format. In the rippled API, ledger objects are represented as JSON objects.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/accountroot.md
         html: accountroot.html
@@ -2343,7 +2343,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: The settings, XRP balance, and other metadata for one account.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/amendments.md
         html: amendments-object.html #amendments.html is taken by the concept page
@@ -2354,7 +2354,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: Singleton object with status of enabled and pending amendments.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/check.md
         html: check.html
@@ -2366,7 +2366,7 @@ pages:
         blurb: A check that can be redeemed for money by its destination.
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/depositpreauth.md
         html: depositpreauth-object.html #depositpreauth.html is taken by the tx type
@@ -2377,7 +2377,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: A record of preauthorization for sending payments to an account that requires authorization.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/directorynode.md
         html: directorynode.html
@@ -2388,7 +2388,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: Contains links to other objects.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/escrow.md
         html: escrow-object.html #escrow.html is taken by the concept page
@@ -2399,7 +2399,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: Contains XRP held for a conditional payment.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/feesettings.md
         html: feesettings.html
@@ -2410,7 +2410,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: Singleton object with consensus-approved base transaction cost and reserve requirements.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/ledgerhashes.md
         html: ledgerhashes.html
@@ -2421,7 +2421,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: Lists of prior ledger versions' hashes for history lookup.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/offer.md
         html: offer.html
@@ -2432,7 +2432,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: An order to make a currency trade.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/paychannel.md
         html: paychannel.html
@@ -2443,7 +2443,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: A channel for asynchronous XRP payments.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/ripplestate.md
         html: ripplestate.html
@@ -2454,7 +2454,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: Links two accounts, tracking the balance of one currency between them. The concept of a trust line is an abstraction of this object type.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/ledger-data-formats/ledger-object-types/signerlist.md
         html: signerlist.html
@@ -2465,7 +2465,7 @@ pages:
         subcategory: Ledger Object Types
         blurb: A list of addresses for multi-signing transactions.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-formats.md
         html: transaction-formats.html
@@ -2476,7 +2476,7 @@ pages:
         blurb: Transactions are the only way to modify the XRP Ledger. Get details about their required format.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-common-fields.md
         html: transaction-common-fields.html
@@ -2486,7 +2486,7 @@ pages:
         category: Transaction Formats
         blurb: These common fields can be provided on any XRP Ledger transaction.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/transaction-types.md
         html: transaction-types.html
@@ -2498,7 +2498,7 @@ pages:
         blurb: All the different types of transactions that the XRP Ledger can process.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/accountset.md
         html: accountset.html
@@ -2509,7 +2509,7 @@ pages:
         subcategory: Transaction Types
         blurb: Set options on an account.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/checkcancel.md
         html: checkcancel.html
@@ -2521,7 +2521,7 @@ pages:
         blurb: Cancel a check.
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/checkcash.md
         html: checkcash.html
@@ -2533,7 +2533,7 @@ pages:
         blurb: Redeem a check.
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/checkcreate.md
         html: checkcreate.html
@@ -2545,7 +2545,7 @@ pages:
         blurb: Create a check.
         status: not_enabled
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/depositpreauth.md
         html: depositpreauth.html
@@ -2556,7 +2556,7 @@ pages:
         subcategory: Transaction Types
         blurb: Preauthorizes an account to send payments to this one.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/escrowcancel.md
         html: escrowcancel.html
@@ -2567,7 +2567,7 @@ pages:
         subcategory: Transaction Types
         blurb: Reclaim escrowed XRP.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
         html: escrowcreate.html
@@ -2578,7 +2578,7 @@ pages:
         subcategory: Transaction Types
         blurb:  Create an escrowed XRP payment.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/escrowfinish.md
         html: escrowfinish.html
@@ -2589,7 +2589,7 @@ pages:
         subcategory: Transaction Types
         blurb: Deliver escrowed XRP to recipient.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/offercancel.md
         html: offercancel.html
@@ -2600,7 +2600,7 @@ pages:
         subcategory: Transaction Types
         blurb: Withdraw a currency-exchange order.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/offercreate.md
         html: offercreate.html
@@ -2611,7 +2611,7 @@ pages:
         subcategory: Transaction Types
         blurb: Submit an order to exchange currency.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/payment.md
         html: payment.html
@@ -2622,7 +2622,7 @@ pages:
         subcategory: Transaction Types
         blurb: Send funds from one account to another.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/paymentchannelclaim.md
         html: paymentchannelclaim.html
@@ -2633,7 +2633,7 @@ pages:
         subcategory: Transaction Types
         blurb: Claim money from a payment channel.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/paymentchannelcreate.md
         html: paymentchannelcreate.html
@@ -2644,7 +2644,7 @@ pages:
         subcategory: Transaction Types
         blurb: Open a new payment channel.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.md
         html: paymentchannelfund.html
@@ -2655,7 +2655,7 @@ pages:
         subcategory: Transaction Types
         blurb: Add more XRP to a payment channel.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/setregularkey.md
         html: setregularkey.html
@@ -2666,7 +2666,7 @@ pages:
         subcategory: Transaction Types
         blurb: Add, remove, or modify an account's regular key pair.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/signerlistset.md
         html: signerlistset.html
@@ -2677,7 +2677,7 @@ pages:
         subcategory: Transaction Types
         blurb: Add, remove, or modify an account's multi-signing list.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/trustset.md
         html: trustset.html
@@ -2688,7 +2688,7 @@ pages:
         subcategory: Transaction Types
         blurb: Add or modify a trust line.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/pseudo-transaction-types/pseudo-transaction-types.md
         html: pseudo-transaction-types.html
@@ -2700,7 +2700,7 @@ pages:
         blurb: Formats of pseudo-transactions that validators sometimes apply to the XRP Ledger.
         template: template-landing-children.html
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/pseudo-transaction-types/enableamendment.md
         html: enableamendment.html
@@ -2711,7 +2711,7 @@ pages:
         subcategory: Pseudo-Transaction Types
         blurb: Enable a change in transaction processing.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/pseudo-transaction-types/setfee.md
         html: setfee.html
@@ -2722,7 +2722,7 @@ pages:
         subcategory: Pseudo-Transaction Types
         blurb: Change global reserve and transaction cost settings.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/transaction-results.md
         html: transaction-results.html
@@ -2733,7 +2733,7 @@ pages:
         subcategory: Transaction Results
         blurb: Learn how to interpret rippled server transaction results.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/tec-codes.md
         html: tec-codes.html
@@ -2744,7 +2744,7 @@ pages:
         subcategory: Transaction Results
         blurb: tec codes indicate that the transaction failed, but it was applied to a ledger to deduct the transaction cost.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/tef-codes.md
         html: tef-codes.html
@@ -2755,7 +2755,7 @@ pages:
         subcategory: Transaction Results
         blurb: tef codes indicate that the transaction failed and was not included in a ledger, but the transaction could have succeeded in some theoretical ledger.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/tel-codes.md
         html: tel-codes.html
@@ -2766,7 +2766,7 @@ pages:
         subcategory: Transaction Results
         blurb: tel codes indicate an error in the local server processing the transaction.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/tem-codes.md
         html: tem-codes.html
@@ -2777,7 +2777,7 @@ pages:
         subcategory: Transaction Results
         blurb: tem codes indicate that the transaction was malformed, and cannot succeed according to the XRP Ledger protocol.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/ter-codes.md
         html: ter-codes.html
@@ -2788,7 +2788,7 @@ pages:
         subcategory: Transaction Results
         blurb: ter codes indicate that the transaction failed, but it could apply successfully in the future, usually if some other hypothetical transaction applies first.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-results/tes-success.md
         html: tes-success.html
@@ -2799,7 +2799,7 @@ pages:
         subcategory: Transaction Results
         blurb: tesSUCCESS is the only code that indicates a transaction succeeded. This does not always mean it accomplished what you expected it to do.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/transaction-formats/transaction-metadata.md
         html: transaction-metadata.html
@@ -2809,7 +2809,7 @@ pages:
         category: Transaction Formats
         blurb: Transaction metadata describes the outcome of the transaction in detail, regardless of whether the transaction is successful.
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/commandline-usage.md
         html: commandline-usage.html
@@ -2830,7 +2830,7 @@ pages:
             - name: Unit Tests
               anchor: "#unit-tests"
         targets:
-            - local
+            - en
 
     -   md: references/rippled-api/peer-crawler.md
         html: peer-crawler.html
@@ -2840,7 +2840,7 @@ pages:
         category: Peer Crawler
         blurb: Special API method for sharing network topology and status metrics.
         targets:
-            - local
+            - en
 
     # XRP-API docs (auto-generated)---------------------------------------------
 
@@ -2851,7 +2851,7 @@ pages:
         doc_type: References
         supercategory: XRP-API
         targets:
-            - local
+            - en
             - xrp-api-only
 
         # API reference generator makes multiple files here
@@ -2862,7 +2862,7 @@ pages:
         doc_type: References
         supercategory: XRP-API
         targets:
-            - local
+            - en
             - xrp-api-only
 
 
@@ -2886,7 +2886,7 @@ pages:
             - remove_doctoc
             - add_version
         targets:
-            - local
+            - en
 
     -   md: references/data-api.md
         html: data-api.html
@@ -2900,7 +2900,7 @@ pages:
             - name: API Conventions
               anchor: "#api-conventions"
         targets:
-            - local
+            - en
             - data-api-only
 
     -   md: references/xrp-ledger-toml.md
@@ -2921,7 +2921,7 @@ pages:
             - name: Account Verification
               anchor: "#account-verification"
         targets:
-            - local
+            - en
 
 
 # --------------- end "Docs" section -------------------------------------------
@@ -2930,7 +2930,7 @@ pages:
         html: use-cases.html
         funnel: Use Cases
         targets:
-            - local
+            - en
 
     -   md: use-cases/run-a-rippled-validator.md
         html: run-a-rippled-validator.html
@@ -2944,7 +2944,7 @@ pages:
         filters:
             - use_case
         targets:
-            - local
+            - en
 
     -   md: use-cases/list-xrp-in-your-exchange.md
         html: list-xrp-in-your-exchange.html
@@ -2957,7 +2957,7 @@ pages:
         filters:
             - use_case
         targets:
-            - local
+            - en
 
     -   md: use-cases/open-a-payment-channel-to-enable-an-inter-exchange-network.md
         html: open-a-payment-channel-to-enable-an-inter-exchange-network.html
@@ -2971,7 +2971,7 @@ pages:
         filters:
             - use_case
         targets:
-            - local
+            - en
 
     -   md: use-cases/contribute-code-to-rippled.md
         html: contribute-code-to-rippled.html
@@ -2983,7 +2983,7 @@ pages:
         filters:
             - use_case
         targets:
-            - local
+            - en
 
     -   md: use-cases/contribute-code-to-ripple-lib.md
         html: contribute-code-to-ripple-lib.html
@@ -2995,7 +2995,7 @@ pages:
         filters:
             - use_case
         targets:
-            - local
+            - en
 
     -   md: use-cases/use-an-escrow-as-a-smart-contract.md
         html: use-an-escrow-as-a-smart-contract.html
@@ -3007,14 +3007,14 @@ pages:
         filters:
             - use_case
         targets:
-            - local
+            - en
 
 # Dev Tools --------------------------------------------------------------------
     -   md: dev-tools/dev-tools.md
         html: dev-tools.html
         funnel: Dev Tools
         targets:
-            - local
+            - en
 
     -   name: Dev Tools # Redirect page for old broken URL
         html: dev-tools-dev-tools.html
@@ -3022,13 +3022,13 @@ pages:
         redirect_url: dev-tools.html
         funnel: Dev Tools
         targets:
-            - local
+            - en
 
     -   name: RPC Tool
         funnel: Dev Tools
         html: xrp-ledger-rpc-tool.html
         targets:
-            - local
+            - en
         template: template-xrp-ledger-rpc-tool.html
 
     -   name: WebSocket API Tool
@@ -3036,7 +3036,7 @@ pages:
         template: template-websocket-api-tool.html
         html: websocket-api-tool.html
         targets:
-            - local
+            - en
 
     -   name: Data API v2 Tool
         funnel: Dev Tools
@@ -3046,7 +3046,7 @@ pages:
         doc_page: data-api.html
         sidebar: custom
         targets:
-            - local
+            - en
         template: template-rest-api-tool.html
 
     -   name: ripple.txt Validator # Redirect from ripple.txt validator to toml
@@ -3055,13 +3055,13 @@ pages:
         template: template-redirect.html
         redirect_url: xrp-ledger-toml-checker.html
         targets:
-            - local
+            - en
 
     -   name: xrp-ledger.toml Checker
         funnel: Dev Tools
         html: xrp-ledger-toml-checker.html
         targets:
-            - local
+            - en
         template: template-xrp-ledger-toml-checker.html
 
     -   name: XRP Faucets
@@ -3069,7 +3069,7 @@ pages:
         funnel: Dev Tools
         template: template-test-net.html
         targets:
-            - local
+            - en
 
     -   name: XRP Test Net Faucet # Redirect from old URL
         html: xrp-test-net-faucet.html
@@ -3077,13 +3077,13 @@ pages:
         template: template-redirect.html
         redirect_url: xrp-testnet-faucet.html
         targets:
-            - local
+            - en
 
     -   name: Transaction Sender
         funnel: Dev Tools
         html: tx-sender.html
         targets:
-            - local
+            - en
         template: template-tx-sender.html
 
 # Custom 404 page
@@ -3091,14 +3091,14 @@ pages:
         html: 404.html
         template: template-404.html
         targets:
-            - local
+            - en
 
 # Special sitemap file (for better Google indexing)
     -   name: Sitemap
         html: sitemap.txt
         template: template-sitemap.txt
         targets:
-            - local
+            - en
 
 
 ignore_anchors_in:


### PR DESCRIPTION
As part of the Translation Plan (#526) this renames the default dev portal
target to "en" so that other targets can be named by language.