### PR TITLE
Reporting mode docs 

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-in-reporting-mode.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-in-reporting-mode.md
@@ -116,7 +116,6 @@ NuDB is installed as part of your `rippled` build setup and does not require any
 
     *macOS*
 
-        <!-- Ensure that a compatible version of CMake is installed -->
 	cmake -B build -G "Unix Makefiles" -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug
         cmake --build build --parallel $(nproc)
 

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-in-reporting-mode.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-in-reporting-mode.md
@@ -37,7 +37,9 @@ Multiple reporting mode servers can share access to the same network accessible 
 
 2. In order to run reporting mode, you also need to run one or more `rippled` servers in [P2P mode](install-rippled.html). Ensure that you have at least one `rippled` server running in P2P mode. 
 
-3. Install and configure the datastores required to run `rippled` in reporting mode. 
+3. A compatible version of CMake must be installed.
+
+4. Install and configure the datastores required to run `rippled` in reporting mode. 
 
     1. Install PostgreSQL.
 
@@ -62,18 +64,6 @@ Multiple reporting mode servers can share access to the same network accessible 
         psql postgres -U newuser
         postgres=# create database reporting;
 
-**Install PostgreSQL on Windows**
-
-1. Download and [install PostgreSQL on Windows](https://www.postgresqltutorial.com/install-postgresql/).
-        
-2. Launch the `psql` program and connect to the PostgreSQL Database Server, and create a user `newuser` and a database `reporting`. 
-
-        psql postgres
-	        CREATE ROLE newuser WITH LOGIN PASSWORD ‘password’;
-            ALTER ROLE newuser CREATEDB;
-        \q
-        psql postgres -U newuser
-        postgres=# create database reporting;
 
 **Install PostgreSQL on macOS**
 
@@ -126,7 +116,8 @@ NuDB is installed as part of your `rippled` build setup and does not require any
 
     *macOS*
 
-        cmake -B build -G "Unix Makefiles" -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug
+        <!-- Ensure that a compatible version of CMake is installed -->
+	cmake -B build -G "Unix Makefiles" -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug
         cmake --build build --parallel $(nproc)
 
     <!-- MULTICODE_BLOCK_END -->

--- a/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-in-reporting-mode.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-run-rippled-in-reporting-mode.md
@@ -118,28 +118,25 @@ NuDB is installed as part of your `rippled` build setup and does not require any
 
     *Linux*
 
-        wget https://github.com/Kitware/CMake/releases/download/v3.13.3/cmake-3.13.3-Linux-x86_64.sh
-    
-        sudo sh cmake-3.13.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug ..
+        wget https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.sh
+        sudo sh cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir 
+        cmake -B build -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug 
+        cmake --build build --parallel $(nproc)
 
 
     *macOS*
 
-        cmake -G "Unix Makefiles" -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug ..
-
-        cmake --build . -- -j 4
+        cmake -B build -G "Unix Makefiles" -Dreporting=ON -DCMAKE_BUILD_TYPE=Debug
+        cmake --build build --parallel $(nproc)
 
     <!-- MULTICODE_BLOCK_END -->
 
 2. Create a configuration file to run `rippled` in reporting mode. 
 
-    Make a copy of the example config file, `rippled.cfg`, and save it as `reporting-mode.cfg` in a location that enables you to run `rippled` as a non-root user. For example:
+    Make a copy of the example config file, `rippled-example.cfg`, and save it as `rippled-reporting-mode.cfg` in a location that enables you to run `rippled` as a non-root user. For example:
     
-        cd /etc/opt/ripple/
-
         mkdir -p $HOME/.config/ripple
-
-        cp cfg/rippled-example.cfg $HOME/.config/ripple/rippled-reporting-mode.cfg
+        cp <RIPPLED_SOURCE>/cfg/rippled-example.cfg $HOME/.config/ripple/rippled-reporting-mode.cfg
 
 3. Edit rippled-reporting-mode.cfg to set necessary file paths. The user you plan to run `rippled` as must have write permissions to all of the paths you specify here.
 
@@ -155,9 +152,9 @@ NuDB is installed as part of your `rippled` build setup and does not require any
 
     1. Uncomment the `[reporting]` stanza or add a new one:
 
-        [reporting]
-        etl_source
-        read_only=0
+            [reporting]
+            etl_source
+            read_only=0
 
     2. List the `rippled` sources (ETL sources) to extract data from. These `rippled` servers must have gRPC enabled.
     
@@ -193,7 +190,6 @@ NuDB is installed as part of your `rippled` build setup and does not require any
 
             [node_db]
             type=Cassandra
-            path=
 
             [ledger_history]
             1000000


### PR DESCRIPTION
I really didn't know how deep to go here. I usually like copy-pastable instructions like this but reporting mode should probably be attempted by slightly more knowledgeable rippled users so maybe that's not necessary.

The linux instructions procedure has an install CMake step but the macOS doesn't.
Then there's reference to `$HOME` one spot then it's `/home/ubuntu` elsewhere.
Minor stuff like inconsistent reference to the `rippled-example.cfg` filename or the location to even find it (`rippled-example.cfg` will never be in `/etc/opt/ripple` but `rippled.cfg` may be on a rippled installation.)

This note had me thinking bc this is only true if you're not running Cassandra on the same machine of course.

>     **Note:** If you choose to use Cassandra as the database, the disk requirements for `rippled` will be lower as the data will not be stored on your local disk.  

 
I could have done more but maybe it'd be more confusing.
Why even hint to someone this could (should) be run on Windows? 
Maybe the CMake line should be removed and just put in prerequisites like "a compatible version of CMake?"