### PR TITLE
Support pages in subfolder

### DIFF
--- a/template/base.html.jinja
+++ b/template/base.html.jinja
@@ -58,15 +58,15 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
     {% if "js_editor" in currentpage.filters %}
-    <script src="assets/vendor/jshint.js"></script>
-    <script src="assets/vendor/codemirror-js-json-lint.min.js"></script>
-    <script src="assets/vendor/cm-javascript-lint.js"></script>
-    <script src="assets/js/js-editor.js"></script>
+    <script src="{{currentpage.prefix}}assets/vendor/jshint.js"></script>
+    <script src="{{currentpage.prefix}}assets/vendor/codemirror-js-json-lint.min.js"></script>
+    <script src="{{currentpage.prefix}}assets/vendor/cm-javascript-lint.js"></script>
+    <script src="{{currentpage.prefix}}assets/js/js-editor.js"></script>
     {% endif %}
 
     {% if target.light_theme_enabled %}
     <!-- Theme switch -->
-    <script src="assets/js/theme-switch.js"></script>
+    <script src="{{currentpage.prefix}}assets/js/theme-switch.js"></script>
     {% endif %}
 
     {% block head %}

--- a/template/component-footer.html.jinja
+++ b/template/component-footer.html.jinja
@@ -5,9 +5,9 @@
         <div class="col-lg">
           <h5>{% if parent_page.top_nav_name is defined %}{{ parent_page.top_nav_name }}{% else %}{{parent_page.name}}{% endif %}</h5>
           <ul class="nav footer-nav flex-column">
-            <li class="nav-item"><a href="{% if '//' not in parent_page.html %}{{target.prefix}}{% endif %}{{parent_page.html}}" class="nav-link">{{parent_page.name}}</a></li>
+            <li class="nav-item"><a href="{% if '//' not in parent_page.html %}{{currentpage.prefix}}{% endif %}{{parent_page.html}}" class="nav-link">{{parent_page.name}}</a></li>
           {% for page in parent_page.children %}
-            <li class="nav-item"><a href="{% if '//' not in page.html %}{{target.prefix}}{% endif %}{{page.html}}" class="nav-link{% if '//' in page.html %} external-link{% endif %}">{% if page.top_nav_name is defined %}{{page.top_nav_name}}{% else %}{{page.name}}{% endif %}</a></li>
+            <li class="nav-item"><a href="{% if '//' not in page.html %}{{currentpage.prefix}}{% endif %}{{page.html}}" class="nav-link{% if '//' in page.html %} external-link{% endif %}">{% if page.top_nav_name is defined %}{{page.top_nav_name}}{% else %}{{page.name}}{% endif %}</a></li>
           {% endfor %}
           </ul>
         </div><!--/.col -->
@@ -18,7 +18,7 @@
   <section class="container-fluid mt-20 absolute-bottom-footer">
 
     <div class="d-lg-flex row">
-      <a href="{% if target.prefix %}{{target.prefix}}{% else %}/{% endif %}" class="footer-brand"><img src="{{currentpage.prefix}}assets/img/XRPLedger_DevPortal-white.svg" class="logo"  height="24" alt="{{target.display_name}}" /></a>
+      <a href="{% if currentpage.prefix %}{{currentpage.prefix}}{% else %}/{% endif %}" class="footer-brand"><img src="{{currentpage.prefix}}assets/img/XRPLedger_DevPortal-white.svg" class="logo"  height="24" alt="{{target.display_name}}" /></a>
       <span class="flex-grow-1">&nbsp;</span>
       <div class="copyright-license">&copy; 2021 XRP Ledger. <a href="https://raw.githubusercontent.com/XRPLF/xrpl-dev-portal/master/LICENSE">{% trans %}Open Source.{% endtrans %}</a>
       </div>

