### PR TITLE
Social link fixes

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -6370,6 +6370,8 @@ known_broken_links:
     - https://www.forte.io/
     - https://www.kraken.com/
     - https://xrpscan.com/amendments
+    - https://twitter.com/xrpsymbol/status/1006925937571713025
+    - https://twitter.com/intent/tweet?url=https%3A%2F%2Fxrpl.org%2Fcarbon-calculator.html&text=XRPL%20Carbon%20Calculator
 
 # Style Checker Config ------------------------------------------------------ #
 

--- a/tool/template-calculator.html
+++ b/tool/template-calculator.html
@@ -77,9 +77,9 @@
                 </ul>
               </div>
               <div class="d-flex mb-3 ml-3">
-                <a href="https://twitter.com/intent/tweet?url=https://xrpl.org/carbon-calculator.html&text=XRPL Carbon Calculator" target="_blank" class="mr-3"><img src="./img/logos/Twitter.png" alt="{% trans %}Twitter share{% endtrans %}" class="mw-100"></a>
-                <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://xrpl.org/carbon-calculator.html" target="_blank" class="mr-3"><img src="./img/logos/LinkedIn.png" alt="{% trans %}LinkedIn share{% endtrans %}" class="mw-100"></a>
-                <a href="https://www.facebook.com/sharer/sharer.php?u=https://xrpl.org/carbon-calculator.html" target="_blank" class="mr-3"><img src="./img/logos/Facebook.png" alt="{% trans %}Facebook share{% endtrans %}" class="mw-100">
+                <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fxrpl.org%2Fcarbon-calculator.html&text=XRPL%20Carbon%20Calculator" target="_blank" class="mr-3"><img src="./img/logos/Twitter.png" alt="{% trans %}Twitter share{% endtrans %}" class="mw-100"></a>
+                <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fxrpl.org%2Fcarbon-calculator.html" target="_blank" class="mr-3"><img src="./img/logos/LinkedIn.png" alt="{% trans %}LinkedIn share{% endtrans %}" class="mw-100"></a>
+                <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fxrpl.org%2Fcarbon-calculator.html" target="_blank" class="mr-3"><img src="./img/logos/Facebook.png" alt="{% trans %}Facebook share{% endtrans %}" class="mw-100">
                 </a>
               </div>
           </div>


### PR DESCRIPTION
- URL-encode hrefs to social sharing links
- Add link checker exceptions for Twitter links since the link checker gets an "unsupported browser" error when trying to check them