### PR TITLE
Add (May be omitted) to account_channels ledger_hash response field

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/account-methods/account_channels.md
+++ b/content/references/rippled-api/public-rippled-methods/account-methods/account_channels.md
@@ -160,7 +160,7 @@ The response follows the [standard format][], with a successful result containin
 |:---------------|:-------------------------|:---------------------------------|
 | `account`      | String                   | The address of the source/owner of the payment channels. This corresponds to the `account` field of the request. |
 | `channels`     | Array of Channel Objects | Payment channels owned by this `account`. [Updated in: rippled 1.5.0][] |
-| `ledger_hash`  | String                   | The identifying [Hash][] of the ledger version used to generate this response. [New in: rippled 0.90.0][] |
+| `ledger_hash`  | String                   | _(May be omitted)_ The identifying [Hash][] of the ledger version used to generate this response. [New in: rippled 0.90.0][] |
 | `ledger_index` | Number                   | The [Ledger Index][] of the ledger version used to generate this response. [New in: rippled 0.90.0][] |
 | `validated`    | Boolean                  | _(May be omitted)_ If `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. [New in: rippled 0.90.0][] |
 | `limit`        | Number                   | _(May be omitted)_ The limit to how many channel objects were actually returned by this request. |


### PR DESCRIPTION
The field descriptions for the [account_channels result](https://xrpl.org/account_channels.html#response-format) currently does not indicate that `ledger_hash` may be omitted.  `ledger_hash` will, however, be omitted when querying a non-validated ledger.

This should be in line with the `ledger_hash` field descriptions from other result object docs.