### PR TITLE
Add links to python and java libs

### DIFF
--- a/content/_snippets/libs-snippet.md
+++ b/content/_snippets/libs-snippet.md
@@ -2,5 +2,4 @@
 |----------|--------------|-------------|---------------|-------------|
 | **Python**   | `xrpl-py`      | [Get Started](get-started-using-python.html) | [API Reference](https://xrpl-py.readthedocs.io/) | [Repo](https://github.com/XRPLF/xrpl-py) |
 | **JavaScript** / **TypeScript** | `ripple-lib` | [Get Started](get-started-with-rippleapi-for-javascript.html) |  [API Reference](rippleapi-reference.html) | [Repo](https://github.com/ripple/ripple-lib) |
-| **C++**      | `rippled` Signing Library | [Get Started](https://github.com/ripple/rippled/tree/develop/Builds/linux#signing-library) |  | (Part of [`rippled`](https://github.com/ripple/rippled/)) |
 | **Java** | `xrpl4j` | [README](https://github.com/XRPLF/xrpl4j#readme) | [API Reference](https://github.com/XRPLF/xrpl4j/tree/main/xrpl4j-integration-tests)  | [Repo](https://github.com/XRPLF/xrpl4j) |

--- a/content/_snippets/libs-snippet.md
+++ b/content/_snippets/libs-snippet.md
@@ -1,0 +1,6 @@
+| Language | Library Name | Get Started | API Reference | Source Code |
+|----------|--------------|-------------|---------------|-------------|
+| **Python**   | `xrpl-py`      | [Get Started](get-started-using-python.html) | [API Reference](https://xrpl-py.readthedocs.io/) | [Repo](https://github.com/XRPLF/xrpl-py) |
+| **JavaScript** / **TypeScript** | `ripple-lib` | [Get Started](get-started-with-rippleapi-for-javascript.html) |  [API Reference](rippleapi-reference.html) | [Repo](https://github.com/ripple/ripple-lib) |
+| **C++**      | `rippled` Signing Library | [Get Started](https://github.com/ripple/rippled/tree/develop/Builds/linux#signing-library) |  | (Part of [`rippled`](https://github.com/ripple/rippled/)) |
+| **Java** | `xrpl4j` | [README](https://github.com/XRPLF/xrpl4j#readme) | [API Reference](https://github.com/XRPLF/xrpl4j/tree/main/xrpl4j-integration-tests)  | [Repo](https://github.com/XRPLF/xrpl4j) |

--- a/content/references/rippled-api/api-conventions/serialization.md
+++ b/content/references/rippled-api/api-conventions/serialization.md
@@ -43,14 +43,7 @@ Both signed and unsigned transactions can be represented in both JSON and binary
 
 The serialization processes described here are implemented in multiple places and programming languages:
 
-- **C++** 
-    - [In the `rippled` code base](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/STObject.cpp).
-- **JavaScript** 
-    - [In the `ripple-binary-codec` package](https://github.com/ripple/ripple-binary-codec/).
-- **Python** 
-    - [In the `xrpl-py` library](https://github.com/XRPLF/xrpl-py#serialize-and-sign-transactions).
-- **Java**
-    - [In the `xrpl4j` library](https://github.com/XRPLF/xrpl4j).
+{% include '_snippets/libs-snippet.md' %}
 
 These implementations are all provided with permissive open-source licenses, so you can import, use, or adapt the code for your needs in addition to using it alongside these documents for learning purposes.
 

--- a/content/references/rippled-api/api-conventions/serialization.md
+++ b/content/references/rippled-api/api-conventions/serialization.md
@@ -43,9 +43,14 @@ Both signed and unsigned transactions can be represented in both JSON and binary
 
 The serialization processes described here are implemented in multiple places and programming languages:
 
-- In C++ [in the `rippled` code base](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/STObject.cpp).
-- In JavaScript in the [`ripple-binary-codec`](https://github.com/ripple/ripple-binary-codec/) package.
-- In Python 3 in [this repository's code samples section]({{target.github_forkurl}}/blob/{{target.github_branch}}/content/_code-samples/tx-serialization/serialize.py).
+- **C++** 
+    - [In the `rippled` code base](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/STObject.cpp).
+- **JavaScript** 
+    - [In the `ripple-binary-codec` package](https://github.com/ripple/ripple-binary-codec/).
+- **Python** 
+    - [In the `xrpl-py` library](https://github.com/XRPLF/xrpl-py#serialize-and-sign-transactions).
+- **Java**
+    - [In the `xrpl4j` library](https://github.com/XRPLF/xrpl4j).
 
 These implementations are all provided with permissive open-source licenses, so you can import, use, or adapt the code for your needs in addition to using it alongside these documents for learning purposes.
 

--- a/content/references/rippled-api/api-conventions/serialization.md
+++ b/content/references/rippled-api/api-conventions/serialization.md
@@ -43,6 +43,12 @@ Both signed and unsigned transactions can be represented in both JSON and binary
 
 The serialization processes described here are implemented in multiple places and programming languages:
 
+- In C++ [in the `rippled` code base](https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/impl/STObject.cpp).
+- In JavaScript in the [`ripple-binary-codec`](https://github.com/ripple/ripple-binary-codec/) package.
+- In Python 3 in [this repository's code samples section]({{target.github_forkurl}}/blob/{{target.github_branch}}/content/_code-samples/tx-serialization/serialize.py).
+
+Additionally, the following libraries also provide serialization support:
+
 {% include '_snippets/libs-snippet.md' %}
 
 These implementations are all provided with permissive open-source licenses, so you can import, use, or adapt the code for your needs in addition to using it alongside these documents for learning purposes.


### PR DESCRIPTION
Updated Python bullet to link to `xrpl-py` and added a Java bullet that links to `xrpl4j`. 