### PR TITLE
fix NFTokenCancelOffer code snippets

### DIFF
--- a/content/_code-samples/nftoken-tester/js/nftoken-tester.html
+++ b/content/_code-samples/nftoken-tester/js/nftoken-tester.html
@@ -211,7 +211,7 @@ async function cancelOffer() {
 	console.log("Connected to Sandbox")
 
 	const tokenOfferID = tokenOfferIndex.value
-  const tokenOffers = [tokenOfferID]
+	const tokenOffers = [tokenOfferID]
 
  // Prepare transaction -------------------------------------------------------
   const transactionBlob = {

--- a/content/_code-samples/nftoken-tester/js/nftoken-tester.html
+++ b/content/_code-samples/nftoken-tester/js/nftoken-tester.html
@@ -210,14 +210,14 @@ async function cancelOffer() {
 	await client.connect()
 	console.log("Connected to Sandbox")
 
-	const tokenID = tokenOfferIndex.value
-	const tokenIDs = [tokenID]
+	const tokenOfferID = tokenOfferIndex.value
+  const tokenOffers = [tokenOfferID]
 
  // Prepare transaction -------------------------------------------------------
   const transactionBlob = {
       	"TransactionType": "NFTokenCancelOffer",
       	"Account": wallet.classicAddress,
-      	"TokenIDs": tokenIDs
+      	"TokenOffers": tokenOffers
   }
 
   // Submit signed blob --------------------------------------------------------

--- a/content/tutorials/use-tokens/nftoken-tester-tutorial.md
+++ b/content/tutorials/use-tokens/nftoken-tester-tutorial.md
@@ -740,13 +740,13 @@ async function cancelOffer() {
 
 
 ```js
-	const tokenID = offerTokenId.value
-	const tokenIDs = [tokenID]
+	const tokenOfferID = tokenOfferIndex.value
+  const tokenOffers = [tokenOfferID]
 
       const transactionBlob = {
-      	  "TransactionType": "NFTokenCancelOffer",
+      	 "TransactionType": "NFTokenCancelOffer",
          "Account": wallet.classicAddress,
-         "TokenIDs": tokenIDs
+         "TokenOffers": tokenOffers
       }
 
 ```

--- a/content/tutorials/use-tokens/nftoken-tester-tutorial.md
+++ b/content/tutorials/use-tokens/nftoken-tester-tutorial.md
@@ -741,7 +741,7 @@ async function cancelOffer() {
 
 ```js
 	const tokenOfferID = tokenOfferIndex.value
-  const tokenOffers = [tokenOfferID]
+	const tokenOffers = [tokenOfferID]
 
       const transactionBlob = {
       	 "TransactionType": "NFTokenCancelOffer",


### PR DESCRIPTION
The [NFT documentation](https://xrpl.org/nftoken-tester-tutorial.html#the-canceloffer-function) and [NFToken Tester](https://github.com/XRPLF/xrpl-dev-portal/blob/master/content/_code-samples/nftoken-tester/js/nftoken-tester.html#L220) are incorrect when constructing the NFTokenCancelOffer transaction object. The correct property name should be TokenOffers rather than TokenIDs.

[xrpl.js Github issue](https://github.com/XRPLF/xrpl.js/issues/1936)