### PR TITLE
Remove <br> tags from [Source] links.

### DIFF
--- a/content/concepts/consensus-network/amendments/known-amendments.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.md
@@ -1,5 +1,5 @@
 # Known Amendments
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Feature.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Feature.cpp "Source")
 
 The following is a comprehensive list of all known amendments and their status on the production XRP Ledger:
 

--- a/content/concepts/payment-system-basics/accounts/accounts.md
+++ b/content/concepts/payment-system-basics/accounts/accounts.md
@@ -105,7 +105,7 @@ For more information on each of these objects, see the [Ledger Format Reference]
 
 **Tip:** These technical details are only relevant for people building low-level library software for XRP Ledger compatibility!
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/AccountID.cpp#L109-L140 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/AccountID.cpp#L109-L140 "Source")
 
 XRP Ledger addresses are encoded using [base58](https://en.wikipedia.org/wiki/Base58) with the _dictionary_ `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`. Since the XRP Ledger encodes several types of keys with base58, it prefixes the encoded data with a one-byte "type prefix" (also called a "version prefix") to distinguish them. The type prefix causes addresses to usually start with different letters in base58 format.
 

--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -101,7 +101,7 @@ Health Checks:
 
 
 ## Get Ledger
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
 
 Retrieve a specific Ledger by hash, index, date, or latest validated.
 
@@ -173,7 +173,7 @@ Response:
 
 
 ## Get Ledger Validations
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
 
 Retrieve a any validations recorded for a specific ledger hash.  This dataset includes ledger versions that are outside the validated ledger chain. _(New in [v2.2.0][])_
 
@@ -263,7 +263,7 @@ Response:
 
 
 ## Get Ledger Validation
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getLedger.js "Source")
 
 Retrieve a validation vote recorded for a specific ledger hash by a specific validator.  This dataset includes ledger versions that are outside the validated ledger chain. _(New in [v2.2.0][])_
 
@@ -327,7 +327,7 @@ Response:
 
 
 ## Get Transaction
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getTransactions.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getTransactions.js "Source")
 
 Retrieve a specific transaction by its identifying hash.
 
@@ -437,7 +437,7 @@ Response (trimmed for size):
 
 
 ## Get Transactions
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getTransactions.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getTransactions.js "Source")
 
 Retrieve transactions by time
 
@@ -596,7 +596,7 @@ Response:
 
 
 ## Get Payments
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getPayments.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getPayments.js "Source")
 
 Retrieve Payments over time, where Payments are defined as `Payment` type transactions where the sender of the transaction is not also the destination. _(New in [v2.0.4][])_
 
@@ -736,7 +736,7 @@ Response:
 
 
 ## Get Exchanges
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getExchanges.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getExchanges.js "Source")
 
 Retrieve Exchanges for a given currency pair over time.  Results can be returned as individual exchanges or aggregated to a specific list of intervals
 
@@ -868,7 +868,7 @@ Response:
 
 
 ## Get Exchange Rates
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getExchangeRate.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getExchangeRate.js "Source")
 
 Retrieve an exchange rate for a given currency pair at a specific time.
 
@@ -936,7 +936,7 @@ Response:
 
 
 ## Normalize
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/normalize.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/normalize.js "Source")
 
 Convert an amount from one currency and issuer to another, using the network exchange rates.
 
@@ -1003,7 +1003,7 @@ Response:
 
 
 ## Get Daily Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/reports.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/reports.js "Source")
 
 Retrieve per account per day aggregated payment summaries
 
@@ -1167,7 +1167,7 @@ Response (trimmed for size):
 
 
 ## Get Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/stats.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/stats.js "Source")
 
 Retrieve statistics about transaction activity in the XRP Ledger, divided into intervals of time.
 
@@ -1272,7 +1272,7 @@ Response:
 
 
 ## Get Active Accounts
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/activeAccounts.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/activeAccounts.js "Source")
 
 Get information on which accounts are actively trading in a specific currency pair. _(New in [v2.0.4][])_
 
@@ -1424,7 +1424,7 @@ Response:
 
 
 ## Get Exchange Volume
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getMetric.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getMetric.js "Source")
 
 Get aggregated exchange volume for a given time period. _(New in [v2.0.4][])_
 
@@ -1571,7 +1571,7 @@ Response:
 
 
 ## Get Payment Volume
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getMetric.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getMetric.js "Source")
 
 Get aggregated payment volume for a given time period. _(New in [v2.0.4][])_
 
@@ -1699,7 +1699,7 @@ Response:
 
 
 ## Get External Markets
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/externalMarkets.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/externalMarkets.js "Source")
 
 Get aggregated exchange volume from a list of off ledger exchanges for a specified rolling interval.
 
@@ -1822,7 +1822,7 @@ Response:
 
 
 ## Get XRP Distribution
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/xrpDistribution.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/xrpDistribution.js "Source")
 
 Get information on the total amount of XRP in existence and in circulation, by weekly intervals. _(New in [v2.2.0][])_
 
@@ -1900,7 +1900,7 @@ Response:
 
 
 ## Get Top Currencies
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/topCurrencies.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/topCurrencies.js "Source")
 
 Returns the top currencies on the XRP Ledger, ordered from highest rank to lowest. The ranking is determined by the volume and count of transactions and the number of unique counterparties. By default, returns results for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. _(New in [v2.1.0][])_
 
@@ -2003,7 +2003,7 @@ Response:
 
 
 ## Get Top Markets
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/topMarkets.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/topMarkets.js "Source")
 
 Returns the top exchange markets on the XRP Ledger, ordered from highest rank to lowest. The rank is determined by the number and volume of exchanges and the number of counterparties participating. By default, returns top markets for the 30-day rolling window ending on the current date. You can specify a date to get results for the 30-day window ending on that date. _(New in [v2.1.0][])_
 
@@ -2107,7 +2107,7 @@ Response:
 
 
 ## Get Transaction Costs
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getFees.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getFees.js "Source")
 
 Returns [transaction cost](transaction-cost.html) stats per ledger, hour, or day.  The data shows the average, minimum, maximum, and total transaction costs paid for the given interval or ledger. _(New in [v2.2.0][])_
 
@@ -2209,7 +2209,7 @@ Response:
 
 
 ## Get Fee Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getFeeStats.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getFeeStats.js "Source")
 
 Returns snapshots of the metrics derived from `rippled`'s [`fee` command](fee.html). _(New in [v2.3.2][])_
 
