### PR TITLE
Deprecate install-rippled-on-centos-rhel-with-yum

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
@@ -1,109 +1,17 @@
 ---
 html: install-rippled-on-centos-rhel-with-yum.html
 parent: install-rippled.html
-blurb: Install a precompiled rippled binary on CentOS or Red Hat Enterprise Linux.
+blurb: Deprecated: CentOS and Red Hat Enterprise Linux are no longer supported.
 labels:
   - Core Server
 ---
 # Install on CentOS/Red Hat with yum
 
-This page describes the recommended instructions for installing the latest stable version of `rippled` on **CentOS 7** or **Red Hat Enterprise Linux 7**, using Ripple's [yum](https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified) repository.
+The `rippled` software no longer supports **CentOS 7** or **Red Hat Enterprise Linux 7**. Instead, Ubuntu is recommended; [build instructions are here](https://github.com/XRPLF/rippled/blob/develop/BUILD.md).
 
-These instructions install a binary that has been compiled by Ripple.
-
-
-## Prerequisites
-
-Before you install `rippled`, you must meet the [System Requirements](system-requirements.html).
-
-
-## Installation Steps
-
-1. Install the Ripple RPM repository:
-
-    Choose the appropriate RPM repository for the stability of releases you want:
-
-    - `stable` for the latest production release (`master` branch)
-    - `unstable` for pre-release builds (`release` branch)
-    - `nightly` for experimental/development builds (`develop` branch)
-
-    <!-- MULTICODE_BLOCK_START -->
-
-    *Stable*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [ripple-stable]
-        name=XRP Ledger Packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/stable/
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/stable/repodata/repomd.xml.key
-        REPOFILE
-
-    *Pre-release*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [ripple-unstable]
-        name=XRP Ledger Packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/unstable/
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/unstable/repodata/repomd.xml.key
-        REPOFILE
-
-    *Development*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [ripple-nightly]
-        name=XRP Ledger Packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/nightly/
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/nightly/repodata/repomd.xml.key
-        REPOFILE
-
-    *XLS-20d*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [xls20]
-        name=xls20
-        baseurl=https://repos.ripple.com/repos/rippled-rpm-test-mirror/xls20
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm-test-mirror/xls20/repodata/repomd.xml.key
-        REPOFILE
-
-    <!-- MULTICODE_BLOCK_START -->
-
-
-2. Fetch the latest repo updates:
-
-        sudo yum -y update
-
-3. Install the new `rippled` package:
-
-        sudo yum install rippled
-
-4. Reload systemd unit files:
-
-        sudo systemctl daemon-reload
-
-5. Configure the `rippled` service to start on boot:
-
-        sudo systemctl enable rippled.service
-
-6. Start the `rippled` service:
-
-        sudo systemctl start rippled.service
-
-
-## Next Steps
-
-{% include '_snippets/post-rippled-install.md' %}<!--_ -->
+- It is extremely difficult to build a modern toolchain on an ancient system like CentOS.
+- Community contributions are welcome; if you care about CentOS and can help to build a modern toolchain on it, please do so. Share your contributions on GitHub.
+- You may want to upgrade to a more modern version of CentOS; for example, CentOS 8 may have fewer problems.
 
 
 ## See Also

--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
@@ -2,6 +2,7 @@
 html: install-rippled-on-centos-rhel-with-yum.html
 parent: install-rippled.html
 blurb: Deprecated: CentOS and Red Hat Enterprise Linux are no longer supported.
+status: removed
 labels:
   - Core Server
 ---
@@ -9,7 +10,7 @@ labels:
 
 The `rippled` software no longer supports **CentOS 7** or **Red Hat Enterprise Linux 7**. Instead, Ubuntu is recommended; [build instructions are here](https://github.com/XRPLF/rippled/blob/develop/BUILD.md).
 
-- It is extremely difficult to build a modern toolchain on an ancient system like CentOS.
+- It is difficult to build a modern toolchain on an older system like CentOS 7.
 - Community contributions are welcome; if you care about CentOS and can help to build a modern toolchain on it, please do so. Share your contributions on GitHub.
 - You may want to upgrade to a more modern version of CentOS; for example, CentOS 8 may have fewer problems.
 


### PR DESCRIPTION
rippled 1.10.0 will not have binaries for CentOS or RHEL. Community contributions are welcome, but there is currently no available expertise to support these operating systems.