### PR TITLE
Send XRP - add Python examples

### DIFF
--- a/content/_code-samples/send-xrp/send-xrp.js
+++ b/content/_code-samples/send-xrp/send-xrp.js
@@ -2,7 +2,7 @@
 let address = "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
 let secret = "s████████████████████████████"
 
-// Connect -------------------------------------------------------------------
+// Connect ---------------------------------------------------------------------
 // ripple = require('ripple-lib') // For Node.js. In browsers, use <script>.
 api = new ripple.RippleAPI({server: 'wss://s.altnet.rippletest.net:51233'})
 api.connect()

--- a/content/_code-samples/send-xrp/send-xrp.js
+++ b/content/_code-samples/send-xrp/send-xrp.js
@@ -1,6 +1,6 @@
 // Example credentials
-let address = "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
-let secret = "s████████████████████████████"
+let address = "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH"
+let secret = "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 
 // Connect ---------------------------------------------------------------------
 // ripple = require('ripple-lib') // For Node.js. In browsers, use <script>.

--- a/content/_code-samples/send-xrp/send-xrp.py
+++ b/content/_code-samples/send-xrp/send-xrp.py
@@ -1,0 +1,58 @@
+# Connect ----------------------------------------------------------------------
+from xrpl.clients import JsonRpcClient
+testnet_url = "https://s.altnet.rippletest.net:51234"
+client = JsonRpcClient(testnet_url)
+
+# Get credentials from the Testnet Faucet -----------------------------------
+faucet_url = "https://faucet.altnet.rippletest.net/accounts"
+print("Getting a new account from the Testnet faucet...")
+from xrpl.wallet import generate_faucet_wallet
+test_wallet = generate_faucet_wallet(client, debug=True)
+
+# Prepare transaction ----------------------------------------------------------
+from xrpl.ledger import get_latest_validated_ledger_sequence
+current_validated_ledger = get_latest_validated_ledger_sequence(client)
+min_ledger = current_validated_ledger + 1
+max_ledger = min_ledger + 20
+
+from xrpl.models.transactions import Payment
+my_payment = Payment(
+    account=test_wallet.classic_address,
+    amount="22000000",
+    destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+    last_ledger_sequence=max_ledger,
+    sequence=test_wallet.next_sequence_num,
+    fee="10",
+)
+print("Payment object:", my_payment)
+print(f"Can be validated in ledger range: {min_ledger} - {max_ledger}")
+
+# Sign transaction -------------------------------------------------------------
+import xrpl.transaction
+signed = xrpl.transaction.safe_sign_transaction(my_payment, test_wallet)
+print("Signed transaction blob:", signed)
+
+# Submit transaction -----------------------------------------------------------
+prelim_result = xrpl.transaction.submit_transaction_blob(signed, client)
+print("Preliminary transaction result:", prelim_result)
+if not prelim_result.is_successful():
+    exit("Submit failed.")
+tx_id = prelim_result.result["tx_json"]["hash"]
+
+# Wait for validation ----------------------------------------------------------
+from time import sleep
+while True:
+    sleep(1)
+    current_validated_ledger = get_latest_validated_ledger_sequence(client)
+    tx_response = xrpl.transaction.get_transaction_from_hash(tx_id, client)
+    if tx_response.is_successful():
+        if tx_response.result.get("validated"):
+            print("Got validated result!")
+            print(tx_response)
+            print(f"Explorer link: https://testnet.xrpl.org/transactions/{tx_id}")
+            break
+        else:
+            print(f"Results not yet validated... "
+                  f"({current_validated_ledger}/{max_ledger})")
+    if current_validated_ledger > max_ledger:
+        print("max_ledger has passed. Last tx response:", tx_response)

--- a/content/_code-samples/send-xrp/send-xrp.py
+++ b/content/_code-samples/send-xrp/send-xrp.py
@@ -1,12 +1,12 @@
 # Example Credentials ----------------------------------------------------------
 from xrpl.wallet import Wallet
