### PR TITLE
PaymentChannelFund: can't extend expiration only

### DIFF
--- a/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.ja.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.ja.md
@@ -1,9 +1,18 @@
+---
+html: paymentchannelfund.html
+funnel: Build
+doc_type: References
+supercategory: rippled API
+category: Transaction Formats
+subcategory: Transaction Types
+blurb: Payment ChannelにXRPを追加します。
+---
 # PaymentChannelFund
 [[ソース]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
 
 _[PayChan Amendment][]が必要です。_
 
-オープンPayment ChannelにXRPを追加するか、Channelの有効期限を更新するか、またはこの両方を行います。このトランザクションは、Channelの支払元アドレスだけが使用できます。（他のアドレスからのトランザクションはエラー`tecNO_PERMISSION`で失敗します。）
+Payment ChannelにXRPを追加する、有効期限の更新も可能。このトランザクションは、Channelの支払元アドレスだけが使用できます。
 
 PaymentChannelFundの例:
 
@@ -23,10 +32,24 @@ PaymentChannelFundの例:
 | フィールド    | JSONの型  | [内部の型][]       | 説明                          |
 |:-------------|:----------|:------------------|:------------------------------|
 | `Channel` | 文字列 | Hash256 | 資金供給するChannelの一意のID（64文字の16進文字列）。 |
-| `Amount` | 文字列 | Amount | Channelに追加する[XRP、drop単位][通貨額]の額。Channelの有効期限を設定し、XRPを追加しない場合は、これを`"0"`に設定します。 |
+| `Amount` | 文字列 | Amount | Channelに追加する[XRP、drop単位][通貨額]の正の額。 |
 | `Expiration` | 数値 | UInt32 | _（省略可）_ Channelに新たに設定する`Expiration`の時刻（Rippleエポック以降の経過秒数）。現行時刻にChannelの`SettleDelay`を加えた時刻よりも後であるか、またはChannelの既存の`Expiration`よりも後である必要があります。`Expiration`時刻の経過後には、トランザクションがそのChannelにアクセスするとChannelが閉鎖し、トランザクションの通常の処理は行われません。Channelの閉鎖時には未使用のXRPはすべて支払元アドレスに返金されます。（`Expiration`は、Channelの不変の`CancelAfter`時刻とは別のものです。）詳細は、[PayChannelレジャーオブジェクトタイプ](paychannel.html)を参照してください。 |
 
-送金先アカウントが削除されている場合、トランザクションは`tecNO_DST`で失敗します。（これは、[DeletableAccounts Amendment](known-amendments.html#deletableaccounts) :not_enabled:が有効になっており、 _かつ_ Payment Channelの作成時に[fixPayChanRecipientOwnerDir amendment](known-amendments.html#fixpaychanrecipientownerdir) :not_enabled:が有効になっていなかった場合にのみ発生する可能性があります。）
+
+## エラーケース
+
+すべてのトランザクションで発生する可能性のあるエラーに加えて、{{currentpage.name}}トランザクションでは、次の[トランザクション結果コード](transaction-results.html)が発生する可能性があります。
+
+| エラーコード | 説明        |
+|:-----------|:------------|
+| `tecINSUFFICIENT_RESERVE` | 支払元アカウントが[必要準備金](reserves.html)のXRPを持っていません。|
+| `tecNO_DST`               | 送金先アカウントが削除されていました。 この可能性は、Payment Channelの作成時は[fixPayChanRecipientOwnerDir amendment](known-amendments.html#fixpaychanrecipientownerdir)が有効になった（2020-05-01）前の場合だけです。|
+| `tecNO_ENTRY`             | `Channel`フィールドに指定されたPayment Channelがありません。 |
+| `tecNO_PERMISSION`        | トランザクションの送金元アカウントはPayment Channelの支払元アカウントではありまっせん。|
+| `tecUNFUNDED`             | 送金元アカウントは[必要準備金](reserves.html)以上に指定されたXRPを持っていません。|
+| `temBAD_AMOUNT`           | トランザクションの`Amount`フィールドの指定が正しくない。負もゼロも無効です。|
+| `temBAD_EXPIRATION`       | `Expiration`フィールドの指定が正しくない。|
+
 
 <!--{# common link defs #}-->
 {% include '_snippets/rippled-api-links.md' %}

--- a/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.md
+++ b/content/references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.md
@@ -1,9 +1,18 @@
+---
+html: paymentchannelfund.html
+funnel: Build
+doc_type: References
+supercategory: rippled API
+category: Transaction Formats
+subcategory: Transaction Types
+blurb: Add more XRP to a payment channel.
+---
 # PaymentChannelFund
 [[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
 
 _Added by the [PayChan amendment][]._
 
-Add additional XRP to an open payment channel, update the expiration time of the channel, or both. Only the source address of the channel can use this transaction. (Transactions from other addresses fail with the error `tecNO_PERMISSION`.)
+Add additional [XRP](xrp.html) to an open [payment channel](payment-channels.html), and optionally update the expiration time of the channel. Only the source address of the channel can use this transaction.
 
 Example PaymentChannelFund:
 
@@ -23,10 +32,23 @@ Example PaymentChannelFund:
 | Field        | JSON Type | [Internal Type][] | Description                   |
 |:-------------|:----------|:------------------|:------------------------------|
 | `Channel`    | String    | Hash256           | The unique ID of the channel to fund, as a 64-character hexadecimal string. |
-| `Amount`     | String    | Amount            | Amount of [XRP, in drops][Currency Amount] to add to the channel. To set the expiration for a channel without adding more XRP, set this to `"0"`. |
-| `Expiration` | Number    | UInt32            | _(Optional)_ New `Expiration` time to set for the channel, in seconds since the Ripple Epoch. This must be later than either the current time plus the `SettleDelay` of the channel, or the existing `Expiration` of the channel. After the `Expiration` time, any transaction that would access the channel closes the channel without taking its normal action. Any unspent XRP is returned to the source address when the channel closes. (`Expiration` is separate from the channel's immutable `CancelAfter` time.) For more information, see the [PayChannel ledger object type](paychannel.html). |
+| `Amount`     | String    | Amount            | Amount of [XRP, in drops][Currency Amount] to add to the channel. Must be a positive amount of XRP. |
+| `Expiration` | Number    | UInt32            | _(Optional)_ New `Expiration` time to set for the channel, in [seconds since the Ripple Epoch][]. This must be later than either the current time plus the `SettleDelay` of the channel, or the existing `Expiration` of the channel. After the `Expiration` time, any transaction that would access the channel closes the channel without taking its normal action. Any unspent XRP is returned to the source address when the channel closes. (`Expiration` is separate from the channel's immutable `CancelAfter` time.) For more information, see the [PayChannel ledger object type](paychannel.html). |
 
-If the destination account has been deleted, the transaction fails with `tecNO_DST`. This is only possible if the payment channel was created before the [fixPayChanRecipientOwnerDir amendment](known-amendments.html#fixpaychanrecipientownerdir) became enabled (on 2020-05-01).
+## Error Cases
+
+In addition to errors that can occur for all transactions, {{currentpage.name}} transactions can result in the following [transaction result codes](transaction-results.html):
+
+| Error Code                | Description                                      |
+|:--------------------------|:-------------------------------------------------|
+| `tecINSUFFICIENT_RESERVE` | The sending account has less XRP than the [reserve requirement](reserves.html). |
+| `tecNO_DST`               | The destination account of the channel has been deleted. This is only possible if the payment channel was created before the [fixPayChanRecipientOwnerDir amendment](known-amendments.html#fixpaychanrecipientownerdir) became enabled (on 2020-05-01). |
+| `tecNO_ENTRY`             | The Payment Channel identified by the `Channel` field does not exist. |
+| `tecNO_PERMISSION`        | The sender of the transaction is not the source address for the channel. |
+| `tecUNFUNDED`             | The sending account does not have enough XRP to fund the channel with the requested amount and still meet the [reserve requirement](reserves.html). |
+| `temBAD_AMOUNT`           | The `Amount` field of the transaction is invalid. The amount must be XRP and it cannot be zero or negative. |
+| `temBAD_EXPIRATION`       | The `Expiration` field is invalid.              |
+
 
 <!--{# common link defs #}-->
 {% include '_snippets/rippled-api-links.md' %}

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -5571,24 +5571,10 @@ pages:
             - ja
 
     -   md: references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.md
-        html: paymentchannelfund.html
-        funnel: Build
-        doc_type: References
-        supercategory: rippled API
-        category: Transaction Formats
-        subcategory: Transaction Types
-        blurb: Add more XRP to a payment channel.
         targets:
             - en
 
     -   md: references/rippled-api/transaction-formats/transaction-types/paymentchannelfund.ja.md
-        html: paymentchannelfund.html
-        funnel: Build
-        doc_type: References
-        supercategory: rippled API
-        category: Transaction Formats
-        subcategory: Transaction Types
-        blurb: オープンPayment ChannelにXRPを追加します。
         targets:
             - ja
 


### PR DESCRIPTION
- Fixes doc bug stating you can extend expiration by "funding" channel with 0 XRP.
- Updates error case info for PaymentChannelFund
- Moves paymentchannelfund.md metadata to frontmatter
- 日本語も含まれています！ (Japanese included.)