### PR TITLE
Use DNS names instead of old invalid IPs

### DIFF
--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.ja.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.ja.md
@@ -62,7 +62,7 @@ Rippleは[代替となるテスト用および開発用ネットワーク](paral
             # https://vl.altnet.rippletest.net
 
             # [validator_list_keys]
-            # ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860        
+            # ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
 
             # [validator_list_sites]
             # https://vl.ripple.com
@@ -84,13 +84,13 @@ Rippleは[代替となるテスト用および開発用ネットワーク](paral
 
 4. `rippled`がXRP TestnetまたはDevnetに接続していることを確認するため、サーバーで[server_infoメソッド][]を使用して、その結果をTestnetまたはDevnetの公開サーバーの結果と比較します。両方のサーバーで`validated_ledger`オブジェクトの`seq`フィールドが同一である必要があります（確認中にこの数が変化した場合は、1～2の差が生じる可能性があります）。
 
-   以下のコマンドは、`s.altnet.rippletest.net`にあるTestnetサーバーの最新の検証済みレジャーをチェックします。
+   以下のコマンドは、Testnetサーバーの最新の検証済みレジャーをチェックします。
 
-        $ ./rippled --rpc_ip 34.210.87.206:51234 server_info | grep seq
+        $ ./rippled --rpc_ip s.altnet.rippletest.net:51234 server_info | grep seq
 
-   以下のコマンドは、`s.devnet.rippletest.net`にあるDevnetサーバーの最新の検証済みレジャーをチェックします。
+   以下のコマンドは、Devnetサーバーの最新の検証済みレジャーをチェックします。
 
-        $ ./rippled --rpc_ip 34.83.125.234:51234 server_info | grep seq
+        $ ./rippled --rpc_ip s.devnet.rippletest.net:51234 server_info | grep seq
 
    以下のコマンドは、ローカルの`rippled`の最新検証済みレジャーインデックスをチェックします。
 

--- a/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
+++ b/content/tutorials/manage-the-rippled-server/configuration/connect-your-rippled-to-the-xrp-test-net.md
@@ -185,35 +185,25 @@ rippled server_info | grep seq
 *Testnet*
 
 ```sh
-# s.altnet.rippletest.net
-rippled --rpc_ip 35.158.96.209:51234 server_info | grep seq
+rippled --rpc_ip s.altnet.rippletest.net:51234 server_info | grep seq
 ```
 
 *Devnet*
 
 ```sh
-# s.devnet.rippletest.net
-rippled --rpc_ip 34.83.125.234:51234 server_info | grep seq
+rippled --rpc_ip s.devnet.rippletest.net:51234 server_info | grep seq
 ```
 
 
 *Mainnet*
 
 ```sh
-# s1.ripple.com
-rippled --rpc_ip 34.201.59.230:51234 server_info | grep seq
+rippled --rpc_ip s1.ripple.com:51234 server_info | grep seq
 ```
 
-*NFT-Devnet*
-
-```sh
-# xls20-sandbox.rippletest.net
-rippled --rpc_ip 34.211.220.150:51234 server_info | grep seq
-```
 
 <!-- MULTICODE_BLOCK_END -->
 
-**Note:** The IP addresses in these examples are for public servers, and may change periodically. If you get no response, look up the IP address of a [public server][public servers], for example using the `dig` command.
 
 
 


### PR DESCRIPTION
Might as well use these since they might be less likely to change than the IPs (which are all wrong.)
Once again, someone might want to double check Japanese.