### PR TITLE
Fix scientific notation typo

### DIFF
--- a/content/references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
+++ b/content/references/rippled-api/public-rippled-methods/server-info-methods/server_info.md
@@ -285,7 +285,7 @@ The `info` object may have some arrangement of the following fields:
 | `uptime`                            | Number          | Number of consecutive seconds that the server has been operational. [New in: rippled 0.30.1][] |
 | `validated_ledger`                  | Object          | _(May be omitted)_ Information about the most recent fully-validated ledger. If the most recent validated ledger is not available, the response omits this field and includes `closed_ledger` instead. |
 | `validated_ledger.age`              | Number          | The time since the ledger was closed, in seconds. |
-| `validated_ledger.base_fee_xrp`     | Number          | Base fee, in XRP. This may be represented in scientific notation such as `1e-05` for 0.00005. |
+| `validated_ledger.base_fee_xrp`     | Number          | Base fee, in XRP. This may be represented in scientific notation such as `1e-05` for 0.00001. |
 | `validated_ledger.hash`             | String          | Unique hash for the ledger, as hexadecimal. |
 | `validated_ledger.reserve_base_xrp` | Number          | Minimum amount of XRP (not drops) necessary for every account to keep in reserve |
 | `validated_ledger.reserve_inc_xrp`  | Number          | Amount of XRP (not drops) added to the account reserve for each object an account owns in the ledger. |


### PR DESCRIPTION
As pointed out by @nixer89.