### PR TITLE
Add command for upgrading Dactyl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@ To build the site locally:
 
 1. Install [**Dactyl**](https://github.com/ripple/dactyl):
 
-        sudo pip3 install dactyl  
+        sudo pip3 install dactyl
 
-2. Clone the repo:
+2. Clone the repo and change into its directory:
 
-        git clone git@github.com:ripple/xrpl-dev-portal.git
+        git clone git@github.com:ripple/xrpl-dev-portal.git && cd xrpl-dev-portal
 
-3. Build the site:
+3. Build the site to the `out/` directory:
 
         dactyl_build -t en
+
+If you get an error, try upgrading Dactyl before building:
+
+      sudo pip3 install --upgrade dactyl
 
 For more details, see the [contribution guidelines](CONTRIBUTING.md).
 


### PR DESCRIPTION
I was getting this error:
```
% dactyl_build -t en
rendering html...
Traceback (most recent call last):
  File "/usr/local/bin/dactyl_build", line 10, in <module>
    sys.exit(dispatch_main())
  File "/usr/local/lib/python3.7/site-packages/dactyl/dactyl_build.py", line 1101, in dispatch_main
    main(cli.cli_args)
  File "/usr/local/lib/python3.7/site-packages/dactyl/dactyl_build.py", line 1082, in main
    es_upload=cli_args.es_upload,
  File "/usr/local/lib/python3.7/site-packages/dactyl/dactyl_build.py", line 770, in render_pages
    default_template = safe_get_template(config["default_template"], env, fallback_env)
  File "/usr/local/lib/python3.7/site-packages/dactyl/dactyl_build.py", line 547, in safe_get_template
    t = env.get_template(template_name)
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 830, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 804, in _load_template
    template = self.loader.load(self, name, globals)
  File "/usr/local/lib/python3.7/site-packages/jinja2/loaders.py", line 125, in load
    code = environment.compile(source, name, filename)
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 591, in compile
    self.handle_exception(exc_info, source_hint=source_hint)
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.7/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "tool/template-doc.html", line 27, in template
    <div class="devportal-callout note mb-5"><strong>{% trans %}Sorry, this page is not available in your language.{% endtrans %}</strong>
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 497, in _parse
    return Parser(self, source, name, encode_filename(filename)).parse()
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 901, in parse
    result = nodes.Template(self.subparse(), lineno=1)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 883, in subparse
    rv = self.parse_statement()
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 130, in parse_statement
    return getattr(self, 'parse_' + self.stream.current.value)()
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 268, in parse_block
    node.body = self.parse_statements(('name:endblock',), drop_needle=True)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 165, in parse_statements
    result = self.subparse(end_tokens)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 883, in subparse
    rv = self.parse_statement()
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 130, in parse_statement
    return getattr(self, 'parse_' + self.stream.current.value)()
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 212, in parse_if
    node.body = self.parse_statements(('name:elif', 'name:else',
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 165, in parse_statements
    result = self.subparse(end_tokens)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 883, in subparse
    rv = self.parse_statement()
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 144, in parse_statement
    self.fail_unknown_tag(token.value, token.lineno)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 97, in fail_unknown_tag
    return self._fail_ut_eof(name, self._end_token_stack, lineno)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 90, in _fail_ut_eof
    self.fail(' '.join(message), lineno)
  File "/usr/local/lib/python3.7/site-packages/jinja2/parser.py", line 59, in fail
    raise exc(msg, lineno, self.name, self.filename)
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'trans'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
```

Upgrading dactyl fixed the issue:
```
[...]
Installing collected packages: dactyl
  Found existing installation: dactyl 0.8.0
    Uninstalling dactyl-0.8.0:
      Successfully uninstalled dactyl-0.8.0
Successfully installed dactyl-0.10.3
```