### PR TITLE
account_tx: legacy mode removed

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.ja.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.ja.md
@@ -67,11 +67,9 @@ rippled -- account_tx r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59 -1 -1 2 5 1 0 1
 | `limit` | 整数 | _（省略可能）_ デフォルトは変化します。取得するトランザクションの数を制限します。サーバーはこの値を受け入れる必要はありません。 |
 | `marker` | [マーカー][] | 以前にページネーションされた応答の値。その応答を停止した箇所からデータの取得を再開します。サーバーが使用できるレジャーの範囲に変更があっても、この値は変わりません。 |
 
-[[ソース]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTxSwitch.cpp "Source")<br>
-
 次の各フィールドは省略可能とされていますが、要求内で**1つ以上は使用する必要があります**: `ledger_index`、`ledger_hash`、`ledger_index_min`、または`ledger_index_max`。
 
-**注記:** WebSocketとJSON-RPCについては、廃止予定の`account_tx`メソッドの従来版もあります。このため、*次のすべてのフィールドの使用を控える*ことをお勧めします: `offset`、`count`、`descending`、`ledger_max`、`ledger_min`。これらの廃止予定のフィールドを使用した場合、メソッドでページネーションはサポートされません。
+次のフィールドは廃止されました： `offset`、`count`、`descending`、`ledger_max`、`ledger_min`。 [削除: rippled 1.7.0][]
 
 ### 照会されたデータの繰り返し
 

--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_tx.md
@@ -68,11 +68,10 @@ The request includes the following parameters:
 | `limit`            | Integer                                    | _(Optional)_ Default varies. Limit the number of transactions to retrieve. The server is not required to honor this value. |
 | `marker`           | [Marker][] | Value from a previous paginated response. Resume retrieving data where that response left off. This value is stable even if there is a change in the server's range of available ledgers. |
 
-[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/AccountTxSwitch.cpp "Source")<br>
+**You must use at least one of the following fields** in your request: `ledger_index`, `ledger_hash`, `ledger_index_min`, or `ledger_index_max`.
 
-While each of these fields is marked as optional, **you must use at least one** in your request: `ledger_index`, `ledger_hash`, `ledger_index_min`, or `ledger_index_max`.
+The following legacy fields are no longer supported: `offset`, `count`, `ledger_min`, `ledger_max`. [Removed in: rippled 1.7.0][]
 
-**Note:** For WebSocket and JSON-RPC, there is also a deprecated legacy variation of the `account_tx` method. For that reason, Ripple recommends *not using any of the following fields*: `offset`, `count`, `descending`, `ledger_max`, and `ledger_min`. If you use any of these deprecated fields, the method does not support pagination.
 
 ### Iterating over queried data
 


### PR DESCRIPTION
Updates the description of account_tx to reflect the fact that the legacy account_tx mode has finally been removed in v1.7.0 (as part of the [Reporting Mode PR](https://github.com/ripple/rippled/pull/3609)).