### PR TITLE
Fix airgapped wallet tests

### DIFF
--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
@@ -129,7 +129,7 @@ def create_wallet_directory():
 
     if not os.path.exists(File):
         print("1. Generating wallet's keypair...")
-        pub, priv, seed = create_wallet(silent=True)
+        pub, seed = create_wallet(silent=True)
 
         print("2. Creating wallet's file directory...")
         os.makedirs(File)
@@ -181,7 +181,7 @@ def showcase_wallet_address_qr_code():
     __path = get_path("/WalletTEST/public.png")
     print(f"1. Getting address from {__path}...")
     print("2. Displaying QR code on the screen...")
-    image = Image.open(get_path("/Wallet/public.png"))
+    image = Image.open(get_path("/WalletTEST/public.png"))
     image.show()
 
 
@@ -189,10 +189,9 @@ if __name__ == '__main__':
     print("Airgapped Machine Unit Test (5 functions):\n")
 
     print(f"UNIT TEST 1. create_wallet():")
-    _address, _private, _seed = create_wallet(silent=False)
+    _address, _seed = create_wallet(silent=False)
     print(f"-- RESULTS --\n"
           f"Address: {_address}\n"
-          f"Private Key: {_private}\n"
           f"Seed: {_seed}\n"
           f"END RESULT: Successful"
           )

--- a/content/_code-samples/airgapped-wallet/py/requirements.txt
+++ b/content/_code-samples/airgapped-wallet/py/requirements.txt
@@ -20,7 +20,7 @@ qrcode==7.2
 rfc3986==1.5.0
 six==1.16.0
 sniffio==1.2.0
-sqlparse==0.4.1
+sqlparse==0.4.2
 typing-extensions==3.10.0.0
 websockets==9.1
 xrpl-py==1.1.1


### PR DESCRIPTION
While testing #1609 I found a couple things in the airgapped wallet tests that were failing, apparently since some changes weren't made to match other updates. 