-test_wallet = Wallet(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9")
+test_wallet = Wallet(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9", sequence=16237283)
 print(test_wallet.classic_address) # "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH"
 
 # Connect ----------------------------------------------------------------------
-from xrpl.clients import JsonRpcClient
+import xrpl
 testnet_url = "https://s.altnet.rippletest.net:51234"
-client = JsonRpcClient(testnet_url)
+client = xrpl.clients.JsonRpcClient(testnet_url)
 
 # Get credentials from the Testnet Faucet -----------------------------------
 # For production, instead create a Wallet instance as above
@@ -16,41 +16,43 @@ from xrpl.wallet import generate_faucet_wallet
 test_wallet = generate_faucet_wallet(client, debug=True)
 
 # Prepare transaction ----------------------------------------------------------
-from xrpl.ledger import get_latest_validated_ledger_sequence
-current_validated_ledger = get_latest_validated_ledger_sequence(client)
-min_ledger = current_validated_ledger + 1
-max_ledger = min_ledger + 20
-
-from xrpl.models.transactions import Payment
-from xrpl.utils import xrp_to_drops
-my_payment = Payment(
+import xrpl.utils # workaround for https://github.com/XRPLF/xrpl-py/issues/222
+my_payment = xrpl.models.transactions.Payment(
     account=test_wallet.classic_address,
-    amount=xrp_to_drops(22),
+    amount=xrpl.utils.xrp_to_drops(22),
     destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
-    last_ledger_sequence=max_ledger,
-    sequence=test_wallet.next_sequence_num,
-    fee="10",
 )
 print("Payment object:", my_payment)
-print(f"Can be validated in ledger range: {min_ledger} - {max_ledger}")
 
 # Sign transaction -------------------------------------------------------------
-import xrpl.transaction
-signed = xrpl.transaction.safe_sign_transaction(my_payment, test_wallet)
-print("Signed transaction blob:", signed)
+signed_tx = xrpl.transaction.safe_sign_and_autofill_transaction(
+        my_payment, test_wallet, client)
+max_ledger = signed_tx.last_ledger_sequence
+print("Signed transaction:", signed_tx)
+print("Transaction cost:", xrpl.utils.drops_to_xrp(signed_tx.fee), "XRP")
+print("Transaction expires after ledger:", max_ledger)
 
 # Submit transaction -----------------------------------------------------------
-prelim_result = xrpl.transaction.submit_transaction_blob(signed, client)
+validated_index = xrpl.ledger.get_latest_validated_ledger_sequence(client)
+min_ledger = validated_index + 1
+print(f"Can be validated in ledger range: {min_ledger} - {max_ledger}")
+
+# Tip: you can use xrpl.transaction.send_reliable_submission(signed_tx, client)
+#  to send the transaction and wait for the results to be validated.
+try:
+    prelim_result = xrpl.transaction.submit_transaction(signed_tx, client)
+except xrpl.transaction.XRPLReliableSubmissionException as e:
+    exit(f"Submit failed: {e}")
 print("Preliminary transaction result:", prelim_result)
-if not prelim_result.is_successful():
-    exit("Submit failed.")
 tx_id = prelim_result.result["tx_json"]["hash"]
 
 # Wait for validation ----------------------------------------------------------
+# Note: If you used xrpl.transaction.send_reliable_submission, you can skip this
+#  and use the result of that method directly.
 from time import sleep
 while True:
     sleep(1)
-    current_validated_ledger = get_latest_validated_ledger_sequence(client)
+    validated_ledger = xrpl.ledger.get_latest_validated_ledger_sequence(client)
     tx_response = xrpl.transaction.get_transaction_from_hash(tx_id, client)
     if tx_response.is_successful():
         if tx_response.result.get("validated"):
@@ -58,8 +60,8 @@ while True:
             break
         else:
             print(f"Results not yet validated... "
-                  f"({current_validated_ledger}/{max_ledger})")
-    if current_validated_ledger > max_ledger:
+                  f"({validated_ledger}/{max_ledger})")
+    if validated_ledger > max_ledger:
         print("max_ledger has passed. Last tx response:", tx_response)
 
 # Check transaction results ----------------------------------------------------
@@ -70,5 +72,5 @@ metadata = tx_response.result.get("meta", {})
 if metadata.get("TransactionResult"):
     print("Result code:", metadata["TransactionResult"])
 if metadata.get("delivered_amount"):
-    from xrpl.utils import drops_to_xrp
-    print("XRP delivered:", drops_to_xrp(metadata["delivered_amount"]))
+    print("XRP delivered:", xrpl.utils.drops_to_xrp(
+                metadata["delivered_amount"]))

--- a/content/references/rippled-api/public-rippled-methods/transaction-methods/tx.md
+++ b/content/references/rippled-api/public-rippled-methods/transaction-methods/tx.md
@@ -1,7 +1,7 @@
 # tx
 [[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/rpc/handlers/Tx.cpp "Source")
 
-The `tx` method retrieves information on a single transaction.
+The `tx` method retrieves information on a single [transaction](transaction-formats.html), by its [identifying hash][].
 
 ## Request Format
 
@@ -432,14 +432,16 @@ An example of a successful response:
 
 The response follows the [standard format][], with a successful result containing the fields of the [Transaction object](transaction-formats.html) as well as the following additional fields:
 
-| `Field`        | Type             | Description                              |
-|:---------------|:-----------------|:-----------------------------------------|
-| `hash`         | String           | The SHA-512 hash of the transaction      |
-| `inLedger`     | Unsigned Integer | (Deprecated) Alias for `ledger_index`.   |
-| `ledger_index` | Unsigned Integer | The [ledger index][] of the ledger that includes this transaction. |
-| `meta`         | Object           | Various metadata about the transaction.  |
-| `validated`    | Boolean          | True if this data is from a validated ledger version; if omitted or set to false, this data is not final. |
-| (Various)      | (Various)        | Other fields from the [Transaction object](transaction-formats.html) |
+| `Field`        | Type                             | Description              |
+|:---------------|:---------------------------------|:-------------------------|
+| `hash`         | String                           | The SHA-512 hash of the transaction |
+| `inLedger`     | Number                           | _(Deprecated)_ Alias for `ledger_index`. |
+| `ledger_index` | Number                           | The [ledger index][] of the ledger that includes this transaction. |
+| `meta`         | Object (JSON) or String (binary) | [Transaction metadata](transaction-metadata.html), which describes the results of the transaction. |
+| `validated`    | Boolean                          | If `true`, this data comes from a validated ledger version; if omitted or set to `false`, this data is not final. |
+| (Various)      | (Various)                        | Other fields from the [Transaction object](transaction-formats.html) |
+
+**Note:** `rippled` 1.7.0 has a known issue where the `meta` field contains JSON even if the request asked for binary. ([#3791](https://github.com/ripple/rippled/pull/3791))
 
 ### Not Found Response
 

--- a/content/tutorials/manage-account-settings/assign-a-regular-key-pair.md
+++ b/content/tutorials/manage-account-settings/assign-a-regular-key-pair.md
@@ -83,7 +83,7 @@ An example of a successful response:
         "master_seed": "sh8i92YRnEjJy3fpFkL8txQSCVo79",
         "master_seed_hex": "966C0F68643EFBA50D58D191D4CA8AA7",
         "public_key": "aBRNH5wUurfhZcoyR6nRwDSa95gMBkovBJ8V4cp1C1pM28H7EPL1",
-        "public_key_hex": "03AEEFE1E8ED4BBC009DE996AC03A8C6B5713B1554794056C66E5B8D1753C7DD0E"
+        "public_key_hex": "03AEEFE1E8ED4BBC009DE996AC03A8C6B5713B1554794056C66E5B8D1753C7DD0E",
         "status": "success"
     }
 }

--- a/content/tutorials/use-simple-xrp-payments/send-xrp.md
+++ b/content/tutorials/use-simple-xrp-payments/send-xrp.md
@@ -172,7 +172,7 @@ The result of the signing operation is a transaction object containing a signatu
 Now that you have a signed transaction, you can submit it to an XRP Ledger server, and that server will relay it through the network. It's also a good idea to take note of the latest validated ledger index before you submit. The earliest ledger version that your transaction could get into as a result of this submission is one higher than the latest validated ledger when you submit it. Of course, if the same transaction was previously submitted, it could already be in a previous ledger. (It can't succeed a second time, but you may not realize it succeeded if you aren't looking in the right ledger versions.)
 
 - **JavaScript:** Use the [submit() method](rippleapi-reference.html#submit) to submit a transaction to the network. Use the [`getLedgerVersion()` method](rippleapi-reference.html#getledgerversion) to get the latest validated ledger index.
-- **Python:** Use the [xrpl.transaction.submit_transaction_blob() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.submit_transaction_blob) to submit a transaction to the network. Use the [xrpl.ledger.get_latest_validated_ledger_sequence() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.ledger.html#xrpl.ledger.get_latest_validated_ledger_sequence) to get the latest validated ledger index.
+- **Python:** Use the [xrpl.transaction.submit_transaction() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.submit_transaction) to submit a transaction to the network. Use the [xrpl.ledger.get_latest_validated_ledger_sequence() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.ledger.html#xrpl.ledger.get_latest_validated_ledger_sequence) to get the latest validated ledger index.
 
 
 <!-- MULTICODE_BLOCK_START -->
@@ -212,6 +212,8 @@ Most transactions are accepted into the next ledger version after they're submit
 
 - **JavaScript:** Use an account [subscription](rippleapi-reference.html#listening-to-streams) to listen for an event when the transaction is confirmed. Use the `ledger` event type to trigger your code to run whenever there is a new validated ledger version so that you can know if the transaction can no longer be confirmed.
 - **Python:** Poll the [xrpl.transaction.get_transaction_from_hash() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash) to see if your transaction has a final result. Periodically use the [xrpl.ledger.get_latest_validated_ledger_sequence() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.ledger.html#xrpl.ledger.get_latest_validated_ledger_sequence) so you can know if the transaction can no longer be confirmed.
+
+    **Tip:** The [xrpl.transaction.send_reliable_submission() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission) handles this process all in one call. You can use this instead of `submit_transaction()` wherever it's appropriate for your code to stop and wait for a transaction's [final result](finality-of-results.html) to be confirmed.
 
 <!-- MULTICODE_BLOCK_START -->
 

--- a/content/tutorials/use-simple-xrp-payments/send-xrp.md
+++ b/content/tutorials/use-simple-xrp-payments/send-xrp.md
@@ -12,7 +12,7 @@ filters:
 ---
 # Send XRP
 
-This tutorial explains how to send a simple XRP Payment using RippleAPI for JavaScript. First, we step through the process with the XRP Test Net. Then, we compare that to the additional requirements for doing the equivalent in production.
+This tutorial explains how to send a simple XRP Payment using ripple-lib for JavaScript or xrpl-py for Python. First, we step through the process with the [XRP Ledger Testnet](parallel-networks.html). Then, we compare that to the additional requirements for doing the equivalent in production.
 
 **Tip:** Check out the [Code Samples](https://github.com/ripple/xrpl-dev-portal/tree/master/content/_code-samples) for a complete version of the code used in this tutorial.
 
@@ -22,7 +22,10 @@ This tutorial explains how to send a simple XRP Payment using RippleAPI for Java
 <script type="application/javascript" src="assets/js/tutorials/send-xrp.js"></script>
 {% set use_network = "Testnet" %}
 
-- This page provides JavaScript examples that use the ripple-lib (RippleAPI) library. The [RippleAPI Beginners Guide](get-started-with-rippleapi-for-javascript.html) describes how to get started using RippleAPI to access XRP Ledger data from JavaScript.
+To interact with the XRP Ledger, you need to set up a dev environment with the necessary tools. This tutorial provides examples using the following options:
+
+- **JavaScript** with the [ripple-lib (RippleAPI) library](https://github.com/ripple/ripple-lib/). See the [RippleAPI Beginners Guide](get-started-with-rippleapi-for-javascript.html) for detailed instructions on getting started.
+- **Python** with the [xrpl-py library](https://xrpl-py.readthedocs.io/). <!--{# TODO: add "get started" link here #}-->
 
 
 ## Send a Payment on the Test Net
@@ -32,9 +35,19 @@ This tutorial explains how to send a simple XRP Payment using RippleAPI for Java
 
 To transact on the XRP Ledger, you need an address and secret key, and some XRP. The address and secret key look like this:
 
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
+
 {{ include_code("_code-samples/send-xrp/send-xrp.js", end_before="// Connect", language="js") }}
 
-For development purposes, you can get these using the following interface:
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py", end_before="# Connect", language="py") }}
+
+<!-- MULTICODE_BLOCK_END -->
+
+The secret key shown here is for example only. For development purposes, you can get your own credentials, pre-funded with XRP, on the Testnet using the following interface:
 
 {% include '_snippets/interactive-tutorials/generate-step.md' %}
 
@@ -43,11 +56,21 @@ When you're [building actual production-ready software](production-readiness.htm
 
 ### {{n.next()}}. Connect to a Testnet Server
 
-To provide the necessary auto-fillable fields, ripple-lib must be connected to a server where it can get the current status of your account and the shared ledger itself. (For more security, you should sign transactions while being offline, but you must provide the auto-fillable fields manually if you do so.) You must be connected to the network to submit transactions to it.
+First, you must connect to an XRP Ledger server so you can get the current status of your account and the shared ledger. You can use this information to automatically fill in certain required fields of a transaction. (For more security, you can sign transactions from a machine that doesn't have an internet connection, but only if you can provide all of the necessary details.) You also must be connected to the network to submit transactions to it.
 
-The following code sample creates a new RippleAPI instance and connects to one of the public Testnet servers that Ripple runs:
+The following code connects to one of the public Testnet servers that Ripple runs:
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 {{ include_code("_code-samples/send-xrp/send-xrp.js", start_with="// Connect", end_before="// Get credentials", language="js") }}
+
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py", start_with="# Connect", end_before="# Get credentials", language="py") }}
+
+<!-- MULTICODE_BLOCK_END -->
 
 For this tutorial, you can connect directly from your browser by pressing the following button:
 
@@ -74,9 +97,24 @@ The bare minimum set of instructions you must provide for an XRP Payment is:
 - The address that should receive the XRP (`"Destination"`). This can't be the same as the sending address.
 - The amount of XRP to send (`"Amount"`). Typically, this is specified as an integer in "drops" of XRP, where 1,000,000 drops equals 1 XRP.
 
-Technically, a viable transaction must contain some additional fields, and certain optional fields such as `LastLedgerSequence` are strongly recommended. The [`prepareTransaction()` method](rippleapi-reference.html#preparetransaction) automatically fills in good defaults for the remaining fields of a transaction. Here's an example of preparing the above payment:
+Technically, a viable transaction must contain some additional fields, and certain optional fields such as `LastLedgerSequence` are strongly recommended. Some other language-specific notes:
+
+- If you're using ripple-lib for JavaScript, you can use the [`prepareTransaction()` method](rippleapi-reference.html#preparetransaction) to automatically fill in good defaults for the remaining fields of a transaction.
+- With xrpl-py for Python, you can use the models in `xrpl.models.transactions` to construct transactions as native Python objects.
+
+Here's an example of preparing the above payment:
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 {{ include_code("_code-samples/send-xrp/send-xrp.js", start_with="// Prepare", end_before="// Sign", language="js" ) }}
+
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py", start_with="# Prepare", end_before="# Sign", language="py" ) }}
+
+<!-- MULTICODE_BLOCK_END -->
 
 {{ start_step("Prepare") }}
 <div class="input-group mb-3">
@@ -98,14 +136,29 @@ Technically, a viable transaction must contain some additional fields, and certa
 
 ### {{n.next()}}. Sign the Transaction Instructions
 
-Use the [sign() method](rippleapi-reference.html#sign) to sign the transaction with RippleAPI. The first argument is a string version of the JSON transaction to sign.
+Signing a transaction uses your credentials to authorize the transaction on your behalf. The input to this step is a completed set of transaction instructions (usually JSON), and the output is a binary blob containing the instructions and a signature from the sender.
+
+- **JavaScript:** Use the [sign() method](rippleapi-reference.html#sign) to sign the transaction with ripple-lib. The first argument is a string version of the JSON transaction to sign.
+- **Python:** Use the [xrpl.transaction.safe_sign_transaction() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.safe_sign_transaction) with a model and wallet object.
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 {{ include_code("_code-samples/send-xrp/send-xrp.js",
     start_with="// Sign", end_before="// Submit", language="js" ) }}
 
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py",
+    start_with="# Sign", end_before="# Submit", language="py" ) }}
+
+<!-- MULTICODE_BLOCK_END -->
+
 The result of the signing operation is a transaction object containing a signature. Typically, XRP Ledger APIs expect a signed transaction to be the hexadecimal representation of the transaction's canonical [binary format](serialization.html), called a "blob".
 
-The signing API also returns the transaction's ID, or identifying hash, which you can use to look up the transaction later. This is a 64-character hexadecimal string that is unique to this transaction.
+- In ripple-lib, the signing API also returns the transaction's ID, or identifying hash, which you can use to look up the transaction later. This is a 64-character hexadecimal string that is unique to this transaction.
+- In xrpl-py, you can get the transaction's hash in the response to submitting it in the next step.
 
 {{ start_step("Sign") }}
 <button id="sign-button" class="btn btn-primary previous-steps-required">Sign
@@ -116,13 +169,25 @@ The signing API also returns the transaction's ID, or identifying hash, which yo
 
 ### {{n.next()}}. Submit the Signed Blob
 
-Use the [submit() method](rippleapi-reference.html#submit) to submit a transaction to the network. It's also a good idea to use the [`getLedgerVersion()` method](rippleapi-reference.html#getledgerversion) to take note of the latest validated ledger index before you submit. The earliest ledger version that your transaction could get into as a result of this submission is one higher than the latest validated ledger when you submit it.
+Now that you have a signed transaction, you can submit it to an XRP Ledger server, and that server will relay it through the network. It's also a good idea to take note of the latest validated ledger index before you submit. The earliest ledger version that your transaction could get into as a result of this submission is one higher than the latest validated ledger when you submit it. Of course, if the same transaction was previously submitted, it could already be in a previous ledger. (It can't succeed a second time, but you may not realize it succeeded if you aren't looking in the right ledger versions.)
 
-Of course, if the same transaction was previously submitted, it could already be in a previous ledger. (It can't succeed a second time, but you may not realize it succeeded if you aren't looking in the right ledger versions.)
+- **JavaScript:** Use the [submit() method](rippleapi-reference.html#submit) to submit a transaction to the network. Use the [`getLedgerVersion()` method](rippleapi-reference.html#getledgerversion) to get the latest validated ledger index.
+- **Python:** Use the [xrpl.transaction.submit_transaction_blob() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.submit_transaction_blob) to submit a transaction to the network. Use the [xrpl.ledger.get_latest_validated_ledger_sequence() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.ledger.html#xrpl.ledger.get_latest_validated_ledger_sequence) to get the latest validated ledger index.
+
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 {{ include_code("_code-samples/send-xrp/send-xrp.js", start_with="// Submit", end_before="// Wait", language="js" ) }}
 
-This method returns the **tentative** result of trying to apply the transaction locally. This result _can_ change when the transaction is included in a validated ledger: transactions that succeed initially might ultimately fail, and transactions that fail initially might ultimately succeed. Still, the tentative result often matches the final result, so it's OK to get excited if you see `tesSUCCESS` here. 😁
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py", start_with="# Submit", end_before="# Wait", language="py") }}
+
+<!-- MULTICODE_BLOCK_END -->
+
+This method returns the **tentative** result of trying to apply the transaction to the open ledger. This result _can_ change when the transaction is included in a validated ledger: transactions that succeed initially might ultimately fail, and transactions that fail initially might ultimately succeed. Still, the tentative result often matches the final result, so it's OK to get excited if you see `tesSUCCESS` here. 😁
 
 If you see any other result, you should check the following:
 
@@ -133,7 +198,6 @@ If you see any other result, you should check the following:
 
 See the full list of [transaction results](transaction-results.html) for more possibilities.
 
-
 {{ start_step("Submit") }}
 <button id="submit-button" class="btn btn-primary previous-steps-required" data-tx-blob-from="#signed-tx-blob" data-wait-step-name="Wait">Submit
 example transaction</button>
@@ -141,13 +205,25 @@ example transaction</button>
 <div class="output-area"></div>
 {{ end_step() }}
 
+
 ### {{n.next()}}. Wait for Validation
 
-Most transactions are accepted into the next ledger version after they're submitted, which means it may take 4-7 seconds for a transaction's outcome to be final. If the XRP Ledger is busy or poor network connectivity delays a transaction from being relayed throughout the network, a transaction may take longer to be confirmed. (For information on how to set an expiration for transactions, see [Reliable Transaction Submission](reliable-transaction-submission.html).)
+Most transactions are accepted into the next ledger version after they're submitted, which means it may take 4-7 seconds for a transaction's outcome to be final. If the XRP Ledger is busy or poor network connectivity delays a transaction from being relayed throughout the network, a transaction may take longer to be confirmed. (For more information on expiration of unconfirmed transactions, see [Reliable Transaction Submission](reliable-transaction-submission.html).)
 
-Use an account [subscription](rippleapi-reference.html#listening-to-streams) to listen for an event when the transaction is confirmed. Use the `ledger` event type to trigger your code to run whenever there is a new validated ledger version so that you can know if the transaction can no longer be confirmed. For example:
+- **JavaScript:** Use an account [subscription](rippleapi-reference.html#listening-to-streams) to listen for an event when the transaction is confirmed. Use the `ledger` event type to trigger your code to run whenever there is a new validated ledger version so that you can know if the transaction can no longer be confirmed.
+- **Python:** Poll the [xrpl.transaction.get_transaction_from_hash() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash) to see if your transaction has a final result. Periodically use the [xrpl.ledger.get_latest_validated_ledger_sequence() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.ledger.html#xrpl.ledger.get_latest_validated_ledger_sequence) so you can know if the transaction can no longer be confirmed.
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 {{ include_code("_code-samples/send-xrp/send-xrp.js", start_with="// Wait", end_before="// There are other", language="js" ) }}
+
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py", start_with="# Wait", end_before="# Check", language="py") }}
+
+<!-- MULTICODE_BLOCK_END -->
 
 {{ start_step("Wait") }}
 {% include '_snippets/interactive-tutorials/wait-step.md' %}
@@ -156,14 +232,26 @@ Use an account [subscription](rippleapi-reference.html#listening-to-streams) to 
 
 ### {{n.next()}}. Check Transaction Status
 
-To know for sure what a transaction did, you must look up the outcome of the transaction when it appears in a validated ledger version. For example, you can use the [`getTransaction()` method](rippleapi-reference.html#gettransaction) to check the status of a transaction:
+To know for sure what a transaction did, you must look up the outcome of the transaction when it appears in a validated ledger version.
 
-{{ include_code("_code-samples/send-xrp/send-xrp.js",
-    start_with="// Check", language="js" ) }}
+- **JavaScript:** Use the [`getTransaction()` method](rippleapi-reference.html#gettransaction) to check the status of a transaction.
+- **Python:** The response of [xrpl.transaction.get_transaction_from_hash() method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash) contains the results if the transaction has been validated by consensus. (See [tx result](https://xrpl.org/tx.html#response-format) for a detailed reference of the fields this can contain.)
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.js", start_with="// Check", language="js" ) }}
+
+_Python_
+
+{{ include_code("_code-samples/send-xrp/send-xrp.py", start_with="# Check", language="py") }}
+
+<!-- MULTICODE_BLOCK_END -->
 
 The RippleAPI `getTransaction()` method only returns success if the transaction is in a validated ledger version. Otherwise, the `await` expression raises an exception.
 
-**Caution:** Other APIs may return tentative results from ledger versions that have not yet been validated. For example, if you use the `rippled` APIs' [tx method][], be sure to look for `"validated": true` in the response to confirm that the data comes from a validated ledger version. Transaction results that are not from a validated ledger version are subject to change. For more information, see [Finality of Results](finality-of-results.html).
+**Caution:** Other APIs, including xrpl-py, may return tentative results from ledger versions that have not yet been validated. For example, if you use the `rippled` APIs' [tx method][], be sure to look for `"validated": true` in the response to confirm that the data comes from a validated ledger version. Transaction results that are not from a validated ledger version are subject to change. For more information, see [Finality of Results](finality-of-results.html).
 
 {{ start_step("Check") }}
 <button id="get-tx-button" class="btn btn-primary previous-steps-required">Check transaction status</button>
@@ -180,13 +268,27 @@ To send an XRP payment on the production XRP Ledger, the steps you take are larg
 
 ### Getting a Real XRP Account
 
-This tutorial uses a button to get an address that's already funded with Test Net XRP, which only works because Test Net XRP is not worth anything. For actual XRP, you need to get XRP from someone who already has some. (For example, you might buy it on an exchange.) You can generate an address and secret that'll work on either production or the test net using RippleAPI's [`generateAddress()` method](rippleapi-reference.html#generateaddress):
+This tutorial uses a button to get an address that's already funded with Test Net XRP, which only works because Test Net XRP is not worth anything. For actual XRP, you need to get XRP from someone who already has some. (For example, you might buy it on an exchange.) You can generate an address and secret that'll work on either production or the Testnet as follows:
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 ```js
 const generated = api.generateAddress()
 console.log(generated.address) // Example: rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f
 console.log(generated.secret) // Example: sp6JS7f14BuwFY8Mw6bTtLKWauoUs
 ```
+
+_Python_
+
+```py
+from xrpl.core.keypairs import generate_seed
+from xrpl.wallet import Wallet
+my_wallet = Wallet(generate_seed()) #TODO: update this with any changes from https://github.com/XRPLF/xrpl-py/pull/194
+```
+
+<!-- MULTICODE_BLOCK_END -->
 
 **Warning:** You should only use an address and secret that you generated securely, on your local machine. If another computer generated the address and secret and sent it to you over a network, it's possible that someone else on the network may see that information. If they do, they'll have as much control over your XRP as you do. It's also recommended not to use the same address for the Testnet and Mainnet, because transactions that you created for use on one network could potentially also be viable on the other network, depending on the parameters you provided.
 
@@ -196,13 +298,31 @@ Generating an address and secret doesn't get you XRP directly; you're only choos
 
 When you instantiate the `RippleAPI` object, you must specify a server that's synced with the appropriate XRP Ledger. For many cases, you can use Ripple's public servers, such as in the following snippet:
 
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
+
 ```js
 ripple = require('ripple-lib')
-api = new ripple.RippleAPI({server: 'wss://s1.ripple.com:51233'})
+api = new ripple.RippleAPI({server: 'wss://xrplcluster.com'})
 api.connect()
 ```
 
-If you [install `rippled`](install-rippled.html) yourself, it connects to the production network by default. (You can also [configure it to connect to the test net](connect-your-rippled-to-the-xrp-test-net.html) instead.) After the server has synced (typically within about 15 minutes of starting it up), you can connect RippleAPI to it locally, which has [various benefits](the-rippled-server.html). The following example shows how to connect RippleAPI to a server running the default configuration:
+_Python_
+
+```py
+from xrpl.clients import JsonRpcClient
+mainnet_url = "https://xrplcluster.com"
+client = JsonRpcClient(mainnet_url)
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+If you [install `rippled`](install-rippled.html) yourself, it connects to the production network by default. (You can also [configure it to connect to the test net](connect-your-rippled-to-the-xrp-test-net.html) instead.) After the server has synced (typically within about 15 minutes of starting it up), you can connect to it locally, which has [various benefits](the-rippled-server.html). The following example shows how to connect to a server running the default configuration:
+
+<!-- MULTICODE_BLOCK_START -->
+
+_JavaScript_
 
 ```js
 ripple = require('ripple-lib')
@@ -210,17 +330,27 @@ api = new ripple.RippleAPI({server: 'ws://localhost:6006'})
 api.connect()
 ```
 
-**Tip:** The local connection uses the WebSocket protocol (`ws`) unencrypted rather than the TLS-encrypted version (`wss`). This is secure only because the communications never leave the same machine, and is easier to set up because it does not require a TLS certificate. For connections on an outside network, always use `wss`.
+_Python_
+
+```py
+from xrpl.clients import JsonRpcClient
+mainnet_url = "http://localhost:5005"
+client = JsonRpcClient(mainnet_url)
+```
+
+<!-- MULTICODE_BLOCK_END -->
+
+**Tip:** The local connection uses an unencrypted protocol (`ws` or `http`) rather than the TLS-encrypted version (`wss` or `https`). This is secure only because the communications never leave the same machine, and is easier to set up because it does not require a TLS certificate. For connections on an outside network, always use `wss` or `https`.
 
 ## Next Steps
 
 After completing this tutorial, you may want to try the following:
 
 - Build [Reliable transaction submission](reliable-transaction-submission.html) for production systems.
-- Consult the [RippleAPI JavaScript Reference](rippleapi-reference.html) for the full range of XRP Ledger functionality.
+- Consult [RippleAPI JavaScript Reference](rippleapi-reference.html) or [xrpl-py Python Reference](https://xrpl-py.readthedocs.io/) for the full range of XRP Ledger functionality.
 - Customize your [Account Settings](manage-account-settings.html).
 - Learn how [Transaction Metadata](transaction-metadata.html) describes the outcome of a transaction in detail.
-- Explore [Complex Payment Types](complex-payment-types.html) like escrow and payment channels.
+- Explore [Specialized Payment Types](specialized-payment-types.html) like Escrows and Payment Channels.
 - Read best practices for [XRP Ledger Businesses](xrp-ledger-businesses.html).
 
 

--- a/content/tutorials/use-simple-xrp-payments/send-xrp.md
+++ b/content/tutorials/use-simple-xrp-payments/send-xrp.md
@@ -25,7 +25,7 @@ This tutorial explains how to send a simple XRP Payment using ripple-lib for Jav
 To interact with the XRP Ledger, you need to set up a dev environment with the necessary tools. This tutorial provides examples using the following options:
 
 - **JavaScript** with the [ripple-lib (RippleAPI) library](https://github.com/ripple/ripple-lib/). See the [RippleAPI Beginners Guide](get-started-with-rippleapi-for-javascript.html) for detailed instructions on getting started.
-- **Python** with the [xrpl-py library](https://xrpl-py.readthedocs.io/). <!--{# TODO: add "get started" link here #}-->
+- **Python** with the [xrpl-py library](https://xrpl-py.readthedocs.io/). See [Get Started using Python](get-started-using-python.html) for setup steps.
 
 
 ## Send a Payment on the Test Net
@@ -283,9 +283,10 @@ console.log(generated.secret) // Example: sp6JS7f14BuwFY8Mw6bTtLKWauoUs
 _Python_
 
 ```py
-from xrpl.core.keypairs import generate_seed
 from xrpl.wallet import Wallet
-my_wallet = Wallet(generate_seed()) #TODO: update this with any changes from https://github.com/XRPLF/xrpl-py/pull/194
+my_wallet = Wallet.create()
+print(my_wallet.classic_address) # Example: rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f
+print(my_wallet.seed)            # Example: sp6JS7f14BuwFY8Mw6bTtLKWauoUs
 ```
 
 <!-- MULTICODE_BLOCK_END -->

--- a/content/tutorials/use-simple-xrp-payments/send-xrp.md
+++ b/content/tutorials/use-simple-xrp-payments/send-xrp.md
@@ -350,7 +350,7 @@ After completing this tutorial, you may want to try the following:
 - Consult [RippleAPI JavaScript Reference](rippleapi-reference.html) or [xrpl-py Python Reference](https://xrpl-py.readthedocs.io/) for the full range of XRP Ledger functionality.
 - Customize your [Account Settings](manage-account-settings.html).
 - Learn how [Transaction Metadata](transaction-metadata.html) describes the outcome of a transaction in detail.
-- Explore [Specialized Payment Types](specialized-payment-types.html) like Escrows and Payment Channels.
+- Explore more [Payment Types](payment-types.html) such as Escrows and Payment Channels.
 - Read best practices for [XRP Ledger Businesses](xrp-ledger-businesses.html).
 
 


### PR DESCRIPTION
With the xrpl-py library almost at 1.0.0, I've extended the "Send XRP" tutorial to have code samples in Python. (The interactive bits, of course, still have to use JavaScript to run in the browser.)