### PR TITLE
Improve meta tags

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -51,6 +51,7 @@ cover_page:
     html: index.html
     template: template-home.html
     sidebar: disabled
+    canonical_url: https://xrpl.org/
 
 languages:
     -   code: en
@@ -6243,6 +6244,7 @@ pages:
         doc_type: Dev Tools
         template: template-websocket-api-tool.html
         html: websocket-api-tool.html
+        canonical_url: https://xrpl.org/websocket-api-tool.html
         targets:
             - en
             - ja

--- a/tool/template-base.html
+++ b/tool/template-base.html
@@ -3,16 +3,25 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>{{ currentpage.name }} - {{target.display_name}}</title>
+
     <meta name="viewport" content="width=device-width">
     <meta property="og:title" content="{{ currentpage.name|escape }} | {{ target.display_name }}">
     <meta property="og:url" content="https://xrpl.org/{% if currentpage.html != 'index.html' %}{{currentpage.html}}{% endif %}" />
     <meta property="og:description" content="{% if currentpage.html == 'index.html' %}{{ target.blurb|escape}}{% else %}{{ currentpage.blurb|escape }}{% endif %}" />
+    <meta name="description" content="{% if currentpage.html == 'index.html' %}{{ target.blurb|escape}}{% else %}{{ currentpage.blurb|escape }}{% endif %}" />
     <meta property="og:image" content="https://xrpl.org/assets/img/{% if currentpage.fb_card %}{{currentpage.fb_card}}{% else %}xrpl-fb-li-card.png{% endif %}" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:image" content="https://xrpl.org/assets/img/{% if currentpage.twitter_card %}{{currentpage.twitter_card}}{% else %}xrpl-twitter-card.png{% endif %}" />
+    {% if currentpage.canonical_url %}<link rel="canonical" href="{{currentpage.canonical_url}}" />{% endif %}
+    <meta name="robots" content="index, follow" />
 
+    {% for lang in config.languages %}
+    <link rel="alternate" href="https://xrpl.org{{lang.prefix}}{{currentpage.html}}" hreflang="{{lang.code}}" />
+    {% endfor %}
+    <link rel="alternate" href="https://xrpl.org/{{currentpage.html}}" hreflang="x-default" /><!-- Default: US english -->
 
-    <title>{{ currentpage.name }} - {{target.display_name}}</title>
 
     <!-- favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicons/apple-touch-icon.png">


### PR DESCRIPTION
- Adds a standard meta description tag in addition to the social media description tags (same content; the page blurb).
- Moves the title element up (no functional difference, it just appeals to my sensibilities to have the title as close to the top as possible)
- Add canonical URLs for the homepage and websocket tool. We can add similar attributes for other pages that use query parameters.
- Add `hreflang` links for the translated version(s) of the page [per Google's recommendations](https://developers.google.com/search/docs/advanced/crawling/localized-versions). (This will automatically scale if/when we add languages other than English and Japanese.)

Example of the generated metadata (for escrow.html):

```

<head>
    <meta charset="utf-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">

    <title>Escrow - XRPL.org</title>

    <meta name="viewport" content="width=device-width">
    <meta property="og:title" content="Escrow | XRPL.org">
    <meta property="og:url" content="https://xrpl.org/escrow.html" />
    <meta property="og:description" content="Escrows set aside XRP and deliver it later when certain conditions are met. Escrows can depend on time limits, cryptographic conditions, or both." />
    <meta name="description" content="Escrows set aside XRP and deliver it later when certain conditions are met. Escrows can depend on time limits, cryptographic conditions, or both." />
    <meta property="og:image" content="https://xrpl.org/assets/img/xrpl-fb-li-card.png" />
    <meta name="twitter:card" content="summary" />
    <meta name="twitter:image" content="https://xrpl.org/assets/img/xrpl-twitter-card.png" />
    <meta name="robots" content="index, follow" />

    <link rel="alternate" href="https://xrpl.org/escrow.html" hreflang="en" />
    <link rel="alternate" href="https://xrpl.org/ja/escrow.html" hreflang="ja" />
    <link rel="alternate" href="https://xrpl.org/escrow.html" hreflang="x-default" /><!-- Default: US english -->
```