### PR TITLE
Docs landing: update NFT links

### DIFF
--- a/template/page-docs.html.jinja
+++ b/template/page-docs.html.jinja
@@ -92,13 +92,13 @@
   </div>
   <div class="row">
     <div class="col-lg-6">
-      <p class="longform">{% trans %}Interested in non-fungible tokens, but concerned about their <a href="impact.html">large carbon footprint</a>? Check out these proposed standards for issuing NFTs on the XRP Ledger:{% endtrans %}</p>
+      <p class="longform">{% trans %}Interested in non-fungible tokens, but concerned about their <a href="impact.html">large carbon footprint</a>? Read more about issuing NFTs on the XRP Ledger:{% endtrans %}</p>
     </div>
     <div class="col-lg-6">
       <ul class="nav flex-column">
-        <li class="nav-item"><a href="https://github.com/XRPLF/XRPL-Standards/discussions/30" class="nav-link external-link" target="_blank">XLS-14d: Non fungible tokens (indivisible NFT's) on the XRPL</a></li>
-        <li class="nav-item"><a href="https://github.com/XRPLF/XRPL-Standards/discussions/40" class="nav-link external-link" target="_blank">XLS-19d: Wallet based Proof of Digital Asset Property and Rights (NFT)</a></li>
-        <li class="nav-item"><a href="https://github.com/XRPLF/XRPL-Standards/discussions/46" class="nav-link external-link" target="_blank">XLS-20d: Non-Fungible Token Support</a></li>
+        <li class="nav-item"><a href="nft-conceptual-overview.html" class="nav-link">NFT Conceptual Overview</a></li>
+        <li class="nav-item"><a href="nftoken.html" class="nav-link">NFToken Format</a></li>
+        <li class="nav-item"><a href="nftoken-tester-tutorial.html" class="nav-link">NFToken Tester Tutorial</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Updates the "Hot Topic: NFTs" section to link the recently-added docs on NFTs (XLS-20) instead of linking the three proposed specs.

[Current version](https://xrpl.org/docs.html#docs-hot-topic)

Updated version:
![2022-02-02_151106_029572169](https://user-images.githubusercontent.com/7515597/152253264-0e594937-c6bf-4a8e-a214-9b7343b73c8f.png)
