### PR TITLE
Ripple data API alternatives

### DIFF
--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -10,3 +10,10 @@ nav_omit: true
 **Warning:** The Ripple Data API v2 is deprecated with no ongoing support. Please use the native [XRP Ledger HTTP APIs](rippled-api.html) instead.
 
 For information on the old Data API, see the [rippled-historical-database repository](https://github.com/ripple/rippled-historical-database).
+
+## Alternatives
+
+Most common operations like requesting account information and balances, transaction history, etc. 
+can be sent to self hosted or public XRP Ledger nodes. Data can be retrieved using a [WebSocket connection](get-started-using-http-websocket-apis.html#websocket-api) or [JSON RPC (HTTP POST)](.org/get-started-using-http-websocket-apis.html#json-rpc).
+
+See the [Get Started Using HTTP / WebSocket APIs](get-started-using-http-websocket-apis.html) page for more information.

--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -13,7 +13,6 @@ For information on the old Data API, see the [rippled-historical-database reposi
 
 ## Alternatives
 
-Most common operations like requesting account information and balances, transaction history, etc. 
-can be sent to self hosted or public XRP Ledger nodes. Data can be retrieved using a [WebSocket connection](get-started-using-http-websocket-apis.html#websocket-api) or [JSON RPC (HTTP POST)](.org/get-started-using-http-websocket-apis.html#json-rpc).
+For most common operations, like requesting account balances or transaction history, you can query a self-hosted or [public XRP Ledger server](public-servers.html) using a [WebSocket connection](get-started-using-http-websocket-apis.html#websocket-api) or [JSON-RPC (HTTP POST)](get-started-using-http-websocket-apis.html#json-rpc).
 
 See the [Get Started Using HTTP / WebSocket APIs](get-started-using-http-websocket-apis.html) page for more information.


### PR DESCRIPTION
Add alternative (as most questions I received so far are about simple things like getting account balance or transaction history, HTTP Post to JSON RPC would do.

Would it make sense to add a quick ready to use snippet __like__ this (not exactly this one)?
https://runkit.com/wietsewind/xrpl-json-rpc

![image](https://user-images.githubusercontent.com/4756161/123642001-1dc77d00-d823-11eb-96bb-791c95684df0.png)