@@ -2309,7 +2309,7 @@ Response:
 
 
 ## Get Topology
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getTopology.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getTopology.js "Source")
 
 Get known `rippled` servers and peer-to-peer connections between them. _(New in [v2.2.0][])_
 
@@ -2414,7 +2414,7 @@ Response:
 
 
 ## Get Topology Nodes
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getNodes.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getNodes.js "Source")
 
 Get known `rippled` nodes. (This is a subset of the data returned by the [Get Topology method](#get-topology).) _(New in [v2.2.0][])_
 
@@ -2505,7 +2505,7 @@ Response:
 
 
 ## Get Topology Node
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getNodes.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getNodes.js "Source")
 
 Get information about a single `rippled` server by its [node public key](#public-keys) (not validator public key). _(New in [v2.2.0][])_
 
@@ -2577,7 +2577,7 @@ Response:
 
 
 ## Get Topology Links
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getLinks.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getLinks.js "Source")
 
 Get information on peer-to-peer connections between `rippled` servers. (This is a subset of the data returned by the [Get Topology method](#get-topology).) _(New in [v2.2.0][])_
 
@@ -2642,7 +2642,7 @@ Response:
 
 
 ## Get Validator
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidators.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidators.js "Source")
 
 Get details of a single validator in the [consensus network](consensus.html). _(Updated in [v2.4.0][])_
 
@@ -2736,7 +2736,7 @@ Response:
 
 
 ## Get Validators
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidators.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidators.js "Source")
 
 Get a list of known validators active in the last 24 hours. _(Updated in [v2.4.0][])_
 
@@ -2859,7 +2859,7 @@ Response:
 
 
 ## Get Validator Manifests
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getManifests.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getManifests.js "Source")
 
 Retrieve manifests signed by a specified validator. (Manifests, also called _subkey authorizations_, designate the ephemeral key a validator uses to sign proposals and validations.) _(New in [v2.3.7][])_
 
@@ -2966,7 +2966,7 @@ Response:
 
 
 ## Get Single Validator Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidatorReports.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidatorReports.js "Source")
 
 Get a single validator's validation vote stats for 24-hour intervals. _(Updated in [v2.4.0][])_
 
@@ -3066,7 +3066,7 @@ Response:
 
 
 ## Get Daily Validator Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidatorReports.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getValidatorReports.js "Source")
 
 Get validation vote stats and validator information for all known validators in a 24-hour period.
 
@@ -3146,7 +3146,7 @@ Response:
 
 
 ## Get rippled Versions
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getVersions.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/network/getVersions.js "Source")
 
 Reports the latest versions of `rippled` available from the official Ripple Yum repositories. _(New in [v2.3.0][].)_
 
@@ -3221,7 +3221,7 @@ Response:
 
 
 ## Get All Gateways
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js "Source")
 
 Get information about [known gateways](https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json). _(New in [v2.0.4][])_
 
@@ -3317,7 +3317,7 @@ Response:
 
 
 ## Get Gateway
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js "Source")
 
 <!-- STYLE_OVERRIDE: gateway, gateways -->
 Get information about a specific gateway from [the Data API's list of known gateways](https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json). _(New in [v2.0.4][])_
@@ -3410,7 +3410,7 @@ Response:
 
 ## Get Currency Image
 
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js#L199 "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/gateways.js#L199 "Source")
 
 Retrieve vector icons for various currencies. _(New in [v2.0.4][])_
 
@@ -3471,7 +3471,7 @@ Content-Type: image/svg+xml
 
 
 ## Get Accounts
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accounts.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accounts.js "Source")
 
 Retrieve information about the creation of new accounts in the XRP Ledger.
 
@@ -3559,7 +3559,7 @@ Response:
 
 
 ## Get Account
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getAccount.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/getAccount.js "Source")
 
 Get creation info for a specific ripple account
 
@@ -3621,7 +3621,7 @@ Response:
 
 
 ## Get Account Balances
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountBalances.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountBalances.js "Source")
 
 Get all balances held or owed by a specific XRP Ledger account.
 
@@ -3706,7 +3706,7 @@ Response:
 
 
 ## Get Account Orders
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountOrders.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountOrders.js "Source")
 
 Get orders in the order books, placed by a specific account. This does not return orders that have already been filled.
 
@@ -3832,7 +3832,7 @@ Response:
 
 
 ## Get Account Transaction History
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountTransactions.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountTransactions.js "Source")
 
 Retrieve a history of transactions that affected a specific account. This includes all transactions the account sent, payments the account received, and payments that rippled through the account.
 
@@ -3964,7 +3964,7 @@ Response:
 
 
 ## Get Transaction By Account And Sequence
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountTxSeq.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountTxSeq.js "Source")
 
 Retrieve a specifc transaction originating from a specified account
 
@@ -4033,7 +4033,7 @@ Response:
 
 
 ## Get Account Payments
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountPayments.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountPayments.js "Source")
 
 Retrieve a payments for a specified account
 
@@ -4138,7 +4138,7 @@ Response:
 
 
 ## Get Account Exchanges
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountExchanges.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountExchanges.js "Source")
 
 Retrieve Exchanges for a given account over time.
 
@@ -4258,7 +4258,7 @@ Response:
 
 
 ## Get Account Balance Changes
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountBalanceChanges.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountBalanceChanges.js "Source")
 
 Retrieve Balance changes for a given account over time.
 
@@ -4363,7 +4363,7 @@ Response:
 
 
 ## Get Account Reports
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountReports.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountReports.js "Source")
 
 Retrieve daily summaries of payment activity for an account.
 
@@ -4476,7 +4476,7 @@ Response:
 
 
 ## Get Account Transaction Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountStats.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountStats.js "Source")
 
 Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.0][].)_
 
@@ -4575,7 +4575,7 @@ Response:
 
 
 ## Get Account Value Stats
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountStats.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/accountStats.js "Source")
 
 Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.0][].)_
 
@@ -4662,7 +4662,7 @@ Response:
 
 
 ## Health Check - API
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the API service.
 
@@ -4725,7 +4725,7 @@ Response:
 
 
 ## Health Check - Ledger Importer
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the Ledger Importer Service.
 
