### PR TITLE
Fixed broken links to rippled-1.7.0 blog post (/blog/2021/rippled-1.7.0)

### DIFF
--- a/content/concepts/consensus-network/amendments/known-amendments.ja.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.ja.md
@@ -10,9 +10,9 @@
 | [CryptoConditionsSuite][]       | 未定        | [開発中: 未定]( "BADGE_LIGHTGREY") |
 | [NegativeUNL][]                 | 未定        | [開発中: 未定]( "BADGE_LIGHTGREY") |
 | [OwnerPaysFee][]                | 未定        | [開発中: 未定]( "BADGE_LIGHTGREY") |
-| [fixSTAmountCanonicalize][]     | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.7.0.html "BADGE_80d0e0") |
-| [FlowSortStrands][]             | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.7.0.html "BADGE_80d0e0") |
-| [TicketBatch][]                 | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.7.0.html "BADGE_80d0e0") |
+| [fixSTAmountCanonicalize][]     | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
+| [FlowSortStrands][]             | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
+| [TicketBatch][]                 | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [fix1781][]                     | v1.6.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
 | [fixAmendmentMajorityCalc][]    | v1.6.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
 | [HardenedValidations][]         | v1.6.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |

--- a/content/concepts/consensus-network/amendments/known-amendments.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.md
@@ -10,9 +10,9 @@ The following is a comprehensive list of all known amendments and their status o
 | [CryptoConditionsSuite][]       | TBD        | [In Development: TBD]( "BADGE_LIGHTGREY") |
 | [NegativeUNL][]                 | TBD        | [In Development: TBD]( "BADGE_LIGHTGREY") |
 | [OwnerPaysFee][]                | TBD        | [In Development: TBD]( "BADGE_LIGHTGREY") |
-| [fixSTAmountCanonicalize][]     | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.7.0.html "BADGE_80d0e0") |
-| [FlowSortStrands][]             | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.7.0.html "BADGE_80d0e0") |
-| [TicketBatch][]                 | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.7.0.html "BADGE_80d0e0") |
+| [fixSTAmountCanonicalize][]     | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
+| [FlowSortStrands][]             | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
+| [TicketBatch][]                 | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [fix1781][]                     | v1.6.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
 | [fixAmendmentMajorityCalc][]    | v1.6.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
 | [HardenedValidations][]         | v1.6.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |


### PR DESCRIPTION
Fixed broken links:

Broken: https://xrpl.org/blog/2020/rippled-1.7.0.html
Working: https://xrpl.org/blog/2021/rippled-1.7.0.html