### PR TITLE
Update latest Ubuntu supported; Random fixes

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-centos-rhel-with-yum.md
@@ -67,7 +67,6 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
     <!-- MULTICODE_BLOCK_START -->
 
-
 2. Fetch the latest repo updates:
 
         sudo yum -y update

--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.ja.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.ja.md
@@ -57,6 +57,7 @@ labels:
     - `bionic` for **Ubuntu 18.04 Bionic Beaver**
     - `buster` for **Debian 10 Buster**
     - `bullseye` for **Debian 11 Bullseye**
+    - `jammy` for **Ubuntu 22.04 Jammy Jellyfish**
 
    `rippled`の開発バージョンまたはプレリリースバージョンにアクセスするには、`stable`ではなく次のいずれかを使用します。
 
@@ -80,12 +81,6 @@ labels:
    `rippled`サービスが自動的に開始します。開始しない場合は、手動で開始できます。
 
         sudo systemctl start rippled.service
-
-   起動時に自動で起動するようにするには、以下の手順に従います。
-
-        sudo systemctl enable rippled.service
-
-
 
 ## 次のステップ
 

--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
@@ -59,6 +59,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
     - `bionic` for **Ubuntu 18.04 Bionic Beaver**
     - `buster` for **Debian 10 Buster**
     - `bullseye` for **Debian 11 Bullseye**
+    - `jammy` for **Ubuntu 22.04 Jammy Jellyfish**
 
     If you want access to development or pre-release versions of `rippled`, use one of the following instead of `stable`:
 
@@ -83,9 +84,6 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
         sudo systemctl start rippled.service
 
-    To configure it to start automatically on boot:
-
-        sudo systemctl enable rippled.service
 
 8. Optional: allow `rippled` to bind to privileged ports.
 

--- a/content/tutorials/manage-the-rippled-server/installation/system-requirements.ja.md
+++ b/content/tutorials/manage-the-rippled-server/installation/system-requirements.ja.md
@@ -11,7 +11,7 @@ labels:
 
 企業の本番環境で最良のパフォーマンスを実現するため、以下の仕様のベアメタルで`rippled`を実行することが推奨されています。
 
-- オペレーティングシステム: Ubuntu (LTF) 、CentOS または RedHat Enterprise Linux (最新版)
+- オペレーティングシステム: Ubuntu (LTF) 、CentOS または Red Hat Enterprise Linux (最新版)
 - CPU: Intel Xeon 3GHz以上のプロセッサー、8コア以上、ハイパースレッディング有効
 - ディスク: SSD / NVMe（10,000 IOPS以上）
 - RAM: 64GB
@@ -21,7 +21,7 @@ labels:
 
 テスト目的やたまにしか使わない場合は、一般的なハードウェア上でXRP Ledgerサーバーを稼働させることができます。以下の最低要件を満たせば、ほとんどの場合は動作しますが、必ずしも[ネットワークと同期](server-doesnt-sync.html)しているとは限りません。
 
-- オペレーティングシステム: Mac OS X、Windows（64ビット）、またはほとんどのLinuxディストリビューション(Red Hat、 Ubuntu、 Debianをサポート)
+- オペレーティングシステム: macOS、Windows（64ビット）、またはほとんどのLinuxディストリビューション(Red Hat、 Ubuntu、 Debianをサポート)
 - CPU: 64ビット x86_64、4コア以上
 - ディスク: データベースパーティション用に最低50GB。SSDを強く推奨（最低でも1000IOPS、それよりも多いことが望ましい）
 - RAM: 16GB以上

--- a/content/tutorials/manage-the-rippled-server/installation/system-requirements.md
+++ b/content/tutorials/manage-the-rippled-server/installation/system-requirements.md
@@ -11,7 +11,7 @@ labels:
 
 For reliable performance in production environments, it is recommended to run an XRP Ledger (`rippled`) server on bare metal with the following characteristics or better:
 
-- Operating System: Ubuntu (LTS) or CentOS or RedHat Enterprise Linux (latest release).
+- Operating System: Ubuntu (LTS) or CentOS or Red Hat Enterprise Linux (latest release).
 - CPU: Intel Xeon 3+ GHz processor with 8+ cores and hyperthreading enabled.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
 - RAM: 64 GB.
@@ -22,7 +22,7 @@ For reliable performance in production environments, it is recommended to run an
 
 For testing purposes or occasional use, you can run an XRP Ledger server on commodity hardware. The following minimum requirements should work for most cases, but may not always [stay synced with the network](server-doesnt-sync.html):
 
-- Operating System: Mac OS X, Windows (64-bit), or most Linux distributions (Red Hat, Ubuntu, and Debian supported).
+- Operating System: macOS, Windows (64-bit), or most Linux distributions (Red Hat, Ubuntu, and Debian supported).
 - CPU: 64-bit x86_64, 4+ cores.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
 - RAM: 16 GB+.


### PR DESCRIPTION
Update supported Ubuntu version. 
Apple always gotta change. 
rippled is enabled by default for awhile. 