### PR TITLE
Tip to change permissions on rippled.cfg

### DIFF
--- a/content/tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
@@ -114,7 +114,7 @@ On your validator:
 
       - The `server_state` value should be _**proposing**_.
 
-
+**Security Tip:** Change the permissions on your `rippled.cfg` file to be more restrictive. On Linux it is recommended to be `0600`. You can do this with `chmod 0600 rippled.cfg`
 
 ## 4. Connect to the network
 


### PR DESCRIPTION
Make the rippled.cfg file readable only by the rippled user and root, with 0600