### PR TITLE
Update get-acct-info.js

### DIFF
--- a/content/_code-samples/get-started/js/get-acct-info.js
+++ b/content/_code-samples/get-started/js/get-acct-info.js
@@ -10,7 +10,7 @@ async function main() {
   await client.connect()
 
   // Create a wallet and fund it with the Testnet faucet:
-  const fund_result = await client.fundWallet(test_wallet)
+  const fund_result = await client.fundWallet()
   const test_wallet = fund_result.wallet
   console.log(fund_result)
 


### PR DESCRIPTION
The call to initiate a new wallet (through fundWallet) must not include parameters.
The previous version of the code gives error: ReferenceError: Cannot access 'test_wallet' before initialization