### PR TITLE
Minor updates to install docs

### DIFF
--- a/content/_snippets/post-rippled-install.md
+++ b/content/_snippets/post-rippled-install.md
@@ -1,21 +1,21 @@
-It can take several minutes for `rippled` to sync with the rest of the network, during which time it outputs warnings about missing ledgers.
+It can take several minutes to sync with the rest of the XRP Ledger network, during which time the server outputs various warnings. For information about log messages, see [Understanding Log Messages](understanding-log-messages.html).
 
-For information about `rippled` log messages, see [Understanding Log Messages](understanding-log-messages.html).
-
-After your `rippled` has synchronized with the rest of the network, you have a fully functional stock `rippled` server that you can use for local signing and API access to the XRP Ledger. Use [`rippled` server states](rippled-server-states.html) to tell whether your `rippled` server has synchronized with the network. You can use the [`rippled` commandline interface](get-started-using-http-websocket-apis.html#commandline) to test this quickly:
+You can use the [`rippled` commandline interface](get-started-using-http-websocket-apis.html#commandline) to see if your server is synced with the network:
 
 {% if currentpage.md == "tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md" or
       currentpage.md == "tutorials/manage-the-rippled-server/installation/build-run-rippled-macos.md" %}
-    $ ./rippled server_info
+    ./rippled server_info
 {% else %}
-    $ /opt/ripple/bin/rippled server_info
+    /opt/ripple/bin/rippled server_info
 {% endif %}
 
-For more information about communicating with your `rippled` server using the rippled APIs, see the [rippled API reference](rippled-api.html).
+If the `server_state` in the response is `full` or `proposing`, then your server is fully synced to the network. Otherwise, you may need to wait longer. Fresh servers usually sync within 15 minutes; servers that already have [ledger history](ledger-history.html) stored can take longer.
 
-Once you have your stock `rippled` server running, you may want to consider running it as a validating server. For information about validating servers and why you might want to run one, see [Run rippled as a Validator](run-rippled-as-a-validator.html).
+After your server has synchronized with the rest of the network, you have a fully functional XRP Ledger peer-to-peer server that you can use to submit transactions or get API access to the XRP Ledger. See [Client Libraries](client-libraries.html) or [HTTP / WebSocket APIs](rippled-api.html) for different ways to communicate with the server.
 
-Having trouble getting your `rippled` server started? See [rippled Server Won't Start](server-wont-start.html).
+If you use the XRP Ledger for your business or you just want to contribute to the stability of the network, you should run one server as a validator. For information about validating servers and why you might want to run one, see [Run rippled as a Validator](run-rippled-as-a-validator.html).
+
+Having trouble getting your server started? See [rippled Server Won't Start](server-wont-start.html).
 
 ### Additional Configuration
 

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-ubuntu.md
@@ -7,13 +7,9 @@ labels:
 ---
 # Build and Run rippled on Ubuntu
 
-`rippled` is the core peer-to-peer server that manages the XRP Ledger. A `rippled` server can connect to a network of peers, relay cryptographically signed transactions, and maintain a local copy of the complete shared global ledger.
+[`rippled`](the-rippled-server.html) is the reference implementation of an XRP Ledger peer-to-peer server. This server can connect to a network of peers, relay cryptographically signed transactions, and maintain a local copy of the complete shared global ledger. Use these instructions to build a `rippled` executable from source. These instructions were tested on Ubuntu 18.04 LTS.
 
-For an overview of `rippled`, see [Operating rippled Servers](install-rippled.html).
-
-Use these instructions to build a `rippled` executable from source. These instructions were tested on Ubuntu 18.04 LTS.
-
-For information about building `rippled` for other platforms, see [Builds](https://github.com/ripple/rippled/tree/develop/Builds) in the `rippled` GitHub repository.
+For information about building for other platforms, see [Builds](https://github.com/ripple/rippled/tree/develop/Builds) in the `rippled` GitHub repository.
 
 
 ## Prerequisites
@@ -38,7 +34,7 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install `ripple
 
 4. Install CMake.
 
-    Version 1.7.2 of `rippled` requires CMake 3.9.0 or higher. For the purposes of this tutorial, we used CMake 3.13.3.
+    Version 1.8.1 of `rippled` requires CMake 3.9.0 or higher. For the purposes of this tutorial, we used CMake 3.13.3.
 
     If you have previously installed CMake 3.9.0 or higher, you can skip these steps.
 
@@ -51,7 +47,7 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install `ripple
 
 5. Compile Boost.
 
-    Version 1.7.2 of `rippled` requires the Boost library and is compatible with Boost versions 1.70.0 to 1.75.0. The Ubuntu 18.04 (or 20.04) software repositories don't have a compatible Boost version, so you must compile it yourself. The following examples use Boost 1.75.0.
+    Version 1.8.1 of `rippled` requires the Boost library and is compatible with Boost versions 1.70.0 to 1.75.0. The Ubuntu 18.04 (or 20.04) software repositories don't have a compatible Boost version, so you must compile it yourself. The following examples use Boost 1.75.0.
 
     If you have previously built Boost 1.75.0 for `rippled` and configured the `BOOST_ROOT` environment variable, you can skip these steps.
 
@@ -95,11 +91,11 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install `ripple
 
     $ git log -1
 
-8. If you previously built, or (more importantly) tried and failed to build `rippled`, you should delete the `my_build/` directory (or whatever you named it) to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like a `rippled` executable that crashes due to a segmentation fault (segfault). <!-- SPELLING_IGNORE: segfault -->
+8. If you previously built, or (more importantly) tried and failed to build the XRPL server, you should delete the `my_build/` directory (or whatever you named it) to start clean before moving on to the next step. Otherwise, you may get unexpected behavior, like an executable that crashes due to a segmentation fault (segfault). <!-- SPELLING_IGNORE: segfault -->
 
-    If this is your first time building `rippled` 1.0.0 or higher, you won't have a `my_build/` directory and can move on to the next step.
+    If this is your first time building `rippled`, you won't have a `my_build/` directory and can move on to the next step.
 
-9. Use CMake to build a `rippled` binary executable from source code. The result will be a `rippled` binary executable in the `my_build` directory.
+9. Use CMake to build a `rippled` binary executable from source code. This creates a `rippled` binary executable in the `my_build` directory.
 
       1. Generate the build system. Builds should be performed in a directory that is separate from the source tree root. In this example, we'll use a `my_build` directory that is a subdirectory of `rippled`.
 
@@ -109,7 +105,7 @@ These instructions use Ubuntu's APT (Advanced Packaging Tool) to install `ripple
 
           **Tip:** The default build includes debugging symbols, which can be useful for development but are inefficient in production. To build `rippled` for use on production servers, add the `-DCMAKE_BUILD_TYPE=Release` flag when running the `cmake` command.
 
-      2. Build the `rippled` binary executable. This may take about 30 minutes, depending on your hardware specs.
+      2. Build the `rippled` executable. This may take about 30 minutes, depending on your hardware specs.
 
               cmake --build .
 

--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
@@ -31,7 +31,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
     *Stable*
 
-        $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
+        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-stable]
         name=XRP Ledger Packages
         enabled=1
@@ -43,7 +43,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
     *Pre-release*
 
-        $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
+        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-unstable]
         name=XRP Ledger Packages
         enabled=1
@@ -55,7 +55,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
     *Development*
 
-        $ cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
+        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
         [ripple-nightly]
         name=XRP Ledger Packages
         enabled=1
@@ -70,25 +70,23 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 2. Fetch the latest repo updates:
 
-        $ sudo yum -y update
+        sudo yum -y update
 
 3. Install the new `rippled` package:
 
-        $ sudo yum install rippled
-
-    Version 1.3.1 does not require any changes to your config files (`rippled.cfg` and `validators.txt`). This update procedure leaves your existing config files in place.
+        sudo yum install rippled
 
 4. Reload systemd unit files:
 
-        $ sudo systemctl daemon-reload
+        sudo systemctl daemon-reload
 
 5. Configure the `rippled` service to start on boot:
 
-        $ sudo systemctl enable rippled.service
+        sudo systemctl enable rippled.service
 
 6. Start the `rippled` service:
 
-        $ sudo systemctl start rippled.service
+        sudo systemctl start rippled.service
 
 
 ## Next Steps

--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
@@ -7,7 +7,7 @@ labels:
 ---
 # Install on Ubuntu or Debian Linux
 
-This page describes the recommended instructions for installing the latest stable version of `rippled` on **Ubuntu Linux 16.04 or higher** or **Debian 9 or higher**, using the [`apt`](https://ubuntu.com/server/docs) utility.
+This page describes the recommended instructions for installing the latest stable version of `rippled` on **Ubuntu Linux 18.04 or higher** or **Debian 9 or higher**, using the [`apt`](https://ubuntu.com/server/docs) utility.
 
 These instructions install a binary that has been compiled by Ripple.
 
@@ -21,20 +21,20 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 1. Update repositories:
 
-        $ sudo apt -y update
+        sudo apt -y update
 
 2. Install utilities:
 
-        $ sudo apt -y install apt-transport-https ca-certificates wget gnupg
+        sudo apt -y install apt-transport-https ca-certificates wget gnupg
 
 3. Add Ripple's package-signing GPG key to your list of trusted keys:
 
-        $ wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | \
+        wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | \
           sudo apt-key add -
 
 4. Check the fingerprint of the newly-added key:
 
-        $ apt-key finger
+        apt-key finger
 
     The output should include an entry for Ripple such as the following:
 
@@ -47,15 +47,16 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 4. Add the appropriate Ripple repository for your operating system version:
 
-        $ echo "deb https://repos.ripple.com/repos/rippled-deb focal stable" | \
+        echo "deb https://repos.ripple.com/repos/rippled-deb focal stable" | \
             sudo tee -a /etc/apt/sources.list.d/ripple.list
 
     The above example is appropriate for **Ubuntu 20.04 Focal Fossa**. For other operating systems, replace the word `focal` with one of the following:
 
     - `bionic` for **Ubuntu 18.04 Bionic Beaver**
-    - `xenial` for **Ubuntu 16.04 Xenial Xerus** <!-- SPELLING_IGNORE: xenial, xerus -->
+    - `xenial` for **Ubuntu 16.04 Xenial Xerus** (Not recommended) <!-- SPELLING_IGNORE: xenial, xerus -->
     - `stretch` for **Debian 9 Stretch**
     - `buster` for **Debian 10 Buster**
+    <!--{# - `bullseye` for **Debian 11 Bullseye** is not available yet -->
 
     If you want access to development or pre-release versions of `rippled`, use one of the following instead of `stable`:
 
@@ -66,27 +67,29 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 5. Fetch the Ripple repository.
 
-        $ sudo apt -y update
+        sudo apt -y update
 
 6. Install the `rippled` software package:
 
-        $ sudo apt -y install rippled
+        sudo apt -y install rippled
 
 7. Check the status of the `rippled` service:
 
-        $ systemctl status rippled.service
+        systemctl status rippled.service
 
     The `rippled` service should start automatically. If not, you can start it manually:
 
-        $ sudo systemctl start rippled.service
+        sudo systemctl start rippled.service
 
     To configure it to start automatically on boot:
 
-        $ sudo systemctl enable rippled.service
+        sudo systemctl enable rippled.service
 
-8. Optional: allow `rippled` to bind to privileged ports (e.g.: run http/https/ws/wss on port 80, 443, etc.)
+8. Optional: allow `rippled` to bind to privileged ports.
 
-        $ sudo setcap 'cap_net_bind_service=+ep' /opt/ripple/bin/rippled
+    This allows you to serve incoming API requests on port 80 or 443. (If you want to do so, you must also update the config file's port settings.)
+
+        sudo setcap 'cap_net_bind_service=+ep' /opt/ripple/bin/rippled
 
 
 ## Next Steps

--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-centos-rhel.md
@@ -32,6 +32,8 @@ To update manually, complete the following steps:
 
         $ sudo yum update rippled
 
+    This update procedure leaves your existing config files in place.
+
 2. Reload the `systemd` unit files:
 
         $ sudo systemctl daemon-reload

--- a/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/update-rippled-manually-on-ubuntu.md
@@ -10,7 +10,7 @@ labels:
 
 This page describes how to update manually to the latest release of `rippled` on Ubuntu Linux. These instructions assume you have already [installed `rippled` using the native package](install-rippled-on-ubuntu.html). Ripple recommends setting up [automatic updates](update-rippled-automatically-on-linux.html) instead, where possible.
 
-> **Caution:** Ripple renewed the GPG key used to sign binary packages shortly before the release of v1.7.0. If you are upgrading to v1.7.0 from an earlier package, you must first download and manually trust the updated public key as follows:
+> **Caution:** Ripple renewed the GPG key used to sign binary packages shortly before the release of v1.7.0. If you are upgrading from a version earlier than 1.7.0, you must first download and manually trust the updated public key as follows:
 >
 >     wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | \
 >       sudo apt-key add -


### PR DESCRIPTION
- Update mentions of Ubuntu 16.04 which is past end-of-life
- Fewer mentions of "rippled" name (so that eventually when it gets renamed to `xrpld` or whatever, the transition is easier)
- Remove $ from copy-pasteable commands
- Other small wording cleanup