### PR TITLE
fix: transfer fee example 1%

### DIFF
--- a/content/concepts/issued-currencies/transfer-fees.md
+++ b/content/concepts/issued-currencies/transfer-fees.md
@@ -7,7 +7,7 @@ The `TransferRate` setting in the XRP Ledger allows [financial institutions that
 
 XRP never has a transfer fee, because it never has an issuer.
 
-For example, ACME Bank might set the transfer fee to 0.5% for ACME issuances. For the recipient of a payment to get 2 EUR.ACME, the sender must send 2.01 EUR.ACME. After the transaction, ACME's outstanding obligations in the XRP Ledger have decreased by 0.01€, which means that ACME no longer needs to hold that amount in the account backing its XRP Ledger issuances.
+For example, ACME Bank might set the transfer fee to 1% for ACME issuances. For the recipient of a payment to get 2 EUR.ACME, the sender must send 2.02 EUR.ACME. After the transaction, ACME's outstanding obligations in the XRP Ledger have decreased by 0.02€, which means that ACME no longer needs to hold that amount in the account backing its XRP Ledger issuances.
 
 The following diagram shows an XRP Ledger payment of 2 EUR.ACME from Alice to Charlie with a transfer fee of 1%:
 


### PR DESCRIPTION
Fixing the transfer fee example, 1% of 2€ is 0,02

0,5% is confusing when looking at the example that follows where the fee is 1%