### PR TITLE
Remove NFT-Devnet from Faucets

### DIFF
--- a/template/page-xrp-faucets.html.jinja
+++ b/template/page-xrp-faucets.html.jinja
@@ -18,14 +18,6 @@
     "desc": "Preview of upcoming amendments."
   },
   {
-    "id": "faucet-select-nftdevnet",
-    "ws_url": "wss://xls20-sandbox.rippletest.net:51233/",
-    "jsonrpc_url": "https://xls20-sandbox.rippletest.net:51234/",
-    "shortname": "NFT-Devnet",
-    "faucet": "https://faucet-nft.ripple.com/accounts",
-    "desc": "XLS-20d Non-Fungible Tokens preview network. <strong>(Deprecated)</strong>"
-  },
-  {
     "id": "faucet-select-ammdevnet",
     "ws_url": "wss://amm.devnet.rippletest.net:51233/",
     "jsonrpc_url": "https://amm.devnet.rippletest.net:51234/",


### PR DESCRIPTION
Remove the NFT-Devnet entry from the Faucets page, per Shashwat Mittal.