### PR TITLE
Currency Formatting synthesis / reorganization

### DIFF
--- a/content/_snippets/data_types/currency_code.md
+++ b/content/_snippets/data_types/currency_code.md
@@ -1,4 +1,6 @@
-There are two kinds of currency code in the XRP Ledger:
+The [`rippled` APIs](rippled-api.html) support two formats of currency code for issued currencies:
 
-* Three-character currency code. We recommend using all-uppercase [ISO 4217 Currency Codes](http://www.xe.com/iso4217.php). However, any combination of the following characters is permitted: all uppercase and lowercase letters, digits, as well as the symbols `?`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `<`, `>`, `(`, `)`, `{`, `}`, `[`, `]`, and <code>&#124;</code>. The currency code `XRP` (all-uppercase) is reserved for XRP and cannot be used by issued currencies.
-* 160-bit hexadecimal values, such as `0158415500000000C1F76FF6ECB0BAC600000000`, according to the XRP Ledger's internal [Currency Format](currency-formats.html). This representation is uncommon.
+- **[Standard Currency Codes](currency-formats.html#standard-currency-codes):** As a 3-character string such as `"EUR"` or `"USD"`.
+- **[Nonstandard Currency Codes](currency-formats.html#nonstandard-currency-codes):** As a 160-bit hexadecimal string, such as `"0158415500000000C1F76FF6ECB0BAC600000000"`. This is uncommon.
+
+Currencies with the same code can [ripple](rippling.html) across connected trust lines. Currency codes have no other behavior built into the XRP Ledger.

--- a/content/_snippets/string-number-formatting.md
+++ b/content/_snippets/string-number-formatting.md
@@ -3,5 +3,6 @@ XRP Ledger APIs generally use strings, rather than native JSON numbers, to repre
 * Base-10.
 * Non-zero-prefaced.
 * May contain `.` as a decimal point. For example, ½ is represented as `0.5`. (American style, not European)
-* May contain `E` or `e` to indicate being raised to a power of 10 (scientific notation). For example, `1.2E5` is equivalent to 1.2×10<sup>5</sup>, or `120000`.
+* Negative amounts start with the character `-`.
+* May contain `E` or `e` to indicate being raised to a power of 10 (scientific notation). For example, `1.2E5` is equivalent to 1.2×10<sup>5</sup>, or `120000`. Negative exponents are also possible.
 * No comma (`,`) characters are used.

--- a/content/references/rippled-api/api-conventions/basic-data-types.md
+++ b/content/references/rippled-api/api-conventions/basic-data-types.md
@@ -81,76 +81,27 @@ If you do not specify a ledger, the `current` (in-progress) ledger is chosen by 
 **Note:** Do not rely on this default behavior for specifying a ledger; it is subject to change. Always specify a ledger version in the request if you can.
 
 
-## Currencies
+## Specifying Currency Amounts
 
-There are two kinds of currencies in the XRP Ledger: XRP, and everything else. There are many differences between the two:
+There are two kinds of currencies in the XRP Ledger: XRP, and issued currencies. These two types of currencies are specified in different formats, and they have different amounts of precision and different rounding behavior.
 
-| `XRP`                                                           | Issued Currencies |
-|:----------------------------------------------------------------|:-----------|
-| Has no issuer.                                                  | Always issued by an XRP Ledger account |
-| Specified as a string                                           | Specified as an object |
-| Tracked in [accounts](accountroot.html) | Tracked in [trust lines](ripplestate.html) |
-| Can never be created; can only be destroyed                     | Can be issued or redeemed freely |
-| Maximum value `100000000000` (`1e11`)                           | Maximum value `9999999999999999e80` |
-| Precise to the nearest ["drop"](#xrp) (0.000001 XRP)            | 15 decimal digits of precision, with a minimum nonzero absolute value of `1000000000000000e-96` |
+Some fields, such as the destination `Amount` of a [Payment transaction][], can be either type. Some fields only accept XRP specifically, such as the `Fee` field ([transaction cost](transaction-cost.html)).
 
-**Caution:** The XRP Ledger uses decimal math with different precision than typical floating-point numbers, so currency amounts are always presented as strings.
+XRP is specified as a string containing an integer number of "drops" of XRP, where 1 million drops equals 1 XRP. Issued currencies are instead specified as an object with fields for the decimal amount, currency code, and issuer. For example:
 
-### Specifying Currency Amounts
+- **XRP** - To specify an `Amount` field with a value of 13.1 XRP:
 
-Some API methods require you to specify an amount of currency. Depending on whether you are dealing in the network's native XRP currency or other currency units (called _issuances_), the style for specifying it is very different.
+        "Amount": "13100000"
 
-#### XRP
-[drops of XRP]: #xrp
-[XRP, in drops]: #xrp
+- **Issued Currency** - To specify an `Amount` field with a value of 13.1 FOO issued by or to rf1B...:
 
-Amounts of XRP are represented as strings. (XRP has precision equivalent to a 64-bit integer, but JSON integers are limited to 32 bits, so XRP can overflow if represented in a JSON integer.) XRP is formally specified in "drops", which are equivalent to 0.000001 (one 1-millionth) of an XRP each. Thus, to represent 1.0 XRP in a JSON document, you would write:
+        "Amount": {
+            "value": "13.1",
+            "code": "FOO",
+            "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+        }
 
-```
-"1000000"
-```
-
-**Do not specify XRP as an object.**
-
-Unit tests are permitted to submit values of XRP (not drops) with a decimal point - for example, "1.23" meaning 1.23 XRP. All other cases should always specify XRP in drops, with no decimal point: e.g. "1230000" meaning 1.23 XRP.
-
-#### Non-XRP
-
-If you are specifying non-XRP currency (including fiat dollars, precious metals, cryptocurrencies, or other custom currency) you must specify it with a currency specification object. This is a JSON object with three fields:
-
-| `Field`    | Type                       | Description                        |
-|:-----------|:---------------------------|:-----------------------------------|
-| `currency` | String - [Currency Code][] | Arbitrary code for currency to issue. Cannot be `XRP`. |
-| `value`    | String                     | Quoted decimal representation of the amount of currency. This can include scientific notation, such as `1.23e11` meaning 123,000,000,000. Both `e` and `E` may be used. |
-| `issuer`   | String                     | Unique account address of the entity issuing the currency. In other words, the person or business where the currency can be redeemed. |
-
-**Caution:** These field names are case-sensitive.
-
-For example, to represent $153.75 US dollars issued by account `r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59`, you would specify:
-
-```
-{
-    "currency": "USD",
-    "value": "153.75",
-    "issuer": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-}
-```
-
-Unit tests are permitted to submit amounts of non-XRP currencies as a slash-separated string in the format `"amount/currency/issuer"`. All other cases should use the JSON object format above.
-
-#### Specifying Currencies Without Amounts
-
-If you are specifying a non-XRP currency without an amount (typically for defining an order book of currency exchange offers) you should specify it as above, but omit the `value` field.
-
-If you are specifying XRP without an amount (typically for defining an order book) you should specify it as a JSON object with _only_ a `currency` field. Never include an `issuer` field for XRP.
-
-Finally, if the recipient account of the payment trusts multiple issuers for a currency, you can indicate that the payment should be made in any combination of issuers that the recipient accepts. To do this, specify the recipient account's address as the `issuer` value in the JSON object.
-
-### Currency Codes
-[Currency Code]: #currency-codes
-
-{% include '_snippets/data_types/currency_code.md' %}
-<!--{#_ #}-->
+For more information, see [Currency Formats](currency-formats.html).
 
 
 ## Specifying Time

--- a/content/references/rippled-api/api-conventions/basic-data-types.md
+++ b/content/references/rippled-api/api-conventions/basic-data-types.md
@@ -83,7 +83,7 @@ If you do not specify a ledger, the `current` (in-progress) ledger is chosen by 
 
 ## Specifying Currency Amounts
 
-There are two kinds of currencies in the XRP Ledger: XRP, and issued currencies. These two types of currencies are specified in different formats, and they have different amounts of precision and different rounding behavior.
+There are two kinds of currencies in the XRP Ledger: XRP, and issued currencies. These two types of currencies are specified in different formats, with different precision and rounding behavior.
 
 Some fields, such as the destination `Amount` of a [Payment transaction][], can be either type. Some fields only accept XRP specifically, such as the `Fee` field ([transaction cost](transaction-cost.html)).
 

--- a/content/references/rippled-api/api-conventions/currency-formats.md
+++ b/content/references/rippled-api/api-conventions/currency-formats.md
@@ -1,66 +1,112 @@
 # Currency Formats
 
-The XRP Ledger has two kinds of money: [XRP](xrp.html), and [issued currencies](issued-currencies.html). In the XRP Ledger, both types have high precision, although their formats are different.
+The XRP Ledger has two kinds of money: [XRP](xrp.html), and [issued currencies](issued-currencies.html). Both types have high precision, although their formats are different.
 
-## String Formatting
+## Comparison
+
+The following table summarizes some of the differences between XRP and [issued currencies](issued-currencies.html) in the XRP Ledger:
+
+| XRP                                                      | Issued Currencies |
+|:---------------------------------------------------------|:------------------|
+| Has no issuer.                                           | Always issued by an XRP Ledger account |
+| Specified as a string.                                   | Specified as an object |
+| Tracked in [accounts](accountroot.html).                 | Tracked in [trust lines](ripplestate.html). |
+| Can never be created; can only be destroyed.             | Can be issued or redeemed freely. |
+| Minimum value: `0`. (Cannot be negative.)                | Minimum value: `-9999999999999999e80`. Minimum nonzero absolute value: `1000000000000000e-96`.
+| Maximum value `100000000000` (1<sup>11</sup>) XRP. That's `100000000000000000` (10<sup>17</sup>) "drops". | Maximum value `9999999999999999e80` |
+| Precise to the nearest "drop" (0.000001 XRP)     | 15 decimal digits of precision. |
+| Can't be [frozen](freezes.html).                         | The issuer can [freeze](freezes.html) balances. |
+| No transfer fees; XRP-to-XRP payments are always direct. | Can take indirect [paths](paths.html) with each issuer charging a percentage [transfer fee](transfer-fees.html). |
+| Can be used in [Payment Channels](payment-channels.html) and [Escrow](escrow.html). | Not compatible with Payment Channels or Escrow. |
+
+For more information, see [XRP](xrp.html) and the [Issued Currencies Overview](issued-currencies-overview.html).
+
+## Specifying Currency Amounts
+
+Use the appropriate format for the type of currency you want to specify:
+
+- [XRP Amounts](#xrp-amounts)
+- [Issued Currency Amounts](#issued-currency-amounts)
+
+### XRP Amounts
+
+To specify an amount of XRP, use a [String Number][] indicating _drops_ of XRP, where each drop is equal to 0.000001 XRP. For example, to specify 13.1 XRP:
+
+```
+"13100000"
+```
+
+**Do not specify XRP as an object.**
+
+XRP amounts cannot be negative.
+
+### Issued Currency Amounts
+
+To specify an amount of any issued currency (including fiat dollars, precious metals, cryptocurrencies, or other custom currency), use a currency specification object. This is a JSON object with three fields:
+
+| `Field`    | Type                       | Description                        |
+|:-----------|:---------------------------|:-----------------------------------|
+| `currency` | String - [Currency Code][] | Arbitrary code for currency to issue. Cannot be `XRP`. |
+| `value`    | [String Number][]          | Quoted decimal representation of the amount of currency. This can include scientific notation, such as `1.23e11` meaning 123,000,000,000. Both `e` and `E` may be used. |
+| `issuer`   | String                     | Unique account address of the entity issuing the currency. In other words, the person or business where the currency can be redeemed. |
+
+[String Number]: #string-numbers
+
+**Caution:** These field names are case-sensitive.
+
+For example, to represent $153.75 US dollars issued by account `r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59`, you would specify:
+
+```
+{
+    "currency": "USD",
+    "value": "153.75",
+    "issuer": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
+}
+```
+
+### String Numbers
 
 {% include '_snippets/string-number-formatting.md' %}
 <!--{#_ #}-->
 
+#### Specifying Currencies Without Amounts
+
+If you are specifying a non-XRP currency without an amount (typically for defining an order book of currency exchange offers) you should specify it as above, but omit the `value` field.
+
+If you are specifying XRP without an amount (typically for defining an order book) you should specify it as a JSON object with _only_ a `currency` field. Never include an `issuer` field for XRP.
+
+Finally, if the recipient account of the payment trusts multiple issuers for a currency, you can indicate that the payment should be made in any combination of issuers that the recipient accepts. To do this, specify the recipient account's address as the `issuer` value in the JSON object.
+
+
 ## XRP Precision
 
-XRP has the same precision as a 64-bit unsigned integer where each unit is equivalent to 0.000001 XRP. Its properties are:
-
-* Minimum value: `0`
-* Maximum value: `100000000000` (10<sup>11</sup>) XRP
-    - `"100000000000000000"` (10<sup>17</sup>) drops of XRP
-* Precise to the nearest `0.000001` (10<sup>-6</sup>) XRP
-    - `"1"` drop of XRP
+XRP has the same precision as a 64-bit unsigned integer where each unit is equivalent to 0.000001 XRP. It uses integer math, so that any amount less than a full drop is rounded down.
 
 ## Issued Currency Precision
 
-Issued currencies in the XRP Ledger are represented with a custom format with the following precision:
+The issued currency format can store a wide variety of assets, including those typically measured in very small or very large denominations. This format uses significant digits and a power-of-ten exponent in a similar way to scientific notation. The format supports positive and negative significant digits and exponents within the specified range. Unlike typical floating-point representations of non-whole numbers, this format uses integer math for all calculations, so it always maintains 15 decimal digits of precision. Multiplication and division have adjustments to compensate for over-rounding in the least significant digits.
 
-* Minimum nonzero absolute value: `1000000000000000e-96`
-* Maximum value: `9999999999999999e80`
-* Minimum value: `-9999999999999999e80`
-* 15 decimal digits of precision
-
-## Issued Currency Math
-[[Source]](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/STAmount.cpp "Source")
-
-![Issued Currency Amount Format diagram](img/currency-number-format.png)
-
-Internally, `rippled` represents numbers for issued currencies in a custom number format. This format can store a wide variety of assets, including those typically measured in very small or very large denominations. This format uses significant digits and a power-of-ten exponent in a similar way to scientific notation. The format supports positive and negative significant digits and exponents within the specified range. Unlike typical floating-point representations of non-whole numbers, this format uses integer math for all calculations, so it always maintains 15 decimal digits of precision. Multiplication and division have adjustments to compensate for over-rounding in the least significant digits.
-
-Unlike "arbitrary precision" number formats, the custom format can be stored in a fixed size of 64 bits. When serialized this way, the format consists of a "not XRP" bit, a sign bit, significant digits, and an exponent. They are present in order:
-
-1. The first (most significant) bit for an issued currency amount is `1` to indicate that it is not an XRP amount. (XRP amounts always have the most significant bit set to `0` to distinguish them from this format.)
-2. The sign bit indicates whether the amount is positive or negative. Unlike standard [two's complement](https://en.wikipedia.org/wiki/Two%27s_complement) integers, `1` indicates **positive** in the XRP Ledger format, and `0` indicates negative.
-3. The next 8 bits represent the exponent as an unsigned integer. The exponent indicates the scale (what power of 10 the significant digits should be multiplied by) in the range -96 to +80 (inclusive). However, when serializing, we add 97 to the exponent to make it possible to serialize as an unsigned integer. Thus, a serialized value of `1` indicates an exponent of `-96`, a serialized value of `177` indicates an exponent of 80, and so on.
-4. The remaining 54 bits represent the significant digits as an unsigned integer. When serializing, this value is normalized to the range 10<sup>15</sup> (`1000000000000000`) to 10<sup>16</sup>-1 (`9999999999999999`) inclusive, except for the special case of the value 0. There is a special case for the value 0. In this case, the sign bit, exponent, and mantissa are all zeroes, so the 64-bit value is serialized as `0x8000000000000000000000000000000000000000`.
-
+When sending issued currency amounts in the XRP Ledger's peer-to-peer network, servers [serialize](serialization.html) the amount to a 64-bit binary value.
 
 ## Currency Codes
+[Currency Code]: #currency-codes
 
-All non-XRP currencies in the XRP Ledger have a 160-bit currency code. The [`rippled` APIs](rippled-api.html) map 3-character ASCII strings (case-sensitive) to 160-bit currency codes using a standard mapping. The currency code `XRP` is disallowed for issued currencies. Currencies with the same code can [ripple](rippling.html) across connected trustlines. Currency codes have no other behavior built into the XRP Ledger.
+{% include '_snippets/data_types/currency_code.md' %}
+<!--{#_ #}-->
+
 
 ### Standard Currency Codes
 
-The standard currency mapping allocates the bits as follows:
+The standard format for currency codes is a three-character string such as `USD`. This is intended for use with [ISO 4217 Currency Codes](http://www.xe.com/iso4217.php). The following rules apply:
 
-![Standard Currency Code Format](img/currency-code-format.png)
+- Currency codes must be exactly 3 ASCII characters in length. The following characters are permitted: all uppercase and lowercase letters, digits, as well as the symbols `?`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `<`, `>`, `(`, `)`, `{`, `}`, `[`, `]`, and <code>&#124;</code>.
+- Currency codes are case-sensitive.
+- The currency code `XRP` (all-uppercase) is disallowed. Real XRP typically does not use a currency code in the XRP Ledger protocol.
 
-1. The first 8 bits must be `0x00`.
-2. The next 88 bits are reserved, and should be all `0`'s.
-3. The next 24 bits represent 3 characters of ASCII.
-    Ripple recommends using [ISO 4217](http://www.xe.com/iso4217.php) codes, or popular pseudo-ISO 4217 codes such as "BTC". However, any combination of the following characters is permitted: all uppercase and lowercase letters, digits, as well as the symbols `?`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `<`, `>`, `(`, `)`, `{`, `}`, `[`, `]`, and <code>&#124;</code>. The currency code `XRP` (all-uppercase) is reserved for XRP and cannot be used by issued currencies.
-4. The next 40 bits are reserved and should be all `0`'s.
-
-Usually, XRP amounts are not specified with currency codes. In the rare case that a field specifies a currency code for XRP, the currency code's binary format is all zeroes.
+At the protocol level, this format is [serialized](serialization.html#currency-codes) into a 160-bit binary value starting with `0x00`.
 
 ### Nonstandard Currency Codes
 
-You can also issue currency of other types by using a 160-bit (40-character) hexadecimal string such as `015841551A748AD2C1F76FF6ECB0CCCD00000000` as the currency code. To prevent this from being treated as a different currency code type, the first 8 bits MUST NOT be `0x00`.
+You can also issue currency of other types by using a 160-bit (40-character) hexadecimal string such as `015841551A748AD2C1F76FF6ECB0CCCD00000000` as the currency code. To prevent this from being treated as a "standard" currency code, the first 8 bits MUST NOT be `0x00`.
 
 **Deprecated:** Some previous versions of [ripple-lib](https://github.com/ripple/ripple-lib) supported an "interest-bearing" or "demurraging" currency code type. These currencies have the first 8 bits `0x01`. Demurraging / interest-bearing currencies are no longer supported, but you may encounter them in ledger data. For more information, see [Demurrage](demurrage.html).

--- a/content/references/rippled-api/api-conventions/currency-formats.md
+++ b/content/references/rippled-api/api-conventions/currency-formats.md
@@ -8,12 +8,12 @@ The following table summarizes some of the differences between XRP and [issued c
 
 | XRP                                                      | Issued Currencies |
 |:---------------------------------------------------------|:------------------|
-| Has no issuer.                                           | Always issued by an XRP Ledger account |
-| Specified as a string.                                   | Specified as an object |
+| Has no issuer.                                           | Always issued by an XRP Ledger account. |
+| Specified as a string.                                   | Specified as an object. |
 | Tracked in [accounts](accountroot.html).                 | Tracked in [trust lines](ripplestate.html). |
 | Can never be created; can only be destroyed.             | Can be issued or redeemed freely. |
 | Minimum value: `0`. (Cannot be negative.)                | Minimum value: `-9999999999999999e80`. Minimum nonzero absolute value: `1000000000000000e-96`.
-| Maximum value `100000000000` (1<sup>11</sup>) XRP. That's `100000000000000000` (10<sup>17</sup>) "drops". | Maximum value `9999999999999999e80` |
+| Maximum value `100000000000` (1<sup>11</sup>) XRP. That's `100000000000000000` (10<sup>17</sup>) "drops". | Maximum value `9999999999999999e80`. |
 | Precise to the nearest "drop" (0.000001 XRP)     | 15 decimal digits of precision. |
 | Can't be [frozen](freezes.html).                         | The issuer can [freeze](freezes.html) balances. |
 | No transfer fees; XRP-to-XRP payments are always direct. | Can take indirect [paths](paths.html) with each issuer charging a percentage [transfer fee](transfer-fees.html). |
@@ -87,6 +87,8 @@ XRP has the same precision as a 64-bit unsigned integer where each unit is equiv
 The issued currency format can store a wide variety of assets, including those typically measured in very small or very large denominations. This format uses significant digits and a power-of-ten exponent in a similar way to scientific notation. The format supports positive and negative significant digits and exponents within the specified range. Unlike typical floating-point representations of non-whole numbers, this format uses integer math for all calculations, so it always maintains 15 decimal digits of precision. Multiplication and division have adjustments to compensate for over-rounding in the least significant digits.
 
 When sending issued currency amounts in the XRP Ledger's peer-to-peer network, servers [serialize](serialization.html) the amount to a 64-bit binary value.
+
+**Note:** The XRP Ledger does not support issued currencies that are not [fungible](https://en.wikipedia.org/wiki/Fungibility). It also does not support limiting an issued currency to whole number amounts only. All issued currencies in the XRP Ledger are always divisible down to the minimum amount.
 
 ## Currency Codes
 [Currency Code]: #currency-codes

--- a/content/references/rippled-api/api-conventions/serialization.md
+++ b/content/references/rippled-api/api-conventions/serialization.md
@@ -224,12 +224,12 @@ The following diagram shows the serialization formats for both XRP amounts and i
 
 ![Issued Currency Amount Format diagram](img/currency-number-format.png)
 
-The XRP Ledger uses 64 bits to serialize the numeric amount of an issued currency. (This is the `value` field of a currency amount object in JSON format.) This consists of a "not XRP" bit, a sign bit, significant digits, and an exponent, in order:
+The XRP Ledger uses 64 bits to serialize the numeric amount of an issued currency. (In JSON format, the numeric amount is the `value` field of a currency amount object.) In binary format, the numeric amount consists of a "not XRP" bit, a sign bit, significant digits, and an exponent, in order:
 
 1. The first (most significant) bit for an issued currency amount is `1` to indicate that it is not an XRP amount. (XRP amounts always have the most significant bit set to `0` to distinguish them from this format.)
 2. The sign bit indicates whether the amount is positive or negative. Unlike standard [two's complement](https://en.wikipedia.org/wiki/Two%27s_complement) integers, `1` indicates **positive** in the XRP Ledger format, and `0` indicates negative.
 3. The next 8 bits represent the exponent as an unsigned integer. The exponent indicates the scale (what power of 10 the significant digits should be multiplied by) in the range -96 to +80 (inclusive). However, when serializing, we add 97 to the exponent to make it possible to serialize as an unsigned integer. Thus, a serialized value of `1` indicates an exponent of `-96`, a serialized value of `177` indicates an exponent of 80, and so on.
-4. The remaining 54 bits represent the significant digits as an unsigned integer. When serializing, this value is normalized to the range 10<sup>15</sup> (`1000000000000000`) to 10<sup>16</sup>-1 (`9999999999999999`) inclusive, except for the special case of the value 0. There is a special case for the value 0. In this case, the sign bit, exponent, and mantissa are all zeroes, so the 64-bit value is serialized as `0x8000000000000000000000000000000000000000`.
+4. The remaining 54 bits represent the significant digits as an unsigned integer. When serializing, this value is normalized to the range 10<sup>15</sup> (`1000000000000000`) to 10<sup>16</sup>-1 (`9999999999999999`) inclusive, except for the special case of the value 0. In the special case for 0, the sign bit, exponent, and mantissa are all zeroes, so the 64-bit value is serialized as `0x8000000000000000000000000000000000000000`.
 
 The numeric amount is serialized alongside the [currency code][] and issuer to form a full [issued currency amount](#amount-fields).
 
@@ -240,7 +240,7 @@ At a protocol level, currency codes in the XRP Ledger are arbitrary 160-bit valu
 - The currency code `0x0000000000000000000000005852500000000000` is **always disallowed**. (This is the "standard format" for an issued currency with code "XRP".)
 - The currency code `0x0000000000000000000000000000000000000000` (all zeroes) is **generally disallowed**. Usually, XRP amounts are not specified with currency codes. However, this code is used to indicate XRP in rare cases where a field must specify a currency code for XRP.
 
-The [`rippled` APIs](rippled-apis.html) support a **standard format** for translating three-character ASCII codes to 160-bit hex values as follows:
+The [`rippled` APIs](rippled-api.html) support a **standard format** for translating three-character ASCII codes to 160-bit hex values as follows:
 
 ![Standard Currency Code Format](img/currency-code-format.png)
 

--- a/content/references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
+++ b/content/references/rippled-api/public-rippled-methods/subscription-methods/subscribe.md
@@ -82,11 +82,11 @@ Each member of the `books` array, if provided, is an object with the following f
 
 | `Field`      | Type    | Description                                         |
 |:-------------|:--------|:----------------------------------------------------|
-| `taker_gets` | Object  | Specification of which currency the account taking the offer would receive, as a [currency object with no amount](basic-data-types.html#specifying-currencies-without-amounts). |
-| `taker_pays` | Object  | Specification of which currency the account taking the offer would pay, as a [currency object with no amount](basic-data-types.html#specifying-currencies-without-amounts). |
-| `taker`      | String  | Unique account address to use as a perspective for viewing offers, in the XRP Ledger's [base58][] format. (This affects the funding status and fees of offers.) |
-| `snapshot`   | Boolean | (Optional, defaults to false) If true, return the current state of the order book once when you subscribe before sending updates |
-| `both`       | Boolean | (Optional, defaults to false) If true, return both sides of the order book. |
+| `taker_gets` | Object  | Specification of which currency the account taking the Offer would receive, as a [currency object with no amount](currency-formats.html#specifying-currencies-without-amounts). |
+| `taker_pays` | Object  | Specification of which currency the account taking the Offer would pay, as a [currency object with no amount](currency-formats.html#specifying-currencies-without-amounts). |
+| `taker`      | String  | Unique [account address](accounts.html) to use as a perspective for viewing offers, in the XRP Ledger's [base58][] format. (This affects the funding status and fees of [Offers](offers.html).) |
+| `snapshot`   | Boolean | _(Optional)_ If `true`, return the current state of the order book once when you subscribe before sending updates. The default is `false`. |
+| `both`       | Boolean | _(Optional)_ If `true`, return both sides of the order book. The default is `false`. |
 
 ## Response Format
 

--- a/content/tutorials/get-started/look-up-transaction-results.md
+++ b/content/tutorials/get-started/look-up-transaction-results.md
@@ -140,7 +140,7 @@ The _only_ changes made by this [no-op transaction](cancel-or-skip-a-transaction
 
 - The `Sequence` value increases from 376 to 377.
 
-- The XRP `Balance` in this account changes from `396015176` to `396015164` [drops of XRP](basic-data-types.html#xrp). This decrease of exactly 12 drops represents the [transaction cost](transaction-cost.html), as specified in the `Fee` field of the transaction.
+- The XRP `Balance` in this account changes from `396015176` to `396015164` [drops of XRP][]. This decrease of exactly 12 drops represents the [transaction cost](transaction-cost.html), as specified in the `Fee` field of the transaction.
 
 - The [`AccountTxnID`](transaction-common-fields.html#accounttxnid) changes to reflect that this transaction is now the one most recently sent from this address.
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -278,6 +278,9 @@ targets:
             "rippled-server-modes.html#public-hubs": "rippled-server-modes.html#公開ハブ"
             "peer-protocol.html#peer-discovery": "peer-protocol.html#ピア発見"
             "ledgers.html#tree-format": "ledgers.html#ツリーの形式"
+            # Fix links from untranslated currency_codes snippet
+            "currency-formats.html#standard-currency-codes": "currency-formats.html#標準通貨コード"
+            "currency-formats.html#nonstandard-currency-codes": "currency-formats.html#非標準通貨コード"
 
 
     -   name: xrp-api-only


### PR DESCRIPTION
Before I put in all the work to fix the (likely many) broken links, I wanted to get some reviews to see if the new organizational structure I put in place made sense.

- The bits about currency formatting in **Basic Data Types** have been stripped down to a minimal illustrative example and a link to the detailed currency formatting page.
- I moved the comparison table between XRP and issued currencies near the top of the **Currency Formatting** page and extended it. After doing that I felt like it was redundant to have the minimum and maximum values of the different formats in separate sections, so those details are only in the table now.
- I rephrased the **currency code snippet** to be a little simpler and to link to the expanded definitions in the Currency Formatting page. (This snippet is used in the currency formatting page, where it links to the sections right below it, and is also used in the Data API docs.)
- I moved the nitty-gritty details about the 160-bit currency code format to the **Serialization** page. Unless you're implementing serialization, you probably don't need to know much more about the 160-bit format than "it exists".

If you have a Ripple VPN, you can see the versions I've staged here:

- [Basic Data Types # Specifying Currency Amounts](https://developers-staging.ripple.com/basic-data-types.html#specifying-currency-amounts)
- [Currency Formats](https://developers-staging.ripple.com/currency-formats.html)
- [Serialization # Amount Fields](https://developers-staging.ripple.com/serialization.html#amount-fields)
- [Data API # Currency Code](https://developers-staging.ripple.com/data-api.html#currency-code) (the page may jump to the wrong place because of the code tabs loading in late)