@@ -4797,7 +4797,7 @@ Response:
 
 
 ## Health Check - Nodes ETL
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the Topology Nodes Extract, Transform, Load (ETL) Service.
 
@@ -4863,7 +4863,7 @@ Response:
 
 
 ## Health Check - Validations ETL
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
+[[Source]](https://github.com/ripple/rippled-historical-database/blob/master/api/routes/checkHealth.js "Source")
 
 Check the health of the Validations Extract, Transform, Load (ETL) Service.
 

--- a/content/references/rippled-api/admin-rippled-methods/key-generation-methods/validation_create.md
+++ b/content/references/rippled-api/admin-rippled-methods/key-generation-methods/validation_create.md
@@ -1,5 +1,5 @@
 # validation_create
-[[Source]<br>](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/ValidationCreate.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/ValidationCreate.cpp "Source")
 
 Use the `validation_create` command to generate [cryptographic keys a `rippled` server can use to identify itself to the network](peer-protocol.html#node-key-pair). Similar to the [wallet_propose method][], this method only generates a set of keys in the proper format. It does not any makes changes to the XRP Ledger data or server configuration.
 

--- a/content/references/rippled-api/admin-rippled-methods/key-generation-methods/wallet_propose.md
+++ b/content/references/rippled-api/admin-rippled-methods/key-generation-methods/wallet_propose.md
@@ -1,5 +1,5 @@
 # wallet_propose
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/WalletPropose.cpp "Source")
 
 Use the `wallet_propose` method to generate a key pair and XRP Ledger address. This command only generates key and address values, and does not affect the XRP Ledger itself in any way. To become a funded address stored in the ledger, the address must [receive a Payment transaction](accounts.html#creating-accounts) that provides enough XRP to meet the [reserve requirement](reserves.html).
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/can_delete.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/can_delete.md
@@ -1,5 +1,5 @@
 # can_delete
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/CanDelete.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/CanDelete.cpp "Source")
 
 The `can_delete` method informs the `rippled` server of the latest ledger version which may be deleted when using [online deletion with advisory deletion enabled](online-deletion.html#advisory-deletion). If advisory deletion is not enabled, this method does nothing.
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/crawl_shards.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/crawl_shards.md
@@ -1,5 +1,5 @@
 # crawl_shards
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/CrawlShards.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/CrawlShards.cpp "Source")
 
 Requests information from peer servers about which [shards of historical ledger data](history-sharding.html) they have available. [New in: rippled 1.2.0][]
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/download_shard.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/download_shard.md
@@ -1,5 +1,5 @@
 # download_shard
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/DownloadShard.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/DownloadShard.cpp "Source")
 
 Instructs the server to download a specific [shard of historical ledger data](history-sharding.html) from an external source. Your `rippled` server must be [configured to store history shards](configure-history-sharding.html). [New in: rippled 1.1.0][]
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_cleaner.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_cleaner.md
@@ -1,5 +1,5 @@
 # ledger_cleaner
