### PR TITLE
Remove tx_history "Try it!"

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/transaction-methods/tx_history.md
+++ b/content/references/http-websocket-apis/public-api-methods/transaction-methods/tx_history.md
@@ -47,8 +47,6 @@ rippled tx_history 0
 
 <!-- MULTICODE_BLOCK_END -->
 
-[Try it! >](websocket-api-tool.html#tx_history)
-
 The request includes the following parameters:
 
 | `Field` | Type             | Description                          |


### PR DESCRIPTION
The "tx_history" command is deprecated and intentionally not listed in the Websocket tool. This removes the broken "Try it!" link to use the WS tool for this method.

Fixes #1460.