### PR TITLE
WebSocket Tool: support NFT methods

### DIFF
--- a/assets/js/apitool-methods-ws.js
+++ b/assets/js/apitool-methods-ws.js
@@ -553,7 +553,7 @@ Request('account_nfts', {
   status: "not_enabled",
   body: {
     "command": "account_nfts",
-    "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+    "account": "rsuHaTvJh1bDmDoxX9QcKP7HEBSBt4XsHx",
     "ledger_index": "validated"
   }
 })

--- a/assets/js/apitool-methods-ws.js
+++ b/assets/js/apitool-methods-ws.js
@@ -544,3 +544,38 @@ Request('random', {
     "command": "random"
   }
 })
+
+Request("NFT Methods")
+
+Request('account_nfts', {
+  description: "Retrieves NFTs owned by an account.",
+  link: "account_nfts.html",
+  status: "not_enabled",
+  body: {
+    "command": "account_nfts",
+    "account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+    "ledger_index": "validated"
+  }
+})
+
+Request('nft_buy_offers', {
+  description: "Retrieves offers to buy a given NFT.",
+  link: "nft_buy_offers.html",
+  status: "not_enabled",
+  body: {
+    "command": "nft_buy_offers",
+    "tokenid": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+    "ledger_index": "validated"
+  }
+})
+
+Request('nft_sell_offers', {
+  description: "Retrieves offers to sell a given NFT.",
+  link: "nft_sell_offers.html",
+  status: "not_enabled",
+  body: {
+    "command": "nft_sell_offers",
+    "tokenid": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+    "ledger_index": "validated"
+  }
+})

--- a/assets/js/apitool-websocket.js
+++ b/assets/js/apitool-websocket.js
@@ -51,7 +51,11 @@ function generate_table_of_contents() {
     if (req.slug === null) {
         commandlist.append("<li class='separator'>"+req.name+"</li>");
     } else {
-        commandlist.append("<li class='method'><a href='#"+req.slug+"'>"+req.name+"</a></li>");
+        let status_label = ""
+        if (req.status == "not_enabled") {
+          status_label = '<span class="status not_enabled" title="This feature is not currently enabled on the production XRP Ledger."><i class="fa fa-flask"></i></span> '
+        }
+        commandlist.append("<li class='method'><a href='#"+req.slug+"'>"+status_label+req.name+"</a></li>");
     }
   });
 }
@@ -284,7 +288,7 @@ const update_curl = function(event) {
   $("#curl-box-1").text(curl_syntax)
 }
 
-function load_from_permalink(params) {
+function server_from_params(params) {
   const server = params.get("server")
   if (server) {
     const server_checkbox = $("input[value='"+server+"']")
@@ -293,7 +297,9 @@ function load_from_permalink(params) {
       // relies on connect_socket() being run shortly thereafter
     }
   }
+}
 
+function req_from_params(params) {
   let req_body = params.get("req")
   let cmd_name = ""
   if (req_body) {
@@ -336,10 +342,14 @@ $(document).ready(function() {
         // default instead.
         select_request()
       }
-    } else if (search_params.has("server") || search_params.has("req")) {
-      load_from_permalink(search_params)
+    } else if (search_params.has("req")) {
+      req_from_params(search_params)
     } else {
-      select_request();
+      select_request()
+    }
+
+    if (search_params.has("server")) {
+      server_from_params(search_params)
     }
 
     connect_socket()


### PR DESCRIPTION
Opening this PR mostly to showcase the staging preview

- Add example syntax for the 3 NFT methods.
- Add the ability to specify the network without the rest of a permalink. NFT method "try it!" links can use this to have the tool use the NFT-Devnet by default.
- Add the ability to mark methods as not enabled on Mainnet.