-[[Source]<br>](https://github.com/ripple/rippled/blob/df54b47cd0957a31837493cd69e4d9aade0b5055/src/ripple/rpc/handlers/LedgerCleaner.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/df54b47cd0957a31837493cd69e4d9aade0b5055/src/ripple/rpc/handlers/LedgerCleaner.cpp "Source")
 
 The `ledger_cleaner` command controls the [Ledger Cleaner](https://github.com/ripple/rippled/blob/f313caaa73b0ac89e793195dcc2a5001786f916f/src/ripple/app/ledger/README.md#the-ledger-cleaner), an asynchronous maintenance process that can find and repair corruption in `rippled`'s database of ledgers.
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_request.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/ledger_request.md
@@ -1,5 +1,5 @@
 # ledger_request
-[[Source]<br>](https://github.com/ripple/rippled/blob/e980e69eca9ea843d200773eb1f43abe3848f1a0/src/ripple/rpc/handlers/LedgerRequest.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/e980e69eca9ea843d200773eb1f43abe3848f1a0/src/ripple/rpc/handlers/LedgerRequest.cpp "Source")
 
 The `ledger_request` command tells server to fetch a specific ledger version from its connected peers. This only works if one of the server's immediately-connected peers has that ledger. You may need to run the command several times to completely fetch a ledger.
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/log_level.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/log_level.md
@@ -1,5 +1,5 @@
 # log_level
-[[Source]<br>](https://github.com/ripple/rippled/blob/155fcdbcd0b4927152892c8c8be01d9cf62bed68/src/ripple/rpc/handlers/LogLevel.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/155fcdbcd0b4927152892c8c8be01d9cf62bed68/src/ripple/rpc/handlers/LogLevel.cpp "Source")
 
 The `log_level` command changes the `rippled` server's logging verbosity, or returns the current logging level for each category (called a _partition_) of log messages.
 

--- a/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/logrotate.md
+++ b/content/references/rippled-api/admin-rippled-methods/logging-and-data-management-methods/logrotate.md
@@ -1,5 +1,5 @@
 # logrotate
-[[Source]<br>](https://github.com/ripple/rippled/blob/743bd6c9175c472814448ea889413be79dfd1c07/src/ripple/rpc/handlers/LogRotate.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/743bd6c9175c472814448ea889413be79dfd1c07/src/ripple/rpc/handlers/LogRotate.cpp "Source")
 
 The `logrotate` command closes and reopens the log file. This is intended to help with log rotation on Linux file systems.
 

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/connect.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/connect.md
@@ -1,5 +1,5 @@
 # connect
-[[Source]<br>](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/Connect.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/Connect.cpp "Source")
 
 The `connect` command forces the `rippled` server to connect to a specific peer `rippled` server.
 

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/ledger_accept.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/ledger_accept.md
@@ -1,5 +1,5 @@
 # ledger_accept
-[[Source]<br>](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/LedgerAccept.cpp "Source")
 
 The `ledger_accept` method forces the server to close the current-working ledger and move to the next ledger number. This method is intended for testing purposes only, and is only available when the `rippled` server is running stand-alone mode.
 

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/stop.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/stop.md
@@ -1,5 +1,5 @@
 # stop
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Stop.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Stop.cpp "Source")
 
 Gracefully shuts down the server.
 

--- a/content/references/rippled-api/admin-rippled-methods/server-control-methods/validation_seed.md
+++ b/content/references/rippled-api/admin-rippled-methods/server-control-methods/validation_seed.md
@@ -1,5 +1,5 @@
 # validation_seed
-[[Source]<br>](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ValidationSeed.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ValidationSeed.cpp "Source")
 
 The `validation_seed` command temporarily sets the secret value that rippled uses to sign validations. This value resets based on the config file when you restart the server. [Disabled since: rippled 0.29.1](https://github.com/ripple/rippled/releases/tag/0.29.1-rc1 "BADGE_RED")
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/consensus_info.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/consensus_info.md
@@ -1,5 +1,5 @@
 # consensus_info
-[[Source]<br>](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ConsensusInfo.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/a61ffab3f9010d8accfaa98aa3cacc7d38e74121/src/ripple/rpc/handlers/ConsensusInfo.cpp "Source")
 
 The `consensus_info` command provides information about the [consensus process](consensus.html) for debugging purposes.
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/feature.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/feature.md
@@ -1,5 +1,5 @@
 # feature
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Feature1.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Feature1.cpp "Source")
 
 The `feature` command returns information about [amendments](amendments.html) this server knows about, including whether they are enabled and whether the server is voting in favor of those amendments in the [amendment process](amendments.html#amendment-process). [New in: rippled 0.31.0][]
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/fetch_info.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/fetch_info.md
@@ -1,5 +1,5 @@
 # fetch_info
-[[Source]<br>](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/FetchInfo.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/FetchInfo.cpp "Source")
 
 The `fetch_info` command returns information about objects that this server is currently fetching from the network, and how many peers have that information. It can also be used to reset current fetches.
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/get_counts.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/get_counts.md
@@ -1,5 +1,5 @@
 # get_counts
-[[Source]<br>](https://github.com/ripple/rippled/blob/c7118a183a660648aa88a3546a6b2c5bce858440/src/ripple/rpc/handlers/GetCounts.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/c7118a183a660648aa88a3546a6b2c5bce858440/src/ripple/rpc/handlers/GetCounts.cpp "Source")
 
 The `get_counts` command provides various stats about the health of the server, mostly the number of objects of different types that it currently holds in memory.
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/peers.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/peers.md
@@ -1,5 +1,5 @@
 # peers
-[[Source]<br>](https://github.com/ripple/rippled/blob/52f298f150fc1530d201d3140c80d3eaf781cb5f/src/ripple/rpc/handlers/Peers.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/52f298f150fc1530d201d3140c80d3eaf781cb5f/src/ripple/rpc/handlers/Peers.cpp "Source")
 
 The `peers` command returns a list of all other `rippled` servers currently connected to this one over the [Peer Protocol](peer-protocol.html), including information on their connection and sync status.
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/print.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/print.md
@@ -1,5 +1,5 @@
 # print
-[[Source]<br>](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/Print.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/315a8b6b602798a4cff4d8e1911936011e12abdb/src/ripple/rpc/handlers/Print.cpp "Source")
 
 The `print` command returns the current status of various internal subsystems, including peers, the ledger cleaner, and the resource manager.
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validator_list_sites.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validator_list_sites.md
@@ -1,5 +1,5 @@
 # validator_list_sites
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ValidatorListSites.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ValidatorListSites.cpp "Source")
 
 The `validator_list_sites` command returns status information of sites serving validator lists. [New in: rippled 0.80.1][]
 

--- a/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validators.md
+++ b/content/references/rippled-api/admin-rippled-methods/status-and-debugging-methods/validators.md
@@ -1,5 +1,5 @@
 # validators
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Validators.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Validators.cpp "Source")
 
 The `validators` command returns human readable information about the current list of published and trusted validators used by the server. [New in: rippled 0.80.1][]
 

--- a/content/references/rippled-api/api-conventions/basic-data-types.md
+++ b/content/references/rippled-api/api-conventions/basic-data-types.md
@@ -22,7 +22,7 @@ Each closed [Ledger](ledger-data-formats.html) has a [Ledger Index][] and a [Has
 <!--{#_ #}-->
 
 ### Hash Prefixes
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/HashPrefix.h "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/HashPrefix.h "Source")
 
 In many cases, the XRP Ledger prefixes an object's binary data with a 4-byte code before calculating its hash, so that objects of different types have different hashes even if their binary formats are the same. The existing 4-byte codes are structured as three alphabetic characters, encoded as ASCII, followed by a zero byte.
 

--- a/content/references/rippled-api/api-conventions/currency-formats.md
+++ b/content/references/rippled-api/api-conventions/currency-formats.md
@@ -27,7 +27,7 @@ Issued currencies in the XRP Ledger are represented with a custom format with th
 * 15 decimal digits of precision
 
 ## Issued Currency Math
-[[Source]<br>](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/STAmount.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/STAmount.cpp "Source")
 
 ![Issued Currency Amount Format diagram](img/currency-number-format.png)
 

--- a/content/references/rippled-api/api-conventions/serialization.md
+++ b/content/references/rippled-api/api-conventions/serialization.md
@@ -1,5 +1,5 @@
 # Serialization Format
-[[Source]<br>](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/STObject.cpp#L696-L718 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/STObject.cpp#L696-L718 "Source")
 
 This page describes the XRP Ledger's canonical binary format for transactions and other data. This binary format is necessary to create and verify digital signatures of those transactions' contents, and is also used in other places including in the [peer-to-peer communications between servers](peer-protocol.html). The [`rippled` APIs](rippled-api.html) typically use JSON to communicate with client applications. However, JSON is unsuitable as a format for serializing transactions for being digitally signed, because JSON can represent the same data in many different but equivalent ways.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-header.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-header.md
@@ -1,5 +1,5 @@
 # Ledger Header
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/ledger/ReadView.h#L71 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/ledger/ReadView.h#L71 "Source")
 
 Every ledger version has a unique header that describes the contents. You can look up a ledger's header information with the [ledger method][]. The contents of the ledger header are as follows:
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/accountroot.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/accountroot.md
@@ -1,5 +1,5 @@
 # AccountRoot
-[[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L27 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L27 "Source")
 
 The `AccountRoot` object type describes a single [account](accounts.html), its settings, and XRP balance.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/amendments.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/amendments.md
@@ -1,5 +1,5 @@
 # Amendments
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L110-L113 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L110-L113 "Source")
 
 The `Amendments` object type contains a list of [Amendments](amendments.html) that are currently active. Each ledger version contains **at most one** `Amendments` object.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/check.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/check.md
@@ -1,5 +1,5 @@
 # Check
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L157-L170 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L157-L170 "Source")
 
 _(Requires the [Checks amendment][] :not_enabled:.)_
 
@@ -49,7 +49,7 @@ A `Check` object has the following fields:
 
 
 ## Check ID Format
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Indexes.cpp#L193-L200 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Indexes.cpp#L193-L200 "Source")
 
 The ID of a `Check` object is the [SHA-512Half][] of the following values, concatenated in order:
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/depositpreauth.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/depositpreauth.md
@@ -1,5 +1,5 @@
 # DepositPreauth
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L172-L178 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L172-L178 "Source")
 
 A `DepositPreauth` object tracks a preauthorization from one account to another. [DepositPreauth transactions][] create these objects.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/directorynode.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/directorynode.md
@@ -1,5 +1,5 @@
 # DirectoryNode
-[[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L44 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L44 "Source")
 
 The `DirectoryNode` object type provides a list of links to other objects in the ledger's state tree. A single conceptual _Directory_　takes the form of a doubly linked list, with one or more DirectoryNode objects each containing up to 32 [IDs](ledgers.html#tree-format) of other objects. The first object is called the root of the directory, and all objects other than the root object can be added or deleted as necessary.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/escrow.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/escrow.md
@@ -1,5 +1,5 @@
 # Escrow
-[[Source]<br>](https://github.com/ripple/rippled/blob/c6b6d82a754fe449cc533e18659df483c10a5c98/src/ripple/protocol/impl/LedgerFormats.cpp#L90-L101 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/c6b6d82a754fe449cc533e18659df483c10a5c98/src/ripple/protocol/impl/LedgerFormats.cpp#L90-L101 "Source")
 
 _(Requires the [Escrow amendment][].)_
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/feesettings.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/feesettings.md
@@ -1,5 +1,5 @@
 # FeeSettings
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L115-L120 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L115-L120 "Source")
 
 The `FeeSettings` object type contains the current base [transaction cost](transaction-cost.html) and [reserve amounts](reserves.html) as determined by [fee voting](fee-voting.html). Each ledger version contains **at most one** `FeeSettings` object.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/ledgerhashes.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/ledgerhashes.md
@@ -1,5 +1,5 @@
 # LedgerHashes
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L104-L108 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L104-L108 "Source")
 
 (Not to be confused with the ["ledger hash" string data type][Hash], which uniquely identifies a ledger version. This section describes the `LedgerHashes` ledger object type.)
 
@@ -57,7 +57,7 @@ The "previous history" `LedgerHashes` entries collectively contain the hash of e
 The "previous history" `LedgerHashes` objects act as a [skip list](https://en.wikipedia.org/wiki/Skip_list) so you can get the hash of any historical flag ledger from its index. From there, you can use that flag ledger's "recent history" object to get the hash of any other ledger.
 
 ## LedgerHashes ID Formats
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Indexes.cpp#L26-L42)
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Indexes.cpp#L26-L42)
 
 There are two formats for `LedgerHashes` object IDs, depending on whether the object is a "recent history" sub-type or a "previous history" sub-type.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/offer.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/offer.md
@@ -1,5 +1,5 @@
 # Offer
-[[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L57 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L57 "Source")
 
 The `Offer` object type describes an offer to exchange currencies, more traditionally known as an _order_, in the XRP Ledger's distributed exchange. An [OfferCreate transaction][] only creates an `Offer` object in the ledger when the offer cannot be fully executed immediately by consuming other offers already in the ledger.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/paychannel.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/paychannel.md
@@ -1,5 +1,5 @@
 # PayChannel
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L141-L155 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L141-L155 "Source")
 
 _(Requires the [PayChan amendment][].)_
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/ripplestate.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/ripplestate.md
@@ -1,5 +1,5 @@
 # RippleState
-[[Source]<br>](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L70 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L70 "Source")
 
 The `RippleState` object type connects two accounts in a single currency. Conceptually, a `RippleState` object represents two [trust lines](trust-lines-and-issuing.html) between the accounts, one from each side. Each account can change the settings for its side of the `RippleState` object, but the balance is a single shared value. A trust line that is entirely in its default state is considered the same as a trust line that does not exist, so `rippled` deletes `RippleState` objects when their properties are entirely default.
 

--- a/content/references/rippled-api/ledger-data-formats/ledger-object-types/signerlist.md
+++ b/content/references/rippled-api/ledger-data-formats/ledger-object-types/signerlist.md
@@ -1,5 +1,5 @@
 # SignerList
-[[Source]<br>](https://github.com/ripple/rippled/blob/6d2e3da30696bd10e3bb11a5ff6d45d2c4dae90f/src/ripple/protocol/impl/LedgerFormats.cpp#L127 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/6d2e3da30696bd10e3bb11a5ff6d45d2c4dae90f/src/ripple/protocol/impl/LedgerFormats.cpp#L127 "Source")
 
 _(Requires the [MultiSign amendment][].)_
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_channels.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_channels.md
@@ -1,5 +1,5 @@
 # account_channels
-[[Source]<br>](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/AccountChannels.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/AccountChannels.cpp "Source")
 
 _(Requires the [PayChan amendment][] to be enabled. [New in: rippled 0.33.0][])_
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
@@ -1,5 +1,5 @@
 # account_currencies
-[[Source]<br>](https://github.com/ripple/rippled/blob/df966a9ac6dd986585ecccb206aff24452e41a30/src/ripple/rpc/handlers/AccountCurrencies.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/df966a9ac6dd986585ecccb206aff24452e41a30/src/ripple/rpc/handlers/AccountCurrencies.cpp "Source")
 
 The `account_currencies` command retrieves a list of currencies that an account can send or receive, based on its trust lines. (This is not a thoroughly confirmed list, but it can be used to populate user interfaces.)
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_info.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_info.md
@@ -1,5 +1,5 @@
 # account_info
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountInfo.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountInfo.cpp "Source")
 
 The `account_info` command retrieves information about an account, its activity, and its XRP balance. All information retrieved is relative to a particular version of the ledger.
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
@@ -1,5 +1,5 @@
 # account_lines
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountLines.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountLines.cpp "Source")
 
 The `account_lines` method returns information about an account's trust lines, including balances in all non-XRP currencies and assets. All information retrieved is relative to a particular version of the ledger.
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_objects.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_objects.md
@@ -1,5 +1,5 @@
 # account_objects
-[[Source]<br>](https://github.com/ripple/rippled/blob/399c43cae6e90a428e9ce6a988123972b0f03c99/src/ripple/rpc/handlers/AccountObjects.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/399c43cae6e90a428e9ce6a988123972b0f03c99/src/ripple/rpc/handlers/AccountObjects.cpp "Source")
 
 The `account_objects` command returns the raw [ledger format][] for all objects owned by an account. For a higher-level view of an account's trust lines and balances, see the [account_lines method][] instead.
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
@@ -1,5 +1,5 @@
 # account_offers
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountOffers.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountOffers.cpp "Source")
 
 The `account_offers` method retrieves a list of [offers](offers.html) made by a given [account](accounts.html) that are outstanding as of a particular [ledger version](ledgers.html).
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
@@ -1,5 +1,5 @@
 # account_tx
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTx.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTx.cpp "Source")
 
 The `account_tx` method retrieves a list of transactions that involved the specified account.
 
@@ -67,7 +67,7 @@ The request includes the following parameters:
 | `limit`            | Integer                                    | _(Optional)_ Default varies. Limit the number of transactions to retrieve. The server is not required to honor this value. |
 | `marker`           | [Marker][] | Value from a previous paginated response. Resume retrieving data where that response left off. This value is stable even if there is a change in the server's range of available ledgers. |
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTxSwitch.cpp "Source")<br>
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTxSwitch.cpp "Source")<br>
 
 While each of these fields is marked as optional, **you must use at least one** in your request: `ledger_index`, `ledger_hash`, `ledger_index_min`, or `ledger_index_max`.
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/gateway_balances.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/gateway_balances.md
@@ -1,5 +1,5 @@
 # gateway_balances
-[[Source]<br>](https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/GatewayBalances.cpp "Source")
 
 The `gateway_balances` command calculates the total balances issued by a given account, optionally excluding amounts held by [operational addresses](issuing-and-operational-addresses.html). [New in: rippled 0.28.2][]
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/noripple_check.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/noripple_check.md
@@ -1,5 +1,5 @@
 # noripple_check
-[[Source]<br>](https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/NoRippleCheck.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/9111ad1a9dc37d49d085aa317712625e635197c0/src/ripple/rpc/handlers/NoRippleCheck.cpp "Source")
 
 The `noripple_check` command provides a quick way to check the status of [the DefaultRipple field for an account and the NoRipple flag of its trust lines](rippling.html), compared with the recommended settings.
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger.md
@@ -1,5 +1,5 @@
 # ledger
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerHandler.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerHandler.cpp "Source")
 
 Retrieve information about the public ledger.
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_closed.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_closed.md
@@ -1,5 +1,5 @@
 # ledger_closed
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerClosed.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerClosed.cpp "Source")
 
 The `ledger_closed` method returns the unique identifiers of the most recently closed ledger. (This ledger is not necessarily validated and immutable yet.)
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_current.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_current.md
@@ -1,5 +1,5 @@
 # ledger_current
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerCurrent.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerCurrent.cpp "Source")
 
 The `ledger_current` method returns the unique identifiers of the current in-progress [ledger](ledgers.html). This command is mostly useful for testing, because the ledger returned is still in flux.
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_data.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_data.md
@@ -1,5 +1,5 @@
 # ledger_data
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerData.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerData.cpp "Source")
 
 The `ledger_data` method retrieves contents of the specified ledger. You can iterate through several calls to retrieve the entire contents of a single ledger version.
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
@@ -1,5 +1,5 @@
 # ledger_entry
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerEntry.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/LedgerEntry.cpp "Source")
 
 The `ledger_entry` method returns a single ledger object from the XRP Ledger in its raw format. See [ledger format][] for information on the different types of objects you can retrieve.
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/book_offers.md
@@ -1,5 +1,5 @@
 # book_offers
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/BookOffers.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/BookOffers.cpp "Source")
 
 The `book_offers` method retrieves a list of offers, also known as the [order book](http://www.investopedia.com/terms/o/order-book.asp), between two currencies. If the results are very large, a partial result is returned with a marker so that later requests can resume from where the previous one left off.
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/deposit_authorized.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/deposit_authorized.md
@@ -1,5 +1,5 @@
 # deposit_authorized
-[[Source]<br>](https://github.com/ripple/rippled/blob/817d2339b8632cb2f97d3edd6f7af33aa7631744/src/ripple/rpc/handlers/DepositAuthorized.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/817d2339b8632cb2f97d3edd6f7af33aa7631744/src/ripple/rpc/handlers/DepositAuthorized.cpp "Source")
 
 The `deposit_authorized` command indicates whether one account is authorized to send payments directly to another. See [Deposit Authorization](depositauth.html) for information on how to require authorization to deliver money to your account.
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/path_find.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/path_find.md
@@ -1,5 +1,5 @@
 # path_find
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp "Source")
 
 *WebSocket API only!* The `path_find` method searches for a [path](paths.html) along which a transaction can possibly be made, and periodically sends updates when the path changes over time. For a simpler version that is supported by JSON-RPC, see the [ripple_path_find method][]. For payments occurring strictly in XRP, it is not necessary to find a path, because XRP can be sent directly to any account.
 
@@ -12,7 +12,7 @@ There are three different modes, or sub-commands, of the path_find command. Spec
 Although the `rippled` server tries to find the cheapest path or combination of paths for making a payment, it is not guaranteed that the paths returned by this method are, in fact, the best paths. Due to server load, pathfinding may not find the best results. Additionally, you should be careful with the pathfinding results from untrusted servers. A server could be modified to return less-than-optimal paths to earn money for its operators. If you do not have your own server that you can trust with pathfinding, you should compare the results of pathfinding from multiple servers run by different parties, to minimize the risk of a single server returning poor results. (**Note:** A server returning less-than-optimal results is not necessarily proof of malicious behavior; it could also be a symptom of heavy server load.)
 
 ## path_find create
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L50-L56 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L50-L56 "Source")
 
 The `create` subcommand of `path_find` creates an ongoing request to find possible paths along which a payment transaction could be made from one specified account such that another account receives a desired amount of some currency. The initial response contains a suggested path between the two addresses that would result in the desired amount being received. After that, the server sends additional messages, with `"type": "path_find"`, with updates to the potential paths. The frequency of updates is left to the discretion of the server, but it usually means once every few seconds when there is a new ledger version.
 
