### PR TITLE
Add DestinationNode to the code sample

### DIFF
--- a/content/references/protocol-reference/ledger-data/ledger-object-types/paychannel.md
+++ b/content/references/protocol-reference/ledger-data/ledger-object-types/paychannel.md
@@ -32,6 +32,7 @@ For an example of using payment channels, see the [Payment Channels Tutorial](us
     "CancelAfter": 536891313,
     "SourceTag": 0,
     "DestinationTag": 1002341,
+    "DesinationNode": "0000000000000000",
     "Flags": 0,
     "LedgerEntryType": "PayChannel",
     "OwnerNode": "0000000000000000",


### PR DESCRIPTION
DestinationNode is listed in the parameter descriptions, but missing from sample code. I've added the entry, copying the OwnerNode value for now. I'm assuming that the value is a placeholder with the correct number of digits. If we can put in a more realistic value, that would probably be better.
This is to address issue https://github.com/XRPLF/xrpl-dev-portal/issues/892