### PR TITLE
Update System Requirements for XRPL servers

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/capacity-planning.md
+++ b/content/tutorials/manage-the-rippled-server/installation/capacity-planning.md
@@ -166,9 +166,9 @@ If you want to contribute to storing ledger history but you do not have enough d
 
 ##### Amazon Web Services
 
-Amazon Web Services (AWS) is a popular virtualized hosting environment. You can run `rippled` in AWS, but if using Elastic Block Storage (EBS), only use either the `io1` or `io2` types, and configure them for at least 10,000 IOPS. <!-- SPELLING_IGNORE: iops, ebs, aws -->
+Amazon Web Services (AWS) is a popular virtualized hosting environment. You can run `rippled` in AWS, but do not use Elastic Block Storage (EBS). See [System Requirements](system-requirements.html). <!-- SPELLING_IGNORE: ebs, aws -->
 
-Alternately, AWS instance stores (`ephemeral` storage) provide suitable performance, but you may lose data in some circumstances, including when you start/stop an instance. This may be acceptable, since an individual XRP Ledger server can usually re-acquire lost ledger history from its peers. Configuration settings should be stored on more reliable storage.
+AWS instance stores (`ephemeral` storage) provide suitable performance, but you may lose data in some circumstances, including when you start/stop an instance. This may be acceptable, since an individual XRP Ledger server can usually re-acquire lost ledger history from its peers. Configuration settings should be stored on more permanent storage.
 
 Make sure the `path` of your `[node_db]` stanza and your `[database_path]` both point to the appropriate storage.
 

--- a/content/tutorials/manage-the-rippled-server/installation/system-requirements.md
+++ b/content/tutorials/manage-the-rippled-server/installation/system-requirements.md
@@ -9,27 +9,29 @@ labels:
 
 ## Recommended Specifications
 
-For reliable performance in production environments, it is recommended to run an XRP Ledger (`rippled`) server on bare metal with the following characteristics:
+For reliable performance in production environments, it is recommended to run an XRP Ledger (`rippled`) server on bare metal with the following characteristics or better:
 
-- Operating System: Ubuntu (LTS) or CentOS or RedHat Enterprise Linux (latest release)
-- CPU: Intel Xeon 3+ GHz processor with 8+ cores and hyperthreading enabled
-- Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better)
-- RAM: 64 GB
-- Network: Enterprise data center network with a gigabit network interface on the host
+- Operating System: Ubuntu (LTS) or CentOS or RedHat Enterprise Linux (latest release).
+- CPU: Intel Xeon 3+ GHz processor with 8+ cores and hyperthreading enabled.
+- Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
+- RAM: 64 GB.
+- Network: Enterprise data center network with a gigabit network interface on the host.
 
 
 ## Minimum Specifications
 
 For testing purposes or occasional use, you can run an XRP Ledger server on commodity hardware. The following minimum requirements should work for most cases, but may not always [stay synced with the network](server-doesnt-sync.html):
 
-- Operating System: Mac OS X, Windows (64-bit), or most Linux distributions (Red Hat, Ubuntu, and Debian supported)
-- CPU: 64-bit x86_64, 4+ cores
-- Disk: Minimum 50 GB for the database partition. SSD strongly recommended (minimum 10,000 IOPS, more is better)
-- RAM: 16 GB+
+- Operating System: Mac OS X, Windows (64-bit), or most Linux distributions (Red Hat, Ubuntu, and Debian supported).
+- CPU: 64-bit x86_64, 4+ cores.
+- Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
+- RAM: 16 GB+.
 
 <!-- SPELLING_IGNORE: iops, ntp, x86_64, ec2 -->
 
-Amazon EC2's `m3.large` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load increases resources needs.
+Amazon EC2's `i3.2xlarge` VM size may be appropriate depending on your workload. A fast network connection is preferable. Any increase in a server's client-handling load increases resources needs.
+
+For a validator, consider `z1d.2xlarge` with an extra 1 TB disk for logging and core dump storage.
 
 
 ## System Time


### PR DESCRIPTION
The prior minimum specifications are no longer sufficient. Servers require super low latency disk, so EBS doesn't work reliably.

Ref: https://github.com/ripple/rippled/issues/4041#issuecomment-1028285740