@@ -489,7 +489,7 @@ Here is an example of an asychronous follow-up from a path_find create request:
 <!-- MULTICODE_BLOCK_END -->
 
 ## path_find close
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L58-L67 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L58-L67 "Source")
 
 The `close` subcommand of `path_find` instructs the server to stop sending information about the current open pathfinding request.
 
@@ -534,7 +534,7 @@ If there was no outstanding pathfinding request, an error is returned instead.
 * `noPathRequest` - You tried to close a pathfinding request when there is not an open one.
 
 ## path_find status
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L69-L77 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/PathFind.cpp#L69-L77 "Source")
 
 The `status` subcommand of `path_find` requests an immediate update about the client's currently-open pathfinding request.
 

--- a/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/ripple_path_find.md
+++ b/content/references/rippled-api/public-rippled-methods/path-and-order-book-methods/ripple_path_find.md
@@ -1,5 +1,5 @@
 # ripple_path_find
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/RipplePathFind.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/RipplePathFind.cpp "Source")
 
 The `ripple_path_find` method is a simplified version of the [path_find method][] that provides a single response with a [payment path](paths.html) you can use right away. It is available in both the WebSocket and JSON-RPC APIs. However, the results tend to become outdated as time passes. Instead of making multiple calls to stay updated, you should instead use the [path_find method][] to subscribe to continued updates where possible.
 

