### PR TITLE
Use dataLayer for page type info

### DIFF
--- a/template/base.html.jinja
+++ b/template/base.html.jinja
@@ -41,6 +41,7 @@
     <script src="{{currentpage.prefix}}assets/vendor/jquery-3.6.0.min.js"></script>
 
     <!-- Google Tag Manager -->
+    {% block analytics %}{% endblock %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/template/macro-get_funnel.jinja
+++ b/template/macro-get_funnel.jinja
@@ -1,0 +1,9 @@
+{% macro get_funnel(pages, page) -%}
+{%- set concepts = pages|selectattr('html', 'defined_and_equalto', 'concepts.html')|first -%}
+{%- set tutorials = pages|selectattr('html', 'defined_and_equalto', 'tutorials.html')|first -%}
+{%- set references = pages|selectattr('html', 'defined_and_equalto', 'references.html')|first -%}
+{%- if concepts.is_ancestor_of(page.html) -%}Concepts
+{%- elif tutorials.is_ancestor_of(page.html) -%}Tutorials
+{%- elif tutorials.is_ancestor_of(page.html) -%}References
+{%- else -%}Other{%- endif -%}
+{%- endmacro %}

--- a/template/macro-get_funnel.jinja
+++ b/template/macro-get_funnel.jinja
@@ -4,6 +4,6 @@
 {%- set references = pages|selectattr('html', 'defined_and_equalto', 'references.html')|first -%}
 {%- if concepts.is_ancestor_of(page.html) -%}Concepts
 {%- elif tutorials.is_ancestor_of(page.html) -%}Tutorials
-{%- elif tutorials.is_ancestor_of(page.html) -%}References
+{%- elif references.is_ancestor_of(page.html) -%}References
 {%- else -%}Other{%- endif -%}
 {%- endmacro %}

--- a/template/page-by-label.html.jinja
+++ b/template/page-by-label.html.jinja
@@ -6,3 +6,14 @@
     {% include 'component-tag-cloud.html.jinja' %}
   </section>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Hub Page",
+      "page_group": "Docs"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-calculator.html.jinja
+++ b/template/page-calculator.html.jinja
@@ -399,10 +399,16 @@
     });
   };
 </script>
-
-
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-
 {% endblock %}
+
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-community.html.jinja
+++ b/template/page-community.html.jinja
@@ -99,8 +99,13 @@
 {% endblock %}
 
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "Community"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-docs.html.jinja
+++ b/template/page-docs.html.jinja
@@ -133,8 +133,16 @@ algoliaOptions: { 'facetFilters': ["lang:{{target.lang}}"] },
 debug: false
 });
 </script>
-
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
 {% endblock %}
+
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Hub Page",
+      "page_group": "Docs"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-faq2.html.jinja
+++ b/template/page-faq2.html.jinja
@@ -19,3 +19,15 @@
     </div>
   </article>
 {% endblock %}
+
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-history.html.jinja
+++ b/template/page-history.html.jinja
@@ -119,8 +119,16 @@
     e.preventDefault();
   })
 </script>
-
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
 {% endblock %}
