### PR TITLE
Include reference to the xrpintel API as alternate data source

### DIFF
--- a/content/references/data-api.md
+++ b/content/references/data-api.md
@@ -16,3 +16,5 @@ For information on the old Data API, see the [rippled-historical-database reposi
 For most common operations, like requesting account balances or transaction history, you can query a self-hosted or [public XRP Ledger server](public-servers.html) using a [WebSocket connection](get-started-using-http-websocket-apis.html#websocket-api) or [JSON-RPC (HTTP POST)](get-started-using-http-websocket-apis.html#json-rpc).
 
 See the [Get Started Using HTTP / WebSocket APIs](get-started-using-http-websocket-apis.html) page for more information.
+
+[The XRP Intel API](https://xrpintel.com/api) run by Dev Null Productions provides many of the same data which the Ripple Data API v2 used to, including account, gateways, and more; derived directly from the XRP Ledger.


### PR DESCRIPTION
As a followup to #1113, we're proposing to add reference to the xrpintel API which provides similar functionality to that which the Data API v2 used to including list of accounts and known gateways. This functionality is useful to seed custom datasets and tools based on the XRPL.