### PR TITLE
reserves.md - accounts can now be deleted

### DIFF
--- a/content/concepts/payment-system-basics/accounts/reserves.md
+++ b/content/concepts/payment-system-basics/accounts/reserves.md
@@ -9,19 +9,19 @@ top_nav_grouping: Popular Pages
 ---
 # Reserves
 
-The XRP Ledger applies _reserve requirements_, in XRP, to protect the shared global ledger from growing excessively large as the result of spam or malicious usage. The goal is to constrain the growth of the ledger to match improvements in technology so that a current commodity-level machine can always fit the current ledger in RAM and the full ledger history on disk.
+The XRP Ledger applies _reserve requirements_, in XRP, to protect the shared global ledger from growing excessively large as the result of spam or malicious usage. The goal is to constrain the growth of the ledger to match improvements in technology so that a current commodity-level machine can always fit the current ledger in RAM.
 
-To submit transactions, an address must hold a minimum amount of XRP in the shared global ledger. You cannot send this XRP to other addresses. To fund a new address, you must send enough XRP to meet the reserve requirement.
+To have an account object, an address must hold a minimum amount of XRP in the shared global ledger. You cannot send this XRP to other addresses. To fund a new address, you must send XRP to that address in an amount that satisfies the minimum reserve requirement.
 
-The current minimum reserve requirement is **20 XRP**. (This is the cost of an address that owns no other objects in the ledger.) Each new [account](accounts.html) must set aside this much XRP, which cannot be recovered or sent to others.
+As determined by [Fee Voting](fee-voting.html), the current minimum reserve requirement is **20 XRP**. (This is the cost of an address that owns no other objects in the ledger.) Each new [account](accounts.html) must set aside this much XRP. Some of this XRP can be recovered by [deleting the account](accounts.html#deletion-of-accounts).
 
 
 ## Base Reserve and Owner Reserve
 
 The reserve requirement is divided into two parts:
 
-* The **Base Reserve** is a minimum amount of XRP that is required for every address in the ledger. Currently, this is 20 XRP (`20000000` drops).
-* The **Owner Reserve** is an increase to the reserve requirement for each object that the address owns in the ledger. Currently, this is 5 XRP (`5000000` drops) per item.
+* The **Base Reserve** is a minimum amount of XRP that is required for each address in the ledger. Currently, this is 20 XRP (`20000000` [drops](xrp.html#xrp-properties)).
+* The **Owner Reserve** is an increase to the reserve requirement for each object that the address owns in the ledger. Currently, this is 5 XRP (`5000000` [drops](xrp.html#xrp-properties)) per item.
 
 
 ### Owner Reserves
@@ -30,7 +30,7 @@ Many objects in the ledger are owned by a particular address, and count toward t
 
 - [Offers](offer.html) are owned by the address that placed them. Transaction processing automatically removes Offers that are fully consumed or found to be unfunded. Alternatively, the owner can cancel an Offer by sending an [OfferCancel transaction][], or by sending an [OfferCreate transaction][] that contains an `OfferSequence` parameter.
 - [Trust lines](ripplestate.html) are shared between two addresses. The owner reserve can apply to one or both of the addresses, depending on whether the fields that address controls are in their default state. See [Contributing to the Owner Reserve](ripplestate.html#contributing-to-the-owner-reserve) for details.
-- Without the [MultiSignReserve amendment][], a single [SignerList](signerlist.html) counts as 3 to 10 objects for purposes of the owner reserve, depending on how many members it has. With the [MultiSignReserve amendment][] enabled, a single SignerList counts as 1 object for purposes of the owner reserve, regardless of the number of members it has. See also: [Signer Lists and Reserves](signerlist.html#signer-lists-and-reserves).
+- A SignerList counts as 1 object for purposes of the owner reserve (since the [MultiSignReserve amendment][] activated in April 2019). See also: [Signer Lists and Reserves](signerlist.html#signer-lists-and-reserves).
 - [Held Payments (Escrow)](escrow-object.html) are owned by the address that placed them.
 - [Payment Channels](use-payment-channels.html) are owned by the address that created them.
 - [Owner directories](directorynode.html) list all the ledger objects that contribute to an address's owner reserve. However, the owner directory itself does not count towards the reserve.
@@ -53,7 +53,7 @@ When an address holds less XRP than its current reserve requirement, it cannot s
 
 ## Changing the Reserve Requirements
 
-The XRP Ledger has a mechanism to adjust the reserve requirements for long-term changes in the value of XRP. Any changes have to be approved by the consensus process. See [Fee Voting](fee-voting.html) for more information.
+The XRP Ledger has a mechanism to adjust the reserve requirements. Such adjustments may consider, for example, long-term changes in the value of XRP, improvements in the capacity of commodity-level machine hardware, or increased efficiency in the server software implementation. Any changes have to be approved by the consensus process. See [Fee Voting](fee-voting.html) for more information.
 
 ## See Also
 

--- a/content/concepts/payment-system-basics/accounts/reserves.md
+++ b/content/concepts/payment-system-basics/accounts/reserves.md
@@ -13,7 +13,9 @@ The XRP Ledger applies _reserve requirements_, in XRP, to protect the shared glo
 
 To have an account, an address must hold a minimum amount of XRP in the shared global ledger. You cannot send this XRP to other addresses. To fund a new address, you must send that address enough XRP to meet the reserve requirement.
 
-As determined by [Fee Voting](fee-voting.html), the current minimum reserve requirement is **20 XRP**. (This is the cost of an address that owns no other objects in the ledger.) Each new [account](accounts.html) must set aside this much XRP. Some of this XRP can be recovered by [deleting the account](accounts.html#deletion-of-accounts).
+The current minimum reserve requirement is **20 XRP**. (This is the cost of an address that owns no other objects in the ledger.) Each new [account](accounts.html) must set aside this much XRP. Some of this XRP can be recovered by [deleting the account](accounts.html#deletion-of-accounts).
+
+The [Fee Voting](fee-voting.html) process can change the reserve requirement if enough validators agree to new reserve settings.
 
 
 ## Base Reserve and Owner Reserve

--- a/content/concepts/payment-system-basics/accounts/reserves.md
+++ b/content/concepts/payment-system-basics/accounts/reserves.md
@@ -11,7 +11,7 @@ top_nav_grouping: Popular Pages
 
 The XRP Ledger applies _reserve requirements_, in XRP, to protect the shared global ledger from growing excessively large as the result of spam or malicious usage. The goal is to constrain the growth of the ledger to match improvements in technology so that a current commodity-level machine can always fit the current ledger in RAM.
 
-To have an account object, an address must hold a minimum amount of XRP in the shared global ledger. You cannot send this XRP to other addresses. To fund a new address, you must send XRP to that address in an amount that satisfies the minimum reserve requirement.
+To have an account, an address must hold a minimum amount of XRP in the shared global ledger. You cannot send this XRP to other addresses. To fund a new address, you must send that address enough XRP to meet the reserve requirement.
 
 As determined by [Fee Voting](fee-voting.html), the current minimum reserve requirement is **20 XRP**. (This is the cost of an address that owns no other objects in the ledger.) Each new [account](accounts.html) must set aside this much XRP. Some of this XRP can be recovered by [deleting the account](accounts.html#deletion-of-accounts).
 


### PR DESCRIPTION
Also: removed "and the full ledger history on disk" because I don't think reserve requirements really reduce the size of the ledger history. (But I could be persuaded.) Transaction fees are the main way that ledger history is kept from growing excessively large.