### PR TITLE
update license and footer date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ The XRP Ledger Dev Portal (XRPL.org) and all its original contents are provided 
 
 The MIT License (MIT)
 
-XRP Ledger Dev Portal Copyright (c) 2021 XRP Ledger Foundation and contributors, https://xrplf.org/
+XRP Ledger Dev Portal Copyright (c) 2023 XRP Ledger Foundation and contributors, https://xrplf.org/
 jQuery Copyright (c) 2005, 2014 jQuery Foundation and other contributors, https://jquery.org/
 Bootstrap Copyright (c) 2011-2019 Twitter, Inc.
 Bootstrap Copyright (c) 2011-2019 The Bootstrap Authors

--- a/template/component-footer.html.jinja
+++ b/template/component-footer.html.jinja
@@ -20,7 +20,7 @@
     <div class="d-lg-flex row">
       <a href="{% if currentpage.prefix %}{{currentpage.prefix}}{% else %}/{% endif %}" class="footer-brand"><img src="{{currentpage.prefix}}assets/img/XRPLedger_DevPortal-white.svg" class="logo"  height="24" alt="{{target.display_name}}" /></a>
       <span class="flex-grow-1">&nbsp;</span>
-      <div class="copyright-license">&copy; 2021 XRP Ledger. <a href="https://raw.githubusercontent.com/XRPLF/xrpl-dev-portal/master/LICENSE">{% trans %}Open Source.{% endtrans %}</a>
+      <div class="copyright-license">&copy; 2023 XRP Ledger. <a href="https://raw.githubusercontent.com/XRPLF/xrpl-dev-portal/master/LICENSE">{% trans %}Open Source.{% endtrans %}</a>
       </div>
     </div><!-- /.absolute_bottom_footer -->
 


### PR DESCRIPTION
update footer and license date to 2023 from 2021 
<img width="249" alt="Screenshot 2023-01-05 at 1 20 51 PM" src="https://user-images.githubusercontent.com/9340787/210882193-b0105d7d-ca5a-4ef1-a65b-5b503647c31f.png">
