### PR TITLE
Update .env in js wallet tutorial

### DIFF
--- a/content/_code-samples/build-a-wallet/js/.env
+++ b/content/_code-samples/build-a-wallet/js/.env
@@ -1,3 +1,3 @@
-CLIENT="wss://s.altnet.rippletest.net/"
+CLIENT="wss://s.altnet.rippletest.net:51233/"
 EXPLORER_NETWORK="testnet"
 SEED="s████████████████████████████"


### PR DESCRIPTION
The tutorial explains the right way to do things, but the example code has a file that is out of date. It shows CLIENT="wss://s.altnet.rippletest.net" which is missing the ":51233/" required to actually connect via websocket. I copied the working text from the tutorial into this file to update it.