### PR TITLE
Fix broken example on NFTokenMint + explain Issuer

### DIFF
--- a/content/references/protocol-reference/transactions/transaction-types/nftokenmint.md
+++ b/content/references/protocol-reference/transactions/transaction-types/nftokenmint.md
@@ -73,12 +73,10 @@ If you need to specify additional information during minting (for example, detai
 
 ## Issuing on behalf of another account
 
-If you want to issue an NFT for another account there's two things you'll need to do:
+If you want to issue an NFT for another account there are two things you must do. Given that *Account A* is your account and *Account B* is the account for which you want to mint a NFToken:
 
-Account A = your account, Account B = the account you're minting for.
-
-1. You'll need to set the `NFTokenMinter` account setting on Account B to be Account A. (This says that Account B trusts Account A to create NFTs on their behalf)
-2. When you mint the NFT, you'll need to set the `Issuer` field to Account B.
+1. Set the `NFTokenMinter` account setting on *Account B* to be *Account A*. (This says that *Account B* trusts *Account A* to create NFTs on their behalf.)
+2. When you mint the NFToken, set the `Issuer` field to Account B.
 
 ### Example of NFTokenMint with an issuer
 ```json

--- a/content/references/protocol-reference/transactions/transaction-types/nftokenmint.md
+++ b/content/references/protocol-reference/transactions/transaction-types/nftokenmint.md
@@ -25,9 +25,9 @@ If the transaction is successful, the newly minted token is owned by the account
   "Issuer": "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
   "TransferFee": 314,
   "NFTokenTaxon": 0,
-  "Flags": 2147483659,
+  "Flags": 8,
   "Fee": 10,
-  "URI": "697066733a2f2f62616679626569676479727a74357366703775646d37687537367568377932366e6634646675796c71616266336f636c67747179353566627a6469",
+  "URI": "697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469",
   "Memos": [
         {
             "Memo": {
@@ -52,7 +52,7 @@ This transaction assumes that the issuer, `rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2`, 
 | `NFTokenTaxon` | Number | UInt32 | The taxon associated with the token. The taxon is generally a value chosen by the minter of the token. A given taxon can be used for multiple tokens. Taxon identifiers greater than `0xFFFF'FFFF` are disallowed. |
 | `Issuer` | String | AccountID | _(Optional)_ The issuer of the token, if the sender of the account is issuing it on behalf of another account. This field must be omitted if the account sending the transaction is the issuer of the `NFToken`. If provided, the issuer's [AccountRoot object][] must have the `NFTokenMinter` field set to the sender of this transaction (this transaction's `Account` field). |
 | `TransferFee` | Number | UInt16 | _(Optional)_ The value specifies the fee charged by the issuer for secondary sales of the NFToken, if such sales are allowed. Valid values for this field are between 0 and 9999 inclusive, allowing transfer rates of between 0.00% and 99.99% in increments of 0.01. If this field is provided, the transaction MUST have the [`tfTransferable` flag](#nftokenmint-flags) enabled. |
-| `URI` | String | Blob | _(Optional)_ Up to 256 bytes of arbitrary data. In JSON, this should be encoded as a string of hexadecimal. You can use the [`xrpl.convertStringToHex`](https://js.xrpl.org/modules.html#convertStringToHex) utility to convert a URI to its hexadecimal equivalent. This is intended to be a URI that points to the data or metadata associated with the NFToken. The contents could decode to an HTTP or HTTPS URL, an IPFS URI, a magnet link, immediate data encoded as an [RFC2379 "data" URL](https://datatracker.ietf.org/doc/html/rfc2397), or even an issuer-specific encoding. The URI is NOT checked for validity.
+| `URI` | String | Blob | _(Optional)_ Up to 256 bytes of arbitrary data. In JSON, this should be encoded as a string of hexadecimal. The hex MUST be capitalized, not lowercase. You can use the [`xrpl.convertStringToHex`](https://js.xrpl.org/modules.html#convertStringToHex) utility to convert a URI to its hexadecimal equivalent. This is intended to be a URI that points to the data or metadata associated with the NFToken. The contents could decode to an HTTP or HTTPS URL, an IPFS URI, a magnet link, immediate data encoded as an [RFC2379 "data" URL](https://datatracker.ietf.org/doc/html/rfc2397), or even an issuer-specific encoding. The URI is NOT checked for validity.
 
 
 ## NFTokenMint Flags
@@ -70,6 +70,41 @@ Transactions of the NFTokenMint type support additional values in the [`Flags` f
 ## Embedding additional information
 
 If you need to specify additional information during minting (for example, details identifying a property by referencing a particular [plat](https://en.wikipedia.org/wiki/Plat), a vehicle by specifying a [VIN](https://en.wikipedia.org/wiki/Vehicle_identification_number), or other object-specific descriptions) you can use a [transaction memo](transaction-common-fields.html#memos-field). Memos are a part of the signed transaction and are available from historical archives, but are not stored in the ledger's state data.
+
+## Issuing on behalf of another account
+
+If you want to issue an NFT for another account there's two things you'll need to do:
+
+Account A = your account, Account B = the account you're minting for.
+
+1. You'll need to set the `NFTokenMinter` account setting on Account B to be Account A. (This says that Account B trusts Account A to create NFTs on their behalf)
+2. When you mint the NFT, you'll need to set the `Issuer` field to Account B.
+
+### Example of NFTokenMint with an issuer
+```json
+{
+  "TransactionType": "NFTokenMint",
+  "Account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+  "Issuer": "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+  "TransferFee": 314,
+  "NFTokenTaxon": 0,
+  "Flags": 8,
+  "Fee": 10,
+  "URI": "697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469",
+  "Memos": [
+        {
+            "Memo": {
+                "MemoType":
+                  "687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963",
+                "MemoData": "72656E74"
+            }
+        }
+    ]
+}
+```
+
+
+This transaction assumes that the issuer, `rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2`, has set the `NFTokenMinter` field in its `AccountRoot` to `rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B`, thereby authorizing that account to mint tokens on its behalf.
 
 ## Error Cases
 


### PR DESCRIPTION
In response to this thread on Discord:
* Initial problem: https://discord.com/channels/886050993802985492/890685878068969472/962675085557235742
* Response: https://discord.com/channels/886050993802985492/890685878068969472/963111448995831838

This attempts to:
1. Simplify the initial example to just work without any setup (Fixing issues which make copy + pasting simply not work)
2. Add a section on minting with another issuer to handle that specific case, with a more complicated example that also simply works to copy + paste. (And putting the "Set the MinterAccount" instruction at the top rather than as a foot note.