### PR TITLE
Update for ripple-lib 1.4.2

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -5480,7 +5480,7 @@ pages:
     # --------------- end "XRP-API" section --------------------------------
 
     -   name: RippleAPI Reference # name is required for remote-sourced files
-        md: https://raw.githubusercontent.com/ripple/ripple-lib/1.4.1/docs/index.md
+        md: https://raw.githubusercontent.com/ripple/ripple-lib/1.4.2/docs/index.md
         html: rippleapi-reference.html
         funnel: Docs
         doc_type: References


### PR DESCRIPTION
Question: I wonder if there's a reason we couldn't have this just use what we have in ripple-lib's `master` branch. I push stable releases to `master` at the time of release. That would be https://raw.githubusercontent.com/ripple/ripple-lib/master/docs/index.md -- maybe using that URL would allow this to auto-update?