### PR TITLE
Interactive tutorials: number steps for analytics

### DIFF
--- a/assets/js/interactive-tutorial.js
+++ b/assets/js/interactive-tutorial.js
@@ -451,9 +451,13 @@ function text_to_hex(s) {
  *                         added to them (in-place).
  */
 function add_memo(event, tx_json) {
+  const block = $(event.target).closest(".interactive-block")
+
   const tutorial_info = {
     "path": window.location.pathname,
-    "button": event.target.id
+    "button": event.target.id,
+    "step": block.data("stepnumber"),
+    "totalsteps": block.data("totalsteps")
   }
 
   const memo = {

--- a/tool/INTERACTIVE_TUTORIALS_README.md
+++ b/tool/INTERACTIVE_TUTORIALS_README.md
@@ -40,6 +40,8 @@ The memo has a `MemoData` field which is ASCII-encoded JSON containing the follo
 |---|---|---|
 | `path` | String | The `window.location.pathname` of the tutorial. For example, `/send-xrp.html`. |
 | `button` | String | The unique html ID of the button that triggered this transaction. For example, `submit-button`. |
+| `step` | String (Number) | The step number that contained the button to trigger this transaction. For example, `"1"`. The first interactive block is step 1 (they are not 0-indexed). |
+| `totalsteps` | String (Number) | The total number of interactive blocks in the tutorial that triggered this transaction. Not all steps of an interactive tutorial involve sending transactions, but all steps are counted. |
 
 For privacy reasons, the memo does not and MUST NOT include personally identifying information about the user or their browser.
 

--- a/tool/filter_interactive_steps.py
+++ b/tool/filter_interactive_steps.py
@@ -48,7 +48,10 @@ def filter_soup(soup, **kwargs):
     in the document. Each step results in a li element such as:
     <li class="breadcrumb-item disabled current bc-connect">
         <a href="#interactive-connect">Connect</a>
-    </li>"""
+    </li>
+
+    Also, add step numbers to the tutorials
+    """
     crumb_uls = soup.find_all(class_="tutorial-step-crumbs")
     steps = [(el.attrs["data-stepid"], el.attrs["data-steplabel"]) for el in crumb_uls]
 
@@ -68,9 +71,17 @@ def filter_soup(soup, **kwargs):
             parent_ul.append(li)
             i += 1
 
-    for ul in crumb_uls:
+    def add_stepnum(crumbs_ul, i, total):
+        steps_div = crumbs_ul.parent.parent.parent
+        if 'interactive-block' not in steps_div['class']:
+            raise ValueError("crumbs_ul not wrapped in .interactive-block as expected")
+        steps_div.attrs['data-stepnumber'] = i+1 # 1-index steps so it's less confusing
+        steps_div.attrs['data-totalsteps'] = total
+
+    for i, ul in enumerate(crumb_uls):
         ul_step_id = ul.attrs["data-stepid"]
         add_lis(ul, steps, ul_step_id)
+        add_stepnum(ul, i, len(steps))
 
 
 


### PR DESCRIPTION
Count the total number of interactive blocks and add this data to the memo when sending transactions from interactive tutorials. This should help track the completion rate of tutorials to better measure effectiveness of the documentation.