### PR TITLE
Fix ledger_entry format for tickets and add to WS tool

### DIFF
--- a/assets/js/apitool-methods-ws.js
+++ b/assets/js/apitool-methods-ws.js
@@ -292,20 +292,19 @@ Request('ledger_entry - DepositPreauth', {
   }
 })
 
-// Waiting for TicketBatch amendment on Mainnet
-// Request('ledger_entry - Ticket', {
-//   description: "Returns a Ticket object in its raw ledger format.",
-//   link: "ledger_entry.html#get-ticket-object",
-//   body: {
-//     "id": "example_get_ticket",
-//     "command": "ledger_entry",
-//     "ticket": {
-//       "owner": DEFAULT_ADDRESS_1,
-//       "ticket_sequence": 0 // TODO: make a real ticket, fill in the seq
-//     },
-//     "ledger_index": "validated"
-//   }
-// })
+Request('ledger_entry - Ticket', {
+  description: "Returns a Ticket object in its raw ledger format.",
+  link: "ledger_entry.html#get-ticket-object",
+  body: {
+    "id": "example_get_ticket",
+    "command": "ledger_entry",
+    "ticket": {
+      "account": DEFAULT_ADDRESS_1,
+      "ticket_seq": 389 // This is a real ticket on Mainnet.
+    },
+    "ledger_index": "validated"
+  }
+})
 
 
 Request("Transaction Methods")

--- a/content/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
+++ b/content/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
@@ -512,11 +512,11 @@ rippled json ledger_entry '{ "deposit_preauth": { "owner": "rf1BiGeXwwQoi8Z2ueFY
 
 Retrieve a [Ticket object](ticket.html), which represents a [sequence number][] set aside for future use. Can be provided as string (object ID of the Ticket) or as an object. _(Added by the [TicketBatch amendment][])_
 
-| `Field`                 | Type                       | Description           |
-|:------------------------|:---------------------------|:----------------------|
-| `ticket`                | Object or String           | The [Ticket object](ticket.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the Ticket, as hexadecimal. If an object, the `owner` and `ticket_sequence` sub-fields are required to uniquely specify the Ticket entry. |
-| `ticket.owner`          | String - [Address][]       | _(Required if `ticket` is specified as an object)_ The owner of the Ticket object. |
-| `ticket.ticket_sequence` | Unsigned Integer          | _(Required if `ticket` is specified as an object)_ The Ticket Sequence number of the Ticket entry to retrieve. |
+| `Field`             | Type                 | Description           |
+|:--------------------|:---------------------|:----------------------|
+| `ticket`            | Object or String     | The [Ticket object](ticket.html) to retrieve. If a string, must be the [object ID](ledger-object-ids.html) of the Ticket, as hexadecimal. If an object, the `account` and `ticket_seq` sub-fields are required to uniquely specify the Ticket entry. |
+| `ticket.account`    | String - [Address][] | _(Required if `ticket` is specified as an object)_ The owner of the Ticket object. |
+| `ticket.ticket_seq` | Number               | _(Required if `ticket` is specified as an object)_ The Ticket Sequence number of the Ticket entry to retrieve. |
 
 <!-- MULTICODE_BLOCK_START -->
 
@@ -527,8 +527,8 @@ Retrieve a [Ticket object](ticket.html), which represents a [sequence number][] 
   "id": "example_get_ticket",
   "command": "ledger_entry",
   "ticket": {
-    "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-    "ticket_sequence": 23
+    "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+    "ticket_seq": 389
   },
   "ledger_index": "validated"
 }
@@ -541,8 +541,8 @@ Retrieve a [Ticket object](ticket.html), which represents a [sequence number][] 
   "method": "ledger_entry",
   "params": [{
     "ticket": {
-      "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-      "ticket_sequence": 23
+      "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "ticket_seq": 389
     },
     "ledger_index": "validated"
   }]
@@ -552,14 +552,12 @@ Retrieve a [Ticket object](ticket.html), which represents a [sequence number][] 
 *Commandline*
 
 ```sh
-rippled json ledger_entry '{ "ticket": { "owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ticket_sequence: 23 }, "ledger_index": "validated" }'
+rippled json ledger_entry '{ "ticket": { "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ticket_seq: 389 }, "ledger_index": "validated" }'
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
-<!-- TODO: enable if/when Tickets are available on Mainnet
 [Try it! >](websocket-api-tool.html#ledger_entry-ticket)
--->
 
 
 


### PR DESCRIPTION
Now that Tickets are available on Mainnet, I wanted to uncomment the example to do that in the WebSocket tool using ledger_entry.

I made some tickets and found that the documented syntax for querying them was incorrect. (I'm not sure where I originally got the documented syntax, but I got the correct syntax from the source code, where it has apparently been the same for 4 years.)

So this PR fixes the examples, updates & uncomments the entry in the WebSocket tool, and links an actual ticket that I created with my test account on Mainnet and intend to leave there indefinitely for demonstration purposes.