### PR TITLE
Fix Get Started w/ Python missing from nav

### DIFF
--- a/content/tutorials/get-started/get-started-using-python.md
+++ b/content/tutorials/get-started/get-started-using-python.md
@@ -1,5 +1,6 @@
 ---
 html: get-started-using-python.html
+parent: get-started.html
 blurb: Build a simple Python app that interacts with the XRP Ledger.
 cta_text: Build an XRP Ledger-connected app
 filters:


### PR DESCRIPTION
#1044 accidentally caused "Get Started Using Python" to disappear from the left nav because it doesn't have a `parent` attribute assigned. This adds that field so it appears in the nav where it should again. 

I wrote a quick script check for other instances of the same and there were no other pages that qualified. (All pages that didn't have a `parent` were either placeholder/redirects, or the homepage.)