--- a/template/component-top-nav.html.jinja
+++ b/template/component-top-nav.html.jinja
@@ -1,6 +1,6 @@
 <!--{#<div class="top-banner fixed-top"><p>{% trans %}Fund your XRPL project with a developer grant. <a href="https://xrplgrants.org/?utm_medium=referral&utm_source=xrpl&utm_campaign=banner" class="btn btn-outline-secondary">Apply now!</a>{% endtrans %}</p></div>#}-->
 <nav class="top-nav navbar navbar-expand-lg navbar-dark fixed-top">
-  <a href="{% if target.prefix %}{{target.prefix}}{% else %}/{% endif %}" class="navbar-brand"><img class="logo"  height="40" alt="{{target.display_name}}" /></a>
+  <a href="{% if currentpage.prefix %}{{currentpage.prefix}}{% else %}/{% endif %}" class="navbar-brand"><img class="logo"  height="40" alt="{{target.display_name}}" /></a>
   <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#top-main-nav" aria-controls="navbarHolder" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"><div></div></span>
   </button>
@@ -10,10 +10,10 @@
       {% set printed_groupings = [] %}
       {% if top_page.children|selectattr('top_nav_omit', 'undefined_or_ne', True)|list|length %}
       <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="{{top_page.html}}" id="topnav_{{slug(top_page.html)}}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span>{% if top_page.top_nav_name is defined %}{{top_page.top_nav_name}}{% else %}{{top_page.name}}{% endif %}</span></a>
+        <a class="nav-link dropdown-toggle" href="{% if "//" not in top_page.html %}{{currentpage.prefix}}{% endif %}{{top_page.html}}" id="topnav_{{slug(top_page.html)}}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span>{% if top_page.top_nav_name is defined %}{{top_page.top_nav_name}}{% else %}{{top_page.name}}{% endif %}</span></a>
         <div class="dropdown-menu" aria-labelledby="topnav_{{slug(top_page.html)}}" id="topnav_dd_{{slug(top_page.html)}}">
           {% if top_page.top_nav_hero_image is defined %}
-          <a class="dropdown-item dropdown-hero" id="dropdown-hero-for-{{slug(top_page.name)}}" href="{{top_page.html}}">
+          <a class="dropdown-item dropdown-hero" id="dropdown-hero-for-{{slug(top_page.name)}}" href="{% if "//" not in top_page.html %}{{currentpage.prefix}}{% endif %}{{top_page.html}}">
             <img id="{{top_page.top_nav_hero_image}}" alt="{{top_page.name}} icon" />
             <div class="dropdown-hero-text">
               <h4>{{top_page.name}}</h4>
@@ -24,7 +24,7 @@
           <div class="navcol col-for-{{slug(top_page.top_nav_grouping)}}">
             <h5 class="dropdown-item">{{top_page.top_nav_grouping}}</h5>
             {% set _ = printed_groupings.append(top_page.top_nav_grouping) %}
-            <a class="dropdown-item {% if currentpage == top_page %} active{% endif %}" href="{{top_page.html}}">{{top_page.name}}</a>
+            <a class="dropdown-item {% if currentpage == top_page %} active{% endif %}" href="{% if "//" not in top_page.html %}{{currentpage.prefix}}{% endif %}{{top_page.html}}">{{top_page.name}}</a>
           {% endif %}
           {% set dropdownchildren = top_page.children|list %}
           {% for linkhtml in top_page.top_nav_shortcuts %}
@@ -43,14 +43,14 @@
             {% endif %}
             {% set _ = printed_groupings.append(link.top_nav_grouping) %}
             {% endif %}
-            <a class="dropdown-item{% if currentpage == link %} active{% endif %}{% if "//" in link.html %} external-link{% endif %}" href="{{link.html}}"{% if "//" in link.html %} target="_blank"{% endif %}>{% if link.top_nav_name is defined %}{{link.top_nav_name}}{% else %}{{link.name}}{% endif %}</a>
+            <a class="dropdown-item{% if currentpage == link %} active{% endif %}{% if "//" in link.html %} external-link{% endif %}" href="{% if "//" not in link.html %}{{currentpage.prefix}}{% endif %}{{link.html}}"{% if "//" in link.html %} target="_blank"{% endif %}>{% if link.top_nav_name is defined %}{{link.top_nav_name}}{% else %}{{link.name}}{% endif %}</a>
           {% endfor %}
           </div><!--./col-->
         </div><!--/.dropdown-menu-->
       </li>
       {% elif not top_page.top_nav_omit %}
       <li class="nav-item">
-            <a class="nav-link{% if "//" in link.html %} external-link{% endif %}" href="{{top_page.html}}"{% if "//" in link.html %} target="_blank"{% endif %}><span>{{top_page.name}}</span></a>
+        <a class="nav-link{% if "//" in top_page.html %} external-link{% endif %}" href="{% if "//" not in top_page.html %}{{currentpage.prefix}}{% endif %}{{top_page.html}}"{% if "//" in top_page.html %} target="_blank"{% endif %}><span>{{top_page.name}}</span></a>
       </li>
       {% endif %}
       {% endmacro %}

--- a/template/page-calculator.html.jinja
+++ b/template/page-calculator.html.jinja
@@ -50,7 +50,7 @@
     <img src="./img/backgrounds/cta-calculator-green.svg" class="cta cta-bottom-right">
     <div class="z-index-1 position-relative">
       <h2 class="h4 mb-10-until-sm mb-8-sm">{% trans %}How Does XRP Compare to Other Currencies?{% endtrans %}</h2>
-      <a class="btn btn-primary btn-arrow" href="assets/pdf/xrpl-sustainability-methodology-2020.pdf">Methodology</a>
+      <a class="btn btn-primary btn-arrow" href="{{currentpage.prefix}}assets/pdf/xrpl-sustainability-methodology-2020.pdf">Methodology</a>
     </div>
   </div>
 </section>
@@ -112,7 +112,7 @@
                 <div class="dot" id="kWh-btc-dot"></div>
               </div>
               <div class="num-wrapper">
-                <img src="assets/img/icons/bw-bitcoin.png" alt="BTC" class="mw-100 mt-3 invertible-img">
+                <img src="{{currentpage.prefix}}assets/img/icons/bw-bitcoin.png" alt="BTC" class="mw-100 mt-3 invertible-img">
                 <p class="h6 mt-2 mb-1">{% trans %}Bitcoin{% endtrans %}</p>
                 <h5 class="normal mb-0" id="kWh-btc"></h5>
                 <p class="text-small black-90">{% trans %}kWh{% endtrans %}</p>
@@ -124,7 +124,7 @@
                 <div class="dot" id="kWh-eth-dot"></div>
               </div>
               <div class="num-wrapper">
-                <img src="assets/img/icons/bw-ethereum.png" alt="ETH" class="mw-100 mt-3 invertible-img">
+                <img src="{{currentpage.prefix}}assets/img/icons/bw-ethereum.png" alt="ETH" class="mw-100 mt-3 invertible-img">
                 <p class="h6 mt-2 mb-1">{% trans %}Ethereum{% endtrans %}</p>
                 <h5 class="normal mb-0" id="kWh-eth"></h5>
                 <p class="text-small black-90">{% trans %}kWh{% endtrans %}</p>
@@ -136,7 +136,7 @@
                 <div class="dot" id="kWh-pap-dot"></div>
               </div>
               <div class="num-wrapper">
-                <img src="assets/img/icons/bw-cash.png" class="mw-100 mt-3 mb-2 invertible-img">
+                <img src="{{currentpage.prefix}}assets/img/icons/bw-cash.png" class="mw-100 mt-3 mb-2 invertible-img">
                 <p class="h6 mt-2 mb-1">{% trans %}Cash{% endtrans %}</p>
                 <h5 class="normal mb-0" id="kWh-pap"></h5>
                 <p class="text-small black-90">{% trans %}kWh{% endtrans %}</p>
@@ -148,7 +148,7 @@
                 <div class="dot" id="kWh-xrp-dot"></div>
               </div>
               <div class="num-wrapper">
-                <img src="assets/img/icons/xrp.png" alt="XRP" class="mw-100 mt-3 invertible-img">
+                <img src="{{currentpage.prefix}}assets/img/icons/xrp.png" alt="XRP" class="mw-100 mt-3 invertible-img">
                 <p class="h6 mt-2 mb-1">XRP</p>
                 <h5 class="normal mb-0" id="kWh-xrp"></h5>
                 <p class="text-small black-90">{% trans %}kWh{% endtrans %}</p>
@@ -160,7 +160,7 @@
                 <div class="dot" id="kWh-vsa-dot"></div>
               </div>
               <div class="num-wrapper">
-                <img src="assets/img/icons/bw-visa.png" alt="{% trans %}Visa{% endtrans %}" class="mw-100 mb-2 invertible-img" style="margin-top: 1.85rem;">
+                <img src="{{currentpage.prefix}}assets/img/icons/bw-visa.png" alt="{% trans %}Visa{% endtrans %}" class="mw-100 mb-2 invertible-img" style="margin-top: 1.85rem;">
                 <p class="h6 mt-2 mb-1">Visa</p>
                 <h5 class="normal mb-0" id="kWh-vsa"></h5>
                 <p class="text-small black-90">{% trans %}kWh{% endtrans %}</p>
@@ -172,7 +172,7 @@
                 <div class="dot" id="kWh-mst-dot"></div>
               </div>
               <div class="num-wrapper">
-                <img src="assets/img/icons/bw-mastercard.png" alt="{% trans %}Mastercard{% endtrans %}" class="mw-100 mb-1 invertible-img" style="margin-top: 1.65rem;">
+                <img src="{{currentpage.prefix}}assets/img/icons/bw-mastercard.png" alt="{% trans %}Mastercard{% endtrans %}" class="mw-100 mb-1 invertible-img" style="margin-top: 1.65rem;">
                 <p class="h6 mt-2 mb-1">{% trans %}Mastercard{% endtrans %}</p>
                 <h5 class="normal mb-0" id="kWh-mst"></h5>
                 <p class="text-small black-90">{% trans %}kWh{% endtrans %}</p>
@@ -334,14 +334,14 @@
 
 
 {% block endbody %}
-<script type="text/javascript" src="assets/js/bodymovin.min.js"></script>
-<script type="text/javascript" src="assets/js/calculator/co2-crypto.json"></script>
-<script type="text/javascript" src="assets/js/calculator/co2-cash.json"></script>
-<script type="text/javascript" src="assets/js/calculator/co2-credit.json"></script>
-<script type="text/javascript" src="assets/js/calculator/gas-crypto.json"></script>
-<script type="text/javascript" src="assets/js/calculator/gas-cash.json"></script>
-<script type="text/javascript" src="assets/js/calculator/gas-credit.json"></script>
-<script type="text/javascript" src="assets/js/calculator/carbon-calculator.js"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/bodymovin.min.js"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/co2-crypto.json"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/co2-cash.json"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/co2-credit.json"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/gas-crypto.json"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/gas-cash.json"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/gas-credit.json"></script>
+<script type="text/javascript" src="{{currentpage.prefix}}assets/js/calculator/carbon-calculator.js"></script>
 
 <script type="text/javascript">
   function co2CashAnimation(){

--- a/template/page-impact.html.jinja
+++ b/template/page-impact.html.jinja
@@ -68,7 +68,7 @@
             <div class="d-flex align-items-baseline mb-3">
               <h5 class="mb-0">{% trans %}2025{% endtrans %}</h5>
               <p class="stat-highlight h6 ml-10 mb-0">
-                <img src="assets/img/icons/green-up-arrow.svg">
+                <img src="{{currentpage.prefix}}assets/img/icons/green-up-arrow.svg">
                 {% trans %}+195.3%{% endtrans %}
               </p>
             </div>
@@ -78,7 +78,7 @@
             <div class="d-flex align-items-baseline mb-3">
               <h5 class="mb-0">{% trans %}2030{% endtrans %}</h5>
               <p class="stat-highlight h6 ml-10 mb-0">
-                <img src="assets/img/icons/green-up-arrow.svg">
+                <img src="{{currentpage.prefix}}assets/img/icons/green-up-arrow.svg">
                 {% trans %}+21.4%{% endtrans %}
               </p>
             </div>

--- a/template/page-toml-checker.html.jinja
+++ b/template/page-toml-checker.html.jinja
@@ -25,8 +25,8 @@
 {% endblock %}
 
 {% block endbody %}
-  <script type="application/javascript" src="assets/vendor/iarna-toml-parse.js"></script>
-  <script type="application/javascript" src="assets/js/xrp-ledger-toml-checker.js"></script>
+  <script type="application/javascript" src="{{currentpage.prefix}}assets/vendor/iarna-toml-parse.js"></script>
+  <script type="application/javascript" src="{{currentpage.prefix}}assets/js/xrp-ledger-toml-checker.js"></script>
 {% endblock %}
 
 {% block analytics %}

--- a/template/page-tx-sender.html.jinja
+++ b/template/page-tx-sender.html.jinja
@@ -50,7 +50,7 @@
       <div class="form-group" id="send_xrp_payment">
         <div class="input-group mb-3">
           <div class="input-group-prepend">
-            <span class="input-group-text loader" style="display: none"><img class="throbber" src="assets/img/xrp-loader-96.png" alt="{% trans %}(loading){% endtrans %}"/></span>
+            <span class="input-group-text loader" style="display: none"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" alt="{% trans %}(loading){% endtrans %}"/></span>
           </div>
           <button class="btn btn-primary form-control disabled needs-connection" type="button" id="send_xrp_payment_btn" disabled="disabled">{% trans %}Send XRP Payment{% endtrans %}</button>
           <input id="send_xrp_payment_amount" class="form-control" type="number" aria-describedby="send_xrp_payment_amount_help" value="100000" min="1" max="10000000000" />
@@ -71,7 +71,7 @@
         </div>
         <div class="input-group mb-3">
           <div class="input-group-prepend">
-            <span class="input-group-text loader" style="display: none"><img class="throbber" src="assets/img/xrp-loader-96.png" /></span>
+            <span class="input-group-text loader" style="display: none"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" /></span>
           </div>
           <button class="btn btn-primary form-control" type="button" id="send_partial_payment_btn" disabled="disabled" autocomplete="off" title="(Please wait for partial payments setup to finish)">{% trans %}Send Partial Payment{% endtrans %}</button>
         </div>
@@ -83,7 +83,7 @@
       <div class="form-group" id="create_escrow">
         <div class="input-group mb-3">
           <div class="input-group-prepend">
-            <span class="input-group-text loader" style="display: none"><img class="throbber" src="assets/img/xrp-loader-96.png" /></span>
+            <span class="input-group-text loader" style="display: none"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" /></span>
           </div>
           <button class="btn btn-primary form-control disabled needs-connection" type="button" id="create_escrow_btn" disabled="disabled">{% trans %}Create Escrow{% endtrans %}</button>
           <input class="form-control" type="number" value="60" min="5" max="10000" id="create_escrow_duration_seconds" />
@@ -108,7 +108,7 @@
       <div class="form-group" id="create_payment_channel">
         <div class="input-group mb-3">
           <div class="input-group-prepend">
-            <span class="input-group-text loader" style="display: none"><img class="throbber" src="assets/img/xrp-loader-96.png" /></span>
+            <span class="input-group-text loader" style="display: none"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" /></span>
           </div>
           <button class="btn btn-primary form-control disabled needs-connection" type="button" id="create_payment_channel_btn" disabled="disabled">{% trans %}Create Payment Channel{% endtrans %}</button>
           <input id="create_payment_channel_amount" class="form-control" type="number" aria-describedby="create_payment_channel_amount_help" value="100000" min="1" max="10000000000" />
@@ -124,7 +124,7 @@
       <div class="form-group" id="send_issued_currency">
         <div class="input-group mb-3">
           <div class="input-group-prepend">
-            <span class="input-group-text loader" style="display: none"><img class="throbber" src="assets/img/xrp-loader-96.png" /></span>
+            <span class="input-group-text loader" style="display: none"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" /></span>
           </div>
           <button class="btn btn-primary form-control disabled needs-connection" type="button" id="send_issued_currency_btn" disabled="disabled">{% trans %}Send Issued Currency{% endtrans %}</button>
           <input id="send_issued_currency_amount" class="form-control" type="text" value="100" /><!-- Note: HTML limits "number" inputs to IEEE 764 double precision, which isn't enough for the full range of issued currency amounts -->
@@ -140,7 +140,7 @@
       <div class="form-group" id="trust_for">
         <div class="input-group mb-3">
           <div class="input-group-prepend">
-            <span class="input-group-text loader" style="display: none"><img class="throbber" src="assets/img/xrp-loader-96.png" /></span>
+            <span class="input-group-text loader" style="display: none"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" /></span>
           </div>
           <button class="btn btn-primary form-control disabled needs-connection" type="button" id="trust_for_btn" disabled="disabled">{% trans %}Trust for{% endtrans %}</button>
           <input id="trust_for_amount" class="form-control disabled" type="number" value="100000" />
@@ -157,9 +157,9 @@
 {% endblock %}
 
 {% block endbody %}
-  <script type="application/javascript" src="assets/vendor/bootstrap-growl.jquery.js"></script>
-  <script type="application/javascript" src="assets/js/submit-and-verify2.js"></script>
-  <script type="application/javascript" src="assets/js/tx-sender.js"></script>
+  <script type="application/javascript" src="{{currentpage.prefix}}assets/vendor/bootstrap-growl.jquery.js"></script>
+  <script type="application/javascript" src="{{currentpage.prefix}}assets/js/submit-and-verify2.js"></script>
+  <script type="application/javascript" src="{{currentpage.prefix}}assets/js/tx-sender.js"></script>
 {% endblock %}
 
 {% block analytics %}

--- a/template/page-websocket-api-tool.html.jinja
+++ b/template/page-websocket-api-tool.html.jinja
@@ -37,7 +37,7 @@
           <button class="btn btn-outline-secondary send-request">Send request</button>
           <div class="input-group loader send-loader" style="display:none;">
             <span class="input-group-append">
-              <img src="assets/img/xrp-loader-96.png" height="24" width="24" />
+              <img src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" height="24" width="24" />
             </span><!--/.input-group-append-->
           </div><!--/.input-group.loader-->
         </div><!--/.btn-group-->
@@ -45,7 +45,7 @@
           <button class="btn btn-outline-secondary connection" data-toggle="modal" data-target="#wstool-1-connection-settings">Offline (Mainnet)</button>
           <div class="input-group loader connect-loader" style="display:none;">
             <span class="input-group-append">
-              <img src="assets/img/xrp-loader-96.png" height="24" width="24" />
+              <img src="{{currentpage.prefix}}assets/img/xrp-loader-96.png" height="24" width="24" />
             </span><!--/.input-group-append-->
           </div><!--/.input-group.loader-->
           <button class="btn btn-outline-secondary permalink" data-toggle="modal" data-target="#wstool-1-permalink" title="Permalink"><i class="fa fa-link"></i></button>
@@ -200,10 +200,10 @@
     </div><!--/.modal-dialog-->
   </div><!--/.modal-->
 
-  <script type="text/javascript" src="assets/vendor/jsonlint.js"></script>
-  <script type="text/javascript" src="assets/vendor/codemirror-js-json-lint.min.js"></script>
-  <script type="text/javascript" src="assets/js/apitool-websocket.js"></script>
-  <script type="text/javascript" src="assets/js/apitool-methods-ws.js"></script>
+  <script type="text/javascript" src="{{currentpage.prefix}}assets/vendor/jsonlint.js"></script>
+  <script type="text/javascript" src="{{currentpage.prefix}}assets/vendor/codemirror-js-json-lint.min.js"></script>
+  <script type="text/javascript" src="{{currentpage.prefix}}assets/js/apitool-websocket.js"></script>
+  <script type="text/javascript" src="{{currentpage.prefix}}assets/js/apitool-methods-ws.js"></script>
 {% endblock %}
 
 {% block analytics %}

--- a/template/page-xrp-faucets.html.jinja
+++ b/template/page-xrp-faucets.html.jinja
@@ -39,11 +39,11 @@ http://xls20-sandbox.rippletest.net:51234</code></pre>
       <button id="nftnet-creds-button" class="btn btn-primary mb-2">Generate NFT-Devnet credentials</button>
     </div><!--/.btn-toolbar-->
     <div id='your-credentials'></div>
-    <div id='loader' style="display: none;"><img class="throbber" src="assets/img/xrp-loader-96.png"> Generating Keys...</div>
+    <div id='loader' style="display: none;"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png"> Generating Keys...</div>
     <div id='address'></div>
     <div id='secret'></div>
     <div id='balance'></div>
-    <div id='sequence'> <div id='loader' style="display: none;"><img class="throbber" src="assets/img/xrp-loader-96.png"> Waiting...</div></div>
+    <div id='sequence'> <div id='loader' style="display: none;"><img class="throbber" src="{{currentpage.prefix}}assets/img/xrp-loader-96.png"> Waiting...</div></div>
   </div>
 </section>
 {% endblock %}
@@ -51,7 +51,7 @@ http://xls20-sandbox.rippletest.net:51234</code></pre>
 {% block endbody %}
   {{target.ripple_lib_tag}}
   <script type='text/javascript' src='assets/js/test-net.js'></script>
-  <script src="assets/js/multicodetab.js"></script>
+  <script src="{{currentpage.prefix}}assets/js/multicodetab.js"></script>
   <script type="application/javascript">
     $(document).ready(function() {
       $(".multicode").minitabs();

--- a/template/page-xrp-overview.html.jinja
+++ b/template/page-xrp-overview.html.jinja
@@ -93,12 +93,12 @@
         <p class="mb-10">{% trans %}XRP can be sent directly without needing a central intermediary, making it a convenient instrument in bridging two different currencies quickly and efficiently. It is freely exchanged on the open market and used in the real world for enabling cross-border payments and microtransactions.{% endtrans %}</p>
         <div class="card-grid card-grid-2xN mb-10">
           <div>
-            <img class="mw-100 mb-2 invertible-img" src="assets/img/icons/briefcase.svg">
+            <img class="mw-100 mb-2 invertible-img" src="{{currentpage.prefix}}assets/img/icons/briefcase.svg">
             <h6 class="fs-4-5">{% trans %}Financial Institutions{% endtrans %}</h6>
             <p class="">{% trans %}Leverage XRP as a bridge currency to facilitate faster, more affordable cross-border payments around the world.{% endtrans %}</p>
           </div>
           <div>
-            <img class="mw-100 mb-2 invertible-img" src="assets/img/icons/user.svg">
+            <img class="mw-100 mb-2 invertible-img" src="{{currentpage.prefix}}assets/img/icons/user.svg">
             <h6 class="fs-4-5">{% trans %}Individual Consumers{% endtrans %}</h6>
             <p>{% trans %}Use XRP to move different currencies around the world. {% endtrans %}</p>
           </div>

--- a/template/page-xrpl-overview.html.jinja
+++ b/template/page-xrpl-overview.html.jinja
@@ -10,7 +10,7 @@
 
 
   <!-- Play videos from youtube -->
-  <script src="assets/js/video.js"></script>
+  <script src="{{currentpage.prefix}}assets/js/video.js"></script>
 
 {% endblock %}
 

--- a/template/pagetype-doc.html.jinja
+++ b/template/pagetype-doc.html.jinja
@@ -3,9 +3,9 @@
 
 
     <!-- expandable code samples -->
-    <script src="assets/js/expandcode.js"></script>
+    <script src="{{currentpage.prefix}}assets/js/expandcode.js"></script>
     <!-- multi-code selection tabs -->
-    <script src="assets/js/multicodetab.js"></script>
+    <script src="{{currentpage.prefix}}assets/js/multicodetab.js"></script>
     <!-- copy code button -->
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js"></script>
     <script>

--- a/template/pdf-doc.html.jinja
+++ b/template/pdf-doc.html.jinja
@@ -11,7 +11,7 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 
-    <script src="assets/vendor/jquery-3.6.0.min.js"></script>
+    <script src="{{currentpage.prefix}}assets/vendor/jquery-3.6.0.min.js"></script>
     <link href="{{currentpage.prefix}}assets/css/devportal2021.css" rel="stylesheet" />
 
     {% block head %}


### PR DESCRIPTION
Pages that exist in subfolders such as `/tutorials/` are now OK, as long as they have this line in the frontmatter:

```yaml
prefix: "/"
```

This ensures that nav elements including top nav, sidebar, breadcrumbs, etc. all work, and that the appropriate JavaScript loads as intended.