### PR TITLE
ledger method: add validated field to table

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger.md
+++ b/content/references/rippled-api/public-rippled-methods/ledger-methods/ledger.md
@@ -206,7 +206,8 @@ The response follows the [standard format][], with a successful result containin
 | `ledger.transactions`          | Array   | (Omitted unless requested) Transactions applied in this ledger version. By default, members are the transactions' identifying [Hash][] strings. If the request specified `expand` as true, members are full representations of the transactions instead, in either JSON or binary depending on whether the request specified `binary` as true. |
 | `ledger_hash`                  | String  | Unique identifying hash of the entire ledger. |
 | `ledger_index`                 | Number  | The [Ledger Index][] of this ledger. |
-| `queue_data`                   | Array   | (Omitted unless requested with the `queue` parameter) Array of objects describing queued transactions, in the same order as the queue. If the request specified `expand` as true, members contain full representations of the transactions, in either JSON or binary depending on whether the request specified `binary` as true. Added by the [FeeEscalation amendment][]. [New in: rippled 0.70.0][] |
+| `validated`                    | Boolean | _(May be omitted)_ If `true`, this is a validated ledger version. If omitted or set to `false`, this ledger's data is not final. |
+| `queue_data`                   | Array   | _(Omitted unless requested with the `queue` parameter)_ Array of objects describing queued transactions, in the same order as the queue. If the request specified `expand` as true, members contain full representations of the transactions, in either JSON or binary depending on whether the request specified `binary` as true. Added by the [FeeEscalation amendment][]. [New in: rippled 0.70.0][] |
 
 The following fields are deprecated and may be removed without further notice: `accepted`, `hash` (use `ledger_hash` instead), `seqNum` (use `ledger_index` instead), `totalCoins` (use `total_coins` instead).
 


### PR DESCRIPTION
Fixes #1156.

I spent some time trying to figure out when the field was added to the response, but didn't reach a definitive conclusion. I'm unclear if it was added as part of the Reporting Mode changes or if it's been there for many years, so I didn't add a "New in" label.