### PR TITLE
Fix duplicate SigningPubKey in Pseudo-Transactions page

### DIFF
--- a/content/references/rippled-api/transaction-formats/pseudo-transaction-types/pseudo-transaction-types.md
+++ b/content/references/rippled-api/transaction-formats/pseudo-transaction-types/pseudo-transaction-types.md
@@ -12,7 +12,7 @@ Some of the required [common fields][] for normal transactions do not make sense
 | `Fee`           | String    | Amount            | `0`                        |
 | `Sequence`      | Number    | UInt32            | `0`                        |
 | `SigningPubKey` | String    | Blob              | `""` (Empty string)        |
-| `SigningPubKey` | String    | Blob              | `""` (Empty string)        |
+| `TxnSignature`  | String    | Blob              | `""` (Empty string)        |
 
 Pseudo-transactions use the following common fields as normal:
 


### PR DESCRIPTION
originally messed up in https://github.com/ripple/xrpl-dev-portal/commit/15b15b7ac00a095f945e803445cba270db10fa45#diff-86530e87bb83057cc9962054e4b68c814eb452b37896739453a8b9d4f7138b57L13 (though the original was wrong too, since it was supposed to be TxnSignature, not Signature)

[source](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/SField.cpp#L209)