### PR TITLE
Domain verification should not expose IP of validator

### DIFF
--- a/content/tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
@@ -282,7 +282,7 @@ Creating this link establishes strong evidence that you own both the validator k
 
 To provide domain verification:
 
-1. Choose a domain name you own that you want to be publicly associated with your validator. You must run a public-facing HTTPS server on port 443 of that domain and you must have access to the private key file associated with that server's TLS certificate. (Note: [TLS was formerly called SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security)). As a precaution against DDoS attempts, your domain name should not resolve to the ip address of your validator.
+1. Choose a domain name you own that you want to be publicly associated with your validator. You must run a public-facing HTTPS server on port 443 of that domain and you must have access to the private key file associated with that server's TLS certificate. (Note: [TLS was formerly called SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security).) As a precaution against DDoS attempts, your domain name should not resolve to the ip address of your validator.
 
 2. Share your validator's public key with the public, especially other `rippled` operators. For example, you can share your validator's public key on your website, on social media, in the [XRPChat community forum](https://www.xrpchat.com/), or in a press release.
 

--- a/content/tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/run-rippled-as-a-validator.md
@@ -282,7 +282,7 @@ Creating this link establishes strong evidence that you own both the validator k
 
 To provide domain verification:
 
-1. Choose a domain name you own that you want to be publicly associated with your validator. You must run a public-facing HTTPS server on port 443 of that domain and you must have access to the private key file associated with that server's TLS certificate. (Note: [TLS was formerly called SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security).)
+1. Choose a domain name you own that you want to be publicly associated with your validator. You must run a public-facing HTTPS server on port 443 of that domain and you must have access to the private key file associated with that server's TLS certificate. (Note: [TLS was formerly called SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security)). As a precaution against DDoS attempts, your domain name should not resolve to the ip address of your validator.
 
 2. Share your validator's public key with the public, especially other `rippled` operators. For example, you can share your validator's public key on your website, on social media, in the [XRPChat community forum](https://www.xrpchat.com/), or in a press release.
 


### PR DESCRIPTION
The verified domain name should not resolve to the ip address of the validator.