### PR TITLE
Known Amendments: 1.6.0 amendment x3 expected

### DIFF
--- a/content/concepts/consensus-network/amendments/known-amendments.ja.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.ja.md
@@ -13,9 +13,9 @@
 | [fixSTAmountCanonicalize][]     | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [FlowSortStrands][]             | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [TicketBatch][]                 | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
-| [fix1781][]                     | v1.6.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
-| [fixAmendmentMajorityCalc][]    | v1.6.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
-| [HardenedValidations][]         | v1.6.0     | [投票中: 未定](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
+| [fix1781][]                     | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
+| [HardenedValidations][]         | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
 | [FlowCross][]                   | v0.70.0    | [有効: 2020/08/04](https://livenet.xrpl.org/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F "BADGE_GREEN") |
 | [fixQualityUpperBound][]        | v1.5.0     | [有効: 2020/07/09](https://livenet.xrpl.org/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E "BADGE_GREEN") |
 | [RequireFullyCanonicalSig][]    | v1.5.0     | [有効: 2020/07/03](https://livenet.xrpl.org/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3 "BADGE_GREEN") |
@@ -332,7 +332,7 @@ fix1623 Amendmentは、固定金額の[CheckCashトランザクション][]（`A
 
 | Amendment ID                                                     | ステータス    |
 |:-----------------------------------------------------------------|:----------|
-| 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E | 投票中 |
+| 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E | 予定 |
 
 Fixes a bug where certain XRP endpoints were not checked when detecting circular paths.
 
@@ -346,7 +346,7 @@ With this amendment, those payments fail with the [`temBAD_PATH_LOOP` result cod
 
 | Amendment ID                                                     | ステータス    |
 |:-----------------------------------------------------------------|:----------|
-| 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 | 投票中 |
+| 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 | 予定 |
 
 Fixes a bug that could cause an amendment to achieve a majority and later activate with support of slightly less than 80% of trusted validators due to rounding semantics.
 
@@ -473,7 +473,7 @@ Without this change, the engine simulates a payment through each possible path t
 
 | Amendment ID                                                     | ステータス    |
 |:-----------------------------------------------------------------|:----------|
-| 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 | 投票中 |
+| 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 | 予定 |
 
 Allows validators to include a new optional field in their validations to attest to the hash of
 the latest ledger that the validator considers to be fully validated. The consensus process can use this information to increase the robustness of consensus.

--- a/content/concepts/consensus-network/amendments/known-amendments.ja.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.ja.md
@@ -13,9 +13,9 @@
 | [fixSTAmountCanonicalize][]     | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [FlowSortStrands][]             | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [TicketBatch][]                 | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
-| [fix1781][]                     | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
-| [fixAmendmentMajorityCalc][]    | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
-| [HardenedValidations][]         | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [fix1781][]                     | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [HardenedValidations][]         | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
 | [FlowCross][]                   | v0.70.0    | [有効: 2020/08/04](https://livenet.xrpl.org/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F "BADGE_GREEN") |
 | [fixQualityUpperBound][]        | v1.5.0     | [有効: 2020/07/09](https://livenet.xrpl.org/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E "BADGE_GREEN") |
 | [RequireFullyCanonicalSig][]    | v1.5.0     | [有効: 2020/07/03](https://livenet.xrpl.org/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3 "BADGE_GREEN") |

--- a/content/concepts/consensus-network/amendments/known-amendments.ja.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.ja.md
@@ -13,9 +13,9 @@
 | [fixSTAmountCanonicalize][]     | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [FlowSortStrands][]             | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [TicketBatch][]                 | v1.7.0     | [投票中: 未定](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
-| [fix1781][]                     | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
-| [fixAmendmentMajorityCalc][]    | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
-| [HardenedValidations][]         | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
+| [fix1781][]                     | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [HardenedValidations][]         | v1.6.0     | [予定: 2021/04/08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
 | [FlowCross][]                   | v0.70.0    | [有効: 2020/08/04](https://livenet.xrpl.org/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F "BADGE_GREEN") |
 | [fixQualityUpperBound][]        | v1.5.0     | [有効: 2020/07/09](https://livenet.xrpl.org/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E "BADGE_GREEN") |
 | [RequireFullyCanonicalSig][]    | v1.5.0     | [有効: 2020/07/03](https://livenet.xrpl.org/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3 "BADGE_GREEN") |

--- a/content/concepts/consensus-network/amendments/known-amendments.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.md
@@ -13,9 +13,9 @@ The following is a comprehensive list of all known amendments and their status o
 | [fixSTAmountCanonicalize][]     | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [FlowSortStrands][]             | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [TicketBatch][]                 | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
-| [fix1781][]                     | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
-| [fixAmendmentMajorityCalc][]    | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
-| [HardenedValidations][]         | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
+| [fix1781][]                     | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [HardenedValidations][]         | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
 | [FlowCross][]                   | v0.70.0    | [Enabled: 2020-08-04](https://livenet.xrpl.org/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F "BADGE_GREEN") |
 | [fixQualityUpperBound][]        | v1.5.0     | [Enabled: 2020-07-09](https://livenet.xrpl.org/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E "BADGE_GREEN") |
 | [RequireFullyCanonicalSig][]    | v1.5.0     | [Enabled: 2020-07-03](https://livenet.xrpl.org/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3 "BADGE_GREEN") |

--- a/content/concepts/consensus-network/amendments/known-amendments.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.md
@@ -13,9 +13,9 @@ The following is a comprehensive list of all known amendments and their status o
 | [fixSTAmountCanonicalize][]     | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [FlowSortStrands][]             | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [TicketBatch][]                 | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
-| [fix1781][]                     | v1.6.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
-| [fixAmendmentMajorityCalc][]    | v1.6.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
-| [HardenedValidations][]         | v1.6.0     | [Open for Voting: TBD](https://xrpl.org/blog/2020/rippled-1.6.0.html "BADGE_80d0e0") |
+| [fix1781][]                     | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
+| [HardenedValidations][]         | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/two-fix-amendments-expected.html "BADGE_BLUE") |
 | [FlowCross][]                   | v0.70.0    | [Enabled: 2020-08-04](https://livenet.xrpl.org/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F "BADGE_GREEN") |
 | [fixQualityUpperBound][]        | v1.5.0     | [Enabled: 2020-07-09](https://livenet.xrpl.org/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E "BADGE_GREEN") |
 | [RequireFullyCanonicalSig][]    | v1.5.0     | [Enabled: 2020-07-03](https://livenet.xrpl.org/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3 "BADGE_GREEN") |
@@ -50,10 +50,10 @@ The following is a comprehensive list of all known amendments and their status o
 | [TrustSetAuth][]                | v0.30.0    | [Enabled: 2016-07-19](https://livenet.xrpl.org/transactions/0E589DE43C38AED63B64FF3DA87D349A038F1821212D370E403EB304C76D70DF "BADGE_GREEN") |
 | [MultiSign][]                   | v0.31.0    | [Enabled: 2016-06-27](https://livenet.xrpl.org/transactions/168F8B15F643395E59B9977FC99D6310E8708111C85659A9BAF8B9222EEAC5A7 "BADGE_GREEN") |
 | [FeeEscalation][]               | v0.31.0    | [Enabled: 2016-05-19](https://livenet.xrpl.org/transactions/5B1F1E8E791A9C243DD728680F108FEF1F28F21BA3B202B8F66E7833CA71D3C3 "BADGE_GREEN") |
-| [Tickets][]                     | v0.30.1    | [Vetoed: Removed in v0.90.0]( "BADGE_RED") |
 | [SHAMapV2][]                    | v0.32.1    | [Vetoed: Removed in v1.4.0](https://xrpl.org/blog/2019/rippled-1.4.0.html "BADGE_RED") |
-| [SusPay][]                      | v0.31.0    | [Vetoed: Removed in v0.60.0](https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features "BADGE_RED") |
 | [FlowV2][]                      | v0.32.1    | [Vetoed: Removed in v0.33.0](https://xrpl.org/blog/2016/flowv2-vetoed.html "BADGE_RED") |
+| [SusPay][]                      | v0.31.0    | [Vetoed: Removed in v0.60.0](https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features "BADGE_RED") |
+| [Tickets][]                     | v0.30.1    | [Vetoed: Removed in v0.90.0]( "BADGE_RED") |
 
 **Note:** In many cases, an incomplete version of the code for an amendment is present in previous versions of the software. The "Introduced" version in the table above is the first stable version. The value "TBD" indicates that the amendment is not yet considered stable.
 
@@ -353,7 +353,7 @@ The fix1623 amendment has no effect on [CheckCash transactions][] for a fixed am
 
 | Amendment ID                                                     | Status    |
 |:-----------------------------------------------------------------|:----------|
-| 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E | Open for Voting |
+| 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E | Expected  |
 
 Fixes a bug where certain XRP endpoints were not checked when detecting circular paths.
 
@@ -367,7 +367,7 @@ With this amendment, those payments fail with the [`temBAD_PATH_LOOP` result cod
 
 | Amendment ID                                                     | Status    |
 |:-----------------------------------------------------------------|:----------|
-| 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 | Open for Voting |
+| 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 | Expected  |
 
 Fixes a bug that could cause an amendment to achieve a majority and later activate with support of slightly less than 80% of trusted validators due to rounding semantics.
 
@@ -501,7 +501,7 @@ This is a previous version of the [Flow](#flow) amendment. It was [rejected due 
 
 | Amendment ID                                                     | Status    |
 |:-----------------------------------------------------------------|:----------|
-| 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 | Open for Voting |
+| 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 | Expected  |
 
 Allows validators to include a new optional field in their validations to attest to the hash of
 the latest ledger that the validator considers to be fully validated. The consensus process can use this information to increase the robustness of consensus.
@@ -644,6 +644,7 @@ This amendment adds [Tickets](tickets.html) as a way of sending transactions out
 
 Standards Draft: [XLS-13d](https://github.com/xrp-community/standards-drafts/issues/16).
 
+
 ## Tickets
 [Tickets]: #tickets
 
@@ -652,6 +653,7 @@ Standards Draft: [XLS-13d](https://github.com/xrp-community/standards-drafts/iss
 | C1B8D934087225F509BEB5A8EC24447854713EE447D277F69545ABFA0E0FD490 | Vetoed    |
 
 This amendment was replaced by the [TicketBatch][] amendment.
+
 
 ## TickSize
 [TickSize]: #ticksize

--- a/content/concepts/consensus-network/amendments/known-amendments.md
+++ b/content/concepts/consensus-network/amendments/known-amendments.md
@@ -13,9 +13,9 @@ The following is a comprehensive list of all known amendments and their status o
 | [fixSTAmountCanonicalize][]     | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [FlowSortStrands][]             | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
 | [TicketBatch][]                 | v1.7.0     | [Open for Voting: TBD](https://xrpl.org/blog/2021/rippled-1.7.0.html "BADGE_80d0e0") |
-| [fix1781][]                     | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
-| [fixAmendmentMajorityCalc][]    | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
-| [HardenedValidations][]         | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [fix1781][]                     | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
+| [HardenedValidations][]         | v1.6.0     | [Expected: 2021-04-08](https://xrpl.org/blog/2021/three-amendments-expected.html "BADGE_BLUE") |
 | [FlowCross][]                   | v0.70.0    | [Enabled: 2020-08-04](https://livenet.xrpl.org/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F "BADGE_GREEN") |
 | [fixQualityUpperBound][]        | v1.5.0     | [Enabled: 2020-07-09](https://livenet.xrpl.org/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E "BADGE_GREEN") |
 | [RequireFullyCanonicalSig][]    | v1.5.0     | [Enabled: 2020-07-03](https://livenet.xrpl.org/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3 "BADGE_GREEN") |


### PR DESCRIPTION
Updates the table with the current status. These amendments ping-ponged back and forth for a while but their majorities seem stable now so it's pretty important for people to upgrade.

The blog post is the expected URL where a post (currently in review) will go.