### PR TITLE
Remove obsolete cross-domain tracking code

### DIFF
--- a/template/base.html.jinja
+++ b/template/base.html.jinja
@@ -48,18 +48,6 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KCQZ3L8');</script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-45576805-2"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-45576805-2');
-      gtag('config', 'UA-157720658-3', { 'linker': {
-        'domains': ['blog.xpring.io', 'forum.xpring.io', 'xpring.io',
-                    'blog.ripplex.io', 'forum.ripplex.io', 'ripplex.io',
-                    'xrpl.org', 'explorer.xrpl.org', 'testnet.xrpl.org']
-        } }
-      );
-    </script>
 
     <!-- Stylesheet -->
     {% if target.lang=="ja" %}


### PR DESCRIPTION
Apparently some things were getting double-logged in Google Analytics as a result of this, but we're no longer tracking cross-domain with RippleX/Xpring stuff so we can just get rid of this whole bit of tracking code.