### PR TITLE
Remove duplicate UNLModify header.

### DIFF
--- a/content/references/protocol-reference/transactions/pseudo-transaction-types/unlmodify.md
+++ b/content/references/protocol-reference/transactions/pseudo-transaction-types/unlmodify.md
@@ -28,8 +28,6 @@ A `UNLModify` [pseudo-transaction](pseudo-transaction-types.html) marks a change
 }
 ```
 
-## {{currentpage.name}} Fields
-
 {% include '_snippets/pseudo-tx-fields-intro.md' %}
 <!--{# fix md highlighting_ #}-->
 


### PR DESCRIPTION
The snippet includes the header so having the header separately is redundant.

Fixes #1590

Edit: Preview link for the affected page: https://xrplf.github.io/xrpl-dev-portal/pr-preview/rr-unlmodify-dupe-header/unlmodify.html