### PR TITLE
Fix dead gateway bulletin links

### DIFF
--- a/content/concepts/tokens/freezes.ja.md
+++ b/content/concepts/tokens/freezes.ja.md
@@ -88,7 +88,6 @@ No Freeze設定は、アドレスのマスターキーのシークレットキ�
 
 # 関連項目
 
-* [GB-2014-02新機能残高凍結](https://ripple.com/files/GB-2014-02.pdf)
 * [凍結コードの例](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/freeze)
 
 <!--{# common link defs #}-->

--- a/content/concepts/tokens/freezes.md
+++ b/content/concepts/tokens/freezes.md
@@ -82,7 +82,6 @@ You can only enable the No Freeze setting with a transaction signed by your addr
 
 # See Also
 
-- [GB-2014-02 New Feature: Balance Freeze](https://ripple.com/files/GB-2014-02.pdf)
 - [Freeze Code Samples](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/freeze)
 - **Concepts:**
     - [Trust Lines and Issuing](trust-lines-and-issuing.html)

--- a/content/tutorials/xrp-ledger-businesses/become-an-xrp-ledger-gateway.md
+++ b/content/tutorials/xrp-ledger-businesses/become-an-xrp-ledger-gateway.md
@@ -355,26 +355,6 @@ You can generate a destination tag on-demand when a customer intends to send mon
 For more information, see [Source and Destination Tags](source-and-destination-tags.html).
 
 
-## Gateway Bulletins
-
-Historically, Ripple (the company) published gateway bulletins to introduce new XRP Ledger features or discuss topics related to compliance and risk for issuers. Gateway Bulletins are listed here in reverse chronological order.
-
-- May 13, 2015 - [GB-2015-06 Gateway Bulletin: Corrections to Autobridging (PDF)](assets/pdf/GB-2015-06.pdf) <!-- SPELLING_IGNORE: autobridging -->
-- April 17, 2015 - [GB-2015-05 Historical Ledger Query Migration](assets/pdf/GB-2015-05.pdf)
-- March 13, 2015 - [GB-2015-04 Action Required: Default Ripple Flag (PDF)](https://ripple.com/files/GB-2015-04.pdf)
-- March 3, 2015 - [GB-2015-03 Gateway Advisory: FinCEN Ruling on MoneyGram Compliance Program (PDF)](https://ripple.com/files/GB-2015-03.pdf) <!-- SPELLING_IGNORE: moneygram -->
-- March 2, 2015 (Updated) - [GB-2015-02 New Standards: How to be Featured on Ripple Trade and Ripple Charts (PDF)](https://ripple.com/files/GB-2015-02.pdf)
-- January 5, 2015 - [GB-2015-01 Gateway Advisory: Reliable Transaction Submission (PDF)](https://ripple.com/files/GB-2015-01.pdf)
-- December 18, 2014 - [GB-2014-08 Gateway Advisory: Recent FinCEN Rulings (PDF)](https://ripple.com/files/GB-2014-08.pdf)
-- November 4, 2014 -[GB-2014-07 Gateway Advisory: FATF Standards (PDF)](https://ripple.com/files/GB-2014-07.pdf)
-- October 17, 2014 -[GB-2014-06 Gateway Advisory: Partial Payment Flag (PDF)](https://ripple.com/files/GB-2014-06.pdf)
-- September 24, 2014 - [GB-2014-05 Gateway Advisory: EBA Opinion On Virtual Currency (PDF)](https://ripple.com/files/GB-2014-05.pdf) <!-- SPELLING_IGNORE: eba -->
-- September 11, 2014 - [GB-2014-04 Gateway Advisory: CFPB Opinion on Virtual Currency (PDF)](https://ripple.com/files/GB-2014-04.pdf) <!-- SPELLING_IGNORE: cfpb -->
-- August 19, 2014 - [GB-2014-03 Updated Feature: Trust Lines UI (PDF)](https://ripple.com/files/GB-2014-03.pdf)
-- August 1, 2014 - [GB-2014-02 New Feature: Balance Freeze (PDF)](https://ripple.com/files/GB-2014-02.pdf)
-- April 23, 2014, Updated August 14, 2014 -[GB-2014-01 New Feature: Ripple Names (PDF)](https://ripple.com/files/GB-2014-01.pdf)
-
-
 # Technical Details
 
 ## Infrastructure


### PR DESCRIPTION
Since Ripple has taken down Gateway Bulletin PDFs (these are mostly from 2014-15) the links to those on this site are dead. This PR removes them.