### PR TITLE
Add warning about failed AccountDelete costs

### DIFF
--- a/content/concepts/payment-system-basics/accounts/accounts.md
+++ b/content/concepts/payment-system-basics/accounts/accounts.md
@@ -75,6 +75,8 @@ To be deleted, an account must meet the following requirements:
 
 After an account has been deleted, it can be re-created in the ledger through the normal method of [creating accounts](#creating-accounts). An account that has been deleted and re-created is no different than an account that has been created for the first time.
 
+**Warning:** The [AccountDelete transaction][]'s transaction cost applies even if the transaction fails because the account does not meet the requirements to be deleted. To avoid paying 5 XRP in case account deletion fails, [submit the transaction](submit.html) with `fail_hard` enabled so that the transaction is rejected unless it is provisionally successful.
+
 Unlike Bitcoin and many other cryptocurrencies, each new version of the XRP Ledger's public ledger chain contains the full state of the ledger, which increases in size with each new account. For that reason, you should not create new XRP Ledger accounts unless necessary. You can recover some of an account's 20 XRP [reserve](reserves.html) by deleting the account, but you must still destroy at least 5 XRP to do so.
 
 Institutions who send and receive value on behalf of many users can use [**Source Tags** and **Destination Tags**](become-an-xrp-ledger-gateway.html#source-and-destination-tags) to distinguish payments from and to their customers while only using one (or a handful) of accounts in the XRP Ledger.

--- a/content/concepts/payment-system-basics/accounts/accounts.md
+++ b/content/concepts/payment-system-basics/accounts/accounts.md
@@ -75,7 +75,7 @@ To be deleted, an account must meet the following requirements:
 
 After an account has been deleted, it can be re-created in the ledger through the normal method of [creating accounts](#creating-accounts). An account that has been deleted and re-created is no different than an account that has been created for the first time.
 
-**Warning:** The [AccountDelete transaction][]'s transaction cost applies even if the transaction fails because the account does not meet the requirements to be deleted. To avoid paying 5 XRP in case account deletion fails, [submit the transaction](submit.html) with `fail_hard` enabled so that the transaction is rejected unless it is provisionally successful.
+**Warning:** The [AccountDelete transaction][]'s transaction cost always applies when the transaction is included in a validated ledger, even if the transaction failed because the account does not meet the requirements to be deleted. To greatly reduce the chances of paying the high transaction cost if the account cannot be deleted, [submit the transaction](submit.html) with `fail_hard` enabled.
 
 Unlike Bitcoin and many other cryptocurrencies, each new version of the XRP Ledger's public ledger chain contains the full state of the ledger, which increases in size with each new account. For that reason, you should not create new XRP Ledger accounts unless necessary. You can recover some of an account's 20 XRP [reserve](reserves.html) by deleting the account, but you must still destroy at least 5 XRP to do so.
 

--- a/content/references/rippled-api/transaction-formats/transaction-types/accountdelete.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/accountdelete.md
@@ -28,6 +28,12 @@ An AccountDelete transaction deletes an [account](accountroot.html) and any obje
 | `Destination`    |  String - [Address][] | Account      | The address of an account to receive any leftover XRP after deleting the sending account. Must be a funded account in the ledger, and must not be the sending account. |
 | `DestinationTag` | Number           | UInt32            | _(Optional)_ Arbitrary [destination tag](source-and-destination-tags.html) that identifies a hosted recipient or other information for the recipient of the deleted account's leftover XRP. |
 
+## Special Transaction Cost
+
+As an additional deterrent against ledger spam, the AccountDelete transaction requires a much higher than usual [transaction cost](transaction-cost.html): instead of the standard minimum of 0.00001 XRP, AccountDelete must destroy at least the owner reserve amount, currently 5 XRP. This discourages excessive creation of new accounts because the [reserve requirement](reserves.html) cannot be fully recouped by deleting the account.
+
+The transaction cost always applies when a transaction is included in a validated ledger, even if the transaction fails to delete the account. (See [Error Cases](#error-cases).) To greatly reduce the chances of paying the high transaction cost if the account cannot be deleted, [submit the transaction](submit.html) with `fail_hard` enabled. 
+
 
 ## Error Cases
 


### PR DESCRIPTION
Fixes #850.

Note, due to the nature of consensus, `fail_hard` is not a failsafe guarantee that the transaction won't be validated with a `tec` code, but it prevents the vast majority of cases.