--- a/content/references/rippled-api/public-rippled-methods/payment-channel-methods/channel_authorize.md
+++ b/content/references/rippled-api/public-rippled-methods/payment-channel-methods/channel_authorize.md
@@ -1,5 +1,5 @@
 # channel_authorize
-[[Source]<br>](https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L41 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L41 "Source")
 
 _(Requires the [PayChan amendment][] to be enabled. [New in: rippled 0.33.0][])_
 

--- a/content/references/rippled-api/public-rippled-methods/payment-channel-methods/channel_verify.md
+++ b/content/references/rippled-api/public-rippled-methods/payment-channel-methods/channel_verify.md
@@ -1,5 +1,5 @@
 # channel_verify
-[[Source]<br>](https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L89 "Source")
+[[Source]](https://github.com/ripple/rippled/blob/d4a56f223a3b80f64ff70b4e90ab6792806929ca/src/ripple/rpc/handlers/PayChanClaim.cpp#L89 "Source")
 
 _(Requires the [PayChan amendment][] to be enabled. [New in: rippled 0.33.0][])_
 

--- a/content/references/rippled-api/public-rippled-methods/server-info-methods/fee.md
+++ b/content/references/rippled-api/public-rippled-methods/server-info-methods/fee.md
@@ -1,5 +1,5 @@
 # fee
-[[Source]<br>](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/Fee1.cpp "Source")
 
 The `fee` command reports the current state of the open-ledger requirements for the [transaction cost](transaction-cost.html). This requires the [FeeEscalation amendment][] to be enabled. [New in: rippled 0.31.0][]
 

--- a/content/references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
+++ b/content/references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
@@ -1,5 +1,5 @@
 # server_info
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ServerInfo.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ServerInfo.cpp "Source")
 
 The `server_info` command asks the server for a human-readable version of various information about the `rippled` server being queried.
 

