### PR TITLE
Add note re download zip

### DIFF
--- a/content/tutorials/quickstart/create-accounts-send-xrp.md
+++ b/content/tutorials/quickstart/create-accounts-send-xrp.md
@@ -34,6 +34,8 @@ To get started, create a new folder on your local disk and install the JavaScrip
 
 Download and expand the [Quickstart Samples](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/quickstart/js/quickstart.zip){.github-code-download} archive.
 
+**Note:** Without the Quickstart Samples, you will not be able to try the examples that follow. 
+
 ## Usage
 
 To get test accounts:

--- a/content/tutorials/quickstart/create-trustline-send-currency.md
+++ b/content/tutorials/quickstart/create-trustline-send-currency.md
@@ -28,6 +28,8 @@ This example shows how to:
 
 You can download the [Quickstart Samples](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/quickstart/js/quickstart.zip){.github-code-download} archive to try each of the samples in your own browser.
 
+**Note:** Without the Quickstart Samples, you will not be able to try the examples that follow. 
+
 
 ## Usage
 

--- a/content/tutorials/quickstart/xrpl-quickstart.md
+++ b/content/tutorials/quickstart/xrpl-quickstart.md
@@ -48,13 +48,13 @@ There are also expanded lessons demonstrating how to [Broker a NFToken Sale](bro
 
 To get started, create a new folder on your local disk and install the JavaScript library using `npm`.
 
-
 ```
     npm install xrpl
 ```
 
-
 Download and expand the [Quickstart Samples](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/quickstart/js/quickstart.zip){.github-code-download} archive.
+
+**Note:** Without the Quickstart Samples, you will not be able to try the examples that follow. 
 
 ---
 


### PR DESCRIPTION
Added notes to the first three files to emphasize that the customer needs to download the Zip file in order to run the samples. Addresses https://github.com/XRPLF/xrpl-dev-portal/issues/1443.