### PR TITLE
Get Started Using JavaScript: use WebSocket URI

### DIFF
--- a/content/_code-samples/get-started/js/base.js
+++ b/content/_code-samples/get-started/js/base.js
@@ -5,7 +5,7 @@
 async function main() {
 
   // Define the network client
-  const client = new xrpl.Client("https://s.altnet.rippletest.net:51234/")
+  const client = new xrpl.Client("wss://s.altnet.rippletest.net:51233")
   await client.connect()
 
   // ... custom code goes here


### PR DESCRIPTION
Using https gives me this error:

```
(node:12516) UnhandledPromiseRejectionWarning: ValidationError: server URI must start with `wss://`, `ws://`, `wss+unix://`, or `ws+unix://`.
    at new Client (/Users/user/project/node_modules/xrpl/dist/npm/client/index.js:84:19)
    at main (/Users/user/project/index.js:7:18)
    at Object.<anonymous> (/Users/user/project/index.js:19:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47
(Use `node --trace-warnings ...` to show where the warning was created)
(node:12516) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:12516) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```