### PR TITLE
FAQ: remove dead tech talk link

### DIFF
--- a/content/faq.ja.md
+++ b/content/faq.ja.md
@@ -20,7 +20,7 @@ name: よくある質問
 
 バリデータは、トランザクションがプロトコル要件を満たしていて、結果として「有効」であるかどうかを判断します。バリデータが提供する独自の機能は、順序付けされた単位にトランザクションをグループ化し、二重支払いを防ぐことを目的としてその順序に同意することです。
 
-コンセンサスプロセスの詳細は、[コンセンサス](consensus.html)と[Ripple Labs Tech Talk: Understanding Consensus](https://ripple.com/insights/ripple-labs-tech-talk-consensus-within-the-ripple-protocol/)を参照してください。
+コンセンサスプロセスの詳細は、[コンセンサス](consensus.html)を参照してください。
 
 
 #### バリデータの実行にはいくらかかりますか?

--- a/content/faq.md
+++ b/content/faq.md
@@ -44,7 +44,7 @@ Although XRPL was initially developed for payment use cases, both the ledger and
 
 All nodes ensure that transactions meet protocol requirements, and are therefore “valid.” The service that validators uniquely provide is administratively grouping transactions into ordered units, agreeing on one such ordering specifically to prevent double spending. <!-- STYLE_OVERRIDE: therefore -->
 
-See [Consensus](consensus.html) and the [Ripple Labs Tech Talk: Understanding Consensus](https://ripple.com/insights/ripple-labs-tech-talk-consensus-within-the-ripple-protocol/) for more information about the consensus process.
+See [Consensus](consensus.html) for more information about the consensus process.
 
 
 #### How much does it cost to run a validator?


### PR DESCRIPTION
Ripple took the link down, and there isn't a direct equivalent (https://ripple.com/developer-resources/ is the nearest thing, I guess?) but the sentence already directs people to a good resource—the docs on Conensus—so I just removed the tech talk link.