### PR TITLE
Fix some typos in the Validator List Method page

### DIFF
--- a/content/references/rippled-api/validator-list.md
+++ b/content/references/rippled-api/validator-list.md
@@ -6,7 +6,8 @@ Like the [Peer Crawler](peer-crawler.html), the validator list method is availab
 
 ## Request Format
 
-To request the Peer Crawler information, make the following HTTP request:
+To request the Validator List information, make the following HTTP
+request:
 
 - **Protocol:** https
 - **HTTP Method:** GET
@@ -67,8 +68,9 @@ If you decode the `blob` from base64, the result is a JSON object with the follo
 | `Field`      | Value  | Description                                          |
 |:-------------|:-------|:-----------------------------------------------------|
 | `sequence`   | Number | Unique sequence number for this list. A larger sequence number indicates a newer list; only the newest list is valid at a time. |
-| `expiration` | Number | The time this list expires, in [seconds since the Ripple Epoch][]. |
-| `validators  | Array  | A list of recommended validators.                    |
+| `expiration` | Number | The time this list expires, in [seconds since
+the Ripple Epoch][]. |
+| `validators` | Array  | A list of recommended validators.  |
 
 Each member of the `validators` array has the following fields:
 
@@ -99,7 +101,7 @@ GET https://localhost:51235/vl
 *cURL*
 
 ```
-curl --insecure https://localhost:51235/vl
+curl --insecure https://localhost:51235/vl/ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
 ```
 
 <!-- MULTICODE_BLOCK_END -->

--- a/content/references/rippled-api/validator-list.md
+++ b/content/references/rippled-api/validator-list.md
@@ -68,9 +68,8 @@ If you decode the `blob` from base64, the result is a JSON object with the follo
 | `Field`      | Value  | Description                                          |
 |:-------------|:-------|:-----------------------------------------------------|
 | `sequence`   | Number | Unique sequence number for this list. A larger sequence number indicates a newer list; only the newest list is valid at a time. |
-| `expiration` | Number | The time this list expires, in [seconds since
-the Ripple Epoch][]. |
-| `validators` | Array  | A list of recommended validators.  |
+| `expiration` | Number | The time this list expires, in [seconds since the Ripple Epoch][]. |
+| `validators` | Array  | A list of recommended validators.                    |
 
 Each member of the `validators` array has the following fields:
 


### PR DESCRIPTION
This only corrects the info as of 1.5.0. Does not include changes pending for 1.6.0, so it can be merged right away.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/xrpl-dev-portal/883)
<!-- Reviewable:end -->
