### PR TITLE
Add NFTokenPage to account_objects.md

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_objects.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_objects.md
@@ -21,6 +21,7 @@ The types of objects that may appear in the `account_objects` response for an ac
 - [Check objects](check.html) for pending Checks.
 - [DepositPreauth objects](depositpreauth-object.html) for deposit preauthorizations. [New in: rippled 1.1.0][]
 - [Ticket objects](known-amendments.html#tickets) for Tickets.
+- [NFTokenPage objects](nftokenpage.html) for collections of NFTs.
 
 
 ## Request Format


### PR DESCRIPTION
Per https://ripplelabs.atlassian.net/jira/software/c/projects/TOK/issues/TOK-275

The account_objects request now returns NFTokenPages in addition to all previous information.