### PR TITLE
Add memo to faucet - for faucet account generation tracking 

### DIFF
--- a/assets/js/test-net.js
+++ b/assets/js/test-net.js
@@ -42,8 +42,16 @@ function rippleTestNetCredentials(url, altnet_name) {
   $.ajax({
     url: url,
     type: 'POST',
-    data: { memos: ["xrpl.org-faucet"] },
-    dataType: 'json',
+    contentType: "application/json; charset=utf-8",
+    data: JSON.stringify({
+      memos: [
+        {
+          Memo: {
+            MemoData: xrpl.convertStringToHex("xrpl.org-faucet"),
+          },
+        },
+      ],
+    }),
     success: function(data) {
       //hide the loader and show results
       loader.hide();

--- a/assets/js/test-net.js
+++ b/assets/js/test-net.js
@@ -42,6 +42,7 @@ function rippleTestNetCredentials(url, altnet_name) {
   $.ajax({
     url: url,
     type: 'POST',
+    data: { memos: ["xrpl.org-faucet"] },
     dataType: 'json',
     success: function(data) {
       //hide the loader and show results


### PR DESCRIPTION
Context:
for internal [DGE ticket](https://ripplelabs.atlassian.net/jira/software/projects/DGE/boards/524?selectedIssue=DGE-562), we are trying to measure developer activities that is generated through testnet/devnet/nft-dev net faucets on xrpl.org, adding a memo field here would be used to identify accounts created by clicking the generate button on https://xrpl.org/xrp-testnet-faucet.html.