### PR TITLE
Google Analytics: group pages by type

### DIFF
--- a/tool/template-doc.html
+++ b/tool/template-doc.html
@@ -45,3 +45,9 @@
     </ul>
   </div>
 {% endblock %}
+
+{% block endbody %}
+<script type="application/javascript">
+  gtag('set', {'content_group1': 'Content Docs'});
+</script>
+{% endblock %}

--- a/tool/template-home.html
+++ b/tool/template-home.html
@@ -305,3 +305,10 @@
 
   </section><!-- / Related Projects -->
 {% endblock %}
+
+
+{% block endbody %}
+<script type="application/javascript">
+  gtag('set', {'content_group1': 'Hub Pages'});
+</script>
+{% endblock %}

--- a/tool/template-landing-children.html
+++ b/tool/template-landing-children.html
@@ -25,3 +25,9 @@
   </section>
   {% endif %}
 {% endblock %}
+
+{% block endbody %}
+<script type="application/javascript">
+  gtag('set', {'content_group1': 'Hub Pages'});
+</script>
+{% endblock %}

--- a/tool/template-landing-docs.html
+++ b/tool/template-landing-docs.html
@@ -53,3 +53,9 @@
     </div>
   </section>
 {% endblock %}
+
+{% block endbody %}
+<script type="application/javascript">
+  gtag('set', {'content_group1': 'Hub Pages'});
+</script>
+{% endblock %}

--- a/tool/template-landing-references.html
+++ b/tool/template-landing-references.html
@@ -72,3 +72,9 @@
   </section>
 
 {% endblock %}
+
+{% block endbody %}
+<script type="application/javascript">
+  gtag('set', {'content_group1': 'Hub Pages'});
+</script>
+{% endblock %}

--- a/tool/template-rest-api-tool.html
+++ b/tool/template-rest-api-tool.html
@@ -63,4 +63,7 @@
     <script type='text/javascript' src='assets/js/apitool-rest.js'></script>
     <script type='text/javascript' src='assets/{{ currentpage.methods_js }}'></script>
 
+    <script type="application/javascript">
+      gtag('set', {'content_group1': 'API Tools'});
+    </script>
 {% endblock %}

--- a/tool/template-test-net.html
+++ b/tool/template-test-net.html
@@ -52,4 +52,8 @@
 
 {% block endbody %}
   <script type='text/javascript' src='assets/js/test-net.js'></script>
+
+  <script type="application/javascript">
+    gtag('set', {'content_group1': 'API Tools'});
+  </script>
 {% endblock %}

--- a/tool/template-tx-sender.html
+++ b/tool/template-tx-sender.html
@@ -160,4 +160,8 @@
   <script type="application/javascript" src="assets/js/ripple-lib-1.4.1-min.js"></script>
   <script type="application/javascript" src="assets/vendor/bootstrap-growl.jquery.js"></script>
   <script type='application/javascript' src='assets/js/tx-sender.js'></script>
+
+  <script type="application/javascript">
+    gtag('set', {'content_group1': 'API Tools'});
+  </script>
 {% endblock %}

--- a/tool/template-use-case.html
+++ b/tool/template-use-case.html
@@ -25,3 +25,9 @@
     </div><!--/.card-body-->
   </div>
 {% endblock %}
+
+{% block endbody %}
+<script type="application/javascript">
+  gtag('set', {'content_group1': 'Use Cases'});
+</script>
+{% endblock %}

--- a/tool/template-websocket-api-tool.html
+++ b/tool/template-websocket-api-tool.html
@@ -180,4 +180,8 @@
   <script type="text/javascript" src="assets/vendor/codemirror-js-json-lint.min.js"></script>
   <script type="text/javascript" src="assets/js/apitool-websocket.js"></script>
   <script type="text/javascript" src="assets/js/apitool-methods-ws.js"></script>
+
+  <script type="application/javascript">
+    gtag('set', {'content_group1': 'API Tools'});
+  </script>
 {% endblock %}

--- a/tool/template-xrp-ledger-rpc-tool.html
+++ b/tool/template-xrp-ledger-rpc-tool.html
@@ -108,4 +108,8 @@
   <script type='text/javascript' src='assets/vendor/async.min.js'></script>
   <script type='text/javascript' src='assets/vendor/cm-javascript.min.js'></script>
   <script type='text/javascript' src='assets/js/rpc-tool.js'></script>
+
+  <script type="application/javascript">
+    gtag('set', {'content_group1': 'API Tools'});
+  </script>
 {% endblock %}

--- a/tool/template-xrp-ledger-toml-checker.html
+++ b/tool/template-xrp-ledger-toml-checker.html
@@ -29,4 +29,8 @@
   <script type="application/javascript" src="assets/js/ripple-lib-1.4.1-min.js"></script>
   <script type='text/javascript' src='assets/vendor/iarna-toml-parse.js'></script>
   <script type='text/javascript' src='assets/js/xrp-ledger-toml-checker.js'></script>
+
+  <script type="application/javascript">
+    gtag('set', {'content_group1': 'API Tools'});
+  </script>
 {% endblock %}


### PR DESCRIPTION
This should extend our existing Google Analytics data collection to tag each page with a type based on what template was used to build it. The groups are:

- "Content Docs" for most pages that contain documentation
- "Hub Pages" for pages that are mostly navigation
- "API Tools" for pages that are interactive tools
- "Use Cases" for pages in the Use Cases category

And yes, it's not a typo that all of them say `content_group1`. The bigger bucket ("grouping") is group 1, which I'm using to be the "Page Type" grouping, although there's no place to actually name the grouping as far as I understand. The smaller buckets ("groups") are each individual page type as indicated.