--- a/content/references/rippled-api/public-rippled-methods/server-info-methods/server_state.md
+++ b/content/references/rippled-api/public-rippled-methods/server-info-methods/server_state.md
@@ -1,5 +1,5 @@
 # server_state
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ServerState.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/ServerState.cpp "Source")
 
 The `server_state` command asks the server for various machine-readable information about the `rippled` server's current state. The response is almost the same as the [server_info method][], but uses units that are easier to process instead of easier to read. (For example, XRP values are given in integer drops instead of scientific notation or decimal values, and time is given in milliseconds instead of seconds.)
 

--- a/content/references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
+++ b/content/references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
@@ -1,5 +1,5 @@
 # subscribe
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Subscribe.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Subscribe.cpp "Source")
 
 The `subscribe` method requests periodic notifications from the server when certain events happen.
 

--- a/content/references/rippled-api/public-rippled-methods/subscription-methods/unsubscribe.md
+++ b/content/references/rippled-api/public-rippled-methods/subscription-methods/unsubscribe.md
@@ -1,5 +1,5 @@
 # unsubscribe
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Unsubscribe.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Unsubscribe.cpp "Source")
 
 The `unsubscribe` command tells the server to stop sending messages for a particular subscription or set of subscriptions.
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/sign.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/sign.md
@@ -1,5 +1,5 @@
 # sign
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/SignHandler.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/SignHandler.cpp "Source")
 
 The `sign` method takes a [transaction in JSON format](transaction-formats.html) and a [seed value](cryptographic-keys.html), and returns a signed binary representation of the transaction. To contribute one signature to a [multi-signed transaction](multi-signing.html), use the [sign_for method][] instead.
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/sign_for.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/sign_for.md
@@ -1,5 +1,5 @@
 # sign_for
-[[Source]<br>](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SignFor.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SignFor.cpp "Source")
 
 The `sign_for` command provides one signature for a [multi-signed transaction](multi-signing.html).
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/submit.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/submit.md
@@ -1,5 +1,5 @@
 # submit
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Submit.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Submit.cpp "Source")
 
 The `submit` method applies a [transaction](transaction-formats.html) and sends it to the network to be confirmed and included in future ledgers.
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/submit_multisigned.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/submit_multisigned.md
@@ -1,5 +1,5 @@
 # submit_multisigned
