### PR TITLE
Update instructions for connecting to Devnet

### DIFF
--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.ja.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.ja.md
@@ -7,87 +7,84 @@ Rippleは[代替となるテスト用および開発用ネットワーク](paral
 `rippled`サーバーをXRP TestnetまたはDevnetに接続するには、以下の構成を設定します。
 
 1. `rippled.cfg`ファイルで以下の手順に従います。
-   
+
    a. [Testnet](xrp-testnet-faucet.html)に接続するには、以下のセクションのコメントを解除し、次のように追加します。
-   
+
         [ips]
         s.altnet.rippletest.net 51235
-   
+
    b. [Devnet](xrp-testnet-faucet.html)に接続するには、以下のセクションのコメントを解除し、次のように追加します。
-   
+
         [ips]
         s.devnet.rippletest.net 51235
-   
+
    c. 以下のセクションを次のようにコメントアウトします。
-   
+
         # [ips]
         # r.ripple.com 51235
 
 
 
 2. `validators.txt`ファイルで以下の手順に従います。
-   
+
    2a. Altnetに接続するための変更
-   
+
         a. 以下のセクションのコメントを解除し、Altnetに接続するようにします。
-       
+
             [validator_list_sites]
             https://vl.altnet.rippletest.net
-       
+
             [validator_list_keys]
             ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
-       
+
         b. 以下のセクションを次のようにコメントアウトします。
-       
+
             # [validator_list_sites]
             # https://vl.ripple.com
             #
             # [validator_list_keys]
             # ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-   
+
    2b. Devnetに接続するための変更
-   
+
         a. 以下のセクションをコメントアウトします。
-       
+
             # [validator_list_sites]
             # https://vl.altnet.rippletest.net
-       
+
             # [validator_list_keys]
             # ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860        
-       
+
             # [validator_list_sites]
             # https://vl.ripple.com
             #
             # [validator_list_keys]
             # ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-       
+
         b. 次の信頼できるバリデータをvalidator.txtファイルに追加します。
-       
-            # Hard-coded List of Devnet Validators
-            [validators]
-            n9Mo4QVGnMrRN9jhAxdUFxwvyM4aeE1RvCuEGvMYt31hPspb1E2c
-            n9MEwP4LSSikUnhZJNQVQxoMCgoRrGm6GGbG46AumH2KrRrdmr6B
-            n9M1pogKUmueZ2r3E3JnZyM3g6AxkxWPr8Vr3zWtuRLqB7bHETFD
-            n9MX7LbfHvPkFYgGrJmCyLh8Reu38wsnnxA4TKhxGTZBuxRz3w1U
-            n94aw2fof4xxd8g3swN2qJCmooHdGv1ajY8Ae42T77nAQhZeYGdd
-            n9LiE1gpUGws1kFGKCM9rVFNYPVS4QziwkQn281EFXX7TViCp2RC
-            n9Jq9w1R8UrvV1u2SQqGhSXLroeWNmPNc3AVszRXhpUr1fmbLyhS
+
+            [validator_list_sites]
+            https://vl.devnet.rippletest.net/index.json
+
+            [validator_list_keys]
+            021B0DE76CED20C8B341086D8F4C8AB3D62657C6EDE19395461B197223D6271CA5
+
 
 
 3. `rippled`を再起動します。
 
 4. `rippled`がXRP TestnetまたはDevnetに接続していることを確認するため、サーバーで[server_infoメソッド][]を使用して、その結果をTestnetまたはDevnetの公開サーバーの結果と比較します。両方のサーバーで`validated_ledger`オブジェクトの`seq`フィールドが同一である必要があります（確認中にこの数が変化した場合は、1～2の差が生じる可能性があります）。
-   
+
    以下のコマンドは、`s.altnet.rippletest.net`にあるTestnetサーバーの最新の検証済みレジャーをチェックします。
-   
+
         $ ./rippled --rpc_ip 34.210.87.206:51234 server_info | grep seq
-   
+
    以下のコマンドは、`s.devnet.rippletest.net`にあるDevnetサーバーの最新の検証済みレジャーをチェックします。
-   
+
         $ ./rippled --rpc_ip 34.83.125.234:51234 server_info | grep seq
-   
+
    以下のコマンドは、ローカルの`rippled`の最新検証済みレジャーインデックスをチェックします。
-   
+
         $ ./rippled server_info | grep seq
 
 

--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.ja.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.ja.md
@@ -67,7 +67,7 @@ Rippleは[代替となるテスト用および開発用ネットワーク](paral
             https://vl.devnet.rippletest.net/index.json
 
             [validator_list_keys]
-            021B0DE76CED20C8B341086D8F4C8AB3D62657C6EDE19395461B197223D6271CA5
+            EDDF2F53DFEC79358F7BE76BC884AC31048CFF6E2A00C628EAE06DB7750A247B12
 
 
 

--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
@@ -4,98 +4,153 @@ Ripple hosts [alternative test and development networks](parallel-networks.html)
 
 **Note:** The XRP Testnet and Devnet ledger and balances are reset on a regular basis.
 
-To connect your `rippled` server to the XRP Testnet or Devnet, set the following configurations:
+## Steps
 
-1. Edit your `rippled.cfg` file to connect to a hub server in the network you want to connect to.
+To connect your `rippled` server to the XRP Testnet or Devnet, complete these steps. You can also use these steps to switch back to the production Mainnet after being on the Testnet or Devnet.
 
-    1. To connect to the [Testnet](xrp-testnet-faucet.html), uncomment or add the following section:
+## 1. Configure your server to connect to the right hub.
 
-            [ips]
-            s.altnet.rippletest.net 51235
+Edit your `rippled.cfg` file.
 
-    2. To connect to the [Devnet](xrp-testnet-faucet.html), uncomment or add the following section:
+{% include '_snippets/conf-file-location.md' %}
+<!--{_ }-->
 
-            [ips]
-            s.devnet.rippletest.net 51235
+1. Set an `[ips]` stanza with the hub for the network you want to connect to:
 
-    3. Comment out the existing `[ips]` stanza:
+    <!-- MULTICODE_BLOCK_START -->
 
-            # [ips]
-            # r.ripple.com 51235
+    *Testnet*
 
+        [ips]
+        s.altnet.rippletest.net 51235
 
+    *Devnet*
 
-2. Edit your `validators.txt` file.
+        [ips]
+        s.devnet.rippletest.net 51235
 
-    - To connect to the Testnet:
+    *Mainnet*
 
-        1. Uncomment the following sections:
-
-                [validator_list_sites]
-                https://vl.altnet.rippletest.net
-
-                [validator_list_keys]
-                ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
-
-        1. Comment out the following sections, as follows:
-
-                # [validator_list_sites]
-                # https://vl.ripple.com
-                #
-                # [validator_list_keys]
-                # ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-
-    - To connect to the Devnet:
-
-        1. Comment out the following sections:
-
-                # [validator_list_sites]
-                # https://vl.altnet.rippletest.net
-
-                # [validator_list_keys]
-                # ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860        
-
-                # [validator_list_sites]
-                # https://vl.ripple.com
-                #
-                # [validator_list_keys]
-                # ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-
-        2. Add the following trusted validators to the `validator.txt` file:
-
-                # Hard-coded List of Devnet Validators
-                [validators]
-                n9Mo4QVGnMrRN9jhAxdUFxwvyM4aeE1RvCuEGvMYt31hPspb1E2c
-                n9MEwP4LSSikUnhZJNQVQxoMCgoRrGm6GGbG46AumH2KrRrdmr6B
-                n9M1pogKUmueZ2r3E3JnZyM3g6AxkxWPr8Vr3zWtuRLqB7bHETFD
-                n9MX7LbfHvPkFYgGrJmCyLh8Reu38wsnnxA4TKhxGTZBuxRz3w1U
-                n94aw2fof4xxd8g3swN2qJCmooHdGv1ajY8Ae42T77nAQhZeYGdd
-                n9LiE1gpUGws1kFGKCM9rVFNYPVS4QziwkQn281EFXX7TViCp2RC
-                n9Jq9w1R8UrvV1u2SQqGhSXLroeWNmPNc3AVszRXhpUr1fmbLyhS
+        # No [ips] stanza. Use the default hubs to connect to Mainnet.
 
 
-3. Restart `rippled`.
+3. Comment out the previous `[ips]` stanza, if there is one:
 
-4. To verify that your `rippled` is connected to the XRP Testnet or Devnet, use the [server_info method][] on your server and compare it to the results from a public server on the Testnet or Devnet. The `seq` field of the `validated_ledger` object should be the same on both servers (possibly off by one or two, if it changed as you were checking).
+        # [ips]
+        # r.ripple.com 51235
+        # zaphod.alloy.ee 51235
+        # sahyadri.isrdc.in 51235
 
-    The following command checks the latest validated ledger of a Testnet server at `s.altnet.rippletest.net`:
+## 2. Set your trusted validator list.
 
-        $ ./rippled --rpc_ip 34.210.87.206:51234 server_info | grep seq
+Edit your `validators.txt` file. This file is located in the same folder as your `rippled.cfg` file and defines which validators your server trusts not to collude.
 
-    The following command checks the latest validated ledger of a Devnet server at `s.devnet.rippletest.net`:
+1. Uncomment or add the `[validator_list_sites]` and `[validator_list_keys]` stanzas for the network you want to connect to:
 
-        $ ./rippled --rpc_ip 34.83.125.234:51234 server_info | grep seq
+    <!-- MULTICODE_BLOCK_START -->
 
-    The following command checks your local `rippled`'s latest validated ledger index:
+    *Testnet*
 
-        $ ./rippled server_info | grep seq
+        [validator_list_sites]
+        https://vl.altnet.rippletest.net
+
+        [validator_list_keys]
+        ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
+
+    *Devnet*
+
+        [validator_list_sites]
+        https://vl.devnet.rippletest.net/index.json
+
+        [validator_list_keys]
+        021B0DE76CED20C8B341086D8F4C8AB3D62657C6EDE19395461B197223D6271CA5
+
+
+    *Mainnet*
+
+      	[validator_list_sites]
+      	https://vl.ripple.com
+
+      	[validator_list_keys]
+      	ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+
+    <!-- MULTICODE_BLOCK_END -->
+
+1. Comment out any previous `[validator_list_sites]`, `[validator_list_keys]`, or `[validators]` stanzas.
+
+    For example:
+
+            # [validator_list_sites]
+            # https://vl.ripple.com
+            #
+            # [validator_list_keys]
+            # ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+
+            # Old hard-coded List of Devnet Validators
+            # [validators]
+            # n9Mo4QVGnMrRN9jhAxdUFxwvyM4aeE1RvCuEGvMYt31hPspb1E2c
+            # n9MEwP4LSSikUnhZJNQVQxoMCgoRrGm6GGbG46AumH2KrRrdmr6B
+            # n9M1pogKUmueZ2r3E3JnZyM3g6AxkxWPr8Vr3zWtuRLqB7bHETFD
+            # n9MX7LbfHvPkFYgGrJmCyLh8Reu38wsnnxA4TKhxGTZBuxRz3w1U
+            # n94aw2fof4xxd8g3swN2qJCmooHdGv1ajY8Ae42T77nAQhZeYGdd
+            # n9LiE1gpUGws1kFGKCM9rVFNYPVS4QziwkQn281EFXX7TViCp2RC
+            # n9Jq9w1R8UrvV1u2SQqGhSXLroeWNmPNc3AVszRXhpUr1fmbLyhS
+
+## 3. Restart the server.
+
+```
+$ sudo systemctl restart rippled
+```
+
+## 4. Verify that your server syncs.
+
+It takes about 5 to 15 minutes to sync to the network after a restart. After your server is synced, the [server_info method][] shows the a `validated_ledger` object based on the network you are connected to.
+
+To verify that your `rippled` is connected to the XRP Testnet or Devnet, compare the results from your server to [a public server](get-started-with-the-rippled-api.html#public-servers) on the Testnet or Devnet. The `seq` field of the `validated_ledger` object should be the same on both servers (possibly off by one or two, if it changed as you were checking).
+
+The following example shows how to check the latest validated ledger from the commandline:
+
+<!-- MULTICODE_BLOCK_START -->
+
+*Local Server*
+
+```sh
+$ rippled server_info | grep seq
+```
+
+*Testnet*
+
+```sh
+# s.altnet.rippletest.net
+$ rippled --rpc_ip 35.158.96.209:51234 server_info | grep seq
+```
+
+*Devnet*
+
+```sh
+# s.devnet.rippletest.net
+$ rippled --rpc_ip 34.83.125.234:51234 server_info | grep seq
+```
+
+
+*Mainnet*
+
+```sh
+# s1.ripple.com
+$ rippled --rpc_ip 34.201.59.230:51234 server_info | grep seq
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+**Note:** The IP addresses in these examples are for public servers, and may change periodically. If you get no response, look up the IP address of a [public server](get-started-with-the-rippled-api.html#public-servers), for example using the `dig` command.
+
 
 
 ## See Also
 
 - **Tools:**
     - [XRP Faucets](xrp-testnet-faucet.html)
-    - [WebSocket API Tool](websocket-api-tool.html) - Select 'Testnet Public Server' in the connection options.
+    - [WebSocket API Tool](websocket-api-tool.html) - Select 'Testnet Public Server' or 'Devnet Public Server' in the connection options.
 - **Concepts:**
     - [Parallel Networks](parallel-networks.html)
     - [Introduction to Consensus](intro-to-consensus.html)

--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
@@ -60,10 +60,10 @@ Edit your `validators.txt` file. This file is located in the same folder as your
     *Devnet*
 
         [validator_list_sites]
-        https://vl.devnet.rippletest.net/index.json
+        https://vl.devnet.rippletest.net
 
         [validator_list_keys]
-        021B0DE76CED20C8B341086D8F4C8AB3D62657C6EDE19395461B197223D6271CA5
+        EDDF2F53DFEC79358F7BE76BC884AC31048CFF6E2A00C628EAE06DB7750A247B12
 
 
     *Mainnet*
@@ -72,7 +72,7 @@ Edit your `validators.txt` file. This file is located in the same folder as your
         https://vl.ripple.com
 
         [validator_list_keys]
-        EDDF2F53DFEC79358F7BE76BC884AC31048CFF6E2A00C628EAE06DB7750A247B12
+        ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
 
     <!-- MULTICODE_BLOCK_END -->
 

--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
@@ -68,11 +68,11 @@ Edit your `validators.txt` file. This file is located in the same folder as your
 
     *Mainnet*
 
-      	[validator_list_sites]
-      	https://vl.ripple.com
+        [validator_list_sites]
+        https://vl.ripple.com
 
-      	[validator_list_keys]
-      	ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+        [validator_list_keys]
+        EDDF2F53DFEC79358F7BE76BC884AC31048CFF6E2A00C628EAE06DB7750A247B12
 
     <!-- MULTICODE_BLOCK_END -->
 


### PR DESCRIPTION
1. New formatting with code tabs and Mainnet equivalents
2. New UNL-based Devnet config
3. I did a short edit of the Japanese page to match (2) but not to implement (1). Also, my editor automatically applied some whitespace changes to the Japanese file when I saved it.