### PR TITLE
Update for ripple-lib 1.6.0

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -5497,7 +5497,7 @@ pages:
     # --------------- end "XRP-API" section --------------------------------
 
     -   name: RippleAPI Reference # name is required for remote-sourced files
-        md: https://raw.githubusercontent.com/ripple/ripple-lib/1.5.0/docs/index.md
+        md: https://raw.githubusercontent.com/ripple/ripple-lib/1.6.0/docs/index.md
         html: rippleapi-reference.html
         funnel: Docs
         doc_type: References


### PR DESCRIPTION
We changed the docs for AccountDelete being added into `ripple-lib`.