### PR TITLE
Fixed xrp-api url

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -5714,7 +5714,7 @@ pages:
             - xrp-api-only
 
         # API reference generator makes multiple files here
-    -   openapi_specification: https://raw.githubusercontent.com/ripple/xrp-api/master/api-doc.yml
+    -   openapi_specification: https://raw.githubusercontent.com/xpring-eng/xrp-api/master/api-doc.yml
         openapi_md_template_path: tool/openapi_templates_alpha/
         api_slug: xrp-api
         funnel: Docs


### PR DESCRIPTION
The XRP-API was moved to here: https://github.com/xpring-eng/xrp-api so I updated the dactyl-config accordingly.