### PR TITLE
Point specifically to the explainer video playlist

### DIFF
--- a/template/page-xrpl-overview.html.jinja
+++ b/template/page-xrpl-overview.html.jinja
@@ -56,7 +56,7 @@
         <h5 class="longform mb-10">{% trans %}The XRP Ledger is a decentralized public blockchain. {% endtrans %}</h5>
         <p class="mb-4">{% trans %}Anyone can connect their computer to the peer-to-peer network that manages the ledger. The global XRP Ledger community—a diverse set of software engineers, server operators, users, and businesses—maintains the ledger.{% endtrans %}</p>
         <div class="d-none d-lg-block">
-          <a class="btn btn-primary btn-arrow" href="docs.html">{% trans %}Read Technical Docs{% endtrans %}</a> <a class="ml-4 video-external-link" target="_blank" href="https://www.youtube.com/channel/UC6zTJdNCBI-TKMt5ubNc_Gg">{% trans %}Watch Explainer Videos {% endtrans %}</a> 
+          <a class="btn btn-primary btn-arrow" href="docs.html">{% trans %}Read Technical Docs{% endtrans %}</a> <a class="ml-4 video-external-link" target="_blank" href="https://www.youtube.com/playlist?list=PLJQ55Tj1hIVZtJ_JdTvSum2qMTsedWkNi">{% trans %}Watch Explainer Videos {% endtrans %}</a> 
         </div>
       </div>
       <div class="col">
@@ -66,7 +66,7 @@
         </a>
 
         <div class="text-center d-lg-none">
-        <a class="btn btn-primary btn-arrow mt-5 mb-4" href="docs.html">{% trans %}Read Technical Docs{% endtrans %}</a> <a class="ml-4 video-external-link" target="_blank" href="https://www.youtube.com/channel/UC6zTJdNCBI-TKMt5ubNc_Gg">{% trans %}Watch Explainer Videos {% endtrans %}</a> 
+        <a class="btn btn-primary btn-arrow mt-5 mb-4" href="docs.html">{% trans %}Read Technical Docs{% endtrans %}</a> <a class="ml-4 video-external-link" target="_blank" href="https://www.youtube.com/playlist?list=PLJQ55Tj1hIVZtJ_JdTvSum2qMTsedWkNi">{% trans %}Watch Explainer Videos {% endtrans %}</a> 
         </div>
 
       </div>


### PR DESCRIPTION
The original link pointed to the XRPLF channel, updated the link to point to the actual playlist for the explainer videos so that they are easier to find when there is more content on the channel