### PR TITLE
CLI syntax cleanup

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_currencies.md
@@ -10,7 +10,7 @@ An example of the request format:
 
 *WebSocket*
 
-```
+```json
 {
     "command": "account_currencies",
     "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
@@ -21,7 +21,7 @@ An example of the request format:
 
 *JSON-RPC*
 
-```
+```json
 {
     "method": "account_currencies",
     "params": [
@@ -35,6 +35,13 @@ An example of the request format:
 }
 ```
 
+*Commandline*
+
+```sh
+#Syntax: account_currencies account [ledger_index|ledger_hash] [strict]
+rippled account_info rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn validated strict
+```
+
 <!-- MULTICODE_BLOCK_END -->
 
 [Try it! >](websocket-api-tool.html#account_currencies)
@@ -44,9 +51,9 @@ The request includes the following parameters:
 | `Field`        | Type                       | Description                    |
 |:---------------|:---------------------------|:-------------------------------|
 | `account`      | String                     | A unique identifier for the account, most commonly the account's [Address][]. |
-| `strict`       | Boolean                    | _(Optional)_ If true, only accept an address or public key for the account parameter. Defaults to false. |
 | `ledger_hash`  | String                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Unsigned Integer | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
+| `strict`       | Boolean                    | _(Optional)_ If `true`, then the `account` field only accepts a public key or XRP Ledger address. Otherwise, `account` can be a secret or passphrase (not recommended). The default is `false`. |
 
 The following field is deprecated and should not be provided: `account_index`.
 
@@ -58,7 +65,7 @@ An example of a successful response:
 
 *WebSocket*
 
-```
+```json
 {
     "result": {
         "ledger_index": 11775844,
@@ -93,7 +100,7 @@ An example of a successful response:
 
 *JSON-RPC*
 
-```
+```json
 200 OK
 {
     "result": {

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_info.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_info.md
@@ -11,11 +11,11 @@ An example of an account_info request:
 
 *WebSocket*
 
-```
+```json
 {
   "id": 2,
   "command": "account_info",
-  "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
   "strict": true,
   "ledger_index": "current",
   "queue": true
@@ -24,7 +24,7 @@ An example of an account_info request:
 
 *JSON-RPC*
 
-```
+```json
 {
     "method": "account_info",
     "params": [
@@ -40,9 +40,9 @@ An example of an account_info request:
 
 *Commandline*
 
-```
+```sh
 #Syntax: account_info account [ledger_index|ledger_hash] [strict]
-rippled account_info r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 true
+rippled account_info rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn validated strict
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -54,11 +54,11 @@ The request contains the following parameters:
 | `Field`        | Type                       | Description                    |
 |:---------------|:---------------------------|:-------------------------------|
 | `account`      | String                     | A unique identifier for the account, most commonly the account's [Address][]. |
-| `strict`       | Boolean                    | (Optional, defaults to False) If set to True, then the `account` field only accepts a public key or XRP Ledger address. |
 | `ledger_hash`  | String                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Unsigned Integer | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 | `queue`        | Boolean                    | _(Optional)_ If `true`, and the [FeeEscalation amendment][] is enabled, also returns stats about queued transactions associated with this account. Can only be used when querying for the data from the current open ledger. [New in: rippled 0.33.0][] |
 | `signer_lists` | Boolean                    | _(Optional)_ If `true`, and the [MultiSign amendment][] is enabled, also returns any [SignerList objects](signerlist.html) associated with this account. [New in: rippled 0.31.0][] |
+| `strict`       | Boolean                    | _(Optional)_ If `true`, then the `account` field only accepts a public key or XRP Ledger address. Otherwise, `account` can be a secret or passphrase (not recommended). The default is `false`. |
 
 The following fields are deprecated and should not be provided: `ident`, `ledger`.
 
@@ -70,7 +70,7 @@ An example of a successful response:
 
 *WebSocket*
 
-```
+```json
 {
     "id": 5,
     "status": "success",
@@ -120,7 +120,7 @@ An example of a successful response:
 
 *JSON-RPC*
 
-```
+```json
 {
     "result": {
         "account_data": {

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_lines.md
@@ -11,7 +11,7 @@ An example of the request format:
 
 *WebSocket*
 
-```
+```json
 {
   "id": 1,
   "command": "account_lines",
@@ -21,7 +21,7 @@ An example of the request format:
 
 *JSON-RPC*
 
-```
+```json
 {
     "method": "account_lines",
     "params": [
@@ -30,6 +30,13 @@ An example of the request format:
         }
     ]
 }
+```
+
+*Commandline*
+
+```sh
+#Syntax:
+rippled account_lines <account> [<peer>] [<ledger>]
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -57,7 +64,7 @@ An example of a successful response:
 
 *WebSocket*
 
-```
+```json
 {
     "id": 1,
     "status": "success",
@@ -102,8 +109,9 @@ An example of a successful response:
 
 *JSON-RPC*
 
-```
+```json
 200 OK
+
 {
     "result": {
         "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_objects.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_objects.md
@@ -21,9 +21,9 @@ An example of the request format:
 
 *WebSocket*
 
-```
+```json
 {
-  "id": 1,
+  "id": 8,
   "command": "account_objects",
   "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
   "ledger_index": "validated",
@@ -34,7 +34,7 @@ An example of the request format:
 
 *JSON-RPC*
 
-```
+```json
 {
     "method": "account_objects",
     "params": [
@@ -51,7 +51,7 @@ An example of the request format:
 
 *Commandline*
 
-```
+```sh
 #Syntax: account_objects <account> [<ledger>]
 rippled account_objects r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 validated
 ```

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_offers.md
@@ -11,9 +11,9 @@ An example of the request format:
 
 *WebSocket*
 
-```
+```json
 {
-  "id": 2,
+  "id": 9,
   "command": "account_offers",
   "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM"
 }
@@ -21,7 +21,7 @@ An example of the request format:
 
 *JSON-RPC*
 
-```
+```json
 {
     "method": "account_offers",
     "params": [
@@ -34,9 +34,9 @@ An example of the request format:
 
 *Commandline*
 
-```
-#Syntax: account_offers account [ledger_index]
-rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current
+```sh
+#Syntax: account_offers account [ledger_index] [strict]
+rippled account_offers r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 current strict
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -53,6 +53,7 @@ A request can include the following parameters:
 | `ledger_index` | Number - [Ledger Index][]   | (Optional, defaults to `current`) The [ledger index][] of the ledger to use, or "current", "closed", or "validated" to select a ledger dynamically. (See [Specifying Ledgers][]) |
 | `limit`        | Integer                     | (Optional, default varies) Limit the number of transactions to retrieve. The server is not required to honor this value. Must be within the inclusive range 10 to 400. [New in: rippled 0.26.4][] |
 | `marker`       | [Marker][]                  | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. [New in: rippled 0.26.4][] |
+| `strict`       | Boolean                    | _(Optional)_ If `true`, then the `account` field only accepts a public key or XRP Ledger address. Otherwise, `account` can be a secret or passphrase (not recommended). The default is `false`. |
 
 The following parameter is deprecated and may be removed without further notice: `ledger`.
 
@@ -64,7 +65,7 @@ An example of a successful response:
 
 *WebSocket*
 
-```
+```json
 {
   "id": 9,
   "status": "success",
@@ -104,8 +105,9 @@ An example of a successful response:
 
 *JSON-RPC*
 
-```
+```json
 200 OK
+
 {
     "result": {
         "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",


### PR DESCRIPTION
Documents https://github.com/ripple/rippled/pull/3196 (ping @movitto)

- consistent use of 'strict' field in account_currencies, account_info,
  account_offers methods
- cleans up CLI request format a bit for these methods
- adds syntax highlighting hints in a couple places that didn't have it