### PR TITLE
Removing google analytics tag

### DIFF
--- a/tool/template-base.html
+++ b/tool/template-base.html
@@ -42,19 +42,7 @@
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KCQZ3L8');</script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-45576805-2"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-45576805-2');
-      gtag('config', 'UA-157720658-3', { 'linker': {
-        'domains': ['blog.xpring.io', 'forum.xpring.io', 'xpring.io',
-                    'blog.ripplex.io', 'forum.ripplex.io', 'ripplex.io',
-                    'xrpl.org', 'explorer.xrpl.org', 'testnet.xrpl.org']
-        } }
-      );
-    </script>
+    <!-- End Google Tag Manager -->
 
     <!-- Stylesheet -->
     {% if target.lang=="ja" %}


### PR DESCRIPTION
- Removing the duplicate GA tag that can be found in Google Tag Manager
- Moved the Linker code over to GTM