### PR TITLE
Update get-started-with-rippleapi-for-javascript

### DIFF
--- a/content/tutorials/get-started/get-started-with-rippleapi-for-javascript.md
+++ b/content/tutorials/get-started/get-started-with-rippleapi-for-javascript.md
@@ -85,7 +85,7 @@ Use the following template, which includes:
 Use Yarn to install RippleAPI and the dependencies defined in the `package.json` file you created for your project.
 
 ```
-yarn
+yarn add ripple-lib
 ```
 
 This installs RippleAPI and the dependencies into the local folder `node_modules/`.


### PR DESCRIPTION
I was following the tutorial, with the ```yarn``` command only, running the script throws an error. Followed the ```$ yarn add ripple-lib ``` command from https://www.npmjs.com/package/ripple-lib and the error was fixed.
```$ node get-account-info.js
internal/modules/cjs/loader.js:983
  throw err;
  ^
Error: Cannot find module 'ripple-lib'
Require stack:
- <my-directory>\get-account-info.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1040:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (<my-directory>\my_ripple_experiment\get-account-info.js:2:19)
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '<my-directory>\\my_ripple_experiment\\get-account-info.js'     
  ]
}```