### PR TITLE
Document the "date" field from the tx method

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/transaction-methods/tx.md
+++ b/content/references/http-websocket-apis/public-api-methods/transaction-methods/tx.md
@@ -442,6 +442,7 @@ The response follows the [standard format][], with a successful result containin
 
 | `Field`        | Type                             | Description              |
 |:---------------|:---------------------------------|:-------------------------|
+| `date`         | Number                           | A [number of seconds](basic-data-types.html#specifying-time) since January 1, 2000 (00:00 UTC) indicating the [close time](ledgers.html#ledger-close-times) of the ledger in which the transaction was applied. This value does not have a precise relationship with physical time, and is dependent on the close time resolution. |
 | `hash`         | String                           | The SHA-512 hash of the transaction |
 | `inLedger`     | Number                           | _(Deprecated)_ Alias for `ledger_index`. |
 | `ledger_index` | Number                           | The [ledger index][] of the ledger that includes this transaction. |


### PR DESCRIPTION
Add some information about the `date` field. 

Per https://xrpl.org/ledgers.html#ledger-close-times, the close time resolution is currently 10 seconds.