### PR TITLE
Add sign and sign_for to admin methods

### DIFF
--- a/content/_snippets/public-signing-note.md
+++ b/content/_snippets/public-signing-note.md
@@ -1,1 +1,1 @@
-_By default, this method is [admin-only](admin-rippled-methods.html). It can be used as a public method if the server has [enabled public signing](enable-public-signing.html)._
+_By default, this method is [admin-only](admin-rippled-methods.html). It can be used as a public method if the server admin has [enabled public signing](enable-public-signing.html)._

--- a/content/concepts/payment-system-basics/accounts/multi-signing.md
+++ b/content/concepts/payment-system-basics/accounts/multi-signing.md
@@ -17,7 +17,7 @@ Benefits of multi-signing include:
 * You can delegate the power to send transactions from your address to a group of people, who can control your address if you are unavailable or unable to sign normally.
 * ... and more.
 
-## Signer Lists
+## SignerLists
 
 Before you can multi-sign, you must create a list of which addresses can sign for you.
 
@@ -25,19 +25,31 @@ The [SignerListSet transaction][] defines which addresses can authorize transact
 
 ### SignerWeight
 
-You can assign a weight to each signer in the signer list. The weight represents the relative authority of the signer to other signers on the list. The higher the value, the more authorization authority. Individual SignerWeight values cannot exceed 2<sup>16</sup>-1.
+You can assign a weight to each signer in the SignerList. The weight represents the relative authority of the signer to other signers on the list. The higher the value, the more authorization authority. Individual SignerWeight values cannot exceed 2<sup>16</sup>-1.
 
 ### SignerQuorum
 
-The SignerQuorum value is the minimum SignerWeight total required to authorize a transaction. The SignerQuorum value must be attainable. The SignerQuorum must be greater than 0 but less than or equal to the sum of the SignerWeight values in the SignerList, or all transactions fail.  
+The SignerQuorum value is the minimum SignerWeight total required to authorize a transaction. The SignerQuorum value must be attainable. The SignerQuorum must be greater than 0 but less than or equal to the sum of the SignerWeight values in the SignerList.  
 
-For example, you might assign a SignerQuorum of 3 to to an account. You assign your CEO a SignerWeight of 3, Vice Presidents a SignerWeight of 2, and Directors  a SignerWeight of 1. To approve a transaction for this account requires the approval of 3 Directors (total weight of 3), 1 Vice President and 1 Director (total weight of 3), 2 Vice Presidents (total weight of 4), or the CEO (total weight of 3). The SignerWeight and SignerQuorum allow you to set an appropriate level of scrutiny for each transaction, based on the relative trust and authority relegated to responsible members of your organization. 
+### Examples Using SignerWeight and SignerQuorum
+
+For a typical use case, you might have a shared account with a SignerQuorum of 1, then give all participants a SignerWeight of 1. A single approval from any one of them is all that is required to approve a transaction.
+
+For a very important account, you might set the SignerQuorum to 3, with 3 participants that have a SignerWeight of 1. All of the participants must agree and approve each transaction.
+
+Another account might also have a SignerQuorum of 3. You assign your CEO a SignerWeight of 3, 3 Vice Presidents a SignerWeight of 2 each, and 3 Directors a SignerWeight of 1 each. To approve a transaction for this account requires the approval of all 3 Directors (total weight of 3), 1 Vice President and 1 Director (total weight of 3), 2 Vice Presidents (total weight of 4), or the CEO (total weight of 3).
+
+In each of the previous three use cases, you would disable the master key without configuring a regular key, so that multi-signing is the only way of authorizing transactions.
+
+There might be a scenario where you create a multi-signing list as a "backup plan." The account owner normally uses a regular key for their transactions (not a multi-signing key). For safety, the owner adds a signer list containing 3 friends, each with a weight of 1. Then the owner sets the SignerQuorum to 3. If the account owner were to lose the private key, they can ask their friends to multi-sign a transaction to replace the regular key.
+
+SignerWeight and SignerQuorum allow you to set an appropriate level of oversight for each transaction, based on the relative trust and authority relegated to responsible participants who manage the account. 
 
 ## Sending Multi-Signed Transactions
 
 To successfully submit a multi-signed transaction, you must do all of the following:
 
