### PR TITLE
Update docs for XRPFees amendment

### DIFF
--- a/content/_snippets/rippled-api-links.md
+++ b/content/_snippets/rippled-api-links.md
@@ -237,7 +237,8 @@
   "TicketBatch",
   "Tickets",
   "TickSize",
-  "TrustSetAuth"
+  "TrustSetAuth",
+  "XRPFees"
 ] %}
 
 {% for amd in amendment_names %}

--- a/content/references/protocol-reference/ledger-data/ledger-object-types/feesettings.md
+++ b/content/references/protocol-reference/ledger-data/ledger-object-types/feesettings.md
@@ -47,7 +47,7 @@ If the _[XRPFees amendment][]_ is enabled, the `FeeSettings` object has these fi
 | Name                    | JSON Type | [Internal Type][] | Required? | Description            |
 |:------------------------|:----------|:------------------|:----------|:-----------------------|
 | `BaseFeeDrops`          | String    | Amount            | Yes       | The [transaction cost](transaction-cost.html) of the "reference transaction" in drops of XRP. |
-| `Flags`                 | Number    | UInt32            | Yes       | A bit-map of boolean flags enabled for this object. Currently, the protocol defines no flags for `FeeSettings` objects. The value is always `0`. |
+| `Flags`                 | Number    | UInt32            | Yes       | A bitmap of boolean flags enabled for this object. Currently, the protocol defines no flags for `FeeSettings` objects. The value is always `0`. |
 | `LedgerEntryType`       | String    | UInt16            | Yes       | The value `0x0073`, mapped to the string `FeeSettings`, indicates that this object contains the ledger's fee settings. |
 | `ReserveBaseDrops`      | String    | Amount            | Yes       | The [base reserve](reserves.html#base-reserve-and-owner-reserve) for an account in the XRP Ledger, as drops of XRP. |
 | `ReserveIncrementDrops` | String    | Amount            | Yes       | The incremental [owner reserve](reserves.html#base-reserve-and-owner-reserve) for owning objects, as drops of XRP. |

--- a/content/references/protocol-reference/ledger-data/ledger-object-types/feesettings.md
+++ b/content/references/protocol-reference/ledger-data/ledger-object-types/feesettings.md
@@ -41,6 +41,18 @@ The `FeeSettings` object has the following fields:
 
 **Warning:** The JSON format for this ledger object type is unusual. The `BaseFee`, `ReserveBase`, and `ReserveIncrement` indicate drops of XRP but ***not*** in the usual format for [specifying XRP][Currency Amount].
 
+
+If the _[XRPFees amendment][]_ is enabled, the `FeeSettings` object has these fields instead:
+
+| Name                    | JSON Type | [Internal Type][] | Required? | Description            |
+|:------------------------|:----------|:------------------|:----------|:-----------------------|
+| `BaseFeeDrops`          | String    | UInt64            | Yes       | The [transaction cost](transaction-cost.html) of the "reference transaction" in drops of XRP. |
+| `Flags`                 | Number    | UInt32            | Yes       | A bit-map of boolean flags enabled for this object. Currently, the protocol defines no flags for `FeeSettings` objects. The value is always `0`. |
+| `LedgerEntryType`       | String    | UInt16            | Yes       | The value `0x0073`, mapped to the string `FeeSettings`, indicates that this object contains the ledger's fee settings. |
+| `ReserveBaseDrops`      | String    | UInt64            | Yes       | The [base reserve](reserves.html#base-reserve-and-owner-reserve) for an account in the XRP Ledger, as drops of XRP. |
+| `ReserveIncrementDrops` | String    | UInt64            | Yes       | The incremental [owner reserve](reserves.html#base-reserve-and-owner-reserve) for owning objects, as drops of XRP. |
+
+
 ## FeeSettings ID Format
 
 The `FeeSettings` object ID is the hash of the `FeeSettings` space key (`0x0065`) only. This means that the ID of the `FeeSettings` object in a ledger is always:
@@ -48,6 +60,7 @@ The `FeeSettings` object ID is the hash of the `FeeSettings` space key (`0x0065`
 ```
 4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A651
 ```
+
 
 <!--{# common link defs #}-->
 {% include '_snippets/rippled-api-links.md' %}			

--- a/content/references/protocol-reference/ledger-data/ledger-object-types/feesettings.md
+++ b/content/references/protocol-reference/ledger-data/ledger-object-types/feesettings.md
@@ -46,11 +46,11 @@ If the _[XRPFees amendment][]_ is enabled, the `FeeSettings` object has these fi
 
 | Name                    | JSON Type | [Internal Type][] | Required? | Description            |
 |:------------------------|:----------|:------------------|:----------|:-----------------------|
-| `BaseFeeDrops`          | String    | UInt64            | Yes       | The [transaction cost](transaction-cost.html) of the "reference transaction" in drops of XRP. |
+| `BaseFeeDrops`          | String    | Amount            | Yes       | The [transaction cost](transaction-cost.html) of the "reference transaction" in drops of XRP. |
 | `Flags`                 | Number    | UInt32            | Yes       | A bit-map of boolean flags enabled for this object. Currently, the protocol defines no flags for `FeeSettings` objects. The value is always `0`. |
 | `LedgerEntryType`       | String    | UInt16            | Yes       | The value `0x0073`, mapped to the string `FeeSettings`, indicates that this object contains the ledger's fee settings. |
-| `ReserveBaseDrops`      | String    | UInt64            | Yes       | The [base reserve](reserves.html#base-reserve-and-owner-reserve) for an account in the XRP Ledger, as drops of XRP. |
-| `ReserveIncrementDrops` | String    | UInt64            | Yes       | The incremental [owner reserve](reserves.html#base-reserve-and-owner-reserve) for owning objects, as drops of XRP. |
+| `ReserveBaseDrops`      | String    | Amount            | Yes       | The [base reserve](reserves.html#base-reserve-and-owner-reserve) for an account in the XRP Ledger, as drops of XRP. |
+| `ReserveIncrementDrops` | String    | Amount            | Yes       | The incremental [owner reserve](reserves.html#base-reserve-and-owner-reserve) for owning objects, as drops of XRP. |
 
 
 ## FeeSettings ID Format

--- a/content/references/protocol-reference/transactions/pseudo-transaction-types/setfee.md
+++ b/content/references/protocol-reference/transactions/pseudo-transaction-types/setfee.md
@@ -46,9 +46,9 @@ If the _[XRPFees amendment][]_ is enabled, `SetFee` pseudo-transactions use thes
 
 | Field                   | JSON Type | [Internal Type][] | Description     |
 |:------------------------|:----------|:------------------|:----------------|
-| `BaseFeeDrops`          | String    | UInt64            | The charge, in drops of XRP, for the reference transaction. (This is the [transaction cost](transaction-cost.html) before scaling for load.) |
-| `ReserveBaseDrops`      | String    | UInt64            | The base reserve, in drops |
-| `ReserveIncrementDrops` | String    | UInt64            | The incremental reserve, in drops |
+| `BaseFeeDrops`          | String    | Amount            | The charge, in drops of XRP, for the reference transaction. (This is the [transaction cost](transaction-cost.html) before scaling for load.) |
+| `ReserveBaseDrops`      | String    | Amount            | The base reserve, in drops |
+| `ReserveIncrementDrops` | String    | Amount            | The incremental reserve, in drops |
 | `LedgerSequence`        | Number    | UInt32            | _(Omitted for some historical `SetFee` pseudo-transactions)_ The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
 
 

--- a/content/references/protocol-reference/transactions/pseudo-transaction-types/setfee.md
+++ b/content/references/protocol-reference/transactions/pseudo-transaction-types/setfee.md
@@ -41,6 +41,17 @@ A `SetFee` [pseudo-transaction](pseudo-transaction-types.html) marks a change in
 | `ReserveIncrement`  | Unsigned Integer | UInt32            | The incremental reserve, in drops |
 | `LedgerSequence`    | Number           | UInt32            | _(Omitted for some historical `SetFee` pseudo-transactions)_ The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
 
+
+If the _[XRPFees amendment][]_ is enabled, `SetFee` pseudo-transactions use these fields instead:
+
+| Field                   | JSON Type | [Internal Type][] | Description     |
+|:------------------------|:----------|:------------------|:----------------|
+| `BaseFeeDrops`          | String    | UInt64            | The charge, in drops of XRP, for the reference transaction. (This is the [transaction cost](transaction-cost.html) before scaling for load.) |
+| `ReserveBaseDrops`      | String    | UInt64            | The base reserve, in drops |
+| `ReserveIncrementDrops` | String    | UInt64            | The incremental reserve, in drops |
+| `LedgerSequence`        | Number    | UInt32            | _(Omitted for some historical `SetFee` pseudo-transactions)_ The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
+
+
 {% include '_snippets/setfee_uniqueness_note.md' %}
 
 <!--{# common link defs #}-->


### PR DESCRIPTION
Fields have been updated for the `SetFee` pseudo-transaction and `FeeSettings` ledger object. Updating corresponding reference docs.

To be merged with 1.10.0 stable release.