### PR TITLE
add steps for zsh profiles

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
@@ -40,12 +40,18 @@ For development purposes, run `rippled` as a non-admin user, not using `sudo`.
 
       1. To find your Boost directory, use `pwd` if you installed the Boost manually or use `brew --prefix boost` if you installed the Boost with Homebrew.
 
-      2. Edit below code with your Boost directory location and run to add Boost environment variable to your `.bash_profile` file so it's automatically set when you log in.
+      2. Edit the code below with your Boost directory location and run it to add Boost environment variable to your `.zshrc` or `.bash_profile` file so it's automatically set when you log in.
 
+              # for zsh
+              $ echo "export BOOST_ROOT=/Users/my_user/boost_1_71_0" >> ~/.zshrc
+              # for bash
               $ echo "export BOOST_ROOT=/Users/my_user/boost_1_71_0" >> ~/.bash_profile
 
 0. If you updated your `.bash_profile` file in the previous step, be sure to source it in a new Terminal window. For example:
 
+        # zsh
+        $ source ~/.zshrc
+        # bash
         $ source ~/.bash_profile
 
 0. Clone the `rippled` source code into your desired location and access the `rippled` directory. To do this, you'll need to set up Git (installed earlier using Homebrew) and GitHub. For example, you'll need to create a GitHub account and set up your SSH key. For more information, see [Set up git](https://help.github.com/articles/set-up-git/).


### PR DESCRIPTION
The current instructions assume a bash profile. Starting with Catalina, [zsh is the default shell for macOS.](https://support.apple.com/en-us/HT208050) We should make sure that zsh users can complete the build steps.