### PR TITLE
ledger_entry and WebSocket Tool updates

### DIFF
--- a/assets/js/apitool-methods-ws.js
+++ b/assets/js/apitool-methods-ws.js
@@ -299,8 +299,9 @@ Request('ledger_entry - DepositPreauth', {
 
 Request("Transaction Methods")
 
-// Signing methods are not provided here because it's a terrible idea to send
-// your secret to another server over the internet.
+// Signing methods are not provided here because they're admin-only by default.
+// (Sending your secret to another server is extremely insecure and could cause
+// someone else to take over your account, steal all your money, etc.)
 
 Request('submit', {
   description: "Submits a transaction to the network to be confirmed and included in future ledgers.",

--- a/assets/js/apitool-methods-ws.js
+++ b/assets/js/apitool-methods-ws.js
@@ -1,3 +1,5 @@
+DEFAULT_ADDRESS_1 = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+
 Request("Account Methods")
 
 Request('account_channels', {
@@ -6,8 +8,8 @@ Request('account_channels', {
     body: {
       "id": 1,
       "command": "account_channels",
-      "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
-      "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH", //TODO: different address
+      "destination_account": DEFAULT_ADDRESS_1,
       "ledger_index": "validated"
     }
 })
@@ -17,7 +19,7 @@ Request('account_currencies', {
   link: "account_currencies.html",
   body: {
     "command": "account_currencies",
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": DEFAULT_ADDRESS_1,
     "strict": true,
     "ledger_index": "validated"
   }
@@ -29,7 +31,7 @@ Request('account_info', {
   body: {
     "id": 2,
     "command": "account_info",
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": DEFAULT_ADDRESS_1,
     "strict": true,
     "ledger_index": "current",
     "queue": true
@@ -42,7 +44,7 @@ Request('account_lines', {
   body: {
     "id": 2,
     "command": "account_lines",
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": DEFAULT_ADDRESS_1,
     "ledger_index": "validated"
   }
 })
@@ -53,7 +55,7 @@ Request('account_objects', {
   body: {
     "id": 1,
     "command": "account_objects",
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": DEFAULT_ADDRESS_1,
     "ledger_index": "validated",
     "type": "state",
     "limit": 10
@@ -66,7 +68,7 @@ Request('account_offers', {
   body: {
     "id": 2,
     "command": "account_offers",
-    "account": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM"
+    "account": DEFAULT_ADDRESS_1
   }
 })
 
@@ -76,7 +78,7 @@ Request('account_tx', {
   body: {
     "id": 2,
     "command": "account_tx",
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": DEFAULT_ADDRESS_1,
     "ledger_index_min": -1,
     "ledger_index_max": -1,
     "binary": false,
@@ -91,9 +93,12 @@ Request('gateway_balances', {
   body: {
     "id": "example_gateway_balances_1",
     "command": "gateway_balances",
-    "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+    "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q", // btc2ripple
     "strict": true,
-    "hotwallet": ["rKm4uWpg9tfwbVSeATv4KxDe6mpE9yPkgJ","ra7JkEzrgeKHdzKgo4EUUVBnxggY4z37kt"],
+    "hotwallet": [
+      "rKm4uWpg9tfwbVSeATv4KxDe6mpE9yPkgJ",
+      "ra7JkEzrgeKHdzKgo4EUUVBnxggY4z37kt"
+    ],
     "ledger_index": "validated"
   }
 })
@@ -104,7 +109,7 @@ Request('noripple_check', {
   body: {
     "id": 0,
     "command": "noripple_check",
-    "account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "account": DEFAULT_ADDRESS_1,
     "role": "gateway",
     "ledger_index": "current",
     "limit": 2,
@@ -159,22 +164,133 @@ Request('ledger_data', {
  }
 })
 
-Request('ledger_entry', {
-  description: "Returns a single ledger object in its raw format.",
-  link: "ledger_entry.html",
+Request('ledger_entry - by object ID', {
+  description: "Returns an object by its unique ID.",
+  link: "ledger_entry.html#TODO",
   body: {
-    "id": 3,
     "command": "ledger_entry",
-    "type": "account_root",
-    "account_root": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "index": "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
     "ledger_index": "validated"
   }
 })
 
+Request('ledger_entry - AccountRoot', {
+  description: "Returns a single account in its raw ledger format.",
+  link: "ledger_entry.html#TODO",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "account_root": DEFAULT_ADDRESS_1,
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - DirectoryNode', {
+  description: "Returns a directory object in its raw ledger format.",
+  link: "ledger_entry.html#get-directorynode-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "directory": {
+      "owner": DEFAULT_ADDRESS_1,
+      "sub_index": 1
+    },
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - Offer', {
+  description: "Returns an Offer object in its raw ledger format.",
+  link: "ledger_entry.html#get-offer-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "offer": {
+      "account": DEFAULT_ADDRESS_1,
+      "seq": 359
+    },
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - RippleState', {
+  description: "Returns a RippleState object in its raw ledger format.",
+  link: "ledger_entry.html#get-ripplestate-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "ripple_state": {
+      "accounts": [
+        DEFAULT_ADDRESS_1,
+        "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
+      ],
+      "currency": "USD"
+    },
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - Check', {
+  description: "Returns a Check object in its raw ledger format.",
+  link: "ledger_entry.html#get-check-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "check": "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334",
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - Escrow', {
+  description: "Returns an Escrow object in its raw ledger format.",
+  link: "ledger_entry.html#get-escrow-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "escrow": ""//todo: make an escrow
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - PayChannel', {
+  description: "Returns a PayChannel object in its raw ledger format.",
+  link: "ledger_entry.html#get-paychannel-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "channel": ""//todo: make a paychannel
+    "ledger_index": "validated"
+  }
+})
+
+Request('ledger_entry - DepositPreauth', {
+  description: "Returns a DepositPreauth object in its raw ledger format.",
+  link: "ledger_entry.html#get-depositpreauth-object",
+  body: {
+    "id": 3,
+    "command": "ledger_entry",
+    "deposit_preauth": ""//todo: find a real example
+    "ledger_index": "validated"
+  }
+})
+
+// Waiting for TicketBatch amendment
+// Request('ledger_entry - Ticket', {
+//   description: "Returns a Ticket object in its raw ledger format.",
+//   link: "ledger_entry.html#get-ticket-object",
+//   body: {
+//     "id": 3,
+//     "command": "ledger_entry",
+//     "ticket": ""//TODO
+//     "ledger_index": "validated"
+//   }
+// })
+
+
 Request("Transaction Methods")
 
-// Future feature: special case sign/sign_for so you can use those if you're
-// connected to a local server (with big warning)
+// Signing methods are not provided here because it's a terrible idea to send
+// your secret to another server over the internet.
 
 Request('submit', {
   description: "Submits a transaction to the network to be confirmed and included in future ledgers.",
@@ -244,16 +360,6 @@ Request('tx', {
   }
 })
 
-Request('tx_history', {
-  description: "Retrieves some of the most recent transactions made. (DEPRECATED)",
-  link: "tx_history.html",
-  body: {
-    "id": 5,
-    "command": "tx_history",
-    "start": 0
-  }
-})
-
 Request("Path and Order Book Methods")
 
 Request('book_offers', {
@@ -262,7 +368,7 @@ Request('book_offers', {
   body: {
     "id": 4,
     "command": "book_offers",
-    "taker": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "taker": DEFAULT_ADDRESS_1,
     "taker_gets": {
       "currency": "XRP"
     },
@@ -294,8 +400,8 @@ Request('path_find', {
     "id": 8,
     "command": "path_find",
     "subcommand": "create",
-    "source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "destination_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "source_account": DEFAULT_ADDRESS_1,
+    "destination_account": DEFAULT_ADDRESS_1,
     "destination_amount": {
         "value": "0.001",
         "currency": "USD",
@@ -310,7 +416,7 @@ Request('ripple_path_find', {
   body: {
     "id": 8,
     "command": "ripple_path_find",
-    "source_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "source_account": DEFAULT_ADDRESS_1,
     "source_currencies": [
         {
             "currency": "XRP"
@@ -319,7 +425,7 @@ Request('ripple_path_find', {
             "currency": "USD"
         }
     ],
-    "destination_account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "destination_account": DEFAULT_ADDRESS_1,
     "destination_amount": {
         "value": "0.001",
         "currency": "USD",

--- a/assets/js/apitool-methods-ws.js
+++ b/assets/js/apitool-methods-ws.js
@@ -1,4 +1,5 @@
 DEFAULT_ADDRESS_1 = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+DEFAULT_ADDRESS_2 = "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"
 
 Request("Account Methods")
 
@@ -8,8 +9,8 @@ Request('account_channels', {
     body: {
       "id": 1,
       "command": "account_channels",
-      "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH", //TODO: different address
-      "destination_account": DEFAULT_ADDRESS_1,
+      "account": DEFAULT_ADDRESS_1,
+      "destination_account": DEFAULT_ADDRESS_2,
       "ledger_index": "validated"
     }
 })
@@ -166,7 +167,7 @@ Request('ledger_data', {
 
 Request('ledger_entry - by object ID', {
   description: "Returns an object by its unique ID.",
-  link: "ledger_entry.html#TODO",
+  link: "ledger_entry.html#get-ledger-object-by-id",
   body: {
     "command": "ledger_entry",
     "index": "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
@@ -176,9 +177,9 @@ Request('ledger_entry - by object ID', {
 
 Request('ledger_entry - AccountRoot', {
   description: "Returns a single account in its raw ledger format.",
-  link: "ledger_entry.html#TODO",
+  link: "ledger_entry.html#get-accountroot-object",
   body: {
-    "id": 3,
+    "id": "example_get_accountroot",
     "command": "ledger_entry",
     "account_root": DEFAULT_ADDRESS_1,
     "ledger_index": "validated"
@@ -189,11 +190,11 @@ Request('ledger_entry - DirectoryNode', {
   description: "Returns a directory object in its raw ledger format.",
   link: "ledger_entry.html#get-directorynode-object",
   body: {
-    "id": 3,
+    "id": "example_get_directorynode",
     "command": "ledger_entry",
     "directory": {
       "owner": DEFAULT_ADDRESS_1,
-      "sub_index": 1
+      "sub_index": 0
     },
     "ledger_index": "validated"
   }
@@ -203,7 +204,7 @@ Request('ledger_entry - Offer', {
   description: "Returns an Offer object in its raw ledger format.",
   link: "ledger_entry.html#get-offer-object",
   body: {
-    "id": 3,
+    "id": "example_get_offer",
     "command": "ledger_entry",
     "offer": {
       "account": DEFAULT_ADDRESS_1,
@@ -217,7 +218,7 @@ Request('ledger_entry - RippleState', {
   description: "Returns a RippleState object in its raw ledger format.",
   link: "ledger_entry.html#get-ripplestate-object",
   body: {
-    "id": 3,
+    "id": "example_get_ripplestate",
     "command": "ledger_entry",
     "ripple_state": {
       "accounts": [
@@ -234,9 +235,9 @@ Request('ledger_entry - Check', {
   description: "Returns a Check object in its raw ledger format.",
   link: "ledger_entry.html#get-check-object",
   body: {
-    "id": 3,
+    "id": "example_get_check",
     "command": "ledger_entry",
-    "check": "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334",
+    "check": "C4A46CCD8F096E994C4B0DEAB6CE98E722FC17D7944C28B95127C2659C47CBEB",
     "ledger_index": "validated"
   }
 })
@@ -245,9 +246,12 @@ Request('ledger_entry - Escrow', {
   description: "Returns an Escrow object in its raw ledger format.",
   link: "ledger_entry.html#get-escrow-object",
   body: {
-    "id": 3,
+    "id": "example_get_escrow",
     "command": "ledger_entry",
-    "escrow": ""//todo: make an escrow
+    "escrow": { // This is a long-lasting Escrow found in public data
+      "owner": "rL4fPHi2FWGwRGRQSH7gBcxkuo2b9NTjKK",
+      "seq": 126
+    },
     "ledger_index": "validated"
   }
 })
@@ -256,9 +260,9 @@ Request('ledger_entry - PayChannel', {
   description: "Returns a PayChannel object in its raw ledger format.",
   link: "ledger_entry.html#get-paychannel-object",
   body: {
-    "id": 3,
+    "id": "example_get_paychannel",
     "command": "ledger_entry",
-    "channel": ""//todo: make a paychannel
+    "payment_channel": "C7F634794B79DB40E87179A9D1BF05D05797AE7E92DF8E93FD6656E8C4BE3AE7",
     "ledger_index": "validated"
   }
 })
@@ -267,21 +271,27 @@ Request('ledger_entry - DepositPreauth', {
   description: "Returns a DepositPreauth object in its raw ledger format.",
   link: "ledger_entry.html#get-depositpreauth-object",
   body: {
-    "id": 3,
+    "id": "example_get_deposit_preauth",
     "command": "ledger_entry",
-    "deposit_preauth": ""//todo: find a real example
+    "deposit_preauth": {
+      "owner": DEFAULT_ADDRESS_1,
+      "authorized": DEFAULT_ADDRESS_2
+    },
     "ledger_index": "validated"
   }
 })
 
-// Waiting for TicketBatch amendment
+// Waiting for TicketBatch amendment on Mainnet
 // Request('ledger_entry - Ticket', {
 //   description: "Returns a Ticket object in its raw ledger format.",
 //   link: "ledger_entry.html#get-ticket-object",
 //   body: {
-//     "id": 3,
+//     "id": "example_get_ticket",
 //     "command": "ledger_entry",
-//     "ticket": ""//TODO
+//     "ticket": {
+//       "owner": DEFAULT_ADDRESS_1,
+//       "ticket_sequence": 0 // TODO: make a real ticket, fill in the seq
+//     },
 //     "ledger_index": "validated"
 //   }
 // })
@@ -296,7 +306,7 @@ Request('submit', {
   description: "Submits a transaction to the network to be confirmed and included in future ledgers.",
   link: "submit.html",
   body: {
-    "id": 3,
+    "id": "example_submit",
     "command": "submit",
     "tx_blob": "1200002280000000240000001E61D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000B732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7447304502210095D23D8AF107DF50651F266259CC7139D0CD0C64ABBA3A958156352A0D95A21E02207FCF9B77D7510380E49FF250C21B57169E14E9B4ACFD314CEDC79DDD0A38B8A681144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754"
   }
@@ -386,8 +396,8 @@ Request('deposit_authorized', {
   body: {
     "id": 1,
     "command": "deposit_authorized",
-    "source_account": "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
-    "destination_account": "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+    "source_account": DEFAULT_ADDRESS_1,
+    "destination_account": DEFAULT_ADDRESS_2,
     "ledger_index": "validated"
   }
 })

--- a/assets/js/apitool-websocket.js
+++ b/assets/js/apitool-websocket.js
@@ -86,12 +86,13 @@ function select_request(request) {
   } else {
     el = commandlist.find("li a[href='#"+request+"']").parent()
   }
-  $(el).siblings().removeClass('active');
-  $(el).addClass('active');
+  $(el).siblings().removeClass('active')
+  $(el).addClass('active')
 
   const command = requests[request];
   if (command === undefined) {
-    console.log("request:", request, "requests:", requests)
+    console.warning("Unknown request identifier from # anchor.")
+    return false
   }
 
   if (command.description) {
@@ -121,6 +122,7 @@ function select_request(request) {
       cm_request.setValue("")
   }
   cm_request.refresh()
+  return true
 };
 
 function send_request() {
@@ -329,7 +331,11 @@ $(document).ready(function() {
 
     if (window.location.hash) {
       var cmd   = window.location.hash.slice(1).toLowerCase();
-      select_request(cmd);
+      if (!select_request(cmd)) {
+        // Didn't find a definition for the request from the hash. Use the
+        // default instead.
+        select_request()
+      }
     } else if (search_params.has("server") || search_params.has("req")) {
       load_from_permalink(search_params)
     } else {

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
@@ -187,7 +187,9 @@ rippled json ledger_entry '{ "directory": { "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9z
 
 
 #### {{n.next()}}. Specify Offer Object
-4. `offer` - Retrieve an [Offer object](offer.html), which defines an offer to exchange currency. Can be provided as string (unique index of the Offer) or as an object.
+
+Retrieve an [Offer object](offer.html), which defines an offer to exchange currency. Can be provided as string (unique index of the Offer) or as an object.
+
 | `Field`                 | Type                       | Description           |
 |:------------------------|:---------------------------|:----------------------|
 | `offer`                 | Object or String           | _(Required if `type` is "offer")_ Specify an [Offer object](offer.html) to retrieve. If a string, interpret as the [unique index](ledgers.html#tree-format) to the Offer. If an object, requires the sub-fields `account` and `seq` to uniquely identify the offer. |

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
@@ -5,9 +5,87 @@ The `ledger_entry` method returns a single ledger object from the XRP Ledger in 
 
 ## Request Format
 
-An example of the request format:
+This method can retrieve several different types of data. You can select which type of item to retrieve by passing the appropriate parameters, comprised of the general and type-specific fields listed below. Please also keep in mind standard [request formatting](request-formatting.html) (e.g. including an optional `id` with WebSocket calls or the `method` field to name the API method with JSON-RPC calls).
+
+For WebSocket calls `command` will be set to "ledger_entry", and for JSON-RPC calls `method` will be set to "ledger_entry".
 
 {% include '_snippets/no-cli-syntax.md' %}
+
+### General Fields 
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `type`                  | String                     | _(Optional)_ The type of ledger entry to be retrieved. Refer to  [Type Specific Fields](ledger_entry.html#type-specific-fields) below for more details. |
+| `binary`                | Boolean                    | _(Optional)_ If true, return the requested ledger object's contents as a hex string. Otherwise, return data in JSON format. The default is `false`. [Updated in: rippled 1.2.0][] |
+| `ledger_hash`           | String                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
+| `ledger_index`          | String or Unsigned Integer | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string (e.g. "validated" or "closed" or "current") to choose a ledger automatically. (See [Specifying Ledgers][]) |
+
+
+
+### Type Specific Fields
+
+In addition to the general fields above, you must specify *exactly 1* of the following fields (and associated sub-fields as appropriate). The field name should match the value of the optional `type` field specified above for WebSocket calls. If you specify more than 1 of these type-specific fields (e.g. in `params` of JSON-RPC call), the server will retrieve results for only 1 of them. This is unwanted behavior and should be avoided as the results will not be predictable. 
+
+{% set n = cycler(* range(1,99)) %}
+
+#### {{n.next()}}. Specify Ledger Object
+
+Retrieve any type of ledger object by its unique ID.
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `index`                 | String                     | _(Required if `type` is "index")_ Specify the [object ID](ledger-object-ids.html) of a single object to retrieve from the ledger. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "type": "index",
+  "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "type": "index",
+            "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
+            "ledger_index": "validated"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05", "ledger_index": "validated", "type": "index" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+
+#### {{n.next()}}. Specify Account Root Object
+
+Retrieve an [AccountRoot object](accountroot.html) by its address. This is roughly equivalent to the [account_info method][].
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `account_root`          | String - [Address][]       | _(Required if `type` is "ticket")_ Specify an [AccountRoot object](accountroot.html) to retrieve. |
 
 <!-- MULTICODE_BLOCK_START -->
 
@@ -48,55 +126,466 @@ rippled json ledger_entry '{ "account_root": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 
 [Try it! >](websocket-api-tool.html#ledger_entry)
 
-This method can retrieve several different types of data. You can select which type of item to retrieve by passing the appropriate parameters. Specifically, you should provide exactly one of the following fields:
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
 
-1. `index` - Retrieve any type of ledger object by its unique ID
-2. `account_root` - Retrieve an [AccountRoot object](accountroot.html). This is roughly equivalent to the [account_info method][].
-3. `directory` - Retrieve a [DirectoryNode](directorynode.html), which contains a list of other ledger objects.
-4. `offer` - Retrieve an [Offer object](offer.html), which defines an offer to exchange currency.
-5. `ripple_state` - Retrieve a [RippleState object](ripplestate.html), which tracks a (non-XRP) currency balance between two accounts.
-6. `check` - Retrieve a [Check object](check.html), which is a potential payment that can be cashed by its recipient. [New in: rippled 1.0.0][]
-7. `escrow` - Retrieve an [Escrow object](escrow-object.html), which holds XRP until a specific time or condition is met. [New in: rippled 1.0.0][]
-8. `payment_channel` - Retrieve a [PayChannel object](paychannel.html), which holds XRP for asynchronous payments. [New in: rippled 1.0.0][]
-9. `deposit_preauth` - Retrieve a [DepositPreauth object](depositpreauth-object.html), which tracks preauthorization for payments to accounts requiring [Deposit Authorization](depositauth.html). [New in: rippled 1.1.0][]
-10. `ticket` - Retrieve a [Ticket object](ticket.html), which records a [sequence number][] set aside for future use. _(Requires the [TicketBatch amendment][])_
 
-If you specify more than one of the above items, the server retrieves only one of them; it is undefined which it chooses.
 
-The full list of parameters recognized by this method is as follows:
+#### {{n.next()}}. Specify Directory Object
+
+Retrieve a [DirectoryNode](directorynode.html), which contains a list of other ledger objects. Can be provided as string (object ID of the Directory) or as an object.
 
 | `Field`                 | Type                       | Description           |
 |:------------------------|:---------------------------|:----------------------|
-| `index`                 | String                     | _(Optional)_ Specify the [object ID](ledger-object-ids.html) of a single object to retrieve from the ledger. |
-| `account_root`          | String - [Address][]       | _(Optional)_ Specify an [AccountRoot object](accountroot.html) to retrieve. |
-| `check`                 | String                     | _(Optional)_ Specify the [object ID](ledger-object-ids.html) of a [Check object](check.html) to retrieve. |
-| `deposit_preauth`       | Object or String           | _(Optional)_ Specify a [DepositPreauth object](depositpreauth-object.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the DepositPreauth object, as hexadecimal. If an object, requires `owner` and `authorized` sub-fields. |
-| `deposit_preauth.owner` | String - [Address][]       | _(Required if `deposit_preauth` is specified as an object)_ The account that provided the preauthorization. |
-| `deposit_preauth.authorized` | String - [Address][]  | _(Required if `deposit_preauth` is specified as an object)_ The account that received the preauthorization. |
-| `directory`             | Object or String           | _(Optional)_ Specify a [DirectoryNode](directorynode.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the directory, as hexadecimal. If an object, requires either `dir_root` or `owner` as a sub-field, plus optionally a `sub_index` sub-field. |
+| `directory`             | Object or String           | _(Required if `type` is "ticket")_ Specify a [DirectoryNode](directorynode.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the directory, as hexadecimal. If an object, requires either `dir_root` or `owner` as a sub-field, plus optionally a `sub_index` sub-field. |
 | `directory.sub_index`   | Unsigned Integer           | _(Optional)_ If provided, jumps to a later "page" of the [DirectoryNode](directorynode.html). |
 | `directory.dir_root`    | String                     | _(Required if `directory` is specified as an object and `directory.owner` is not provided)_ Unique index identifying the directory to retrieve, as a hex string. |
 | `directory.owner`       | String                     | _(Required if `directory` is specified as an object and `directory.dir_root` is not provided)_ Unique address of the account associated with this directory. |
-| `escrow` | Object or String | _(Optional)_ Specify an [Escrow object](escrow-object.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the Escrow, as hexadecimal. If an object, requires `owner` and `seq` sub-fields. |
-| `escrow.owner` | String - [Address][] | _(Required if `escrow` is specified as an object)_ The owner (sender) of the Escrow object. |
-| `escrow.seq` | Unsigned Integer | _(Required if `escrow` is specified as an object)_ The sequence number of the transaction that created the Escrow object. |
-| `offer`                 | Object or String           | _(Optional)_ Specify an [Offer object](offer.html) to retrieve. If a string, interpret as the [unique index](ledgers.html#tree-format) to the Offer. If an object, requires the sub-fields `account` and `seq` to uniquely identify the offer. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "directory": {
+    "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c"
+  },
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "directory": {
+              "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c"
+            },
+            "ledger_index": "validated",
+            "type": "directory"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "directory": { "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c"}, "ledger_index": "validated", "type": "directory" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+#### {{n.next()}}. Specify Offer Object
+4. `offer` - Retrieve an [Offer object](offer.html), which defines an offer to exchange currency. Can be provided as string (unique index of the Offer) or as an object.
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `offer`                 | Object or String           | _(Required if `type` is "offer")_ Specify an [Offer object](offer.html) to retrieve. If a string, interpret as the [unique index](ledgers.html#tree-format) to the Offer. If an object, requires the sub-fields `account` and `seq` to uniquely identify the offer. |
 | `offer.account`         | String - [Address][]       | _(Required if `offer` is specified)_ The account that placed the offer. |
 | `offer.seq`             | Unsigned Integer           | _(Required if `offer` is specified)_ The sequence number of the transaction that created the Offer object. |
-| `payment_channel` | String | _(Optional)_ Specify the [object ID](ledger-object-ids.html) of a [PayChannel object](paychannel.html) to retrieve. |
-| `ripple_state`          | Object                     | _(Optional)_ Object specifying the RippleState (trust line) object to retrieve. The `accounts` and `currency` sub-fields are required to uniquely specify the RippleState entry to retrieve. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "offer": {
+    "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
+    "seq": 6134107
+  },
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+      {
+        "offer": {
+          "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
+          "seq": 6134107
+        },
+        "ledger_index": "validated"
+      }
+  ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "offer": { "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu", "seq": 6134107}, "ledger_index": "validated", "type": "offer" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+#### {{n.next()}}. Specify RippleState Object
+
+Retrieve a [RippleState object](ripplestate.html), which tracks a (non-XRP) currency balance between two accounts.
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `ripple_state`          | Object                     | _(Required if `type` is "ticket")_ Object specifying the RippleState (trust line) object to retrieve. The `accounts` and `currency` sub-fields are required to uniquely specify the RippleState entry to retrieve. |
 | `ripple_state.accounts` | Array                      | _(Required if `ripple_state` is specified)_ 2-length array of account [Address][]es, defining the two accounts linked by this [RippleState object](ripplestate.html). |
 | `ripple_state.currency` | String                     | _(Required if `ripple_state` is specified)_ [Currency Code][] of the [RippleState object](ripplestate.html) to retrieve. |
-| `ticket`                | Object or String           | _(Optional)_ Object specifying the [Ticket object](ticket.html) to retrieve. If a string, the must be the [object ID](ledger-object-ids.html) of the Ticket, as hexadecimal. If an object, the `owner` and `ticket_sequence` sub-fields are required to uniquely specify the Ticket entry to retrieve. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "ripple_state": {
+    "accounts": ["rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"],
+    "currency": "USD"
+  },
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "ripple_state": {
+              "accounts": ["rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"],
+              "currency": "USD"
+            },
+            "ledger_index": "validated",
+            "type": "ripple_state"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "ripple_state": { "accounts": ["rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"], "currency": "USD"}, "ledger_index": "validated", "type": "ripple_state" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+#### {{n.next()}}. Specify Check Object
+
+Retrieve a [Check object](check.html), which is a potential payment that can be cashed by its recipient. [New in: rippled 1.0.0][]
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `check`                 | String                     | _(Required if `type` is "check")_ Specify the [object ID](ledger-object-ids.html) of a [Check object](check.html) to retrieve. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "type": "check",
+  "check": "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "type": "check",
+            "check": "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
+            "ledger_index": "validated"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "check": "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo", "ledger_index": "validated", "type": "check" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+#### {{n.next()}}. Specify Escrow Object
+
+Retrieve an [Escrow object](escrow-object.html), which holds XRP until a specific time or condition is met. Can be provided as string (object ID of the Escrow) or as an object. [New in: rippled 1.0.0][]
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `escrow`                | Object or String           | _(Required if `type` is "ticket")_ Specify an [Escrow object](escrow-object.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the Escrow, as hexadecimal. If an object, requires `owner` and `seq` sub-fields. |
+| `escrow.owner`          | String - [Address][]       | _(Required if `escrow` is specified as an object)_ The owner (sender) of the Escrow object. |
+| `escrow.seq`            | Unsigned Integer           | _(Required if `escrow` is specified as an object)_ The sequence number of the transaction that created the Escrow object. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "type": "escrow",
+  "escrow": {
+    "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
+    "seq": 6134107
+  },
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "escrow": {
+              "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
+              "seq": 6134107
+            },
+            "ledger_index": "validated",
+            "type": "escrow"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "escrow": { "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu", "seq": 6134107 }, "ledger_index": "validated", "type": "escrow" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+#### {{n.next()}}. Specify PayChannel Object
+
+Retrieve a [PayChannel object](paychannel.html), which holds XRP for asynchronous payments. [New in: rippled 1.0.0][]
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `payment_channel`       | String                     | _(Required if `type` is "payment_channel")_ Specify the [object ID](ledger-object-ids.html) of a [PayChannel object](paychannel.html) to retrieve. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "type": "payment_channel",
+  "payment_channel": "rJ8x2MTstFJRWfMXyatcXYuB1TXQMeHtP2",
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "payment_channel": "rJ8x2MTstFJRWfMXyatcXYuB1TXQMeHtP2",
+            "ledger_index": "validated",
+            "type": "payment_channel"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "payment_channel": "rJ8x2MTstFJRWfMXyatcXYuB1TXQMeHtP2", "ledger_index": "validated", "type": "payment_channel" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. ALSO PLEASE NOTE THAT YOU WILL NEED TO CHANGE CONNECTION SETTINGS TO "TESTNET PUBLIC CLUSTER"  
+
+
+#### {{n.next()}}. Specify DepositPreauth Object
+
+Retrieve a [DepositPreauth object](depositpreauth-object.html), which tracks preauthorization for payments to accounts requiring [Deposit Authorization](depositauth.html). Can be provided as string (object ID of the DepositPreauth) or as an object. [New in: rippled 1.1.0][]
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `deposit_preauth`       | Object or String           | _(Required if `type` is "ticket")_ Specify a [DepositPreauth object](depositpreauth-object.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the DepositPreauth object, as hexadecimal. If an object, requires `owner` and `authorized` sub-fields. |
+| `deposit_preauth.owner` | String - [Address][]       | _(Required if `deposit_preauth` is specified as an object)_ The account that provided the preauthorization. |
+| `deposit_preauth.authorized` | String - [Address][]  | _(Required if `deposit_preauth` is specified as an object)_ The account that received the preauthorization. |
+
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "type": "deposit_preauth",
+  "deposit_preauth": {
+    "owner": "rPRVdmDUwV4q5FTpwPijLQuzJ4WjDbgNrE",
+    "authorized": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
+  },
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "deposit_preauth": {
+              "owner": "rPRVdmDUwV4q5FTpwPijLQuzJ4WjDbgNrE",
+              "authorized": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
+            },
+            "ledger_index": "validated",
+            "type": "deposit_preauth"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "deposit_preauth": { "owner": "rPRVdmDUwV4q5FTpwPijLQuzJ4WjDbgNrE", "authorized": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe" }, "ledger_index": "validated", "type": "deposit_preauth" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. ALSO PLEASE NOTE THAT YOU WILL NEED TO CHANGE CONNECTION SETTINGS TO "TESTNET PUBLIC CLUSTER"  
+
+
+#### {{n.next()}}. Specify Ticket Object
+
+Retrieve a [Ticket object](ticket.html), which records a [sequence number][] set aside for future use. Can be provided as string (object ID of the Ticket) or as an object. _(Requires the [TicketBatch amendment][])_
+
+| `Field`                 | Type                       | Description           |
+|:------------------------|:---------------------------|:----------------------|
+| `ticket`                | Object or String           | _(Required if `type` is "ticket")_ The [Ticket object](ticket.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the Ticket, as hexadecimal. If an object, the `owner` and `ticket_sequence` sub-fields are required to uniquely specify the Ticket entry. |
 | `ticket.owner`          | String - [Address][]       | _(Required if `ticket` is specified as an object)_ The owner of the Ticket object. |
 | `ticket.ticket_sequence` | Unsigned Integer          | _(Required if `ticket` is specified as an object)_ The Ticket Sequence number of the Ticket entry to retrieve. |
-| `binary`                | Boolean                    | _(Optional)_ If true, return the requested ledger object's contents as a hex string. Otherwise, return data in JSON format. The default is `false`. [Updated in: rippled 1.2.0][] |
-| `ledger_hash`           | String                     | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
-| `ledger_index`          | String or Unsigned Integer | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 
-The `generator` and `ledger` parameters are deprecated and may be removed without further notice.
+<!-- MULTICODE_BLOCK_START -->
+
+*WebSocket*
+
+```json
+{
+  "id": 3,
+  "command": "ledger_entry",
+  "type": "ticket",
+  "ticket": {
+    "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "ticket_sequence: 23
+  },
+  "ledger_index": "validated"
+}
+```
+
+*JSON-RPC*
+
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+          "type": "ticket",
+          "ticket": {
+            "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "ticket_sequence: 23
+          },
+          "ledger_index": "validated"
+        }
+    ]
+}
+```
+
+*Commandline*
+
+```sh
+rippled json ledger_entry '{ "ticket": { "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59", "ticket_sequence: 23 }, "ledger_index": "validated", "type": "ticket" }'
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+[Try it! >](websocket-api-tool.html#ledger_entry)
+
+**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. 
+
+
+#### Deprecated Parameters
+
+**Note:** The `generator` and `ledger` parameters are deprecated and may be removed without further notice.
+
 
 ## Response Format
+
+The response follows the [standard format][], with a successful result containing the following fields:
+
+| `Field`        | Type             | Description                              |
+|:---------------|:-----------------|:-----------------------------------------|
+| `index`        | String           | The unique ID of this [ledger object](ledger-object-types.html). |
+| `ledger_index` | Unsigned Integer | The [ledger index][] of the ledger that was used when retrieving this data. |
+| `node`         | Object           | _(Omitted if `"binary": true` specified.)_ Object containing the data of this ledger object, according to the [ledger format][]. |
+| `node_binary`  | String           | _(Omitted unless `"binary":true` specified)_ The [binary representation](serialization.html) of the ledger object, as hexadecimal. |
 
 An example of a successful response:
 
@@ -179,14 +668,6 @@ An example of a successful response:
 
 <!-- MULTICODE_BLOCK_END -->
 
-The response follows the [standard format][], with a successful result containing the following fields:
-
-| `Field`        | Type             | Description                              |
-|:---------------|:-----------------|:-----------------------------------------|
-| `index`        | String           | The unique ID of this [ledger object](ledger-object-types.html). |
-| `ledger_index` | Unsigned Integer | The [ledger index][] of the ledger that was used when retrieving this data. |
-| `node`         | Object           | _(Omitted if `"binary": true` specified.)_ Object containing the data of this ledger object, according to the [ledger format][]. |
-| `node_binary`  | String           | _(Omitted unless `"binary":true` specified)_ The [binary representation](serialization.html) of the ledger object, as hexadecimal. |
 
 ## Possible Errors
 

--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger_entry.md
@@ -49,9 +49,8 @@ Retrieve any type of ledger object by its unique ID.
 
 ```json
 {
-  "id": 3,
   "command": "ledger_entry",
-  "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
+  "index": "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
   "ledger_index": "validated"
 }
 ```
@@ -103,9 +102,9 @@ Retrieve an [AccountRoot object](accountroot.html) by its address. This is rough
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_accountroot",
   "command": "ledger_entry",
-  "account_root": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "account_root": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
   "ledger_index": "validated"
 }
 ```
@@ -117,9 +116,8 @@ Retrieve an [AccountRoot object](accountroot.html) by its address. This is rough
     "method": "ledger_entry",
     "params": [
         {
-            "account_root": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-            "ledger_index": "validated",
-            "type": "account_root"
+            "account_root": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "ledger_index": "validated"
         }
     ]
 }
@@ -133,9 +131,8 @@ rippled json ledger_entry '{ "account_root": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-accountroot)
 
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
 
 
 
@@ -159,7 +156,8 @@ Retrieve a [DirectoryNode](directorynode.html), which contains a list of other l
   "id": 3,
   "command": "ledger_entry",
   "directory": {
-    "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c"
+    "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "sub_index": 0
   },
   "ledger_index": "validated"
 }
@@ -173,7 +171,8 @@ Retrieve a [DirectoryNode](directorynode.html), which contains a list of other l
     "params": [
         {
             "directory": {
-              "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c"
+              "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+              "sub_index": 0
             },
             "ledger_index": "validated"
         }
@@ -184,14 +183,13 @@ Retrieve a [DirectoryNode](directorynode.html), which contains a list of other l
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "directory": { "owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c"}, "ledger_index": "validated" }'
+rippled json ledger_entry '{ "directory": { "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "sub_index": 0 }, "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-directorynode)
 
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
 
 
 ### Get Offer Object
@@ -210,11 +208,11 @@ Retrieve an [Offer object](offer.html), which defines an offer to exchange curre
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_offer",
   "command": "ledger_entry",
   "offer": {
-    "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
-    "seq": 6134107
+    "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "seq": 359
   },
   "ledger_index": "validated"
 }
@@ -224,15 +222,15 @@ Retrieve an [Offer object](offer.html), which defines an offer to exchange curre
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-      {
-        "offer": {
-          "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
-          "seq": 6134107
-        },
-        "ledger_index": "validated"
-      }
+  "method": "ledger_entry",
+  "params": [
+    {
+      "offer": {
+        "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "seq": 359
+      },
+      "ledger_index": "validated"
+    }
   ]
 }
 ```
@@ -240,14 +238,13 @@ Retrieve an [Offer object](offer.html), which defines an offer to exchange curre
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "offer": { "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu", "seq": 6134107}, "ledger_index": "validated" }'
+rippled json ledger_entry '{ "offer": { "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "seq": 359}, "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-offer)
 
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
 
 
 ### Get RippleState Object
@@ -266,10 +263,13 @@ Retrieve a [RippleState object](ripplestate.html), which tracks a (non-XRP) curr
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_ripplestate",
   "command": "ledger_entry",
   "ripple_state": {
-    "accounts": ["rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"],
+    "accounts": [
+      "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
+    ],
     "currency": "USD"
   },
   "ledger_index": "validated"
@@ -280,16 +280,17 @@ Retrieve a [RippleState object](ripplestate.html), which tracks a (non-XRP) curr
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-        {
-            "ripple_state": {
-              "accounts": ["rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"],
-              "currency": "USD"
-            },
-            "ledger_index": "validated"
-        }
-    ]
+  "method": "ledger_entry",
+  "params": [{
+    "ripple_state": {
+      "accounts": [
+        "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
+      ],
+      "currency": "USD"
+    },
+    "ledger_index": "validated"
+  }]
 }
 ```
 
@@ -301,9 +302,8 @@ rippled json ledger_entry '{ "ripple_state": { "accounts": ["rf1BiGeXwwQoi8Z2ueF
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-ripplestate)
 
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
 
 
 ### Get Check Object
@@ -320,9 +320,9 @@ Retrieve a [Check object](check.html), which is a potential payment that can be 
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_check",
   "command": "ledger_entry",
-  "check": "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334",
+  "check": "C4A46CCD8F096E994C4B0DEAB6CE98E722FC17D7944C28B95127C2659C47CBEB",
   "ledger_index": "validated"
 }
 ```
@@ -331,27 +331,24 @@ Retrieve a [Check object](check.html), which is a potential payment that can be 
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-        {
-            "check": "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334",
-            "ledger_index": "validated"
-        }
-    ]
+  "method": "ledger_entry",
+  "params": [{
+    "check": "C4A46CCD8F096E994C4B0DEAB6CE98E722FC17D7944C28B95127C2659C47CBEB",
+    "ledger_index": "validated"
+  }]
 }
 ```
 
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "check": "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334", "ledger_index": "validated" }'
+rippled json ledger_entry '{ "check": "C4A46CCD8F096E994C4B0DEAB6CE98E722FC17D7944C28B95127C2659C47CBEB", "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-check)
 
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
 
 
 ### Get Escrow Object
@@ -370,11 +367,11 @@ Retrieve an [Escrow object](escrow-object.html), which holds XRP until a specifi
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_escrow",
   "command": "ledger_entry",
   "escrow": {
-    "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
-    "seq": 6134107
+    "owner": "rL4fPHi2FWGwRGRQSH7gBcxkuo2b9NTjKK",
+    "seq": 126
   },
   "ledger_index": "validated"
 }
@@ -384,30 +381,27 @@ Retrieve an [Escrow object](escrow-object.html), which holds XRP until a specifi
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-        {
-            "escrow": {
-              "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu",
-              "seq": 6134107
-            },
-            "ledger_index": "validated"
-        }
-    ]
+  "method": "ledger_entry",
+  "params": [{
+    "escrow": {
+      "account": "rL4fPHi2FWGwRGRQSH7gBcxkuo2b9NTjKK",
+      "seq": 126
+    },
+    "ledger_index": "validated"
+  }]
 }
 ```
 
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "escrow": { "account": "rH2k8SkwoWgwry9J89jgFP9NbSWu13jnsu", "seq": 6134107 }, "ledger_index": "validated" }'
+rippled json ledger_entry '{ "escrow": { "account": "rL4fPHi2FWGwRGRQSH7gBcxkuo2b9NTjKK", "seq": 126 }, "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-escrow)
 
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
 
 
 ### Get PayChannel Object
@@ -424,9 +418,9 @@ Retrieve a [PayChannel object](paychannel.html), which holds XRP for asynchronou
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_paychannel",
   "command": "ledger_entry",
-  "payment_channel": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
+  "payment_channel": "C7F634794B79DB40E87179A9D1BF05D05797AE7E92DF8E93FD6656E8C4BE3AE7",
   "ledger_index": "validated"
 }
 ```
@@ -435,25 +429,23 @@ Retrieve a [PayChannel object](paychannel.html), which holds XRP for asynchronou
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-        {
-            "payment_channel": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
-            "ledger_index": "validated"
-        }
-    ]
+  "method": "ledger_entry",
+  "params": [{
+    "payment_channel": "C7F634794B79DB40E87179A9D1BF05D05797AE7E92DF8E93FD6656E8C4BE3AE7",
+    "ledger_index": "validated"
+  }]
 }
 ```
 
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "payment_channel": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3", "ledger_index": "validated" }'
+rippled json ledger_entry '{ "payment_channel": "C7F634794B79DB40E87179A9D1BF05D05797AE7E92DF8E93FD6656E8C4BE3AE7", "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
+[Try it! >](websocket-api-tool.html#ledger_entry-paychannel)
 
 
 ### Get DepositPreauth Object
@@ -472,11 +464,11 @@ Retrieve a [DepositPreauth object](depositpreauth-object.html), which tracks pre
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_deposit_preauth",
   "command": "ledger_entry",
   "deposit_preauth": {
-    "owner": "rPRVdmDUwV4q5FTpwPijLQuzJ4WjDbgNrE",
-    "authorized": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
+    "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "authorized": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"
   },
   "ledger_index": "validated"
 }
@@ -486,30 +478,26 @@ Retrieve a [DepositPreauth object](depositpreauth-object.html), which tracks pre
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-        {
-            "deposit_preauth": {
-              "owner": "rPRVdmDUwV4q5FTpwPijLQuzJ4WjDbgNrE",
-              "authorized": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
-            },
-            "ledger_index": "validated"
-        }
-    ]
+  "method": "ledger_entry",
+  "params": [{
+    "deposit_preauth": {
+      "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "authorized": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"
+    },
+    "ledger_index": "validated"
+  }]
 }
 ```
 
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "deposit_preauth": { "owner": "rPRVdmDUwV4q5FTpwPijLQuzJ4WjDbgNrE", "authorized": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe" }, "ledger_index": "validated" }'
+rippled json ledger_entry '{ "deposit_preauth": { "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "authorized": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX" }, "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
-
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button. ALSO PLEASE NOTE THAT YOU WILL NEED TO CHANGE CONNECTION SETTINGS TO "TESTNET PUBLIC CLUSTER"  
+[Try it! >](websocket-api-tool.html#ledger_entry-depositpreauth)
 
 
 ### Get Ticket Object
@@ -528,10 +516,10 @@ Retrieve a [Ticket object](ticket.html), which represents a [sequence number][] 
 
 ```json
 {
-  "id": 3,
+  "id": "example_get_ticket",
   "command": "ledger_entry",
   "ticket": {
-    "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
     "ticket_sequence": 23
   },
   "ledger_index": "validated"
@@ -542,30 +530,28 @@ Retrieve a [Ticket object](ticket.html), which represents a [sequence number][] 
 
 ```json
 {
-    "method": "ledger_entry",
-    "params": [
-        {
-          "ticket": {
-            "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-            "ticket_sequence": 23
-          },
-          "ledger_index": "validated"
-        }
-    ]
+  "method": "ledger_entry",
+  "params": [{
+    "ticket": {
+      "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "ticket_sequence": 23
+    },
+    "ledger_index": "validated"
+  }]
 }
 ```
 
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "ticket": { "owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59", "ticket_sequence: 23 }, "ledger_index": "validated" }'
+rippled json ledger_entry '{ "ticket": { "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ticket_sequence: 23 }, "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#ledger_entry)
-
-**Tip:** Copy the WebSocket example request above before clicking on the "Try It!" button.
+<!-- TODO: enable if/when Tickets are available on Mainnet
+[Try it! >](websocket-api-tool.html#ledger_entry-ticket)
+-->
 
 
 
@@ -588,24 +574,32 @@ An example of a successful response:
 
 ```json
 {
-    "id": 3,
-    "result": {
-        "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-        "ledger_index": 6889347,
-        "node": {
-            "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-            "Balance": "27389517749",
-            "Flags": 0,
-            "LedgerEntryType": "AccountRoot",
-            "OwnerCount": 18,
-            "PreviousTxnID": "B6B410172C0B65575D89E464AF5B99937CC568822929ABF87DA75CBD11911932",
-            "PreviousTxnLgrSeq": 6592159,
-            "Sequence": 1400,
-            "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05"
-        }
+  "id": "example_get_accountroot",
+  "result": {
+    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+    "ledger_hash": "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+    "ledger_index": 61966146,
+    "node": {
+      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "AccountTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
+      "Balance": "424021949",
+      "Domain": "6D64756F31332E636F6D",
+      "EmailHash": "98B4375E1D753E5B91627516F6D70977",
+      "Flags": 9568256,
+      "LedgerEntryType": "AccountRoot",
+      "MessageKey": "0000000000000000000000070000000300",
+      "OwnerCount": 12,
+      "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
+      "PreviousTxnLgrSeq": 61965653,
+      "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
+      "Sequence": 385,
+      "TransferRate": 4294967295,
+      "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
     },
-    "status": "success",
-    "type": "response"
+    "validated": true
+  },
+  "status": "success",
+  "type": "response"
 }
 ```
 
@@ -615,47 +609,61 @@ An example of a successful response:
 200 OK
 
 {
-    "result": {
-        "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-        "ledger_index": 8696234,
-        "node": {
-            "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-            "Balance": "13176802787",
-            "Flags": 0,
-            "LedgerEntryType": "AccountRoot",
-            "OwnerCount": 17,
-            "PreviousTxnID": "E5D0235A236F7CD162C1AB87A0325056AE61CFC63D92D1494AB5D826AAD0CDCA",
-            "PreviousTxnLgrSeq": 8554742,
-            "Sequence": 1406,
-            "index": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05"
-        },
-        "status": "success",
-        "validated": true
-    }
+  "result": {
+    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+    "ledger_hash": "395946243EA36C5092AE58AF729D2875F659812409810A63096AC006C73E656E",
+    "ledger_index": 61966165,
+    "node": {
+      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "AccountTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
+      "Balance": "424021949",
+      "Domain": "6D64756F31332E636F6D",
+      "EmailHash": "98B4375E1D753E5B91627516F6D70977",
+      "Flags": 9568256,
+      "LedgerEntryType": "AccountRoot",
+      "MessageKey": "0000000000000000000000070000000300",
+      "OwnerCount": 12,
+      "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
+      "PreviousTxnLgrSeq": 61965653,
+      "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
+      "Sequence": 385,
+      "TransferRate": 4294967295,
+      "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+    },
+    "status": "success",
+    "validated": true
+  }
 }
 ```
 
 *Commandline*
+
 ```json
 {
-   "result" : {
-      "index" : "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-      "ledger_hash" : "F434A8F21E401F84A2CDEDFDF801E6F3FC8B2567C6841818E684BEE019460179",
-      "ledger_index" : 56866309,
-      "node" : {
-         "Account" : "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-         "Balance" : "13315612685",
-         "Flags" : 0,
-         "LedgerEntryType" : "AccountRoot",
-         "OwnerCount" : 17,
-         "PreviousTxnID" : "D2FA1C28EF87E53029327AA832C378674B3ACA0551CF9EA1F65BB8CA34913FAB",
-         "PreviousTxnLgrSeq" : 55180009,
-         "Sequence" : 1406,
-         "index" : "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05"
-      },
-      "status" : "success",
-      "validated" : true
-   }
+  "result": {
+    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+    "ledger_hash": "395946243EA36C5092AE58AF729D2875F659812409810A63096AC006C73E656E",
+    "ledger_index": 61966165,
+    "node": {
+      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "AccountTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
+      "Balance": "424021949",
+      "Domain": "6D64756F31332E636F6D",
+      "EmailHash": "98B4375E1D753E5B91627516F6D70977",
+      "Flags": 9568256,
+      "LedgerEntryType": "AccountRoot",
+      "MessageKey": "0000000000000000000000070000000300",
+      "OwnerCount": 12,
+      "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
+      "PreviousTxnLgrSeq": 61965653,
+      "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
+      "Sequence": 385,
+      "TransferRate": 4294967295,
+      "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+    },
+    "status": "success",
+    "validated": true
+  }
 }
 ```
 


### PR DESCRIPTION
Continues the work of #948, but with more extensive updates:

- Fixes some mistakes in `ledger_entry` description including the `type` field (not actually used in the code as far as I can tell!)
- Updates some examples in the WebSocket tool. In particular, discontinues the use of `r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59` which probably belongs to a former Ripple employee of unknown identity
- Adds examples in the WebSocket tool for various `ledger_entry` modes