### PR TITLE
Fix tool/build_all_langs.sh continuing after failure

### DIFF
--- a/tool/build_all_langs.sh
+++ b/tool/build_all_langs.sh
@@ -10,5 +10,6 @@ then
   shift 2
 fi
 
+set -e
 dactyl_build --vars "$dactyl_vars"
 dactyl_build -t ja -o out/ja --vars "$dactyl_vars"


### PR DESCRIPTION
This should make the "build docs" step actually display as a failure in CI so that you can accurately debug build failures.