### PR TITLE
[IA.v2] Fix Absolute path link to internal content

### DIFF
--- a/content/_snippets/data_types/address.ja.md
+++ b/content/_snippets/data_types/address.ja.md
@@ -3,7 +3,7 @@ XRP Ledgerのアカウントは、XRP Ledgerの[base58][]フォーマットの�
 * 長さは25から35文字です
 * 文字`r`で始まります
 
-  **注記:** XRPコミュニティは、取引所およびウォレットで[宛先タグ](https://xrpl.org/source-and-destination-tags.html)の代わりに使用できる新しいフォーマット、**X**アドレスを[提案](https://github.com/XRPLF/XRPL-Standards/issues/6)（これをサポートする[コーデック](https://github.com/xrp-community/xrpl-tagged-address-codec)も開発）しました。これらの「パック化」したアドレスは、`r`ではなく`X`で開始します。詳細は、[𝗫-address format](https://xrpaddress.info/)のサイトを参照してください。
+  **注記:** XRPコミュニティは、取引所およびウォレットで[宛先タグ](source-and-destination-tags.html)の代わりに使用できる新しいフォーマット、**X**アドレスを[提案](https://github.com/XRPLF/XRPL-Standards/issues/6)（これをサポートする[コーデック](https://github.com/xrp-community/xrpl-tagged-address-codec)も開発）しました。これらの「パック化」したアドレスは、`r`ではなく`X`で開始します。詳細は、[𝗫-address format](https://xrpaddress.info/)のサイトを参照してください。
 
 * 英数字を使用します（数字「`0`」、大文字「`O`」、大文字「`I`」、小文字「`l`」を除く）
 * 大/小文字を区別します

--- a/content/references/data-api.ja.md
+++ b/content/references/data-api.ja.md
@@ -7,7 +7,7 @@ nav_omit: true
 ---
 # Ripple Data API v2
 
-**警告:** Ripple Data API v2は廃止されました。代わりに[HTTP / WebSocket API](https://xrpl.org/http-websocket-apis.html)を使って下さい。
+**警告:** Ripple Data API v2は廃止されました。代わりに[HTTP / WebSocket API](http-websocket-apis.html)を使って下さい。
 
 Ripple Data API v2を使用すると、XRP Ledgerの変更に関する情報（トランザクション履歴や処理済みの分析データなど）にアクセスできます。このような情報は専用データベースに保管されるので、`rippled`サーバーで保持する必要のある履歴レジャーバージョンの数が少なくなります。Data API v2は[XRP Charts](https://xrpcharts.ripple.com/)や[ripple.com](https://www.ripple.com)などのアプリケーションのデータソースとしても機能します。
 

--- a/content/references/http-websocket-apis/api-conventions/request-formatting.md
+++ b/content/references/http-websocket-apis/api-conventions/request-formatting.md
@@ -90,7 +90,7 @@ See [Response Formatting](response-formatting.html) for the response from the se
 
 ## Commandline Format
 
-Put the API method name after any normal (dash-prefaced) commandline options, followed by a limited set of parameters, separated by spaces. For any parameter values that might contain spaces or other unusual characters, use single-quotes to encapsulate them. Not all methods have commandline API syntax. For more information, see [Commandline Usage](https://xrpl.org/commandline-usage.html#client-mode-options).
+Put the API method name after any normal (dash-prefaced) commandline options, followed by a limited set of parameters, separated by spaces. For any parameter values that might contain spaces or other unusual characters, use single-quotes to encapsulate them. Not all methods have commandline API syntax. For more information, see [Commandline Usage](commandline-usage.html#client-mode-options).
 
 The commandline calls JSON-RPC, so its responses always match the JSON-RPC response format.
 

--- a/content/tutorials/get-started/get-started-using-javascript.ja.md
+++ b/content/tutorials/get-started/get-started-using-javascript.ja.md
@@ -132,7 +132,7 @@ const test_wallet = xrpl.Wallet.fromSeed("sn3nxiW7v8KXzPzAqzyHXbSSKNuN9") // テ
 
 ### 4. XRP Ledgerの参照
 
-クライアントの`request()`メソッドを使って、XRP Ledgerの[WebSocket API](https://xrpl.org/request-formatting.html)にアクセスします。例えば、以下のようになります。
+クライアントの`request()`メソッドを使って、XRP Ledgerの[WebSocket API](request-formatting.html)にアクセスします。例えば、以下のようになります。
 
 {{ include_code("_code-samples/get-started/js/get-acct-info.js", start_with="// Get info", end_before="// Listen to ledger close events", language="js") }}
 

--- a/content/use-cases/interoperability/sidechains-uc.md
+++ b/content/use-cases/interoperability/sidechains-uc.md
@@ -14,6 +14,6 @@ _As an XRP Ledger developer, I want to create my own, independent ledger instanc
 
 A sidechain is an independent ledger with its own consensus algorithm and transaction types and rules. It acts as its own blockchain. Federation enables value in the form of XRP and other tokens to move efficiently between a sidechain and an XRP Ledger mainchain.
 
-For more information, see [Federated Sidechains](https://xrpl.org/federated-sidechains.html?_ga=2.208834706.1673393542.1670970919-696076472.1670970919#federated-sidechains)
+For more information, see [Federated Sidechains](federated-sidechains.html?_ga=2.208834706.1673393542.1670970919-696076472.1670970919#federated-sidechains)
 
 To get started creating your own sidechain, see [XRPL Hooks](https://hooks-testnet-v2.xrpl-labs.com/)

--- a/content/use-cases/tokenization/authorized-minter.md
+++ b/content/use-cases/tokenization/authorized-minter.md
@@ -17,36 +17,36 @@ You can learn more in the tutorial [Assign an Authorized Minter](authorize-minte
 
 ## Set up a rippled instance
 
-If you want to set up a larger site with high volume, it might be worth investing in your own XRP Ledger server instance. See [Install rippled](https://xrpl.org/install-rippled.html).
+If you want to set up a larger site with high volume, it might be worth investing in your own XRP Ledger server instance. See [Install rippled](install-rippled.html).
 
 ## Set up your marketplace
 
-Rather than designing NFTs yourself, you coordinate with an NFT creator to become an authorized minter and generate NFTs on their behalf. This allows the creator to focus on making new NFTs while you handle production and sales of the NFTs. See [Authorized Minter](https://xrpl.org/nftoken-authorized-minting.html).
+Rather than designing NFTs yourself, you coordinate with an NFT creator to become an authorized minter and generate NFTs on their behalf. This allows the creator to focus on making new NFTs while you handle production and sales of the NFTs. See [Authorized Minter](nftoken-authorized-minting.html).
 
-Once you finish creating NFTs, the creator can revoke your privileges and reassert control over the NFTs. You might also transfer the tokens to a marketplace that will handle sales of the NFTs. You can act as a broker to match sell offers to buy offers. See [Running an NFT auction](https://xrpl.org/nftoken-auctions.html).
+Once you finish creating NFTs, the creator can revoke your privileges and reassert control over the NFTs. You might also transfer the tokens to a marketplace that will handle sales of the NFTs. You can act as a broker to match sell offers to buy offers. See [Running an NFT auction](nftoken-auctions.html).
 
-To mint your first NFTs on behalf of another account, see [Authorizing Another Account to Mint Your NFTs](https://xrpl.org/authorize-minter.html).
+To mint your first NFTs on behalf of another account, see [Authorizing Another Account to Mint Your NFTs](authorize-minter.html).
 
-If you, as the owner or issuer, want to be able to burn the token in the future, set the `Flags` field to _1._ To make the NFT transferable, set the `Flags` field to _8_. Set the `Flags` field to _9_ to make the NFT both burnable and transferable. See[ Burnable flag](https://xrpl.org/nftoken.html#nftoken-flags) and [Transferable flag](https://xrpl.org/nftoken.html#nftoken-flags).
+If you, as the owner or issuer, want to be able to burn the token in the future, set the `Flags` field to _1._ To make the NFT transferable, set the `Flags` field to _8_. Set the `Flags` field to _9_ to make the NFT both burnable and transferable. See[ Burnable flag](nftoken.html#nftoken-flags) and [Transferable flag](nftoken.html#nftoken-flags).
 
-You can arrange for the creator to receive royalties from future sales by setting a <code>transfer fee<em>. </em></code>This is a value from 0-50000 representing 0-50% of the sale price. See [Transfer Fee](https://xrpl.org/nftoken.html#transferfee).
+You can arrange for the creator to receive royalties from future sales by setting a <code>transfer fee<em>. </em></code>This is a value from 0-50000 representing 0-50% of the sale price. See [Transfer Fee](nftoken.html#transferfee).
 
 The NFToken URL is a link to the location where the content of the NFT is stored. One option is create an IPFS account and store the NFToken content at a persistent URL. See [Best Practices for Storing NFT Data](https://docs.ipfs.io/how-to/best-practices-for-nft-data).
 
 Considerations that might be most interesting to you:
 
-* [Minting NFTs into Collections](https://xrpl.org/nft-collections.html)
+* [Minting NFTs into Collections](nft-collections.html)
 Use the TokenTaxon field to gather a set of NFTs centered around a specific theme or purpose. 
-* [Guaranteeing a Fixed Supply of NFTs](https://xrpl.org/nft-fixed-supply.html)
-You can assure scarcity of NFTs you create by creating them with what might be characterized as a “burner” account that you use to mint a set number of NFTs for another account, then delete the account you used to mint the NFTs. See [Guaranteeing a Fixed Supply of NFTs](https://xrpl.org/nft-fixed-supply.html).
+* [Guaranteeing a Fixed Supply of NFTs](nft-fixed-supply.html)
+You can assure scarcity of NFTs you create by creating them with what might be characterized as a “burner” account that you use to mint a set number of NFTs for another account, then delete the account you used to mint the NFTs. See [Guaranteeing a Fixed Supply of NFTs](nft-fixed-supply.html).
 
 ## Transferring NFTs
 
-You transfer NFTs by creating a sell offer or accepting a buy offer. See [Transfer NFTokens](https://xrpl.org/transfer-nftokens.html).
+You transfer NFTs by creating a sell offer or accepting a buy offer. See [Transfer NFTokens](transfer-nftokens.html).
 
-You can sell your NFTs in an auction format. See [Running an NFT Auction](https://xrpl.org/nftoken-auctions.html#running-an-nft-auction).
+You can sell your NFTs in an auction format. See [Running an NFT Auction](nftoken-auctions.html#running-an-nft-auction).
 
-You can act as a broker, connecting sellers with bidders, completing the transfer and keeping a percentage of the purchase price. See [Broker a NFToken sale](https://xrpl.org/broker-sale.html).
+You can act as a broker, connecting sellers with bidders, completing the transfer and keeping a percentage of the purchase price. See [Broker a NFToken sale](broker-sale.html).
 
 ### Reserve requirements
 
@@ -74,12 +74,12 @@ When listing NFTs for sale, it can be useful to use object metadata to organize 
 
 See:
 
-- [Clio setup](https://xrpl.org/install-clio-on-ubuntu.html) 
+- [Clio setup](install-clio-on-ubuntu.html) 
 - [XRPL Data API](https://api.xrpldata.com/docs/static/index.html#/)
 - [Bithomp](https://docs.bithomp.com/#nft-xls-20)
 
 <!-- 
-[Clio setup](https://xrpl.org/install-clio-on-ubuntu.html) 
+[Clio setup](install-clio-on-ubuntu.html) 
 
 [https://api.xrpldata.com/docs/static/index.html#/](https://api.xrpldata.com/docs/static/index.html#/)
 

--- a/content/use-cases/tokenization/digital-artist.md
+++ b/content/use-cases/tokenization/digital-artist.md
@@ -78,7 +78,7 @@ When listing NFTs for sale, it can be useful to use object metadata to organize 
 
 See:
 
-- [Clio setup](https://xrpl.org/install-clio-on-ubuntu.html) 
+- [Clio setup](install-clio-on-ubuntu.html) 
 - [XRPL Data API](https://api.xrpldata.com/docs/static/index.html#/)
 - [Bithomp](https://docs.bithomp.com/#nft-xls-20)
 

--- a/content/use-cases/tokenization/nft-mkt-overview.md
+++ b/content/use-cases/tokenization/nft-mkt-overview.md
@@ -118,7 +118,7 @@ When listing NFTs for sale, it can be useful to use object metadata to organize 
 
 See:
 
-- [Clio setup](https://xrpl.org/install-clio-on-ubuntu.html) 
+- [Clio setup](install-clio-on-ubuntu.html) 
 - [XRPL Data API](https://api.xrpldata.com/docs/static/index.html#/)
 - [Bithomp](https://docs.bithomp.com/#nft-xls-20)
 
@@ -156,7 +156,7 @@ Although IPFS / Arweave are great solutions to promote decentralization, fetchin
 
 Cloudflare, Infura, and many other providers are increasingly focusing on storing these decentralized files and retrieving them fast for users.
 
-See [NFT Caching](https://xrpl.org/nftoken.html#retrieving-nftoken-data-and-metadata).
+See [NFT Caching](nftoken.html#retrieving-nftoken-data-and-metadata).
 
 <!-- 
 You can also consider a solution such as Pinata. [https://drive.google.com/file/d/14wuulkvjVjtGlUJj0ppaJ4Sziyp5WFGA/view?usp=sharing](https://drive.google.com/file/d/14wuulkvjVjtGlUJj0ppaJ4Sziyp5WFGA/view?usp=sharing) 

--- a/content/use-cases/tokenization/nftoken-marketplace.md
+++ b/content/use-cases/tokenization/nftoken-marketplace.md
@@ -20,7 +20,7 @@ NFToken Marketplaces act as intermediaries between NFToken creators and collecto
 
 ## Set up a rippled instance
 
-When you set up a serious marketplace site with high volume, it justifies the decision to set up your own XRP Ledger server instance. See [Install rippled](https://xrpl.org/install-rippled.html).
+When you set up a serious marketplace site with high volume, it justifies the decision to set up your own XRP Ledger server instance. See [Install rippled](install-rippled.html).
 
 
 ### Setting up a wallet
@@ -74,7 +74,7 @@ When listing NFTs for sale, it can be useful to use object metadata to organize 
 
 See:
 
-- [Clio setup](https://xrpl.org/install-clio-on-ubuntu.html) 
+- [Clio setup](install-clio-on-ubuntu.html) 
 - [XRPL Data API](https://api.xrpldata.com/docs/static/index.html#/)
 - [Bithomp](https://docs.bithomp.com/#nft-xls-20)
 


### PR DESCRIPTION
On newly created pages and on some existing pages, links to internal content are not relative (install-rippled.html) but absolute (https://xrpl.org/install-rippled.html) to xrpl.org. The paths have been changed to relative paths.

The relevant link also exists in code-samples, but this PR does not fix it.

I will correct it if necessary.