### PR TITLE
NFToken Batch Minting: link Tickets

### DIFF
--- a/content/concepts/tokens/nftoken-batch-minting.md
+++ b/content/concepts/tokens/nftoken-batch-minting.md
@@ -27,7 +27,7 @@ Any market activity prior to the initial sale of the NFToken object is not recor
 
 ## Scripted Minting
 
-Use a program or script to mint many tokens at once. You might find the XRP Ledger ticket functionality helps you submit transactions in parallel, up to a current limit of 200 transactions in one group.
+Use a program or script to mint many tokens at once. You might find that [Tickets](tickets.html) help you submit transactions in parallel, up to a current limit of 200 transactions in one group.
 
 For a practical example, see the [Batch Mint NFTokens](batch-minting.html) tutorial.
 


### PR DESCRIPTION
This is a case where linking the relevant background reading seems quite helpful.