### PR TITLE
Add missing `Owner` field to NFTokenBurn page

### DIFF
--- a/content/references/protocol-reference/transactions/transaction-types/nftokenburn.md
+++ b/content/references/protocol-reference/transactions/transaction-types/nftokenburn.md
@@ -77,6 +77,18 @@ If this operation succeeds, the corresponding `NFToken` is removed. If this oper
    <td>Identifies the <code>NFToken</code> object to be removed by the transaction.
    </td>
   </tr>
+    <tr>
+   <td><code>Owner</code>
+   </td>
+   <td>No
+   </td>
+   <td>string
+   </td>
+   <td>AccountID
+   </td>
+   <td>Identifies the owner of the NFToken with the given TokenID. Only used if that owner is different than the account signing this transaction. This is used to burn tokens with the lsfBurnable flag that have been traded.
+   </td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
When burning a token which has `lsfBurnable` enabled as the original minter, the `Owner` field is required to specify which NFTokenPages to search for the NFTokenID. 

Here's the original issue which prompted this discovery: https://github.com/XRPLF/xrpl.js/issues/1947