-* The address sending the transaction (specified in the `Account` field) must have a [signer list in the ledger](signerlist.html). For instructions on how to do this, see [Set Up Multi-Signing](set-up-multi-signing.html).
+* The address sending the transaction (specified in the `Account` field) must have a [SignerList in the ledger](signerlist.html). For instructions on how to do this, see [Set Up Multi-Signing](set-up-multi-signing.html).
 * The transaction must include the `SigningPubKey` field as an empty string.
 * The transaction must include a [`Signers` field](transaction-common-fields.html#signers-field) containing an array of signatures.
 * The signatures present in the `Signers` array must match signers defined in the SignerList.

--- a/content/concepts/payment-system-basics/accounts/multi-signing.md
+++ b/content/concepts/payment-system-basics/accounts/multi-signing.md
@@ -39,9 +39,9 @@ For a very important account, you might set the SignerQuorum to 3, with 3 partic
 
 Another account might also have a SignerQuorum of 3. You assign your CEO a SignerWeight of 3, 3 Vice Presidents a SignerWeight of 2 each, and 3 Directors a SignerWeight of 1 each. To approve a transaction for this account requires the approval of all 3 Directors (total weight of 3), 1 Vice President and 1 Director (total weight of 3), 2 Vice Presidents (total weight of 4), or the CEO (total weight of 3).
 
-In each of the previous three use cases, you would disable the master key without configuring a regular key, so that multi-signing is the only way of authorizing transactions.
+In each of the previous three use cases, you would disable the master key without configuring a regular key, so that multi-signing is the only way of [authorizing transactions](transaction-basics.html#authorizing-transactions).
 
-There might be a scenario where you create a multi-signing list as a "backup plan." The account owner normally uses a regular key for their transactions (not a multi-signing key). For safety, the owner adds a signer list containing 3 friends, each with a weight of 1. Then the owner sets the SignerQuorum to 3. If the account owner were to lose the private key, they can ask their friends to multi-sign a transaction to replace the regular key.
+There might be a scenario where you create a multi-signing list as a "backup plan." The account owner normally uses a regular key for their transactions (not a multi-signing key). For safety, the owner adds a SignerList containing 3 friends, each with a weight of 1, and a SignerQuorum of 3. If the account owner were to lose the private key, they can ask their friends to multi-sign a transaction to replace the regular key.
 
 SignerWeight and SignerQuorum allow you to set an appropriate level of oversight for each transaction, based on the relative trust and authority relegated to responsible participants who manage the account. 
 

--- a/content/concepts/payment-system-basics/accounts/multi-signing.md
+++ b/content/concepts/payment-system-basics/accounts/multi-signing.md
@@ -21,7 +21,17 @@ Benefits of multi-signing include:
 
 Before you can multi-sign, you must create a list of which addresses can sign for you.
 
-The [SignerListSet transaction][] defines which addresses can authorize transactions from your address. You can include up to 8 addresses in a SignerList. You can control how many signatures are needed, in which combinations, by using the quorum and weight values of the SignerList.
+The [SignerListSet transaction][] defines which addresses can authorize transactions from your address. You can include 1 to 8 addresses in a SignerList. The SignerList cannot include the sender's address and there can be no duplicate entries. You can control how many signatures are needed, in which combinations, by using the *SignerWeight* and *SignerQuorum* values of the SignerList.
+
+### SignerWeight
+
+You can assign a weight to each signer in the signer list. The weight represents the relative authority of the signer to other signers on the list. The higher the value, the more authorization authority. Individual SignerWeight values cannot exceed 2<sup>16</sup>-1.
+
+### SignerQuorum
+
+The SignerQuorum value is the minimum SignerWeight total required to authorize a transaction. The SignerQuorum value must be attainable. The SignerQuorum must be greater than 0 but less than or equal to the sum of the SignerWeight values in the SignerList, or all transactions fail.  
+
+For example, you might assign a SignerQuorum of 3 to to an account. You assign your CEO a SignerWeight of 3, Vice Presidents a SignerWeight of 2, and Directors  a SignerWeight of 1. To approve a transaction for this account requires the approval of 3 Directors (total weight of 3), 1 Vice President and 1 Director (total weight of 3), 2 Vice Presidents (total weight of 4), or the CEO (total weight of 3). The SignerWeight and SignerQuorum allow you to set an appropriate level of scrutiny for each transaction, based on the relative trust and authority relegated to responsible members of your organization. 
 
 ## Sending Multi-Signed Transactions
 

--- a/content/references/rippled-api/admin-rippled-methods/admin-rippled-methods.md
+++ b/content/references/rippled-api/admin-rippled-methods/admin-rippled-methods.md
@@ -39,6 +39,15 @@ Use these methods to manage the `rippled` server.
 * **[`ledger_accept`](ledger_accept.html)** - Close and advance the ledger in stand-alone mode.
 * **[`stop`](stop.html)** - Shut down the `rippled` server.
 
+## [Transaction Methods](transaction-methods.html)
+
+Use these methods to work with transactions. 
+
+* **[`sign`](sign.html)** - Cryptographically sign a transaction.
+* **[`sign_for`](sign_for.html)** - Contribute to a multi-signature.
+
+By default, these methods are [admin-only](admin-rippled-methods.html). They can be used as public methods if the server has [enabled public signing](enable-public-signing.html).
+
 ## [Peer Management Methods](peer-management-methods.html)
 
 Use these methods to manage the server's connections in the peer-to-peer XRP Ledger network.

--- a/content/references/rippled-api/admin-rippled-methods/admin-rippled-methods.md
+++ b/content/references/rippled-api/admin-rippled-methods/admin-rippled-methods.md
@@ -39,14 +39,14 @@ Use these methods to manage the `rippled` server.
 * **[`ledger_accept`](ledger_accept.html)** - Close and advance the ledger in stand-alone mode.
 * **[`stop`](stop.html)** - Shut down the `rippled` server.
 
-## [Transaction Methods](transaction-methods.html)
+## [Signing Methods](signing-methods.html)
 
-Use these methods to work with transactions. 
+Use these methods to sign transactions. 
 
 * **[`sign`](sign.html)** - Cryptographically sign a transaction.
 * **[`sign_for`](sign_for.html)** - Contribute to a multi-signature.
 
-By default, these methods are [admin-only](admin-rippled-methods.html). They can be used as public methods if the server has [enabled public signing](enable-public-signing.html).
+By default, these methods are [admin-only](get-started-using-http-websocket-apis.html#admin-access). They can be used as public methods if the server admin has [enabled public signing](enable-public-signing.html).
 
 ## [Peer Management Methods](peer-management-methods.html)
 

--- a/content/references/rippled-api/admin-rippled-methods/signing-methods/sign.ja.md
+++ b/content/references/rippled-api/admin-rippled-methods/signing-methods/sign.ja.md
@@ -1,6 +1,6 @@
 ---
 html: sign.html # watch for clashes w/ this filename
-parent: transaction-methods.html
+parent: signing-methods.html
 blurb: トランザクションの署名済みバイナリー表現を返します。
 labels:
   - トランザクション送信

--- a/content/references/rippled-api/admin-rippled-methods/signing-methods/sign.md
+++ b/content/references/rippled-api/admin-rippled-methods/signing-methods/sign.md
@@ -1,6 +1,6 @@
 ---
 html: sign.html # watch for clashes w/ this filename
-parent: transaction-methods.html
+parent: signing-methods.html
 blurb: Cryptographically sign a transaction.
 labels:
   - Transaction Sending

--- a/content/references/rippled-api/admin-rippled-methods/signing-methods/sign_for.ja.md
+++ b/content/references/rippled-api/admin-rippled-methods/signing-methods/sign_for.ja.md
@@ -1,6 +1,6 @@
 ---
 html: sign_for.html
-parent: transaction-methods.html
+parent: signing-methods.html
 blurb: マルチ署名済みトランザクションの署名を1つ提供します。
 labels:
   - トランザクション送信

--- a/content/references/rippled-api/admin-rippled-methods/signing-methods/sign_for.md
+++ b/content/references/rippled-api/admin-rippled-methods/signing-methods/sign_for.md
@@ -1,6 +1,6 @@
 ---
 html: sign_for.html
-parent: transaction-methods.html
+parent: signing-methods.html
 blurb: Contribute to a multi-signature.
 labels:
   - Transaction Sending

--- a/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
+++ b/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
@@ -42,13 +42,16 @@ A ledger version contains a header, a transaction tree, and a state tree, which 
 
 Transactions are the only thing that can modify the shared state of the XRP Ledger. All business on the XRP Ledger takes the form of transactions. Use these methods to work with transactions.
 
-* **[`sign`](sign.html)** - Cryptographically sign a transaction.
-* **[`sign_for`](sign_for.html)** - Contribute to a multi-signature.
 * **[`submit`](submit.html)** - Send a transaction to the network.
 * **[`submit_multisigned`](submit_multisigned.html)** - Send a multi-signed transaction to the network.
 * **[`transaction_entry`](transaction_entry.html)** - Retrieve info about a transaction from a particular ledger version.
 * **[`tx`](tx.html)** - Retrieve info about a transaction from all the ledgers on hand.
 * **[`tx_history`](tx_history.html)** - Retrieve info about all recent transactions.
+
+By default, the following methods are [admin-only](admin-rippled-methods.html). They can be used as public methods if the server has [enabled public signing](enable-public-signing.html).
+
+* **[`sign`](sign.html)** - Cryptographically sign a transaction. 
+* **[`sign_for`](sign_for.html)** - Contribute to a multi-signature.
 
 
 ## [Path and Order Book Methods](path-and-order-book-methods.html)

--- a/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
+++ b/content/references/rippled-api/public-rippled-methods/public-rippled-methods.md
@@ -48,7 +48,7 @@ Transactions are the only thing that can modify the shared state of the XRP Ledg
 * **[`tx`](tx.html)** - Retrieve info about a transaction from all the ledgers on hand.
 * **[`tx_history`](tx_history.html)** - Retrieve info about all recent transactions.
 
-By default, the following methods are [admin-only](admin-rippled-methods.html). They can be used as public methods if the server has [enabled public signing](enable-public-signing.html).
+By default, the following methods are [admin-only](admin-rippled-methods.html). They can be used as public methods if the server admin has [enabled public signing](enable-public-signing.html).
 
 * **[`sign`](sign.html)** - Cryptographically sign a transaction. 
 * **[`sign_for`](sign_for.html)** - Contribute to a multi-signature.

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2599,22 +2599,6 @@ pages:
         targets:
             - ja
 
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign.md
-        targets:
-            - en
-
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign.ja.md
-        targets:
-            - ja
-
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign_for.md
-        targets:
-            - en
-
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign_for.ja.md
-        targets:
-            - ja
-
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/submit.md
         targets:
             - en
@@ -2985,6 +2969,30 @@ pages:
         targets:
             - ja
 
+    -   name: Signing Methods
+        html: signing-methods.html
+        parent: admin-rippled-methods.html
+        blurb: Use these methods to work with transactions. #TODO:translate
+        template: pagetype-category.html.jinja
+        targets:
+            - en
+            - ja
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign.md
+        targets:
+            - en
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign.ja.md
+        targets:
+            - ja
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign_for.md
+        targets:
+            - en
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign_for.ja.md
+        targets:
+            - ja
 
     -   name: Peer Management Methods
         html: peer-management-methods.html

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -2643,22 +2643,6 @@ pages:
         targets:
             - ja
 
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign.md
-        targets:
-            - en
-
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign.ja.md
-        targets:
-            - ja
-
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign_for.md
-        targets:
-            - en
-
-    -   md: references/rippled-api/public-rippled-methods/transaction-methods/sign_for.ja.md
-        targets:
-            - ja
-
     -   md: references/rippled-api/public-rippled-methods/transaction-methods/submit.md
         targets:
             - en
@@ -3029,6 +3013,30 @@ pages:
         targets:
             - ja
 
+    -   name: Signing Methods
+        html: signing-methods.html
+        parent: admin-rippled-methods.html
+        blurb: Use these methods to work with transactions. #TODO:translate
+        template: pagetype-category.html.jinja
+        targets:
+            - en
+            - ja
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign.md
+        targets:
+            - en
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign.ja.md
+        targets:
+            - ja
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign_for.md
+        targets:
+            - en
+
+    -   md: references/rippled-api/admin-rippled-methods/signing-methods/sign_for.ja.md
+        targets:
+            - ja
 
     -   name: Peer Management Methods
         html: peer-management-methods.html


### PR DESCRIPTION
Per #1137, added sign and sign_for to admin-rippled-methods.html. 
@mDuo13 need some guidance to move the files from under public to admin sections in the config file. 