-[[Source]<br>](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SubmitMultiSigned.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/release/src/ripple/rpc/handlers/SubmitMultiSigned.cpp "Source")
 
 The `submit_multisigned` command applies a [multi-signed](multi-signing.html) transaction and sends it to the network to be included in future ledgers. (You can also submit multi-signed transactions in binary form using the [`submit` command in submit-only mode](submit.html#submit-only-mode).)
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/transaction_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/transaction_entry.md
@@ -1,5 +1,5 @@
 # transaction_entry
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TransactionEntry.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TransactionEntry.cpp "Source")
 
 The `transaction_entry` method retrieves information on a single transaction from a specific ledger version. (The [tx method][], by contrast, searches all ledgers for the specified transaction. We recommend using that method instead.)
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/tx.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/tx.md
@@ -1,5 +1,5 @@
 # tx
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Tx.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Tx.cpp "Source")
 
 The `tx` method retrieves information on a single transaction.
 

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/tx_history.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/tx_history.md
@@ -1,5 +1,5 @@
 # tx_history
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TxHistory.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/TxHistory.cpp "Source")
 
 The `tx_history` method retrieves some of the most recent transactions made.
 

--- a/content/references/rippled-api/public-rippled-methods/utility-methods/ping.md
+++ b/content/references/rippled-api/public-rippled-methods/utility-methods/ping.md
@@ -1,5 +1,5 @@
 # ping
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Ping.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Ping.cpp "Source")
 
 The `ping` command returns an acknowledgement, so that clients can test the connection status and latency.
 

--- a/content/references/rippled-api/public-rippled-methods/utility-methods/random.md
+++ b/content/references/rippled-api/public-rippled-methods/utility-methods/random.md
@@ -1,5 +1,5 @@
 # random
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Random.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Random.cpp "Source")
 
 The `random` command provides a random number to be used as a source of entropy for random number generation by clients.
 

--- a/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
+++ b/content/references/rippled-api/transaction-formats/transaction-results/transaction-results.md
@@ -1,6 +1,6 @@
 # Transaction Results
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/TER.h "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/TER.h "Source")
 
 The `rippled` server summarizes transaction results with result codes, which appear in fields such as `engine_result` and `meta.TransactionResult`. These codes are grouped into several categories of with different prefixes:
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/accountset.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/accountset.md
@@ -1,6 +1,6 @@
 # AccountSet
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/f65cea66ef99b1de149c02c15f06de6c61abf360/src/ripple/app/transactors/SetAccount.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/f65cea66ef99b1de149c02c15f06de6c61abf360/src/ripple/app/transactors/SetAccount.cpp "Source")
 
 An AccountSet transaction modifies the properties of an [account in the XRP Ledger](accountroot.html).
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/checkcancel.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/checkcancel.md
@@ -1,5 +1,5 @@
 # CheckCancel
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelCheck.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelCheck.cpp "Source")
 
 _(Requires the [Checks amendment][] :not_enabled:.)_
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/depositpreauth.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/depositpreauth.md
@@ -1,5 +1,5 @@
 # DepositPreauth
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/DepositPreauth.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/DepositPreauth.cpp "Source")
 
 _Requires the [DepositPreauth amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/escrowcancel.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/escrowcancel.md
@@ -1,6 +1,6 @@
 # EscrowCancel
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
 
 _Requires the [Escrow amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/escrowcreate.md
@@ -1,6 +1,6 @@
 # EscrowCreate
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
 
 _Requires the [Escrow amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/escrowfinish.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/escrowfinish.md
@@ -1,6 +1,6 @@
 # EscrowFinish
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
 
 _Requires the [Escrow amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/offercancel.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/offercancel.md
@@ -1,6 +1,6 @@
 # OfferCancel
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp "Source")
 
 An OfferCancel transaction removes an Offer object from the XRP Ledger.
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/offercreate.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/offercreate.md
@@ -1,6 +1,6 @@
 # OfferCreate
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CreateOffer.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/CreateOffer.cpp "Source")
 
 An OfferCreate transaction is effectively a [limit order](http://en.wikipedia.org/wiki/limit_order). It defines an intent to exchange currencies, and creates an [Offer object](offer.html) if not completely fulfilled when placed. Offers can be partially fulfilled.
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/payment.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/payment.md
@@ -1,5 +1,5 @@
 # Payment
-[[Source]<br>](https://github.com/ripple/rippled/blob/5425a90f160711e46b2c1f1c93d68e5941e4bfb6/src/ripple/app/transactors/Payment.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/5425a90f160711e46b2c1f1c93d68e5941e4bfb6/src/ripple/app/transactors/Payment.cpp "Source")
 
 A Payment transaction represents a transfer of value from one account to another. (Depending on the path taken, this can involve additional exchanges of value, which occur atomically.) This transaction type can be used for several [types of payments](#types-of-payments).
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelclaim.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelclaim.md
@@ -1,5 +1,5 @@
 # PaymentChannelClaim
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
 
 _Requires the [PayChan amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelcreate.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelcreate.md
@@ -1,5 +1,5 @@
 # PaymentChannelCreate
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
 
 _Requires the [PayChan amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.md
@@ -1,5 +1,5 @@
 # PaymentChannelFund
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
 
 _Requires the [PayChan amendment][]._
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/setregularkey.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/setregularkey.md
@@ -1,6 +1,6 @@
 # SetRegularKey
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/4239880acb5e559446d2067f00dabb31cf102a23/src/ripple/app/transactors/SetRegularKey.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/4239880acb5e559446d2067f00dabb31cf102a23/src/ripple/app/transactors/SetRegularKey.cpp "Source")
 
 A `SetRegularKey` transaction assigns, changes, or removes the regular key pair associated with an account.
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/signerlistset.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/signerlistset.md
@@ -1,5 +1,5 @@
 # SignerListSet
-[[Source]<br>](https://github.com/ripple/rippled/blob/ef511282709a6a0721b504c6b7703f9de3eecf38/src/ripple/app/tx/impl/SetSignerList.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/ef511282709a6a0721b504c6b7703f9de3eecf38/src/ripple/app/tx/impl/SetSignerList.cpp "Source")
 
 The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to [multi-sign](multi-signing.html) a transaction. This transaction type was introduced by the [MultiSign amendment][]. [New in: rippled 0.31.0][]
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/trustset.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/trustset.md
@@ -1,6 +1,6 @@
 # TrustSet
 
-[[Source]<br>](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/SetTrust.cpp "Source")
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/SetTrust.cpp "Source")
 
 Create or modify a trust line linking two accounts.
 


### PR DESCRIPTION
These were necessary in a very old build of the site but under the new design they're extraneous.