+
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-home.html.jinja
+++ b/template/page-home.html.jinja
@@ -211,8 +211,13 @@
 {% endblock %}
 
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "Home"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-impact.html.jinja
+++ b/template/page-impact.html.jinja
@@ -121,8 +121,13 @@
 {% endblock %}
 
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-references.html.jinja
+++ b/template/page-references.html.jinja
@@ -102,8 +102,16 @@
 
 {% endblock %}
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+{% from "macro-get_funnel.jinja" import get_funnel %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Hub Page",
+      "page_group": "Docs",
+      "page_funnel": "{{get_funnel(pages, currentpage)}}",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-rpc-tool.html.jinja
+++ b/template/page-rpc-tool.html.jinja
@@ -101,8 +101,16 @@
 {% block endbody %}
   {{currentpage.ripple_lib_tag}}
   <script type='text/javascript' src='assets/js/rpc-tool.js'></script>
-
-  <script type="application/javascript">
-    gtag('config', 'UA-157720658-3', {'content_group1': 'API Tools'});
-  </script>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Tool",
+      "page_group": "Docs",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-toml-checker.html.jinja
+++ b/template/page-toml-checker.html.jinja
@@ -27,8 +27,16 @@
 {% block endbody %}
   <script type="application/javascript" src="assets/vendor/iarna-toml-parse.js"></script>
   <script type="application/javascript" src="assets/js/xrp-ledger-toml-checker.js"></script>
-
-  <script type="application/javascript">
-    gtag('config', 'UA-157720658-3', {'content_group1': 'API Tools'});
-  </script>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Tool",
+      "page_group": "Docs",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-tx-sender.html.jinja
+++ b/template/page-tx-sender.html.jinja
@@ -159,8 +159,16 @@
 {% block endbody %}
   <script type="application/javascript" src="assets/vendor/bootstrap-growl.jquery.js"></script>
   <script type="application/javascript" src="assets/js/tx-sender.js"></script>
-
-  <script type="application/javascript">
-    gtag('config', 'UA-157720658-3', {'content_group1': 'API Tools'});
-  </script>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Tool",
+      "page_group": "Docs",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-uses.html.jinja
+++ b/template/page-uses.html.jinja
@@ -150,9 +150,13 @@
 
 {% endblock %}
 
-
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-validator-domain-verifier.html.jinja
+++ b/template/page-validator-domain-verifier.html.jinja
@@ -27,7 +27,16 @@
 {% block endbody %}
   <script type='text/javascript' src='assets/vendor/iarna-toml-parse.js'></script>
   <script type='text/javascript' src='assets/js/domain-verifier-bundle.js'></script>
-  <script type="application/javascript">
-    gtag('config', 'UA-157720658-3', {'content_group1': 'API Tools'});
-  </script>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Tool",
+      "page_group": "Docs",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-websocket-api-tool.html.jinja
+++ b/template/page-websocket-api-tool.html.jinja
@@ -185,8 +185,16 @@
   <script type="text/javascript" src="assets/vendor/codemirror-js-json-lint.min.js"></script>
   <script type="text/javascript" src="assets/js/apitool-websocket.js"></script>
   <script type="text/javascript" src="assets/js/apitool-methods-ws.js"></script>
-
-  <script type="application/javascript">
-    gtag('config', 'UA-157720658-3', {'content_group1': 'API Tools'});
-  </script>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Tool",
+      "page_group": "Docs",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-xrp-faucets.html.jinja
+++ b/template/page-xrp-faucets.html.jinja
@@ -48,8 +48,16 @@ https://s.devnet.rippletest.net:51234</code></pre>
       $(".multicode").minitabs();
     });
   </script>
-
-  <script type="application/javascript">
-    gtag('config', 'UA-157720658-3', {'content_group1': 'API Tools'});
-  </script>
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Tool",
+      "page_group": "Docs",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-xrp-overview.html.jinja
+++ b/template/page-xrp-overview.html.jinja
@@ -272,9 +272,13 @@
 {% endblock %}
 
 
-{% block endbody %}
-<script type="application/javascript">
-
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-xrpl-foundation.html.jinja
+++ b/template/page-xrpl-foundation.html.jinja
@@ -111,8 +111,13 @@
 {% endblock %}
 
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/page-xrpl-overview.html.jinja
+++ b/template/page-xrpl-overview.html.jinja
@@ -141,9 +141,13 @@
 {% endblock %}
 
 
-{% block endbody %}
-
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Splash Page",
+      "page_group": "About"
+    })
+    </script>
+{% endblock analytics %}

--- a/template/pagetype-category.html.jinja
+++ b/template/pagetype-category.html.jinja
@@ -28,8 +28,16 @@
   {% endif %}
 {% endblock %}
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-{% endblock %}
+{% block analytics %}
+{% from "macro-get_funnel.jinja" import get_funnel %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Hub Page",
+      "page_group": "Docs",
+      "page_funnel": "{{get_funnel(pages, currentpage)}}",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/pagetype-doc.html.jinja
+++ b/template/pagetype-doc.html.jinja
@@ -49,9 +49,16 @@
   </div>
 {% endblock %}
 
-{% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Content Docs'});
-</script>
-
-{% endblock %}
+{% block analytics %}
+{% from "macro-get_funnel.jinja" import get_funnel %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Document",
+      "page_group": "Docs",
+      "page_funnel": "{{get_funnel(pages, currentpage)}}",
+      "page_labels": {{currentpage.labels or []}}
+    })
+    </script>
+{% endblock analytics %}

--- a/template/pagetype-label.html.jinja
+++ b/template/pagetype-label.html.jinja
@@ -33,9 +33,17 @@
 {% endblock %}
 
 {% block endbody %}
-<script type="application/javascript">
-  gtag('config', 'UA-157720658-3', {'content_group1': 'Hub Pages'});
-</script>
-
 {% include 'component-feedback-widget.html.jinja' %}
 {% endblock %}
+
+{% block analytics %}
+    <script type="application/javascript">
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      "event": "page_info",
+      "page_type": "Hub Page",
+      "page_group": "Docs",
+      "page_labels": ["{{currentpage.landing_for}}"]
+    })
+    </script>
+{% endblock analytics %}


### PR DESCRIPTION
Adds a `page_info` event that communicates some of the page's metadata to Google Analytics so we can more accurately analyze the performance of different types or groupings of pages. (For example: people spending a long time on documentation pages is often a good sign but people spending a long time on hub pages is probably a bad thing, so we can measure and set goals differently for these different types of pages.)