### PR TITLE
Faucet: show starting sequence number

### DIFF
--- a/assets/js/test-net.js
+++ b/assets/js/test-net.js
@@ -1,9 +1,28 @@
+
+async function wait_for_seq(network_url, address) {
+  const api = new ripple.RippleAPI({server: network_url})
+  await api.connect()
+  let result;
+  while (true) {
+    try {
+      result = await api.request("account_info", {account: address, ledger_index: "validated"})
+      break
+    } catch(e) {
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    }
+  }
+  $("#sequence").html('<h3>Sequence Number</h3> '+result.account_data.Sequence)
+  api.disconnect()
+}
+
+
 function rippleTestNetCredentials(url, altnet_name) {
 
   const credentials = $('#your-credentials')
   const address = $('#address')
   const secret = $('#secret')
   const balance = $('#balance')
+  const sequence = $('#sequence')
   const loader = $('#loader')
 
   //reset the fields initially and for re-generation
@@ -11,6 +30,7 @@ function rippleTestNetCredentials(url, altnet_name) {
   address.html('')
   secret.html('')
   balance.html('')
+  sequence.html('')
   loader.css('display', 'inline')
 
 
@@ -29,12 +49,23 @@ function rippleTestNetCredentials(url, altnet_name) {
         data.account.secret).fadeIn('fast')
       balance.hide().html('<h3>Balance</h3> ' +
         Number(data.balance).toLocaleString('en') + ' XRP').fadeIn('fast')
+      sequence.html('<h3>Sequence</h3> <img class="throbber" src="assets/img/xrp-loader-96.png"> Waiting...').fadeIn('fast')
+      if (altnet_name=="Testnet") {
+        wait_for_seq("wss://s.altnet.rippletest.net:51233", data.account.address)
+      } else {
+        wait_for_seq("wss://s.devnet.rippletest.net:51233", data.account.address)
+      }
+
     },
     error: function() {
       loader.hide();
       alert("There was an error with the "+altnet_name+" faucet. Please try again.");
     }
   })
+}
+
+async function fill_starting_sequence(address) {
+
 }
 
 $(document).ready(function() {

--- a/template/page-xrp-faucets.html.jinja
+++ b/template/page-xrp-faucets.html.jinja
@@ -34,11 +34,13 @@ https://s.devnet.rippletest.net:51234</code></pre>
     <div id='address'></div>
     <div id='secret'></div>
     <div id='balance'></div>
+    <div id='sequence'> <div id='loader' style="display: none;"><img class="throbber" src="assets/img/xrp-loader-96.png"> Waiting...</div></div>
   </div>
 </section>
 {% endblock %}
 
 {% block endbody %}
+  {{target.ripple_lib_tag}}
   <script type='text/javascript' src='assets/js/test-net.js'></script>
   <script src="assets/js/multicodetab.js"></script>
   <script type="application/javascript">


### PR DESCRIPTION
When using an account from the Testnet/Devnet faucet it can be useful to know your starting sequence number. Before deletable accounts, it was always 1, but nowadays it's set based on the ledger when your account gets funded, so this adds a script to check and tell you the account's starting sequence number.

I considered also refactoring to remove jQuery dependence and to use the faucet function built into ripple-lib 1.10.0 but opted for the smaller refactor for now.