### PR TITLE
Going above/below? the limit

### DIFF
--- a/content/concepts/tokens/trust-lines-and-issuing.md
+++ b/content/concepts/tokens/trust-lines-and-issuing.md
@@ -15,7 +15,7 @@ Each "trust line" is a _bidirectional_ relationship consisting of:
 - A single, shared **balance**, which is positive from the perspective of one account and negative from the other perspective.
     - The account with a negative balance is generally considered the "issuer" of the tokens. However, in the [APIs](http-websocket-apis.html), the name `issuer` can refer to either side.
 - Various **settings** and metadata. _Each_ of the two accounts can control its own settings on the trust line.
-    - Most importantly, each side sets a **limit** on the trust line, which is 0 by default. Each account's balance (from its perspective on the trust line) can't go above that account's limit, except [through that account's own actions](#going-below-the-limit).
+    - Most importantly, each side sets a **limit** on the trust line, which is 0 by default. Each account's balance (from its perspective on the trust line) can't go above that account's limit, except [through that account's own actions](#going-above-the-limit).
 
 Each trust line is specific to a given [currency code][]. Two accounts can have any number of trust lines between them for different currency codes, but only one shared trust line for any particular currency code.
 

--- a/content/concepts/tokens/trust-lines-and-issuing.md
+++ b/content/concepts/tokens/trust-lines-and-issuing.md
@@ -27,7 +27,7 @@ Any account can unilaterally "trust" another account to issue a token by sending
 Trust lines can be implicitly created by some transactions, such as when you buy a token in the [decentralized exchange](decentralized-exchange.html). In this case, the trust line uses entirely default settings.
 
 
-## Going Below the Limit
+## Going Above the Limit
 
 There are three cases where you can hold a balance that is _greater_ than your limit on that trust line:
 


### PR DESCRIPTION
I may be misunderstanding but the third bullet point under **Trust Lines and Issuing** states "Each account's balance (from its perspective on the trust line) can't go *above* that account's limit", but the section title in question is currently named **Going Below the Limit**.  Should it be called **Going Above the Limit**?