### PR TITLE
Update ecosystem.svg

### DIFF
--- a/img/ecosystem.svg
+++ b/img/ecosystem.svg
@@ -181,9 +181,9 @@
     ><rect x="0.5" width="168.5" height="68.5" y="0.5" clip-path="url(#clipPath10)" stroke="none"
     /></g
     ><g transform="translate(350,360)"
-    ><rect fill="none" x="0.5" width="168.5" height="68.5" y="0.5" clip-path="url(#clipPath10)"
+    ><rect fill="none" x="0.5" width="100" height="68.5" y="0.5" clip-path="url(#clipPath10)"
       /><text x="5" font-size="14px" y="34.2188" clip-path="url(#clipPath10)" font-family="sans-serif" stroke="none" xml:space="preserve"
-      >ripple-lib (JavaScript)</text
+      >xrpl.js</text
     ></g
     ><g fill="rgb(255,255,255)" fill-opacity="0" transform="translate(550,540)" stroke-opacity="0" stroke="rgb(255,255,255)"
     ><rect x="0.5" width="198.5" height="88.5" y="0.5" clip-path="url(#clipPath11)" stroke="none"


### PR DESCRIPTION
Formally called ripple-lib, but now called xrpl.js for Javascript removed extraneous Javascript for the reason that .js is already provided

https://xrpl.org/software-ecosystem.html#programming-libraries