### PR TITLE
Updated typo in burnToken() function description

### DIFF
--- a/content/tutorials/use-tokens/nftoken-tester-tutorial.md
+++ b/content/tutorials/use-tokens/nftoken-tester-tutorial.md
@@ -241,7 +241,7 @@ To destroy a `NFToken`:
 
 ### The `burnToken()` function
 
-The `getTokens` function steps are:
+The `burnToken` function steps are:
 
 
 


### PR DESCRIPTION
`burnToken` instead of `getToken`