### PR TITLE
fix: wallet generation in the JS tutorial

### DIFF
--- a/content/tutorials/get-started/get-started-using-javascript.md
+++ b/content/tutorials/get-started/get-started-using-javascript.md
@@ -121,7 +121,7 @@ The `xrpl.js` library has a `Wallet` class for handling the keys and address of 
 If you just want to generate keys, you can create a new Wallet instance like this:
 
 ```js
-const test_wallet = new xrpl.Wallet()
+const test_wallet = xrpl.Wallet.generate()
 ```
 
 Or, if you already have a seed encoded in [base58][], you can instantiate a Wallet from it like this:


### PR DESCRIPTION
There was incorrect instructions for initializing a wallet in the tutorial. It tripped someone up: https://github.com/XRPLF/xrpl.js/issues/1831