### PR TITLE
Submit - document the `notSupported` error

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/submit.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/submit.md
@@ -320,7 +320,7 @@ The response follows the [standard format][], with a successful result containin
 * `invalidTransaction` - The transaction is malformed or otherwise invalid.
 * `noPath` - The transaction did not include paths, and the server was unable to find a path by which this payment can occur. (Sign-and-Submit mode only)
 * `tooBusy` - The transaction did not include paths, but the server is too busy to do pathfinding right now. Does not occur if you are connected as an admin. (Sign-and-Submit mode only)
-* `notSupported` - Signing is not supported by this server. (Sign-and-Submit mode only)
+* `notSupported` - Signing is not supported by this server (Sign-and-Submit mode only.) If you are the server admin, you can still access signing when connected [as an admin](admin-rippled-methods.html), or you could [enable public signing](enable-public-signing.html). [New in: rippled 1.1.0][]
 
 
 <!--{# common link defs #}-->

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/submit.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/submit.md
@@ -320,6 +320,7 @@ The response follows the [standard format][], with a successful result containin
 * `invalidTransaction` - The transaction is malformed or otherwise invalid.
 * `noPath` - The transaction did not include paths, and the server was unable to find a path by which this payment can occur. (Sign-and-Submit mode only)
 * `tooBusy` - The transaction did not include paths, but the server is too busy to do pathfinding right now. Does not occur if you are connected as an admin. (Sign-and-Submit mode only)
+* `notSupported` - Signing is not supported by this server. (Sign-and-Submit mode only)
 
 
 <!--{# common link defs #}-->


### PR DESCRIPTION
Per https://github.com/ripple/rippled/pull/2657 some rippled servers no
longer support signing, so Sign-and-Submit mode has a possible error of
`notSupported`.

The change was introduced in rippled version 1.1.0 and merged via:

https://github.com/ripple/rippled/commit/38c3a46a337916216a1e3ad481229fe87e07d542

The error looks like:

            "name": "notSupported",
            "message": "Signing is not supported by this server.",
            "code": 75,
            ...