### PR TITLE
Fixup CI and links

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -1,7 +1,13 @@
 name: Link Checker (PR Build)
 
 on:
-  pull_request:
+  # Note: this job runs with in-repo permissions so it can comment and commit
+  # on stuff in the repo even when the PR is coming from a PR. This means that
+  # it can, potentially, wreak havoc on the repository by running arbitrary
+  # code. Be sure to ONLY approve job runs AFTER you have confirmed that the
+  # commits in question do not contain malicious or suspicious code (especially
+  # to the .sh or .py files in the tool/ directory.)
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 jobs:
@@ -11,6 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/template/page-uses.html.jinja
+++ b/template/page-uses.html.jinja
@@ -135,7 +135,7 @@
 
     <div class="mt-10 card-grid card-grid-3xN">
       {% for card in cards %}
-      <a class="col-new col-new-card ls-none bg-grey-800 br-8" href="{{card.href}}" target="_blank" id="{{card.id}}">
+      <a class="col-new col-new-card ls-none bg-grey-800 br-8" href="{{card.link}}" target="_blank" id="{{card.id}}">
         <span class="card-new d-block">
           <img class="mw-100 mb-3 biz-logo" alt="{{card.name|default(card.id)}}">
           <h4 class="h5">{{card.title}}</h4>


### PR DESCRIPTION
- fix a typo that was causing a lot of empty broken links on uses.html
- change the CI to hopefully run successfully on PRs from forks. Note, doing this carelessly is a security risk since external contributors could wreak havoc on the repo this way. It _should_ be OK though because the security settings on this repo are configured so that external contributors' GitHub Actions runs require explicit approval every time, so an admin needs to look over the diff to be sure it doesn't invoke any suspicious code and then approve the run.