### PR TITLE
PR build improvements

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
 
@@ -43,7 +43,7 @@ jobs:
       run: |
         sed -i '1,/---------------------------------------/d' linkreport.txt
         echo 'LINKREPORT<<EOF' >> $GITHUB_ENV
-        cat linkreport.txt >> $GITHUB_ENV
+        head -c 65300 linkreport.txt >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
         cat linkreport.txt
 


### PR DESCRIPTION
- Update `checkout`, `setup-python` actions to latest versions
- Use `head` instead of `cat` so very long link reports don't fail the build with an 'Argument list too long' error