### PR TITLE
Prepare-Transaction-txJSON-must-be-a-string

### DIFF
--- a/content/tutorials/use-simple-xrp-payments/send-xrp.md
+++ b/content/tutorials/use-simple-xrp-payments/send-xrp.md
@@ -183,7 +183,7 @@ async function doPrepare() {
   console.log("Transaction expires after ledger:", maxLedgerVersion)
   return preparedTx.txJSON
 }
-txJSON = doPrepare()
+txJSON = JSON.stringify(doPrepare())
 ```
 
 {{ start_step("Prepare") }}


### PR DESCRIPTION
As stated in https://xrpl.org/rippleapi-reference.html#sign, ```sign(txJSON: string, secret: string, options: object)``` txJSON must be a string; however ```doPrepare()``` returns a json.

```$ node sendtest.js 
<my_directory>\my_ripple_experiment\node_modules\ripple-lib\dist\npm\common\schema-validator.js:167
        throw new errors_1.ValidationError(result.errors.join());
        ^

ValidationError: instance.txJSON is not of a type(s) string
    at Object.schemaValidate (<my_directory>\my_ripple_experiment\node_modules\r
ipple-lib\dist\npm\common\schema-validator.js:167:15)
    at apply (<my_directory>\my_ripple_experiment\node_modules\lodash\lodas
h.js:475:27)
    at Object.wrapper [as sign] (<my_directory>\my_ripple_experiment\node_modules\
4mlodash\lodash.js:5317:16)
    at RippleAPI.sign (<my_directory>\my_ripple_experiment\node_modules\ripple-l
ib\dist\npm\transaction\sign.js:136:18)
    at Object.<anonymous> (<my_directory>\my_ripple_experiment\sendtest.js:28:22)   
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12) {
  name: 'ValidationError',
  data: undefined
}
```
