### PR TITLE
yum install/upgrade notes for 1.7.0

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
@@ -27,11 +27,11 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
         $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-stable]
         name=XRP Ledger Packages
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/stable/
         enabled=1
         gpgcheck=0
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/stable/repodata/repomd.xml.key
         repo_gpgcheck=1
+        baseurl=https://repos.ripple.com/repos/rippled-rpm/stable/
+        gpgkey=https://repos.ripple.com/repos/rippled-rpm/stable/repodata/repomd.xml.key
         REPOFILE
 
     *Pre-release*
@@ -39,11 +39,11 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
         $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-unstable]
         name=XRP Ledger Packages
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/unstable/
         enabled=1
         gpgcheck=0
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/unstable/repodata/repomd.xml.key
         repo_gpgcheck=1
+        baseurl=https://repos.ripple.com/repos/rippled-rpm/unstable/
+        gpgkey=https://repos.ripple.com/repos/rippled-rpm/unstable/repodata/repomd.xml.key
         REPOFILE
 
     *Development*
@@ -51,11 +51,11 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
         $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-nightly]
         name=XRP Ledger Packages
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/nightly/
         enabled=1
         gpgcheck=0
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/nightly/repodata/repomd.xml.key
         repo_gpgcheck=1
+        baseurl=https://repos.ripple.com/repos/rippled-rpm/nightly/
+        gpgkey=https://repos.ripple.com/repos/rippled-rpm/nightly/repodata/repomd.xml.key
         REPOFILE
 
     <!-- MULTICODE_BLOCK_START -->

--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.ja.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.ja.md
@@ -8,16 +8,28 @@
 
 手動で更新するには、以下の手順を実行します。
 
+1. `rippled` 1.7.0にその以前のバージョンから更新する場合は、リポジトリを再度追加して、Rippleの更新されたGPGキーを取得します。それ以外の場合は、この手順をスキップしてください。
+
+        $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
+        [ripple-stable]
+        name=XRP Ledger Packages
+        enabled=1
+        gpgcheck=0
+        repo_gpgcheck=1
+        baseurl=https://repos.ripple.com/repos/rippled-rpm/stable
+        gpgkey=https://repos.ripple.com/repos/rippled-rpm/stable/repodata/repomd.xml.key
+        REPOFILE
+
 1. 最新の`rippled`パッケージをダウンロードしてインストールします。
-   
+
         $ sudo yum update rippled
 
 2. `systemd`ユニットファイルを再度読み込みます。
-   
+
         $ sudo systemctl daemon-reload
 
 3. `rippled`サービスを再起動します。
-   
+
         $ sudo service rippled restart
 
 

--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
@@ -8,6 +8,18 @@ These instructions assume you have already [installed `rippled` from the `yum` r
 
 To update manually, complete the following steps:
 
+1. If you are upgrading to `rippled` 1.7.0 from an earlier version, re-add the the repository to get Ripple's updated GPG key. Otherwise, skip this step:
+
+        $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
+        [ripple-stable]
+        name=XRP Ledger Packages
+        enabled=1
+        gpgcheck=0
+        repo_gpgcheck=1
+        baseurl=https://repos.ripple.com/repos/rippled-rpm/stable
+        gpgkey=https://repos.ripple.com/repos/rippled-rpm/stable/repodata/repomd.xml.key
+        REPOFILE
+
 1. Download and install the latest `rippled` package:
 
         $ sudo yum update rippled

--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
@@ -8,7 +8,7 @@ These instructions assume you have already [installed `rippled` from the `yum` r
 
 To update manually, complete the following steps:
 
-1. If you are upgrading to `rippled` 1.7.0 from an earlier version, re-add the the repository to get Ripple's updated GPG key. Otherwise, skip this step:
+1. If you are upgrading to `rippled` 1.7.0 from an earlier version, re-add the repository to get Ripple's updated GPG key. Otherwise, skip this step:
 
         $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-stable]


### PR DESCRIPTION
@alloynetworks noted that several people had reported problems with upgrading to 1.7.0 on CentOS. These instructions should help alleviate those issues. (It's not clear if/how the different order of instructions in the repofile are helping, but this specific version has had several people corroborate that they work, so I've changed them just in case.)