### PR TITLE
AMM: Fix trading fee decimal comparison

### DIFF
--- a/content/references/protocol-reference/ledger-data/ledger-object-types/amm.md
+++ b/content/references/protocol-reference/ledger-data/ledger-object-types/amm.md
@@ -79,7 +79,7 @@ The `AMM` object has the following fields:
 | `AMMAccount`     | String              | AccountID         | Yes       | The address of the [special account](accountroot.html#special-amm-accountroot-objects) that holds this AMM's assets. |
 | `AuctionSlot`    | Object              | STObject          | No        | Details of the current owner of the auction slot, as an [Auction Slot object](#auction-slot-object). |
 | `LPTokenBalance` | [Currency Amount][] | Amount            | Yes       | The total outstanding balance of liquidity provider tokens from this AMM instance. The holders of these tokens can vote on the AMM's trading fee in proportion to their holdings, or redeem the tokens for a share of the AMM's assets which grows with the trading fees collected. |
-| `TradingFee`     | Number              | UInt16            | Yes       | The percentage fee to be charged for trades against this AMM instance, in units of 1/10,000. The maximum value is 1000, for a 1% fee. |
+| `TradingFee`     | Number              | UInt16            | Yes       | The percentage fee to be charged for trades against this AMM instance, in units of 1/100,000. The maximum value is 1000, for a 1% fee. |
 | `VoteSlots`      | Array               | STArray           | No        | A list of vote objects, representing votes on the pool's trading fee. |
 
 ### Auction Slot Object


### PR DESCRIPTION
"units of 1/100,000" is equivalent to "⅒ basis points" which is correct. This 10,000 number is a carry over from when it was basis points, not ⅒ thereof.

(The AMMCreate page already has it right; the object definition fixed here was a typo.)