### PR TITLE
Add source link for ledger object IDs

### DIFF
--- a/content/references/protocol-reference/ledger-data/ledger-object-ids.md
+++ b/content/references/protocol-reference/ledger-data/ledger-object-ids.md
@@ -6,6 +6,7 @@ labels:
   - Data Retention
 ---
 # Ledger Object IDs
+[[Source]](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/impl/Indexes.cpp)
 <a id="sha512half"></a>
 
 Each [object in a ledger's state data](ledger-object-types.html) has a unique ID. The ID is derived by hashing important contents of the object, along with a [namespace identifier](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/LedgerFormats.h#L99). The [ledger object type](ledger-object-types.html) determines which namespace identifier to use and which contents to include in the hash. This ensures every ID is unique. To calculate the hash, `rippled` uses SHA-512 and then truncates the result to the first 256 bits. This algorithm, informally called **SHA-512Half**, provides an output that has comparable security to SHA-256, but runs faster on 64-bit processors.


### PR DESCRIPTION
This file is pretty useful to know about since it tells you the formula for calculating the ID of any ledger entry.