### PR TITLE
account_tx: fix CLI syntax.

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
@@ -45,8 +45,9 @@ An example of the request format:
 *Commandline*
 
 ```
-#Syntax account_tx account ledger_index_min ledger_index_max [offset] [limit] [binary] [count] [forward]
-rippled -- account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 5 1 0 1
+# Syntax: account_tx account [ledger_index_min [ledger_index_max]] [limit] [offset] [binary] [count] [descending]
+# For binary/count/descending use the parameter name for true and omit for false.
+rippled -- account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 0 binary descending
 ```
 
 <!-- MULTICODE_BLOCK_END -->

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
@@ -46,7 +46,7 @@ An example of the request format:
 
 ```
 # Syntax: account_tx account [ledger_index_min [ledger_index_max]] [limit] [offset] [binary] [count] [descending]
-# For binary/count/descending use the parameter name for true and omit for false.
+# For binary/count/descending, use the parameter name for true and omit for false.
 rippled -- account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 0 binary descending
 ```
 


### PR DESCRIPTION
The `limit` and `offset` parameters in the CLI were swapped, and the example had the wrong syntax for `binary`/`count`/`descending` on the commandline.

This should fix the example up a little bit, at least until https://github.com/ripple/rippled/issues/3279 or https://github.com/ripple/rippled/issues/2926 touch up this area of the code.