### PR TITLE
Build instructions: minor updates & cleanup

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.ja.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.ja.md
@@ -29,9 +29,9 @@ blurb: macOSでrippledを自分でコンパイルします。
 
         $ brew install git cmake pkg-config protobuf openssl ninja
 
-0. Boost 1.70.0以降をインストールします。`rippled`1.7.0はBoost 1.70.0以降と互換性があります。HomebrewのリポジトリにあるBoostの最新バージョンでは不十分であるため、Boostを手動でインストールする必要があります。（次の例では、本書執筆時点の最新バージョンであるBoost 1.71.0を使用しています。）
+0. Boost 1.75.0以降をインストールします。`rippled`1.7.2はBoost 1.75.0以降と互換性があります。HomebrewのリポジトリにあるBoostの最新バージョンでは不十分であるため、Boostを手動でインストールする必要があります。
 
-   1. [Boost 1.71.0](https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2)をダウンロードします。
+   1. [Boost 1.75.0](https://www.boost.org/users/history/version_1_75_0.html)をダウンロードします。
 
    2. フォルダに抽出します。場所をメモしておいてください。
 
@@ -47,7 +47,7 @@ blurb: macOSでrippledを自分でコンパイルします。
 
    2. 以下のコードをBoostディレクトリーの場所に編集して実行し、Boost環境変数が`.bash_profile`ファイルに追加されるようにします。そうすることで、ログイン時にこの環境変数が自動的に設定されます。
 
-      $ echo $"export BOOST_ROOT=/Users/my_user/boost_1_71_0" >> ~/.bash_profile
+      $ echo $"export BOOST_ROOT=/Users/my_user/boost_1_75_0" >> ~/.bash_profile
 
 0. 前のステップで`.bash_profile`ファイルをアップデートした場合には、新しいターミナルウィンドウでそれを読み込みます。例:
 
@@ -118,52 +118,52 @@ blurb: macOSでrippledを自分でコンパイルします。
 
     以下は、ターミナルに表示される内容の抜粋です。
 
-```
-      2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
-      2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
-      2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
-      2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
-      2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
-      ...
-      2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
-      2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
-      2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
-      2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
-      2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
-      2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
-      2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
-      2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
-      2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
-      2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
-      2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
-      2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
-      2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
-      2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
-      2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
-      2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
-      2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
-      2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
-      2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
-      2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
-      2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
-      2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
-      2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
-      2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
-      2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
-      {
-      	"command" : "log_level",
-      	"severity" : "warning"
-      }
-      2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
-      2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
-      2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
-      2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
-      2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
-      2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
-      2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
-      2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
-      2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
-      2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
+```text
+2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
+2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
+2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
+2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
+2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
+...
+2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
+2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
+2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
+2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
+2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
+2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
+2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
+2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
+2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
+2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
+2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
+2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
+2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
+2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
+2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
+2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
+2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
+2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
+2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
+2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
+2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
+2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
+2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
+2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
+2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
+{
+	"command" : "log_level",
+	"severity" : "warning"
+}
+2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
+2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
+2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
+2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
+2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
+2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
+2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
+2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
+2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
+2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
 ```
 
 `rippled`ログメッセージの詳細は、[ログメッセージについて](understanding-log-messages.html)を参照してください。

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.ja.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.ja.md
@@ -7,7 +7,7 @@ blurb: macOSでrippledを自分でコンパイルします。
 
 [`rippled`](the-rippled-server.html)の本番環境にmacOSプラットフォームを使用することは推奨されていません。本番環境には、最高レベルの品質管理とテストを経た、[Ubuntuプラットフォーム](install-rippled-on-ubuntu-with-alien.html)のご使用をご検討ください。
 
-しかしながら、macOSは多くの開発やテストの作業に適しています。`rippled`は、10.13 High SierraまでのmacOSでテスト済みです。
+しかしながら、macOSは多くの開発やテストの作業に適しています。`rippled`は、10.15.7 CatalinaまでのmacOSでテスト済みです。
 
 開発目的の場合は、`sudo`を使用するのではなく、非管理者ユーザーとして`rippled`を実行します。
 

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
@@ -132,52 +132,52 @@ For development purposes, run `rippled` as a non-admin user, not using `sudo`.
 
       Here's an excerpt of what you can expect to see in your terminal:
 
-```
-      2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
-      2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
-      2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
-      2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
-      2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
-      ...
-      2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
-      2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
-      2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
-      2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
-      2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
-      2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
-      2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
-      2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
-      2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
-      2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
-      2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
-      2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
-      2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
-      2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
-      2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
-      2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
-      2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
-      2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
-      2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
-      2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
-      2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
-      2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
-      2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
-      2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
-      2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
-      {
-      	"command" : "log_level",
-      	"severity" : "warning"
-      }
-      2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
-      2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
-      2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
-      2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
-      2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
-      2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
-      2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
-      2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
-      2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
-      2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
+```text
+2018-Oct-26 18:21:39.593738 JobQueue:NFO Auto-tuning to 6 validation/transaction/proposal threads.
+2018-Oct-26 18:21:39.599634 Amendments:DBG Amendment 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 is supported.
+2018-Oct-26 18:21:39.599874 Amendments:DBG Amendment 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC is supported.
+2018-Oct-26 18:21:39.599965 Amendments:DBG Amendment 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE is supported.
+2018-Oct-26 18:21:39.600024 Amendments:DBG Amendment 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 is supported.
+...
+2018-Oct-26 18:21:39.603201 OrderBookDB:DBG Advancing from 0 to 3
+2018-Oct-26 18:21:39.603291 OrderBookDB:DBG OrderBookDB::update>
+2018-Oct-26 18:21:39.603480 OrderBookDB:DBG OrderBookDB::update< 0 books found
+2018-Oct-26 18:21:39.649617 ValidatorList:DBG Loading configured trusted validator list publisher keys
+2018-Oct-26 18:21:39.649709 ValidatorList:DBG Loaded 0 keys
+2018-Oct-26 18:21:39.649798 ValidatorList:DBG Loading configured validator keys
+2018-Oct-26 18:21:39.650213 ValidatorList:DBG Loaded 5 entries
+2018-Oct-26 18:21:39.650266 ValidatorSite:DBG Loading configured validator list sites
+2018-Oct-26 18:21:39.650319 ValidatorSite:DBG Loaded 0 sites
+2018-Oct-26 18:21:39.650829 NodeObject:DBG NodeStore.main target size set to 131072
+2018-Oct-26 18:21:39.650876 NodeObject:DBG NodeStore.main target age set to 120000000000
+2018-Oct-26 18:21:39.650931 TaggedCache:DBG LedgerCache target size set to 256
+2018-Oct-26 18:21:39.650981 TaggedCache:DBG LedgerCache target age set to 180000000000
+2018-Oct-26 18:21:39.654252 TaggedCache:DBG TreeNodeCache target size set to 512000
+2018-Oct-26 18:21:39.654336 TaggedCache:DBG TreeNodeCache target age set to 90000000000
+2018-Oct-26 18:21:39.674131 NetworkOPs:NFO Consensus time for #3 with LCL AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D
+2018-Oct-26 18:21:39.674271 ValidatorList:DBG 5  of 5 listed validators eligible for inclusion in the trusted set
+2018-Oct-26 18:21:39.674334 ValidatorList:DBG Using quorum of 4 for new set of 5 trusted validators (5 added, 0 removed)
+2018-Oct-26 18:21:39.674400 LedgerConsensus:NFO Entering consensus process, watching, synced=no
+2018-Oct-26 18:21:39.674475 LedgerConsensus:NFO Consensus mode change before=observing, after=observing
+2018-Oct-26 18:21:39.674539 NetworkOPs:DBG Initiating consensus engine
+2018-Oct-26 18:21:39.751225 Server:NFO Opened 'port_rpc_admin_local' (ip=127.0.0.1:5005, admin IPs:127.0.0.1, http)
+2018-Oct-26 18:21:39.751515 Server:NFO Opened 'port_peer' (ip=0.0.0.0:51235, peer)
+2018-Oct-26 18:21:39.751689 Server:NFO Opened 'port_ws_admin_local' (ip=127.0.0.1:6006, admin IPs:127.0.0.1, ws)
+2018-Oct-26 18:21:39.751915 Application:FTL Startup RPC:
+{
+	"command" : "log_level",
+	"severity" : "warning"
+}
+2018-Oct-26 18:21:39.752079 Application:FTL Result: {}
+2018-Oct-26 18:22:33.013409 NetworkOPs:WRN We are not running on the consensus ledger
+2018-Oct-26 18:22:33.013875 LedgerConsensus:WRN Need consensus ledger 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628
+2018-Oct-26 18:22:33.883648 LedgerConsensus:WRN View of consensus changed during open status=open,  mode=wrongLedger
+2018-Oct-26 18:22:33.883815 LedgerConsensus:WRN 81804C95ADE119CC874572BAF24DB0C0D240AC58168597951B0CB64C4DA2C628 to 9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1
+2018-Oct-26 18:22:33.884068 LedgerConsensus:WRN {"accepted":true,"account_hash":"BBA0E7273005D42E5548DD6456E5AD1F7C89B6EDCB01881E1EECD393E8545947","close_flags":0,"close_time":593893350,"close_time_human":"2018-Oct-26 18:22:30.000000","close_time_resolution":30,"closed":true,"hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_hash":"9250C6C8326A48C339E6F99167F4E6BFD0DB00C35518027724D7B376340D21A1","ledger_index":"3","parent_close_time":593893290,"parent_hash":"AF8D8984A226AE7099D8A9749B09CE1D84360D5AF9FB86CE2F37500FE1009F9D","seqNum":"3","totalCoins":"100000000000000000","total_coins":"100000000000000000","transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"}
+2018-Oct-26 18:23:03.034119 InboundLedger:WRN Want: D901E53926E68EFDA33172DDAC74E8C767D280B68EE68E3010AB0E3179D07B1C
+2018-Oct-26 18:23:03.034334 InboundLedger:WRN Want: 1C01EE79083DE5CE76F3634519D6364C589C4D48631CB9CD10FC2408F87684E2
+2018-Oct-26 18:23:03.034560 InboundLedger:WRN Want: 8CFE3912001BDC5B2C4B2691F3C7811B9F3F193E835D293459D80FBF1C4E684E
+2018-Oct-26 18:23:03.034750 InboundLedger:WRN Want: 8DFAD21AD3090DE5D6F7592B3821C3DA77A72287705B4CF98DC0F84D5DD2BDF8
 ```
 
 For information about `rippled` log messages, see [Understanding Log Messages](understanding-log-messages.html).

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md
@@ -7,7 +7,7 @@ blurb: Compile rippled yourself on macOS.
 
 The macOS platform is not recommended for [`rippled`](the-rippled-server.html) production use. For production, consider using the [Ubuntu platform](install-rippled-on-ubuntu-with-alien.html), which has received the highest level of quality assurance and testing.
 
-That said, macOS is suitable for many development and testing tasks. `rippled` has been tested for use with macOS up to 10.13 High Sierra.
+That said, macOS is suitable for many development and testing tasks. `rippled` has been tested for use with macOS up to 10.15.7 Catalina.
 
 For development purposes, run `rippled` as a non-admin user, not using `sudo`.
 

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.ja.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.ja.md
@@ -9,7 +9,7 @@ blurb: Ubuntu Linuxでrippledを自分でコンパイルします。
 
 `rippled`の概要については、[Operating rippled Servers](install-rippled.html)を参照してください。
 
-次の手順を使用し、16.04以降のUbuntu Linux上で、ソースバージョン1.2.0以上から、`rippled`実行可能ファイルを構築します。これらの手順は、Ubuntu 16.04 LTSでテスト済みです。
+次の手順を使用し、Ubuntu Linux上で、`rippled`実行可能ファイルを構築します。これらの手順は、Ubuntu 18.04 LTSでテスト済みです。
 
 その他のプラットフォームでの`rippled`の構築については、`rippled` GitHubリポジトリの[Builds](https://github.com/ripple/rippled/tree/develop/Builds)を参照してください。
 
@@ -49,21 +49,21 @@ blurb: Ubuntu Linuxでrippledを自分でコンパイルします。
 
 5. Boostをコンパイルします。
 
-   `rippled`のバージョン1.7.0は、Boostバージョン1.70.0以降を必要とします。Ubuntu 18.04（または16.04）ソフトウェアリポジトリにBoostバージョン1.70.0以降がないため、自分でコンパイルする必要があります。（次の例では、執筆時点の最新バージョンであるBoost 1.71.0を使用しています。）
+   `rippled`のバージョン1.7.2は、Boostバージョン1.70.0ライブラリを必要とします、Boostバージョン1.70.0から1.75.0と互換性があります。 Ubuntu 18.04（または20.04）ソフトウェアリポジトリに互換性なBoostバージョンがないため、自分でコンパイルする必要があります。（次の例では、執筆時点の最新バージョンであるBoost 1.75.0を使用しています。）
 
-   以前に`rippled`用にBoost 1.71.0をインストールしていて、`BOOST_ROOT`環境変数を構成した場合には、このステップはスキップできます。
+   以前に`rippled`用にBoost 1.75.0をインストールしていて、`BOOST_ROOT`環境変数を構成した場合には、このステップはスキップできます。
 
-   1. Boost 1.71.0をダウンロードします。
+   1. Boost 1.75.0をダウンロードします。
 
-           wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+           wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
 
-   2. `boost_1_71_0.tar.gz`を抽出します。
+   2. `boost_1_75_0.tar.gz`を抽出します。
 
-           tar xvzf boost_1_71_0.tar.gz
+           tar xvzf boost_1_75_0.tar.gz
 
-   3. 新しい`boost_1_71_0`ディレクトリーに移動します。
+   3. 新しい`boost_1_75_0`ディレクトリーに移動します。
 
-           cd boost_1_71_0
+           cd boost_1_75_0
 
    4. 使用するBoost.Buildシステムを準備します。
 
@@ -75,9 +75,9 @@ blurb: Ubuntu Linuxでrippledを自分でコンパイルします。
 
       **ヒント:** この例では、4つのプロセスを並行して構築します。使用する最適なプロセス数は、お使いのハードウェアで使用可能なCPUコア数によって異なります。`cat /proc/cpuinfo`を使用して、ハードウェアプロセッサーに関する情報を取得できます。
 
-   6. `BOOST_ROOT`環境変数を、新しい`boost_1_71_0`ディレクトリーを参照するように設定します。ログイン時に自動的に設定されるようにするため、この環境変数を、シェル用の`.profile`またはそれに相当するファイルに入れることをお勧めします。ファイルに次の行を追加します。
+   6. `BOOST_ROOT`環境変数を、新しい`boost_1_75_0`ディレクトリーを参照するように設定します。ログイン時に自動的に設定されるようにするため、この環境変数を、シェル用の`.profile`またはそれに相当するファイルに入れることをお勧めします。ファイルに次の行を追加します。
 
-           export BOOST_ROOT=/home/my_user/boost_1_71_0
+           export BOOST_ROOT=/home/my_user/boost_1_75_0
 
    7. 更新した`.profile`ファイルを読み込みます。例:
 
@@ -144,8 +144,8 @@ blurb: Ubuntu Linuxでrippledを自分でコンパイルします。
 ## 3. `rippled`の実行
 
 定義した構成を使用し、構築した実行可能ファイルからストック`rippled`サーバーを実行するには、以下を実行します。
-```
-cd my_build
+
+```sh
 ./rippled
 ```
 
@@ -154,7 +154,7 @@ cd my_build
 
 `rippled`を実行するとターミナルに表示される内容の抜粋を以下に示します。
 
-```
+```text
 Loading: "/home/ubuntu/.config/ripple/rippled.cfg"
 Watchdog: Launching child 1
 2018-Jun-06 00:51:35.094331139 JobQueue:NFO Auto-tuning to 4 validation/transaction/proposal threads.

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
@@ -9,7 +9,7 @@ blurb: Compile rippled yourself on Ubuntu Linux.
 
 For an overview of `rippled`, see [Operating rippled Servers](install-rippled.html).
 
-Use these instructions to build a `rippled` executable from source version 1.2.0 or higher on Ubuntu Linux 16.04 or higher. These instructions were tested on Ubuntu 16.04 LTS.
+Use these instructions to build a `rippled` executable from source. These instructions were tested on Ubuntu 18.04 LTS.
 
 For information about building `rippled` for other platforms, see [Builds](https://github.com/ripple/rippled/tree/develop/Builds) in the `rippled` GitHub repository.
 
@@ -20,7 +20,7 @@ Before you compile or install `rippled`, you must meet the [System Requirements]
 
 ## 1. Build `rippled`
 
-These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the software prerequisites you need to build and run `rippled`.
+These instructions use Ubuntu's APT (Advanced Packaging Tool) to install `rippled`'s build dependencies.
 
 1. Update the list of packages that are available for `apt-get` to install or upgrade.
 
@@ -36,7 +36,7 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
 4. Install CMake.
 
-    Version 1.7.0 of `rippled` requires CMake 3.9.0 or higher. For the purposes of this tutorial, we used CMake 3.13.3, which was the latest version available at the time of writing.
+    Version 1.7.2 of `rippled` requires CMake 3.9.0 or higher. For the purposes of this tutorial, we used CMake 3.13.3.
 
     If you have previously installed CMake 3.9.0 or higher, you can skip these steps.
 
@@ -49,12 +49,12 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install the sof
 
 5. Compile Boost.
 
-    Version 1.7.0 of `rippled` requires the Boost library and is compatible with Boost versions 1.70.0 to 1.75.0. The Ubuntu 18.04 (or 16.04) software repositories don't have a compatible Boost version, so you must compile it yourself. The following examples use Boost 1.75.0.
+    Version 1.7.2 of `rippled` requires the Boost library and is compatible with Boost versions 1.70.0 to 1.75.0. The Ubuntu 18.04 (or 20.04) software repositories don't have a compatible Boost version, so you must compile it yourself. The following examples use Boost 1.75.0.
 
     If you have previously built Boost 1.75.0 for `rippled` and configured the `BOOST_ROOT` environment variable, you can skip these steps.
 
       1. Download Boost 1.75.0.
-              
+
 	      wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
 
       2. Extract `boost_1_75_0.tar.gz`.
@@ -142,9 +142,9 @@ Complete the following configurations that are required for `rippled` to start u
 
 ## 3. Run `rippled`
 
-To run your stock `rippled` server from the executable you built, using the configurations you defined:
-```
-cd my_build
+To run your `rippled` server from the executable you built:
+
+```sh
 ./rippled
 ```
 
@@ -153,7 +153,7 @@ cd my_build
 
 Once you've run `rippled`, here are excerpts of what you can expect to see in your terminal.
 
-```
+```text
 Loading: "/home/ubuntu/.config/ripple/rippled.cfg"
 Watchdog: Launching child 1
 2018-Jun-06 00:51:35.094331139 JobQueue:NFO Auto-tuning to 4 validation/transaction/proposal threads.


### PR DESCRIPTION
Continuing from #1099 and #1084, touch up some other parts of the build instructions:

- Update the Japanese-translated instructions
- Recommend Boost 1.75 across the board
- Default to Ubuntu 18.04, mention 20.04. (Support for Ubuntu 16.04 is complicated because of outdated dependencies, and not particularly relevant since 16.04 finally hit end-of-life the past April.)
- Other small touchups