### PR TITLE
Add link compression tutorial

### DIFF
--- a/content/tutorials/manage-the-rippled-server/configure-peering/enable-link-compression.md
+++ b/content/tutorials/manage-the-rippled-server/configure-peering/enable-link-compression.md
@@ -8,13 +8,13 @@ blurb: Save bandwidth by compressing peer-to-peer communications.
 ---
 # Enable Link Compression
 
-The `rippled` server can save bandwidth by compressing its [peer-to-peer communications](peer-protocol.html), at a cost of greater CPU usage. If you enable link compression, the server automatically compresses communications with peer servers that also have link compression enabled. The server uses uncompressed communications with peers who do not have have link compression enabled or do not support link compression. [New in: rippled 1.6.0][]
+The `rippled` server can save bandwidth by compressing its [peer-to-peer communications](peer-protocol.html), at a cost of greater CPU usage. If you enable link compression, the server automatically compresses communications with peer servers that also have link compression enabled. [New in: rippled 1.6.0][]
 
 ## Steps
 
 To enable link compression on your server, complete the following steps:
 
-### 1. Edit your `rippled`'s config file.
+### 1. Edit your `rippled` server's config file.
 
 ```sh
 $ vim /etc/opt/ripple/rippled.cfg

--- a/content/tutorials/manage-the-rippled-server/configure-peering/enable-link-compression.md
+++ b/content/tutorials/manage-the-rippled-server/configure-peering/enable-link-compression.md
@@ -1,0 +1,52 @@
+---
+html: enable-link-compression.html
+funnel: Docs
+doc_type: Tutorials
+category: Manage the rippled Server
+subcategory: Configure Peering
+blurb: Save bandwidth by compressing peer-to-peer communications.
+---
+# Enable Link Compression
+
+The `rippled` server can save bandwidth by compressing its [peer-to-peer communications](peer-protocol.html), at a cost of greater CPU usage. If you enable link compression, the server automatically compresses communications with peer servers that also have link compression enabled. The server uses uncompressed communications with peers who do not have have link compression enabled or do not support link compression. [New in: rippled 1.6.0][]
+
+## Steps
+
+To enable link compression on your server, complete the following steps:
+
+### 1. Edit your `rippled`'s config file.
+
+```sh
+$ vim /etc/opt/ripple/rippled.cfg
+```
+
+{% include '_snippets/conf-file-location.md' %}<!--_ -->
+
+### 2. In the config file, add or uncomment the `[compression]` stanza.
+
+To enable compression:
+
+```text
+[compression]
+true
+```
+
+Use `false` to disable compression (the default).
+
+### 3. Restart the `rippled` server
+
+```sh
+$ sudo systemctl restart rippled.service
+```
+
+After the restart, your server automatically uses link compression with other peers that also have link compression enabled.
+
+## See Also
+
+- [Capacity Planning](capacity-planning.html)
+- [Peer Protocol](peer-protocol.html)
+
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}
+{% include '_snippets/tx-type-links.md' %}
+{% include '_snippets/rippled_versions.md' %}

--- a/content/tutorials/manage-the-rippled-server/installation/capacity-planning.md
+++ b/content/tutorials/manage-the-rippled-server/installation/capacity-planning.md
@@ -1,3 +1,11 @@
+---
+html: capacity-planning.html
+funnel: Docs
+doc_type: Tutorials
+category: Manage the rippled Server
+subcategory: Installation
+blurb: Plan system specs and tune configuration for rippled in production environments.
+---
 # Capacity Planning
 
 This section describes configuration, network, and hardware recommendations that you can use to tune and optimize the performance of your `rippled` server. Being aware of these considerations can help you ensure that your `rippled` server is ready to handle XRP Ledger network capacity today and in the near future.
@@ -181,7 +189,7 @@ Any enterprise or carrier-class data center should have substantial network band
 
 During exceptionally high periods of transaction volume, some operators have reported that their `rippled` servers have completely saturated a 100MBit/s network link. Therefore, a gigabit network interface is required for reliable performance.
 
-Here are examples of observed network bandwidth use for common `rippled` tasks:
+Here are examples of observed uncompressed network bandwidth use for common `rippled` tasks:
 
 | Task                                            | Transmit/Receive           |
 |:------------------------------------------------|:---------------------------|
@@ -189,6 +197,9 @@ Here are examples of observed network bandwidth use for common `rippled` tasks:
 | Process peak transaction volumes                | >100Mbps transmit          |
 | Serve historical ledger and transaction reports | 100Mbps transmit           |
 | Start up `rippled`                              | 20Mbps receive             |
+
+You can save bandwidth by [enabling compression on peer-to-peer communications](enable-link-compression.html), at a cost of higher CPU. Many hardware configurations have spare CPU capacity during normal use, so this can be an economical option if your network bandwidth is limited.
+
 
 ## See Also
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2248,12 +2248,6 @@ pages:
             - ja
 
     -   md: tutorials/manage-the-rippled-server/installation/capacity-planning.md
-        html: capacity-planning.html
-        funnel: Docs
-        doc_type: Tutorials
-        category: Manage the rippled Server
-        subcategory: Installation
-        blurb: Plan system specs and tune configuration for rippled in production environments.
         targets:
             - en
 
@@ -2566,6 +2560,12 @@ pages:
         blurb: rippledサーバーがステータスとピアについてどの程度の情報を公表するか設定します。
         untranslated_warning: true
         targets:
+            - ja
+
+    # TODO: translate this page including the blurb in its frontmatter.
+    -   md: tutorials/manage-the-rippled-server/configure-peering/enable-link-compression.md
+        targets:
+            - en
             - ja
 
     -   md: tutorials/manage-the-rippled-server/configure-peering/forward-ports-for-peering.md


### PR DESCRIPTION
- Add tutorial for enabling link compression as introduced in https://github.com/ripple/rippled/pull/3287
- Add mention of the tutorial to Capacity Planning document
- Move metadata to frontmatter for the two affected pages