### PR TITLE
Remove deleted wikipedia base58 page link

### DIFF
--- a/content/concepts/payment-system-basics/accounts/accounts.ja.md
+++ b/content/concepts/payment-system-basics/accounts/accounts.ja.md
@@ -107,7 +107,7 @@ XRP Ledgerでは、トランザクション（取引）履歴をトランザク�
 
 [[ソース]](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/AccountID.cpp#L109-L140 "Source")
 
-XRP Ledgerのアドレスは、[base58](https://en.wikipedia.org/wiki/Base58)_形式のディクショナリ_`rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`を使用してエンコードされています。XRP Ledgerはbase58でいくつかのタイプのキーをエンコードするため、それらを区別するためにエンコードされたデータの前に1バイトの「タイププレフィクス」（「バージョンプレフィクス」とも呼ばれます）を付けます。タイププレフィクスによりアドレスは通常、base58形式の異なる文字で始まります。
+XRP Ledgerのアドレスは、[base58][]_形式のディクショナリ_`rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`を使用してエンコードされています。XRP Ledgerはbase58でいくつかのタイプのキーをエンコードするため、それらを区別するためにエンコードされたデータの前に1バイトの「タイププレフィクス」（「バージョンプレフィクス」とも呼ばれます）を付けます。タイププレフィクスによりアドレスは通常、base58形式の異なる文字で始まります。
 
 次の図は、キーとアドレスの関係を示しています。
 

--- a/content/concepts/payment-system-basics/accounts/accounts.md
+++ b/content/concepts/payment-system-basics/accounts/accounts.md
@@ -109,7 +109,7 @@ For more information on each of these objects, see the [Ledger Format Reference]
 
 [[Source]](https://github.com/ripple/rippled/blob/35fa20a110e3d43ffc1e9e664fc9017b6f2747ae/src/ripple/protocol/impl/AccountID.cpp#L109-L140 "Source")
 
-XRP Ledger addresses are encoded using [base58](https://en.wikipedia.org/wiki/Base58) with the _dictionary_ `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`. Since the XRP Ledger encodes several types of keys with base58, it prefixes the encoded data with a one-byte "type prefix" (also called a "version prefix") to distinguish them. The type prefix causes addresses to usually start with different letters in base58 format.
+XRP Ledger addresses are encoded using [base58][] with the _dictionary_ `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`. Since the XRP Ledger encodes several types of keys with base58, it prefixes the encoded data with a one-byte "type prefix" (also called a "version prefix") to distinguish them. The type prefix causes addresses to usually start with different letters in base58 format.
 
 The following diagram shows the relationship between keys and addresses:
 

--- a/content/references/rippled-api/api-conventions/base58-encodings.ja.md
+++ b/content/references/rippled-api/api-conventions/base58-encodings.ja.md
@@ -1,6 +1,6 @@
 # base58エンコード
 
-`rippled` APIでは、チェックサムを含む[base58](https://en.wikipedia.org/wiki/Base58)エンコード（「Base58Check」とも呼ばれます）を使用して[アカウントアドレス](accounts.html#アドレス)や暗号鍵に関連するその他のタイプの値が表現されることがよくあります。このエンコードは、Bitcoinのアドレスに使用されているエンコードと同じですが、XRP Ledgerでは以下のディクショナリが使用される点が異なります。`rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`。
+`rippled` APIでは、チェックサムを含む**base58**エンコード（「Base58Check」とも呼ばれます）を使用して[アカウントアドレス](accounts.html#アドレス)や暗号鍵に関連するその他のタイプの値が表現されることがよくあります。このエンコードは、[Bitcoinのアドレスに使用されているエンコード](https://en.bitcoin.it/wiki/Base58Check_encoding)と同じですが、XRP Ledgerでは以下のディクショナリが使用される点が異なります。`rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`。
 
 XRP Ledgerにより、さまざまなタイプの値をエンコードする前に、データタイプを区別する固有の8ビット数値が値の前に付加されます。XRP Ledgerのbase58ディクショナリの文字配列と組み合わされた、さまざまなタイプのエンコード値のbase58表現は、タイプごとに固有の文字で始まります。
 

--- a/content/references/rippled-api/api-conventions/base58-encodings.md
+++ b/content/references/rippled-api/api-conventions/base58-encodings.md
@@ -1,8 +1,8 @@
 # base58 Encodings
 
-The `rippled` APIs often use a [base58](https://en.wikipedia.org/wiki/Base58) encoding with a checksum (sometimes called "Base58Check") to represent [account addresses](accounts.html#addresses) and other types of values related to cryptographic keys. This encoding is the same as the one used for Bitcoin addresses, except that the XRP Ledger uses the following dictionary: `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`.
+The `rippled` APIs often use a "base58" encoding with a checksum (sometimes called "Base58Check") to represent [account addresses](accounts.html#addresses) and other types of values related to cryptographic keys. This encoding is the same as [the one used for Bitcoin addresses](https://en.bitcoin.it/wiki/Base58Check_encoding), except that the XRP Ledger uses the following dictionary: `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz`.
 
-The XRP Ledger prefixes different types of values with a specific 8-bit number before encoding them to distinguish between different data types. Combined with the arrangement of characters in the XRP Ledger's base58 dictionary, the result is that the base58 representations for different types of encoded values start with specific letters by type.
+The XRP Ledger prefixes different types of values with a specific 8-bit number before encoding them to distinguish between different data types. With the arrangement of characters in the XRP Ledger's base58 dictionary, the result is that the base58 representations for different types of encoded values start with specific letters by type.
 
 The following table lists all the encodings the XRP Ledger uses:
 


### PR DESCRIPTION
Wikipedia deleted the base58 page for "lack of notability" so I've removed the now-dead link from our base58 page and added a link to the Bitcoin wiki.