### PR TITLE
Update the number of Ripple owned nodes

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -19,7 +19,7 @@ name: FAQ
 
 #### Is XRPL a private blockchain, owned by Ripple?
 
-No, the XRP Ledger is a decentralized, public blockchain. Any changes that would impact transaction processing or consensus need to be approved by at least 80%% of the network. Ripple is a contributor to the network, but its rights are the same as those of other contributors. In terms of validation, there are 150+ validators on the network with 35+ on the default Unique Node List (see [“What are Unique Node Lists (UNLs)?” below](#what-are-unique-node-lists-unls)) — Ripple runs 6 of these nodes.
+No, the XRP Ledger is a decentralized, public blockchain. Any changes that would impact transaction processing or consensus need to be approved by at least 80%% of the network. Ripple is a contributor to the network, but its rights are the same as those of other contributors. In terms of validation, there are 150+ validators on the network with 35+ on the default Unique Node List (see [“What are Unique Node Lists (UNLs)?” below](#what-are-unique-node-lists-unls)) — Ripple runs [only 2](https://foundation.xrpl.org/2022/10/06/unl-update-october-2022) of these nodes.
 
 #### Isn’t Proof of Work the best validation mechanism?
 


### PR DESCRIPTION
I update the number of Ripple owned nodes on doc. Thanks to @mDuo13 for poiting it out in #1662!
The current doc has "6" but it should be "2".
I linked UNL Update Oct 2022 to clarify the information source. https://foundation.xrpl.org/2022/10/06/unl-update-october-2022