### PR TITLE
feat: Update xrpl-dev-portal to use xrpl-py 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 package-lock.json
 yarn-error.log
 /.idea
+.venv/

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
@@ -12,6 +12,7 @@ from xrpl.core import keypairs
 from xrpl.utils import xrp_to_drops
 from xrpl.models.transactions import Payment
 from xrpl.transaction import safe_sign_transaction
+from xrpl.wallet.main import Wallet
 
 
 def create_wallet(silent: False):
@@ -63,7 +64,7 @@ def sign_transaction(xrp_amount, destination, ledger_seq, wallet_seq, password):
     seed = crypt.decrypt(seed)
 
     print("4. Initializing wallet using decrypted private key")
-    _wallet = wallet.Wallet.from_seed(seed=seed.decode())
+    _wallet = Wallet.from_seed(seed=seed.decode())
 
     validated_seq = ledger_seq
 

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
@@ -69,7 +69,7 @@ def sign_transaction(xrp_amount, destination, ledger_seq, wallet_seq, password):
 
     print("5. Constructing payment transaction...")
     my_tx_payment = Payment(
-        account=_wallet.classic_address,
+        account=_wallet.address,
         amount=xrp_to_drops(xrp=xrp_amount),
         destination=destination,
         last_ledger_sequence=validated_seq + 100,

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
@@ -11,7 +11,7 @@ from xrpl import wallet
 from xrpl.core import keypairs
 from xrpl.utils import xrp_to_drops
 from xrpl.models.transactions import Payment
-from xrpl.transaction import safe_sign_transaction
+from xrpl.transaction import sign
 from xrpl.wallet.main import Wallet
 
 
@@ -80,7 +80,7 @@ def sign_transaction(xrp_amount, destination, ledger_seq, wallet_seq, password):
     )
 
     print("6. Signing transaction...")
-    my_tx_payment_signed = safe_sign_transaction(transaction=my_tx_payment, wallet=_wallet)
+    my_tx_payment_signed = sign(transaction=my_tx_payment, wallet=_wallet)
 
     img = qrcode.make(my_tx_payment_signed.to_dict())
 

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
@@ -7,7 +7,6 @@ from pathlib import Path, PureWindowsPath, PurePath
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from xrpl import wallet
 from xrpl.core import keypairs
 from xrpl.utils import xrp_to_drops
 from xrpl.models.transactions import Payment

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet-TEST.py
@@ -63,10 +63,9 @@ def sign_transaction(xrp_amount, destination, ledger_seq, wallet_seq, password):
     seed = crypt.decrypt(seed)
 
     print("4. Initializing wallet using decrypted private key")
-    _wallet = wallet.Wallet(seed=seed.decode(), sequence=0)
+    _wallet = wallet.Wallet.from_seed(seed=seed.decode())
 
     validated_seq = ledger_seq
-    _wallet.sequence = wallet_seq
 
     print("5. Constructing payment transaction...")
     my_tx_payment = Payment(
@@ -75,7 +74,7 @@ def sign_transaction(xrp_amount, destination, ledger_seq, wallet_seq, password):
         destination=destination,
         last_ledger_sequence=validated_seq + 100,
         # +100 to catch up with the ledger when we transmit the signed tx blob to Machine 2
-        sequence=_wallet.sequence,
+        sequence=wallet_seq,
         fee="10"
     )
 

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet.py
@@ -58,19 +58,18 @@ def sign_transaction(_xrp_amount, _destination, _ledger_seq, _wallet_seq, passwo
 
     # Decrypts the wallet's private key
     _seed = crypt.decrypt(_seed)
-    _wallet = wallet.Wallet(seed=_seed.decode(), sequence=0)
+    _wallet = wallet.Wallet.from_seed(seed=_seed.decode())
 
     validated_seq = _ledger_seq
-    _wallet.sequence = _wallet_seq
 
     # Construct Payment transaction
     my_tx_payment = Payment(
-        account=_wallet.classic_address,
+        account=_wallet.address,
         amount=xrp_to_drops(xrp=_xrp_amount),
         destination=_destination,
         last_ledger_sequence=validated_seq + 100,
         # +100 to catch up with the ledger when we transmit the signed tx blob to Machine 2
-        sequence=_wallet.sequence,
+        sequence=_wallet_seq,
         fee="10"
     )
 

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet.py
@@ -8,7 +8,7 @@ from pathlib import Path, PureWindowsPath, PurePath
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from xrpl import wallet
+from xrpl.wallet import Wallet
 from xrpl.core import keypairs
 from xrpl.utils import xrp_to_drops
 from xrpl.models.transactions import Payment
@@ -58,7 +58,7 @@ def sign_transaction(_xrp_amount, _destination, _ledger_seq, _wallet_seq, passwo
 
     # Decrypts the wallet's private key
     _seed = crypt.decrypt(_seed)
-    _wallet = wallet.Wallet.from_seed(seed=_seed.decode())
+    _wallet = Wallet.from_seed(seed=_seed.decode())
 
     validated_seq = _ledger_seq
 

--- a/content/_code-samples/airgapped-wallet/py/airgapped-wallet.py
+++ b/content/_code-samples/airgapped-wallet/py/airgapped-wallet.py
@@ -12,7 +12,7 @@ from xrpl.wallet import Wallet
 from xrpl.core import keypairs
 from xrpl.utils import xrp_to_drops
 from xrpl.models.transactions import Payment
-from xrpl.transaction import safe_sign_transaction
+from xrpl.transaction import sign
 
 
 def create_wallet():
@@ -75,7 +75,7 @@ def sign_transaction(_xrp_amount, _destination, _ledger_seq, _wallet_seq, passwo
 
     # Signs transaction and displays the signed_tx blob in QR code
     # Scan the QR code and transmit the signed_tx blob to an online machine (Machine 2) to relay it to the XRPL
-    my_tx_payment_signed = safe_sign_transaction(transaction=my_tx_payment, wallet=_wallet)
+    my_tx_payment_signed = sign(transaction=my_tx_payment, wallet=_wallet)
 
     img = qrcode.make(my_tx_payment_signed.to_dict())
     img.save(get_path("/Wallet/transactionID.png"))

--- a/content/_code-samples/airgapped-wallet/py/relay-transaction.py
+++ b/content/_code-samples/airgapped-wallet/py/relay-transaction.py
@@ -1,6 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import Payment
-from xrpl.transaction import send_reliable_submission
+from xrpl.transaction import submit_and_wait
 
 
 def connect_node(_node):
@@ -27,7 +27,7 @@ def send_transaction(transaction_dict):
     # Since we manually inserted the tx blob, we need to initialize it into a Payment so xrpl-py could process it
     my_tx_signed = Payment.from_dict(transaction_dict)
 
-    tx = send_reliable_submission(transaction=my_tx_signed, client=client)
+    tx = submit_and_wait(transaction=my_tx_signed, client=client)
 
     tx_hash = tx.result['hash']
     tx_destination = tx.result['Destination']

--- a/content/_code-samples/airgapped-wallet/py/requirements.txt
+++ b/content/_code-samples/airgapped-wallet/py/requirements.txt
@@ -22,4 +22,4 @@ sniffio==1.2.0
 sqlparse==0.4.4
 typing-extensions==4.2.0
 websockets==10.0
-xrpl-py==2.0.0beta
+xrpl-py==2.0.0

--- a/content/_code-samples/airgapped-wallet/py/requirements.txt
+++ b/content/_code-samples/airgapped-wallet/py/requirements.txt
@@ -9,7 +9,7 @@ Django==3.2.19
 ECPy==1.2.5
 h11==0.12.0
 httpcore==0.13.6
-httpx==0.23.0
+# httpx==0.23.0
 idna==3.2
 image==1.5.33
 pifacedigitalio==3.0.5
@@ -21,6 +21,6 @@ rfc3986==1.5.0
 six==1.16.0
 sniffio==1.2.0
 sqlparse==0.4.4
-typing-extensions==3.10.0.0
-websockets==9.1
-xrpl-py==2.0.0
+typing-extensions==4.2.0
+websockets==10.0
+xrpl-py==2.0.0beta

--- a/content/_code-samples/airgapped-wallet/py/requirements.txt
+++ b/content/_code-samples/airgapped-wallet/py/requirements.txt
@@ -9,7 +9,6 @@ Django==3.2.19
 ECPy==1.2.5
 h11==0.12.0
 httpcore==0.13.6
-# httpx==0.23.0
 idna==3.2
 image==1.5.33
 pifacedigitalio==3.0.5

--- a/content/_code-samples/airgapped-wallet/py/requirements.txt
+++ b/content/_code-samples/airgapped-wallet/py/requirements.txt
@@ -23,4 +23,4 @@ sniffio==1.2.0
 sqlparse==0.4.4
 typing-extensions==3.10.0.0
 websockets==9.1
-xrpl-py==1.1.1
+xrpl-py==2.0.0

--- a/content/_code-samples/build-a-wallet/py/3_account.py
+++ b/content/_code-samples/build-a-wallet/py/3_account.py
@@ -233,7 +233,7 @@ class TWaXLFrame(wx.Frame):
             try:
                 # Check if it's a valid seed
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
-                wallet = xrpl.wallet.Wallet(seed=value, sequence=0)
+                wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
                 classic_address = wallet.classic_address
             except Exception as e:

--- a/content/_code-samples/build-a-wallet/py/3_account.py
+++ b/content/_code-samples/build-a-wallet/py/3_account.py
@@ -235,7 +235,7 @@ class TWaXLFrame(wx.Frame):
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
                 wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
-                classic_address = wallet.classic_address
+                classic_address = wallet.address
             except Exception as e:
                 print(e)
                 exit(1)

--- a/content/_code-samples/build-a-wallet/py/4_tx_history.py
+++ b/content/_code-samples/build-a-wallet/py/4_tx_history.py
@@ -264,7 +264,7 @@ class TWaXLFrame(wx.Frame):
             try:
                 # Check if it's a valid seed
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
-                wallet = xrpl.wallet.Wallet(seed=value, sequence=0)
+                wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
                 classic_address = wallet.classic_address
             except Exception as e:

--- a/content/_code-samples/build-a-wallet/py/4_tx_history.py
+++ b/content/_code-samples/build-a-wallet/py/4_tx_history.py
@@ -266,7 +266,7 @@ class TWaXLFrame(wx.Frame):
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
                 wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
-                classic_address = wallet.classic_address
+                classic_address = wallet.address
             except Exception as e:
                 print(e)
                 exit(1)

--- a/content/_code-samples/build-a-wallet/py/5_send_xrp.py
+++ b/content/_code-samples/build-a-wallet/py/5_send_xrp.py
@@ -130,7 +130,7 @@ class XRPLMonitorThread(Thread):
         # Autofill provides a sequence number, but this may fail if you try to
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
-        tx_signed = await xrpl.asyncio.transaction.safe_sign_and_autofill_transaction(
+        tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
         await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)

--- a/content/_code-samples/build-a-wallet/py/5_send_xrp.py
+++ b/content/_code-samples/build-a-wallet/py/5_send_xrp.py
@@ -132,7 +132,7 @@ class XRPLMonitorThread(Thread):
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
-        await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
+        await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 
 

--- a/content/_code-samples/build-a-wallet/py/5_send_xrp.py
+++ b/content/_code-samples/build-a-wallet/py/5_send_xrp.py
@@ -380,7 +380,7 @@ class TWaXLFrame(wx.Frame):
             try:
                 # Check if it's a valid seed
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
-                wallet = xrpl.wallet.Wallet(seed=value, sequence=0)
+                wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
                 classic_address = wallet.classic_address
             except Exception as e:

--- a/content/_code-samples/build-a-wallet/py/5_send_xrp.py
+++ b/content/_code-samples/build-a-wallet/py/5_send_xrp.py
@@ -382,7 +382,7 @@ class TWaXLFrame(wx.Frame):
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
                 wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
-                classic_address = wallet.classic_address
+                classic_address = wallet.address
             except Exception as e:
                 print(e)
                 exit(1)

--- a/content/_code-samples/build-a-wallet/py/5_send_xrp.py
+++ b/content/_code-samples/build-a-wallet/py/5_send_xrp.py
@@ -131,7 +131,7 @@ class XRPLMonitorThread(Thread):
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
-                tx, self.wallet, self.client)
+                tx, self.client, self.wallet)
         await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 

--- a/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
+++ b/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
@@ -541,7 +541,7 @@ class TWaXLFrame(wx.Frame):
             try:
                 # Check if it's a valid seed
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
-                wallet = xrpl.wallet.Wallet(seed=value, sequence=0)
+                wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
                 classic_address = wallet.classic_address
             except Exception as e:

--- a/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
+++ b/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
@@ -184,7 +184,7 @@ class XRPLMonitorThread(Thread):
         # Autofill provides a sequence number, but this may fail if you try to
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
-        tx_signed = await xrpl.asyncio.transaction.safe_sign_and_autofill_transaction(
+        tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
         await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)

--- a/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
+++ b/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
@@ -185,7 +185,7 @@ class XRPLMonitorThread(Thread):
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
-                tx, self.wallet, self.client)
+                tx, self.client, self.wallet)
         await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 

--- a/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
+++ b/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
@@ -543,7 +543,7 @@ class TWaXLFrame(wx.Frame):
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
                 wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
-                classic_address = wallet.classic_address
+                classic_address = wallet.address
             except Exception as e:
                 print(e)
                 exit(1)

--- a/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
+++ b/content/_code-samples/build-a-wallet/py/6_verification_and_polish.py
@@ -186,7 +186,7 @@ class XRPLMonitorThread(Thread):
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
-        await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
+        await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 
 

--- a/content/_code-samples/build-a-wallet/py/7_owned_objects.py
+++ b/content/_code-samples/build-a-wallet/py/7_owned_objects.py
@@ -590,7 +590,7 @@ class TWaXLFrame(wx.Frame):
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
                 wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
-                classic_address = wallet.classic_address
+                classic_address = wallet.address
             except Exception as e:
                 print(e)
                 exit(1)

--- a/content/_code-samples/build-a-wallet/py/7_owned_objects.py
+++ b/content/_code-samples/build-a-wallet/py/7_owned_objects.py
@@ -204,7 +204,7 @@ class XRPLMonitorThread(Thread):
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
-        await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
+        await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 
 

--- a/content/_code-samples/build-a-wallet/py/7_owned_objects.py
+++ b/content/_code-samples/build-a-wallet/py/7_owned_objects.py
@@ -202,7 +202,7 @@ class XRPLMonitorThread(Thread):
         # Autofill provides a sequence number, but this may fail if you try to
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
-        tx_signed = await xrpl.asyncio.transaction.safe_sign_and_autofill_transaction(
+        tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
         await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)

--- a/content/_code-samples/build-a-wallet/py/7_owned_objects.py
+++ b/content/_code-samples/build-a-wallet/py/7_owned_objects.py
@@ -588,7 +588,7 @@ class TWaXLFrame(wx.Frame):
             try:
                 # Check if it's a valid seed
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
-                wallet = xrpl.wallet.Wallet(seed=value, sequence=0)
+                wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
                 classic_address = wallet.classic_address
             except Exception as e:

--- a/content/_code-samples/build-a-wallet/py/7_owned_objects.py
+++ b/content/_code-samples/build-a-wallet/py/7_owned_objects.py
@@ -203,7 +203,7 @@ class XRPLMonitorThread(Thread):
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
-                tx, self.wallet, self.client)
+                tx, self.client, self.wallet)
         await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 

--- a/content/_code-samples/build-a-wallet/py/8_regular_key.py
+++ b/content/_code-samples/build-a-wallet/py/8_regular_key.py
@@ -132,7 +132,7 @@ class XRPLMonitorThread(Thread):
         ))
         if response.is_successful():
             print("set regular key: got account")
-            if response.result["account_data"].get("RegularKey") == wallet.classic_address:
+            if response.result["account_data"].get("RegularKey") == wallet.address:
                 print("set regular key: regular key matches")
                 self.wallet = wallet
                 wx.CallAfter(self.gui.enable_readwrite)
@@ -640,7 +640,7 @@ class TWaXLFrame(wx.Frame):
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
                 wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
-                classic_address = wallet.classic_address
+                classic_address = wallet.address
             except Exception as e:
                 print(e)
                 exit(1)

--- a/content/_code-samples/build-a-wallet/py/8_regular_key.py
+++ b/content/_code-samples/build-a-wallet/py/8_regular_key.py
@@ -220,7 +220,7 @@ class XRPLMonitorThread(Thread):
         # Autofill provides a sequence number, but this may fail if you try to
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
-        tx_signed = await xrpl.asyncio.transaction.safe_sign_and_autofill_transaction(
+        tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
         await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)

--- a/content/_code-samples/build-a-wallet/py/8_regular_key.py
+++ b/content/_code-samples/build-a-wallet/py/8_regular_key.py
@@ -638,7 +638,7 @@ class TWaXLFrame(wx.Frame):
             try:
                 # Check if it's a valid seed
                 seed_bytes, alg = xrpl.core.addresscodec.decode_seed(value)
-                wallet = xrpl.wallet.Wallet(seed=value, sequence=0)
+                wallet = xrpl.wallet.Wallet.from_seed(seed=value)
                 x_address = wallet.get_xaddress(is_test=self.test_network)
                 classic_address = wallet.classic_address
             except Exception as e:

--- a/content/_code-samples/build-a-wallet/py/8_regular_key.py
+++ b/content/_code-samples/build-a-wallet/py/8_regular_key.py
@@ -222,7 +222,7 @@ class XRPLMonitorThread(Thread):
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
                 tx, self.wallet, self.client)
-        await xrpl.asyncio.transaction.submit_transaction(tx_signed, self.client)
+        await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 
 

--- a/content/_code-samples/build-a-wallet/py/8_regular_key.py
+++ b/content/_code-samples/build-a-wallet/py/8_regular_key.py
@@ -221,7 +221,7 @@ class XRPLMonitorThread(Thread):
         # send too many transactions too fast. You can send transactions more
         # rapidly if you track the sequence number more carefully.
         tx_signed = await xrpl.asyncio.transaction.autofill_and_sign(
-                tx, self.wallet, self.client)
+                tx, self.client, self.wallet)
         await xrpl.asyncio.transaction.submit(tx_signed, self.client)
         wx.CallAfter(self.gui.add_pending_tx, tx_signed)
 

--- a/content/_code-samples/build-a-wallet/py/requirements.txt
+++ b/content/_code-samples/build-a-wallet/py/requirements.txt
@@ -1,4 +1,4 @@
-xrpl-py==2.0.0
+xrpl-py==2.0.0beta
 wxPython==4.1.1
 toml==0.10.2
 requests==2.25.1

--- a/content/_code-samples/build-a-wallet/py/requirements.txt
+++ b/content/_code-samples/build-a-wallet/py/requirements.txt
@@ -1,4 +1,4 @@
-xrpl-py==2.0.0beta
-wxPython==4.1.1
+xrpl-py==2.0.0
+wxPython==4.2.1
 toml==0.10.2
 requests==2.25.1

--- a/content/_code-samples/build-a-wallet/py/requirements.txt
+++ b/content/_code-samples/build-a-wallet/py/requirements.txt
@@ -1,4 +1,4 @@
-xrpl-py==1.3.0
+xrpl-py==2.0.0
 wxPython==4.1.1
 toml==0.10.2
 requests==2.25.1

--- a/content/_code-samples/checks/py/cancel_check.py
+++ b/content/_code-samples/checks/py/cancel_check.py
@@ -16,7 +16,7 @@ check_id = "F944CB379DEE18EFDA7A58A4F81AF1A98C46E54A8B9F2D268F1E26610BC0EB03"
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check cancel transaction
-check_txn = CheckCancel(account=sender_wallet.classic_address, check_id=check_id)
+check_txn = CheckCancel(account=sender_wallet.address, check_id=check_id)
 
 # Sign and submit transaction
 stxn_response = submit_and_wait(check_txn, client, sender_wallet)

--- a/content/_code-samples/checks/py/cancel_check.py
+++ b/content/_code-samples/checks/py/cancel_check.py
@@ -1,8 +1,7 @@
-from xrpl.wallet import Wallet, generate_faucet_wallet
+from xrpl.wallet import generate_faucet_wallet
 from xrpl.clients import JsonRpcClient
 from xrpl.models import CheckCancel
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to the testnetwork
 
@@ -20,8 +19,7 @@ sender_wallet = generate_faucet_wallet(client=client)
 check_txn = CheckCancel(account=sender_wallet.classic_address, check_id=check_id)
 
 # Sign and submit transaction
-stxn = safe_sign_and_autofill_transaction(check_txn, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+stxn_response = submit_and_wait(check_txn, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result

--- a/content/_code-samples/checks/py/cash_check.py
+++ b/content/_code-samples/checks/py/cash_check.py
@@ -1,7 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import CheckCash, IssuedCurrencyAmount
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.utils import str_to_hex, xrp_to_drops
 from xrpl.wallet import generate_faucet_wallet
 
@@ -23,11 +22,9 @@ sender_wallet = generate_faucet_wallet(client=client)
 # Build check cash transaction
 check_txn = CheckCash(account=sender_wallet.classic_address, check_id=check_id, amount=xrp_to_drops(amount))
 
-# Sign transaction
-stxn = safe_sign_and_autofill_transaction(check_txn, sender_wallet, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(check_txn, client, sender_wallet)
 
-# Submit transaction and wait for result
-stxn_response = send_reliable_submission(stxn, client)
 
 # Parse response for result
 stxn_result = stxn_response.result
@@ -60,11 +57,8 @@ check_txn = CheckCash(account=sender_wallet.classic_address, check_id=check_id, 
     issuer=issuer,
     value=amount))
 
-# Sign transaction
-stxn = safe_sign_and_autofill_transaction(check_txn, sender_wallet, client)
-
-# Submit transaction and wait for result
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(check_txn, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result

--- a/content/_code-samples/checks/py/cash_check.py
+++ b/content/_code-samples/checks/py/cash_check.py
@@ -20,7 +20,7 @@ amount = 10.00
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check cash transaction
-check_txn = CheckCash(account=sender_wallet.classic_address, check_id=check_id, amount=xrp_to_drops(amount))
+check_txn = CheckCash(account=sender_wallet.address, check_id=check_id, amount=xrp_to_drops(amount))
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(check_txn, client, sender_wallet)
@@ -46,13 +46,13 @@ token = "USD"
 amount = 10.00
 
 # Token issuer address
-issuer = generate_faucet_wallet(client=client).classic_address
+issuer = generate_faucet_wallet(client=client).address
 
 # Create sender wallet object
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check cash transaction
-check_txn = CheckCash(account=sender_wallet.classic_address, check_id=check_id, amount=IssuedCurrencyAmount(
+check_txn = CheckCash(account=sender_wallet.address, check_id=check_id, amount=IssuedCurrencyAmount(
     currency=str_to_hex(token),
     issuer=issuer,
     value=amount))

--- a/content/_code-samples/checks/py/cash_check.py
+++ b/content/_code-samples/checks/py/cash_check.py
@@ -1,7 +1,7 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import CheckCash, IssuedCurrencyAmount
 from xrpl.transaction import submit_and_wait
-from xrpl.utils import str_to_hex, xrp_to_drops
+from xrpl.utils import xrp_to_drops
 from xrpl.wallet import generate_faucet_wallet
 
 # Connect to a network
@@ -53,7 +53,7 @@ sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check cash transaction
 check_txn = CheckCash(account=sender_wallet.address, check_id=check_id, amount=IssuedCurrencyAmount(
-    currency=str_to_hex(token),
+    currency=token,
     issuer=issuer,
     value=amount))
 

--- a/content/_code-samples/checks/py/create_check.py
+++ b/content/_code-samples/checks/py/create_check.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from xrpl.clients import JsonRpcClient
 from xrpl.models import CheckCreate, IssuedCurrencyAmount
 from xrpl.transaction import submit_and_wait
-from xrpl.utils import datetime_to_ripple_time, str_to_hex, xrp_to_drops
+from xrpl.utils import datetime_to_ripple_time, xrp_to_drops
 from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to the testnetwork
@@ -25,12 +25,12 @@ expiry_date = datetime_to_ripple_time(datetime.now() + timedelta(days=5))
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check create transaction
-check_txn = CheckCreate(account=sender_wallet.address, destination=receiver_addr,
-send_max=IssuedCurrencyAmount(
-    currency=str_to_hex(token), 
-    issuer=issuer,
-    value=amount),
-    expiration=expiry_date)
+check_txn = CheckCreate(account=sender_wallet.address, destination=check_receiver_addr,
+                        send_max=IssuedCurrencyAmount(
+                            currency=token_name,
+                            issuer=token_issuer,
+                            value=amount_to_deliver),
+                        expiration=expiry_date)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(check_txn, client, sender_wallet)
@@ -60,9 +60,9 @@ sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check create transaction
 check_txn = CheckCreate(account=sender_wallet.address,
-        destination=receiver_addr,
-        send_max=xrp_to_drops(amount),
-        expiration=expiry_date)
+                        destination=check_receiver_addr,
+                        send_max=xrp_to_drops(amount_to_deliver),
+                        expiration=expiry_date)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(check_txn, client, sender_wallet)

--- a/content/_code-samples/checks/py/create_check.py
+++ b/content/_code-samples/checks/py/create_check.py
@@ -25,7 +25,7 @@ expiry_date = datetime_to_ripple_time(datetime.now() + timedelta(days=5))
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check create transaction
-check_txn = CheckCreate(account=sender_wallet.classic_address, destination=receiver_addr,
+check_txn = CheckCreate(account=sender_wallet.address, destination=receiver_addr,
 send_max=IssuedCurrencyAmount(
     currency=str_to_hex(token), 
     issuer=issuer,
@@ -59,7 +59,7 @@ expiry_date = datetime_to_ripple_time(datetime.now() + timedelta(days=5))
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build check create transaction
-check_txn = CheckCreate(account=sender_wallet.classic_address,
+check_txn = CheckCreate(account=sender_wallet.address,
         destination=receiver_addr,
         send_max=xrp_to_drops(amount),
         expiration=expiry_date)

--- a/content/_code-samples/checks/py/create_check.py
+++ b/content/_code-samples/checks/py/create_check.py
@@ -2,8 +2,7 @@ from datetime import datetime, timedelta
 
 from xrpl.clients import JsonRpcClient
 from xrpl.models import CheckCreate, IssuedCurrencyAmount
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.utils import datetime_to_ripple_time, str_to_hex, xrp_to_drops
 from xrpl.wallet import generate_faucet_wallet
 
@@ -29,13 +28,12 @@ sender_wallet = generate_faucet_wallet(client=client)
 check_txn = CheckCreate(account=sender_wallet.classic_address, destination=receiver_addr,
 send_max=IssuedCurrencyAmount(
     currency=str_to_hex(token), 
-    issuer=issuer, 
+    issuer=issuer,
     value=amount),
     expiration=expiry_date)
 
-# Sign, submit transaction and wait for result
-stxn = safe_sign_and_autofill_transaction(check_txn, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(check_txn, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result
@@ -66,9 +64,8 @@ check_txn = CheckCreate(account=sender_wallet.classic_address,
         send_max=xrp_to_drops(amount),
         expiration=expiry_date)
 
-# Sign, submit transaction and wait for result
-stxn = safe_sign_and_autofill_transaction(check_txn, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(check_txn, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result

--- a/content/_code-samples/delete-account/py/blackhole-account.py
+++ b/content/_code-samples/delete-account/py/blackhole-account.py
@@ -1,5 +1,5 @@
 from xrpl.clients import JsonRpcClient
-from xrpl.models.transactions import AccountSet, SetRegularKey, AccountSetFlag
+from xrpl.models.transactions import AccountSet, SetRegularKey, AccountSetAsfFlag
 from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountInfo
@@ -41,7 +41,7 @@ print(f"                            Tx content: {submit_tx_regular}")
 # This permanently blackholes an account!
 tx_disable_master_key = AccountSet(
     account=myAddr,
-    set_flag=AccountSetFlag.ASF_DISABLE_MASTER
+    set_flag=AccountSetAsfFlag.ASF_DISABLE_MASTER
 )
 
 # Sign and submit the transaction

--- a/content/_code-samples/delete-account/py/blackhole-account.py
+++ b/content/_code-samples/delete-account/py/blackhole-account.py
@@ -1,6 +1,6 @@
 from xrpl.clients import JsonRpcClient
-from xrpl.models.transactions import AccountSet, SetRegularKey, AccountSetFlag, Payment
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.models.transactions import AccountSet, SetRegularKey, AccountSetFlag
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountInfo
 
@@ -31,9 +31,8 @@ tx_regulary_key = SetRegularKey(
     regular_key=blackhole_address
 )
 
-# Sign the transaction
-tx_regulary_key_signed = safe_sign_and_autofill_transaction(tx_regulary_key, wallet=test_wallet, client=client)
-submit_tx_regular = send_reliable_submission(client=client, transaction=tx_regulary_key_signed)
+# Sign and submit the transaction
+submit_tx_regular = submit_and_wait(transaction=tx_regulary_key, client=client, wallet=test_wallet)
 submit_tx_regular = submit_tx_regular.result
 print(f"\n Submitted a SetRegularKey tx.  Result: {submit_tx_regular['meta']['TransactionResult']}")
 print(f"                            Tx content: {submit_tx_regular}")
@@ -45,9 +44,8 @@ tx_disable_master_key = AccountSet(
     set_flag=AccountSetFlag.ASF_DISABLE_MASTER
 )
 
-# Sign the transaction
-tx_disable_master_key_signed = safe_sign_and_autofill_transaction(tx_disable_master_key, wallet=test_wallet, client=client)
-submit_tx_disable = send_reliable_submission(client=client, transaction=tx_disable_master_key_signed)
+# Sign and submit the transaction
+submit_tx_disable = submit_and_wait(transaction=tx_disable_master_key, client=client, wallet=test_wallet)
 submit_tx_disable = submit_tx_disable.result
 print(f"\n Submitted a DisableMasterKey tx.  Result: {submit_tx_disable['meta']['TransactionResult']}")
 print(f"                               Tx content: {submit_tx_disable}")

--- a/content/_code-samples/delete-account/py/blackhole-account.py
+++ b/content/_code-samples/delete-account/py/blackhole-account.py
@@ -17,9 +17,9 @@ client = JsonRpcClient(JSON_RPC_URL)
 # Get credentials from the Testnet Faucet
 print("Requesting an account from the Testnet faucet...")
 test_wallet = generate_faucet_wallet(client=client)
-myAddr = test_wallet.classic_address
+myAddr = test_wallet.address
 
-print(f"\n Account: {test_wallet.classic_address}")
+print(f"\n Account: {test_wallet.address}")
 print(f"    Seed: {test_wallet.seed}")
 
 # This is a well known blackhole address

--- a/content/_code-samples/escrow/py/cancel_escrow.py
+++ b/content/_code-samples/escrow/py/cancel_escrow.py
@@ -14,7 +14,7 @@ escrow_sequence = 30215126
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build escrow cancel transaction
-cancel_txn = EscrowCancel(account=sender_wallet.classic_address, owner=sender_wallet.classic_address, offer_sequence=escrow_sequence)
+cancel_txn = EscrowCancel(account=sender_wallet.address, owner=sender_wallet.address, offer_sequence=escrow_sequence)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(cancel_txn, client, sender_wallet)

--- a/content/_code-samples/escrow/py/cancel_escrow.py
+++ b/content/_code-samples/escrow/py/cancel_escrow.py
@@ -1,7 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import EscrowCancel
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to the testnetwork
@@ -17,9 +16,8 @@ sender_wallet = generate_faucet_wallet(client=client)
 # Build escrow cancel transaction
 cancel_txn = EscrowCancel(account=sender_wallet.classic_address, owner=sender_wallet.classic_address, offer_sequence=escrow_sequence)
 
-# Sign and submit transaction
-stxn = safe_sign_and_autofill_transaction(cancel_txn, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(cancel_txn, client, sender_wallet)
 
 # Parse response and return result
 stxn_result = stxn_response.result

--- a/content/_code-samples/escrow/py/create_escrow.py
+++ b/content/_code-samples/escrow/py/create_escrow.py
@@ -1,10 +1,8 @@
-import json
 from datetime import datetime, timedelta
 
 from xrpl.clients import JsonRpcClient
 from xrpl.models import EscrowCreate
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.utils import datetime_to_ripple_time, xrp_to_drops
 from xrpl.wallet import generate_faucet_wallet
 
@@ -38,9 +36,8 @@ create_txn = EscrowCreate(
     cancel_after=expiry_date,
     condition=condition)
 
-# Sign and send transaction 
-stxn = safe_sign_and_autofill_transaction(create_txn, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(create_txn, client, sender_wallet)
 
 # Return result of transaction
 stxn_result = stxn_response.result

--- a/content/_code-samples/escrow/py/create_escrow.py
+++ b/content/_code-samples/escrow/py/create_escrow.py
@@ -29,7 +29,7 @@ sender_wallet = generate_faucet_wallet(client=client)
 
 # Build escrow create transaction
 create_txn = EscrowCreate(
-    account=sender_wallet.classic_address,
+    account=sender_wallet.address,
     amount=xrp_to_drops(amount_to_escrow), 
     destination=receiver_addr,
     finish_after=claim_date, 

--- a/content/_code-samples/escrow/py/finish_escrow.py
+++ b/content/_code-samples/escrow/py/finish_escrow.py
@@ -9,7 +9,7 @@ client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to the
 # Cannot be called until the finish time is reached
 
 # Required fields (modify to match an escrow you create)
-escrow_creator = generate_faucet_wallet(client=client).classic_address
+escrow_creator = generate_faucet_wallet(client=client).address
 
 escrow_sequence = 27641268
 
@@ -25,7 +25,7 @@ fulfillment = "A0228020AED2C5FE4D147D310D3CFEBD9BFA81AD0F63CE1ADD92E00379DDDAF8E
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build escrow finish transaction
-finish_txn = EscrowFinish(account=sender_wallet.classic_address, owner=escrow_creator, offer_sequence=escrow_sequence, condition=condition, fulfillment=fulfillment)
+finish_txn = EscrowFinish(account=sender_wallet.address, owner=escrow_creator, offer_sequence=escrow_sequence, condition=condition, fulfillment=fulfillment)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(finish_txn, client, sender_wallet)

--- a/content/_code-samples/escrow/py/finish_escrow.py
+++ b/content/_code-samples/escrow/py/finish_escrow.py
@@ -1,8 +1,7 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import EscrowFinish
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
-from xrpl.wallet import Wallet, generate_faucet_wallet
+from xrpl.transaction import submit_and_wait
+from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to the testnetwork
 
@@ -28,15 +27,12 @@ sender_wallet = generate_faucet_wallet(client=client)
 # Build escrow finish transaction
 finish_txn = EscrowFinish(account=sender_wallet.classic_address, owner=escrow_creator, offer_sequence=escrow_sequence, condition=condition, fulfillment=fulfillment)
 
-# Sign transaction with wallet
-stxn = safe_sign_and_autofill_transaction(finish_txn, sender_wallet, client)
-
-# Send transaction and wait for response
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(finish_txn, client, sender_wallet)
 
 # Parse response and return result
 stxn_result = stxn_response.result
 
-# Parse result and print out the transaction result and transaction hash 
-print(stxn_result["meta"]["TransactionResult"]) 
+# Parse result and print out the transaction result and transaction hash
+print(stxn_result["meta"]["TransactionResult"])
 print(stxn_result["hash"])

--- a/content/_code-samples/freeze/py/enable_no_freeze.py
+++ b/content/_code-samples/freeze/py/enable_no_freeze.py
@@ -1,8 +1,7 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import AccountSet, AccountSetFlag
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
-from xrpl.wallet import Wallet, generate_faucet_wallet
+from xrpl.transaction import submit_and_wait
+from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # connect to testnet
 
@@ -15,13 +14,10 @@ print("Successfully generated test wallet")
 # build accountset transaction to disable freezing
 accountset = AccountSet(account=sender_wallet.classic_address, set_flag=AccountSetFlag.ASF_NO_FREEZE)
 
-# sign transaction
-stxn = safe_sign_and_autofill_transaction(accountset, sender_wallet, client)
-
 print("Now sending an AccountSet transaction to set the ASF_NO_FREEZE flag...")
 
-# submit transaction and wait for result
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(accountset, client, sender_wallet)
 
 
 # parse response for result
@@ -31,4 +27,4 @@ stxn_result = stxn_response.result
 if stxn_result["meta"]["TransactionResult"] == "tesSUCCESS":
   print(f'Successfully enabled no freeze for {sender_wallet.classic_address}')
   print(stxn_result["hash"])
- 
+

--- a/content/_code-samples/freeze/py/enable_no_freeze.py
+++ b/content/_code-samples/freeze/py/enable_no_freeze.py
@@ -1,5 +1,5 @@
 from xrpl.clients import JsonRpcClient
-from xrpl.models import AccountSet, AccountSetFlag
+from xrpl.models import AccountSet, AccountSetAsfFlag
 from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
@@ -12,7 +12,7 @@ sender_wallet = generate_faucet_wallet(client=client)
 print("Successfully generated test wallet")
 
 # build accountset transaction to disable freezing
-accountset = AccountSet(account=sender_wallet.address, set_flag=AccountSetFlag.ASF_NO_FREEZE)
+accountset = AccountSet(account=sender_wallet.address, set_flag=AccountSetAsfFlag.ASF_NO_FREEZE)
 
 print("Now sending an AccountSet transaction to set the ASF_NO_FREEZE flag...")
 

--- a/content/_code-samples/freeze/py/enable_no_freeze.py
+++ b/content/_code-samples/freeze/py/enable_no_freeze.py
@@ -12,7 +12,7 @@ sender_wallet = generate_faucet_wallet(client=client)
 print("Successfully generated test wallet")
 
 # build accountset transaction to disable freezing
-accountset = AccountSet(account=sender_wallet.classic_address, set_flag=AccountSetFlag.ASF_NO_FREEZE)
+accountset = AccountSet(account=sender_wallet.address, set_flag=AccountSetFlag.ASF_NO_FREEZE)
 
 print("Now sending an AccountSet transaction to set the ASF_NO_FREEZE flag...")
 
@@ -25,6 +25,6 @@ stxn_result = stxn_response.result
 
 # print result and transaction hash
 if stxn_result["meta"]["TransactionResult"] == "tesSUCCESS":
-  print(f'Successfully enabled no freeze for {sender_wallet.classic_address}')
+  print(f'Successfully enabled no freeze for {sender_wallet.address}')
   print(stxn_result["hash"])
 

--- a/content/_code-samples/freeze/py/freeze_token.py
+++ b/content/_code-samples/freeze/py/freeze_token.py
@@ -1,8 +1,7 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import IssuedCurrencyAmount, TrustSet
 from xrpl.models.transactions import TrustSetFlag
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to testnet
@@ -25,13 +24,10 @@ trustset = TrustSet(account=sender_wallet.classic_address, limit_amount=IssuedCu
     value = value),
     flags=TrustSetFlag.TF_SET_FREEZE) 
 
-# Sign transaction
-stxn = safe_sign_and_autofill_transaction(trustset, sender_wallet, client)
-
 print("Now setting a trustline with the TF_SET_FREEZE flag enabled...")
 
-# Submit transaction and wait for result
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(trustset, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result

--- a/content/_code-samples/freeze/py/freeze_token.py
+++ b/content/_code-samples/freeze/py/freeze_token.py
@@ -11,14 +11,14 @@ token_name = "FOO"
 # Amount a trustline can handle, for this transaction it is set to 0
 value = "100"
 
-target_addr = generate_faucet_wallet(client=client).classic_address
+target_addr = generate_faucet_wallet(client=client).address
 
 sender_wallet = generate_faucet_wallet(client=client)
 
 print("Successfully generated test wallets")
 
 # Build trustline freeze transaction
-trustset = TrustSet(account=sender_wallet.classic_address, limit_amount=IssuedCurrencyAmount(
+trustset = TrustSet(account=sender_wallet.address, limit_amount=IssuedCurrencyAmount(
     currency= token_name,
     issuer=target_addr,
     value = value),
@@ -33,6 +33,6 @@ stxn_response = submit_and_wait(trustset, client, sender_wallet)
 stxn_result = stxn_response.result
 
 if(stxn_result["meta"]["TransactionResult"] == 'tesSUCCESS'):
-    print(f"Froze {token_name} issued by {target_addr} for address {sender_wallet.classic_address}")
+    print(f"Froze {token_name} issued by {target_addr} for address {sender_wallet.address}")
 if(stxn_result["meta"]["TransactionResult"] == 'tesSUCCESS'):
-    print(f"Froze {token_name} issued by {target_addr} for address {sender_wallet.classic_address}")
+    print(f"Froze {token_name} issued by {target_addr} for address {sender_wallet.address}")

--- a/content/_code-samples/freeze/py/set_global_freeze.py
+++ b/content/_code-samples/freeze/py/set_global_freeze.py
@@ -1,7 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import AccountSet, AccountSetFlag
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # Connect to testnet
@@ -17,9 +16,8 @@ accountset = AccountSet(account=sender_wallet.classic_address,
 
 print("Preparing and submitting Account set transaction with ASF_GLOBAL_FREEZE ...")
 
-# Sign and submit transaction
-stxn = safe_sign_and_autofill_transaction(accountset, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(accountset, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result

--- a/content/_code-samples/freeze/py/set_global_freeze.py
+++ b/content/_code-samples/freeze/py/set_global_freeze.py
@@ -11,7 +11,7 @@ sender_wallet = generate_faucet_wallet(client)
 print("Successfully generated test wallet")
 
 # Build accountset transaction to enable global freeze
-accountset = AccountSet(account=sender_wallet.classic_address,
+accountset = AccountSet(account=sender_wallet.address,
     set_flag=AccountSetFlag.ASF_GLOBAL_FREEZE)
 
 print("Preparing and submitting Account set transaction with ASF_GLOBAL_FREEZE ...")
@@ -24,5 +24,5 @@ stxn_result = stxn_response.result
 
 # Print result and transaction hash
 if stxn_result["meta"]["TransactionResult"] == "tesSUCCESS":
-  print(f'Successfully enabled global freeze for {sender_wallet.classic_address}')
+  print(f'Successfully enabled global freeze for {sender_wallet.address}')
   print(stxn_result["hash"])

--- a/content/_code-samples/freeze/py/set_global_freeze.py
+++ b/content/_code-samples/freeze/py/set_global_freeze.py
@@ -1,5 +1,5 @@
 from xrpl.clients import JsonRpcClient
-from xrpl.models import AccountSet, AccountSetFlag
+from xrpl.models import AccountSet, AccountSetAsfFlag
 from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
@@ -12,7 +12,7 @@ print("Successfully generated test wallet")
 
 # Build accountset transaction to enable global freeze
 accountset = AccountSet(account=sender_wallet.address,
-    set_flag=AccountSetFlag.ASF_GLOBAL_FREEZE)
+    set_flag=AccountSetAsfFlag.ASF_GLOBAL_FREEZE)
 
 print("Preparing and submitting Account set transaction with ASF_GLOBAL_FREEZE ...")
 

--- a/content/_code-samples/freeze/py/unfreeze_token.py
+++ b/content/_code-samples/freeze/py/unfreeze_token.py
@@ -1,7 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models import IssuedCurrencyAmount, TrustSet, TrustSetFlag
-from xrpl.transaction import (safe_sign_and_autofill_transaction,
-                              send_reliable_submission)
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234") # connect to testnet
@@ -32,9 +31,8 @@ flags=TrustSetFlag.TF_CLEAR_FREEZE)
 
 print("prepared and submitting TF_CLEAR_FREEZE transaction")
 
-# Sign and Submit transaction
-stxn = safe_sign_and_autofill_transaction(trustset, sender_wallet, client)
-stxn_response = send_reliable_submission(stxn, client)
+# Autofill, sign, then submit transaction and wait for result
+stxn_response = submit_and_wait(trustset, client, sender_wallet)
 
 # Parse response for result
 stxn_result = stxn_response.result

--- a/content/_code-samples/freeze/py/unfreeze_token.py
+++ b/content/_code-samples/freeze/py/unfreeze_token.py
@@ -12,7 +12,7 @@ value = "0"
 print("Generating two test wallets...")
 
 # Address to unfreeze trustline
-target_addr = generate_faucet_wallet(client=client).classic_address
+target_addr = generate_faucet_wallet(client=client).address
 print("Successfully generated the target account")
 
 # Sender wallet
@@ -22,7 +22,7 @@ print("Successfully generated the sender account")
 print("Successfully generated test wallets")
 
 # Build trustline freeze transaction
-trustset = TrustSet(account=sender_wallet.classic_address, limit_amount=IssuedCurrencyAmount(
+trustset = TrustSet(account=sender_wallet.address, limit_amount=IssuedCurrencyAmount(
     currency=token_name,
     issuer=target_addr,
     value = value 
@@ -39,7 +39,7 @@ stxn_result = stxn_response.result
 
 # Print result and transaction hash
 if stxn_result["meta"]["TransactionResult"] == "tesSUCCESS":
-  print(f'Successfully enabled no freeze for {sender_wallet.classic_address}')
+  print(f'Successfully enabled no freeze for {sender_wallet.address}')
 if stxn_result["meta"]["TransactionResult"] == "tecNO_LINE_REDUNDANT":
   print("This was used on an account which didn't have a trustline yet. To try this out, modify `target_addr` to point to an account with a frozen trustline, and make sure the currency code matches.")
 else:  

--- a/content/_code-samples/get-started/py/get-acct-info.py
+++ b/content/_code-samples/get-started/py/get-acct-info.py
@@ -10,7 +10,7 @@ from xrpl.wallet import generate_faucet_wallet
 test_wallet = generate_faucet_wallet(client, debug=True)
 
 # Create an account str from the wallet
-test_account = test_wallet.classic_address
+test_account = test_wallet.address
 
 # Derive an x-address from the classic address:
 # https://xrpaddress.info/

--- a/content/_code-samples/get-started/py/prepare-payment.py
+++ b/content/_code-samples/get-started/py/prepare-payment.py
@@ -11,7 +11,7 @@ from xrpl.wallet import generate_faucet_wallet
 test_wallet = generate_faucet_wallet(client, debug=True)
 
 # Create an account str from the wallet
-test_account = test_wallet.classic_address
+test_account = test_wallet.address
 
 # Derive an x-address from the classic address:
 # https://xrpaddress.info/

--- a/content/_code-samples/get-started/py/prepare-payment.py
+++ b/content/_code-samples/get-started/py/prepare-payment.py
@@ -32,18 +32,10 @@ my_tx_payment = Payment(
 # print prepared payment
 print(my_tx_payment)
 
-# Sign the transaction
-from xrpl.transaction import safe_sign_and_autofill_transaction
+# Sign and submit the transaction
+from xrpl.transaction import submit_and_wait
 
-my_tx_payment_signed = safe_sign_and_autofill_transaction(my_tx_payment, test_wallet, client)
-
-# Print signed tx
-print("Signed tx:", my_tx_payment_signed)
-
-# Submit and send the transaction
-from xrpl.transaction import send_reliable_submission
-
-tx_response = send_reliable_submission(my_tx_payment_signed, client)
+tx_response = submit_and_wait(my_tx_payment, client, test_wallet)
 
 # Print tx response
 print("Tx response:", tx_response)

--- a/content/_code-samples/issue-a-token/py/issue-a-token.py
+++ b/content/_code-samples/issue-a-token/py/issue-a-token.py
@@ -23,7 +23,7 @@ cold_settings_tx = xrpl.models.transactions.AccountSet(
     transfer_rate=0,
     tick_size=5,
     domain=bytes.hex("example.com".encode("ASCII")),
-    set_flag=xrpl.models.transactions.AccountSetFlag.ASF_DEFAULT_RIPPLE,
+    set_flag=xrpl.models.transactions.AccountSetAsfFlag.ASF_DEFAULT_RIPPLE,
 )
 
 print("Sending cold address AccountSet transaction...")
@@ -34,7 +34,7 @@ print(response)
 # Configure hot address settings -----------------------------------------------
 hot_settings_tx = xrpl.models.transactions.AccountSet(
     account=hot_wallet.address,
-    set_flag=xrpl.models.transactions.AccountSetFlag.ASF_REQUIRE_AUTH,
+    set_flag=xrpl.models.transactions.AccountSetAsfFlag.ASF_REQUIRE_AUTH,
 )
 
 print("Sending hot address AccountSet transaction...")

--- a/content/_code-samples/issue-a-token/py/issue-a-token.py
+++ b/content/_code-samples/issue-a-token/py/issue-a-token.py
@@ -25,13 +25,9 @@ cold_settings_tx = xrpl.models.transactions.AccountSet(
     domain=bytes.hex("example.com".encode("ASCII")),
     set_flag=xrpl.models.transactions.AccountSetFlag.ASF_DEFAULT_RIPPLE,
 )
-cst_prepared = xrpl.transaction.safe_sign_and_autofill_transaction(
-    transaction=cold_settings_tx,
-    wallet=cold_wallet,
-    client=client,
-)
+
 print("Sending cold address AccountSet transaction...")
-response = xrpl.transaction.send_reliable_submission(cst_prepared, client)
+response = xrpl.transaction.submit_and_wait(cold_settings_tx, client, cold_wallet)
 print(response)
 
 
@@ -40,13 +36,9 @@ hot_settings_tx = xrpl.models.transactions.AccountSet(
     account=hot_wallet.classic_address,
     set_flag=xrpl.models.transactions.AccountSetFlag.ASF_REQUIRE_AUTH,
 )
-hst_prepared = xrpl.transaction.safe_sign_and_autofill_transaction(
-    transaction=hot_settings_tx,
-    wallet=hot_wallet,
-    client=client,
-)
+
 print("Sending hot address AccountSet transaction...")
-response = xrpl.transaction.send_reliable_submission(hst_prepared, client)
+response = xrpl.transaction.submit_and_wait(hot_settings_tx, client, hot_wallet)
 print(response)
 
 
@@ -60,13 +52,9 @@ trust_set_tx = xrpl.models.transactions.TrustSet(
         value="10000000000", # Large limit, arbitrarily chosen
     )
 )
-ts_prepared = xrpl.transaction.safe_sign_and_autofill_transaction(
-    transaction=trust_set_tx,
-    wallet=hot_wallet,
-    client=client,
-)
+
 print("Creating trust line from hot address to issuer...")
-response = xrpl.transaction.send_reliable_submission(ts_prepared, client)
+response = xrpl.transaction.submit_and_wait(trust_set_tx, client, hot_wallet)
 print(response)
 
 
@@ -81,13 +69,9 @@ send_token_tx = xrpl.models.transactions.Payment(
         value=issue_quantity
     )
 )
-pay_prepared = xrpl.transaction.safe_sign_and_autofill_transaction(
-    transaction=send_token_tx,
-    wallet=cold_wallet,
-    client=client,
-)
+
 print(f"Sending {issue_quantity} {currency_code} to {hot_wallet.classic_address}...")
-response = xrpl.transaction.send_reliable_submission(pay_prepared, client)
+response = xrpl.transaction.submit_and_wait(send_token_tx, client, cold_wallet)
 print(response)
 
 

--- a/content/_code-samples/issue-a-token/py/issue-a-token.py
+++ b/content/_code-samples/issue-a-token/py/issue-a-token.py
@@ -19,7 +19,7 @@ hot_wallet = generate_faucet_wallet(client, debug=True)
 
 # Configure issuer (cold address) settings -------------------------------------
 cold_settings_tx = xrpl.models.transactions.AccountSet(
-    account=cold_wallet.classic_address,
+    account=cold_wallet.address,
     transfer_rate=0,
     tick_size=5,
     domain=bytes.hex("example.com".encode("ASCII")),
@@ -33,7 +33,7 @@ print(response)
 
 # Configure hot address settings -----------------------------------------------
 hot_settings_tx = xrpl.models.transactions.AccountSet(
-    account=hot_wallet.classic_address,
+    account=hot_wallet.address,
     set_flag=xrpl.models.transactions.AccountSetFlag.ASF_REQUIRE_AUTH,
 )
 
@@ -45,10 +45,10 @@ print(response)
 # Create trust line from hot to cold address -----------------------------------
 currency_code = "FOO"
 trust_set_tx = xrpl.models.transactions.TrustSet(
-    account=hot_wallet.classic_address,
+    account=hot_wallet.address,
     limit_amount=xrpl.models.amounts.issued_currency_amount.IssuedCurrencyAmount(
         currency=currency_code,
-        issuer=cold_wallet.classic_address,
+        issuer=cold_wallet.address,
         value="10000000000", # Large limit, arbitrarily chosen
     )
 )
@@ -61,16 +61,16 @@ print(response)
 # Send token -------------------------------------------------------------------
 issue_quantity = "3840"
 send_token_tx = xrpl.models.transactions.Payment(
-    account=cold_wallet.classic_address,
-    destination=hot_wallet.classic_address,
+    account=cold_wallet.address,
+    destination=hot_wallet.address,
     amount=xrpl.models.amounts.issued_currency_amount.IssuedCurrencyAmount(
         currency=currency_code,
-        issuer=cold_wallet.classic_address,
+        issuer=cold_wallet.address,
         value=issue_quantity
     )
 )
 
-print(f"Sending {issue_quantity} {currency_code} to {hot_wallet.classic_address}...")
+print(f"Sending {issue_quantity} {currency_code} to {hot_wallet.address}...")
 response = xrpl.transaction.submit_and_wait(send_token_tx, client, cold_wallet)
 print(response)
 
@@ -78,15 +78,15 @@ print(response)
 # Check balances ---------------------------------------------------------------
 print("Getting hot address balances...")
 response = client.request(xrpl.models.requests.AccountLines(
-    account=hot_wallet.classic_address,
+    account=hot_wallet.address,
     ledger_index="validated",
 ))
 print(response)
 
 print("Getting cold address balances...")
 response = client.request(xrpl.models.requests.GatewayBalances(
-    account=cold_wallet.classic_address,
+    account=cold_wallet.address,
     ledger_index="validated",
-    hotwallet=[hot_wallet.classic_address]
+    hotwallet=[hot_wallet.address]
 ))
 print(response)

--- a/content/_code-samples/multisigning/py/multisigning.py
+++ b/content/_code-samples/multisigning/py/multisigning.py
@@ -33,7 +33,7 @@ signer_list_set_tx = SignerListSet(
     signer_quorum=2,
     signer_entries=signer_entries,
 )
-signed_signer_list_set_tx = autofill_and_sign(signer_list_set_tx, master_wallet, client)
+signed_signer_list_set_tx = autofill_and_sign(signer_list_set_tx, client, master_wallet)
 
 print("Constructed SignerListSet and submitting it to the ledger...")
 signed_list_set_tx_response = submit_and_wait(

--- a/content/_code-samples/multisigning/py/multisigning.py
+++ b/content/_code-samples/multisigning/py/multisigning.py
@@ -10,7 +10,7 @@ from xrpl.transaction import (
     autofill,
     autofill_and_sign,
     multisign,
-    send_reliable_submission,
+    submit_and_wait,
     sign,
 )
 from xrpl.utils import str_to_hex
@@ -36,7 +36,7 @@ signer_list_set_tx = SignerListSet(
 signed_signer_list_set_tx = autofill_and_sign(signer_list_set_tx, master_wallet, client)
 
 print("Constructed SignerListSet and submitting it to the ledger...")
-signed_list_set_tx_response = send_reliable_submission(
+signed_list_set_tx_response = submit_and_wait(
     signed_signer_list_set_tx, client
 )
 print("SignerListSet submitted, here's the response:")

--- a/content/_code-samples/multisigning/py/multisigning.py
+++ b/content/_code-samples/multisigning/py/multisigning.py
@@ -25,11 +25,11 @@ signer_wallet_1 = generate_faucet_wallet(client, debug=True)
 signer_wallet_2 = generate_faucet_wallet(client, debug=True)
 
 signer_entries = [
-    SignerEntry(account=signer_wallet_1.classic_address, signer_weight=1),
-    SignerEntry(account=signer_wallet_2.classic_address, signer_weight=1),
+    SignerEntry(account=signer_wallet_1.address, signer_weight=1),
+    SignerEntry(account=signer_wallet_2.address, signer_weight=1),
 ]
 signer_list_set_tx = SignerListSet(
-    account=master_wallet.classic_address,
+    account=master_wallet.address,
     signer_quorum=2,
     signer_entries=signer_entries,
 )
@@ -45,7 +45,7 @@ print(signed_list_set_tx_response)
 # Now that we've set up multisigning, let's try using it to submit an AccountSet
 # transaction.
 account_set_tx = AccountSet(
-    account=master_wallet.classic_address, domain=str_to_hex("example.com")
+    account=master_wallet.address, domain=str_to_hex("example.com")
 )
 autofilled_account_set_tx = autofill(account_set_tx, client, len(signer_entries))
 print("AccountSet transaction is ready to be multisigned")

--- a/content/_code-samples/non-fungible-token/py/authorize-minter.py
+++ b/content/_code-samples/non-fungible-token/py/authorize-minter.py
@@ -1,4 +1,4 @@
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_mint import NFTokenMint, NFTokenMintFlag
 from xrpl.models.transactions.account_set import AccountSet, AccountSetFlag
 from xrpl.wallet import generate_faucet_wallet
@@ -44,9 +44,8 @@ authorize_minter_tx = AccountSet(
     nftoken_minter=minterAddr
 )
 
-# Sign authorize_minter_tx using issuer account
-authorize_minter_tx_signed = safe_sign_and_autofill_transaction(transaction=authorize_minter_tx, wallet=issuer_wallet, client=client)
-authorize_minter_tx_signed = send_reliable_submission(transaction=authorize_minter_tx_signed, client=client)
+# Sign and submit authorize_minter_tx using issuer account
+authorize_minter_tx_signed = submit_and_wait(transaction=authorize_minter_tx, client=client, wallet=issuer_wallet)
 authorize_minter_tx_result = authorize_minter_tx_signed.result
 print(f"\nAuthorize minter tx result: {authorize_minter_tx_result}")
 
@@ -67,8 +66,7 @@ mint_tx_1 = NFTokenMint(
 
 # Sign using previously authorized minter's account, this will result in the NFT's issuer field to be the Issuer Account
 # while the NFT's owner would be the Minter Account
-mint_tx_1_signed = safe_sign_and_autofill_transaction(transaction=mint_tx_1, wallet=nftoken_minter_wallet, client=client)
-mint_tx_1_signed = send_reliable_submission(transaction=mint_tx_1_signed, client=client)
+mint_tx_1_signed = submit_and_wait(transaction=mint_tx_1, client=client, wallet=nftoken_minter_wallet)
 mint_tx_1_result = mint_tx_1_signed.result
 print(f"\n Mint tx result: {mint_tx_1_result['meta']['TransactionResult']}")
 print(f"    Tx response: {mint_tx_1_result}")

--- a/content/_code-samples/non-fungible-token/py/authorize-minter.py
+++ b/content/_code-samples/non-fungible-token/py/authorize-minter.py
@@ -14,7 +14,7 @@ seed = ""
 custom_wallet = None
 
 if seed:
-    custom_wallet = Wallet(seed=seed, sequence=0)
+    custom_wallet = Wallet.from_seed(seed=seed)
 
 # Connect to a testnet node
 print("Connecting to Testnet...")

--- a/content/_code-samples/non-fungible-token/py/authorize-minter.py
+++ b/content/_code-samples/non-fungible-token/py/authorize-minter.py
@@ -1,6 +1,6 @@
 from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_mint import NFTokenMint, NFTokenMintFlag
-from xrpl.models.transactions.account_set import AccountSet, AccountSetFlag
+from xrpl.models.transactions.account_set import AccountSet, AccountSetAsfFlag
 from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountNFTs
 from xrpl.clients import JsonRpcClient
@@ -40,7 +40,7 @@ print(f"                     Seed: {nftoken_minter_wallet.seed}")
 print(f"\nAuthorizing account {minterAddr} as a NFT minter on account {issuerAddr}...")
 authorize_minter_tx = AccountSet(
     account=issuerAddr,
-    set_flag=AccountSetFlag.ASF_AUTHORIZED_NFTOKEN_MINTER,
+    set_flag=AccountSetAsfFlag.ASF_AUTHORIZED_NFTOKEN_MINTER,
     nftoken_minter=minterAddr
 )
 

--- a/content/_code-samples/non-fungible-token/py/authorize-minter.py
+++ b/content/_code-samples/non-fungible-token/py/authorize-minter.py
@@ -23,12 +23,12 @@ client = JsonRpcClient(JSON_RPC_URL)
 
 # Initialize wallet from seed
 issuer_wallet = generate_faucet_wallet(client=client, wallet=custom_wallet)
-issuerAddr = issuer_wallet.classic_address
+issuerAddr = issuer_wallet.address
 
 # Get minter account credentials from the testnet faucet
 print("Requesting address from the Testnet faucet...")
 nftoken_minter_wallet = generate_faucet_wallet(client=client)
-minterAddr = nftoken_minter_wallet.classic_address
+minterAddr = nftoken_minter_wallet.address
 
 print(f"\nMinter Account: {issuerAddr}")
 print(f"          Seed: {issuer_wallet.seed}")

--- a/content/_code-samples/non-fungible-token/py/burn-nft.py
+++ b/content/_code-samples/non-fungible-token/py/burn-nft.py
@@ -23,7 +23,7 @@ else:
 
     # Initialize wallet from seed
     issuer_wallet = Wallet.from_seed(seed=seed)
-    issuerAddr = issuer_wallet.classic_address
+    issuerAddr = issuer_wallet.address
 
     print(f"\nIssuer Account: {issuerAddr}")
     print(f"          Seed: {issuer_wallet.seed}")

--- a/content/_code-samples/non-fungible-token/py/burn-nft.py
+++ b/content/_code-samples/non-fungible-token/py/burn-nft.py
@@ -22,7 +22,7 @@ else:
     client = JsonRpcClient(JSON_RPC_URL)
 
     # Initialize wallet from seed
-    issuer_wallet = Wallet(seed=seed, sequence=0)
+    issuer_wallet = Wallet.from_seed(seed=seed)
     issuerAddr = issuer_wallet.classic_address
 
     print(f"\nIssuer Account: {issuerAddr}")

--- a/content/_code-samples/non-fungible-token/py/burn-nft.py
+++ b/content/_code-samples/non-fungible-token/py/burn-nft.py
@@ -1,4 +1,4 @@
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_burn import NFTokenBurn
 from xrpl.models.requests import AccountNFTs
 from xrpl.clients import JsonRpcClient
@@ -52,10 +52,9 @@ else:
             nftoken_id=get_account_nfts.result['account_nfts'][0]['NFTokenID']
         )
 
-        # Sign burn_tx using the issuer account
-        burn_tx_signed = safe_sign_and_autofill_transaction(transaction=burn_tx, wallet=issuer_wallet, client=client)
-        burn_tx_signed = send_reliable_submission(transaction=burn_tx_signed, client=client)
-        burn_tx_result = burn_tx_signed.result
+        # Sign and submit burn_tx using the issuer account
+        burn_tx_response = submit_and_wait(transaction=burn_tx, client=client, wallet=issuer_wallet)
+        burn_tx_result = burn_tx_response.result
         print(f"\nBurn tx result: {burn_tx_result['meta']['TransactionResult']}")
         print(f"   Tx response:{burn_tx_result}")
 

--- a/content/_code-samples/non-fungible-token/py/cancel-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/cancel-offer-nft.py
@@ -22,7 +22,7 @@ else:
     client = JsonRpcClient(JSON_RPC_URL)
 
     # Initialize wallet from seed
-    wallet = Wallet(seed=seed, sequence=0)
+    wallet = Wallet.from_seed(seed=seed)
     Addr = wallet.classic_address
 
     print(f"\n  Account: {Addr}")

--- a/content/_code-samples/non-fungible-token/py/cancel-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/cancel-offer-nft.py
@@ -23,7 +23,7 @@ else:
 
     # Initialize wallet from seed
     wallet = Wallet.from_seed(seed=seed)
-    Addr = wallet.classic_address
+    Addr = wallet.address
 
     print(f"\n  Account: {Addr}")
     print(f"     Seed: {seed}")

--- a/content/_code-samples/non-fungible-token/py/cancel-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/cancel-offer-nft.py
@@ -1,4 +1,4 @@
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_cancel_offer import NFTokenCancelOffer
 from xrpl.models.requests import AccountObjects, AccountObjectType
 from xrpl.clients import JsonRpcClient
@@ -60,11 +60,9 @@ else:
             ]
         )
 
-        # Sign cancel_sell_offer_tx using minter account
-        cancel_sell_offer_tx_signed = safe_sign_and_autofill_transaction(transaction=cancel_sell_offer_tx, wallet=wallet,
-                                                                         client=client)
-        cancel_sell_offer_tx_signed = send_reliable_submission(transaction=cancel_sell_offer_tx_signed, client=client)
-        cancel_sell_offer_tx_result = cancel_sell_offer_tx_signed.result
+        # Sign and submit cancel_sell_offer_tx using minter account
+        cancel_sell_offer_tx_response = submit_and_wait(transaction=cancel_sell_offer_tx, client=client, wallet=wallet)
+        cancel_sell_offer_tx_result = cancel_sell_offer_tx_response.result
         print(f"\n Cancel Sell Offer tx result: {cancel_sell_offer_tx_result['meta']['TransactionResult']}"
               f"\n                 Tx response: {cancel_sell_offer_tx_result}")
 

--- a/content/_code-samples/non-fungible-token/py/create-buy-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/create-buy-offer-nft.py
@@ -24,7 +24,7 @@ else:
     client = JsonRpcClient(JSON_RPC_URL)
 
     # Initialize wallet from seed
-    issuer_wallet = Wallet(seed=seed, sequence=0)
+    issuer_wallet = Wallet.from_seed(seed=seed)
     issuerAddr = issuer_wallet.classic_address
 
     # Get buyer account credentials from the testnet faucet

--- a/content/_code-samples/non-fungible-token/py/create-buy-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/create-buy-offer-nft.py
@@ -1,4 +1,4 @@
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_create_offer import NFTokenCreateOffer
 from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountNFTs
@@ -56,9 +56,8 @@ else:
         amount=buy_offer_amount, # 10 XRP in drops, 1 XRP = 1,000,000 drops
     )
 
-    # Sign buy_tx using the issuer account
-    buy_tx_signed = safe_sign_and_autofill_transaction(transaction=buy_tx, wallet=buyer_wallet, client=client)
-    buy_tx_signed = send_reliable_submission(transaction=buy_tx_signed, client=client)
+    # Sign and submit buy_tx using the issuer account
+    buy_tx_signed = submit_and_wait(transaction=buy_tx, client=client, wallet=buyer_wallet)
     buy_tx_result = buy_tx_signed.result
 
     print(f"\n  NFTokenCreateOffer tx result: {buy_tx_result['meta']['TransactionResult']}")

--- a/content/_code-samples/non-fungible-token/py/create-buy-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/create-buy-offer-nft.py
@@ -25,12 +25,12 @@ else:
 
     # Initialize wallet from seed
     issuer_wallet = Wallet.from_seed(seed=seed)
-    issuerAddr = issuer_wallet.classic_address
+    issuerAddr = issuer_wallet.address
 
     # Get buyer account credentials from the testnet faucet
     print("Requesting address from the Testnet faucet...")
     buyer_wallet = generate_faucet_wallet(client=client)
-    buyerAddr = buyer_wallet.classic_address
+    buyerAddr = buyer_wallet.address
 
     print(f"\n   Minter Account: {issuerAddr}")
     print(f"             Seed: {issuer_wallet.seed}")

--- a/content/_code-samples/non-fungible-token/py/create-sell-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/create-sell-offer-nft.py
@@ -23,7 +23,7 @@ else:
     client = JsonRpcClient(JSON_RPC_URL)
 
     # Initialize wallet from seed
-    issuer_wallet = Wallet(seed=seed, sequence=0)
+    issuer_wallet = Wallet.from_seed(seed=seed)
     issuerAddr = issuer_wallet.classic_address
 
     print(f"\nIssuer Account: {issuerAddr}")

--- a/content/_code-samples/non-fungible-token/py/create-sell-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/create-sell-offer-nft.py
@@ -1,5 +1,5 @@
 from xrpl.models.transactions.nftoken_create_offer import NFTokenCreateOffer, NFTokenCreateOfferFlag
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.requests import AccountNFTs
 from xrpl.clients import JsonRpcClient
 from xrpl.models import NFTSellOffers
@@ -55,9 +55,8 @@ else:
         )
 
         # Sign sell_tx using the issuer account
-        sell_tx_signed = safe_sign_and_autofill_transaction(transaction=sell_tx, wallet=issuer_wallet, client=client)
-        sell_tx_signed = send_reliable_submission(transaction=sell_tx_signed, client=client)
-        sell_tx_result = sell_tx_signed.result
+        sell_tx_response = submit_and_wait(transaction=sell_tx, client=client, wallet=issuer_wallet)
+        sell_tx_result = sell_tx_response.result
 
         print(f"\n  Sell Offer tx result: {sell_tx_result['meta']['TransactionResult']}")
         print(f"           Tx response: {sell_tx_result}")

--- a/content/_code-samples/non-fungible-token/py/create-sell-offer-nft.py
+++ b/content/_code-samples/non-fungible-token/py/create-sell-offer-nft.py
@@ -24,7 +24,7 @@ else:
 
     # Initialize wallet from seed
     issuer_wallet = Wallet.from_seed(seed=seed)
-    issuerAddr = issuer_wallet.classic_address
+    issuerAddr = issuer_wallet.address
 
     print(f"\nIssuer Account: {issuerAddr}")
     print(f"          Seed: {issuer_wallet.seed}")

--- a/content/_code-samples/non-fungible-token/py/mint-nft.py
+++ b/content/_code-samples/non-fungible-token/py/mint-nft.py
@@ -1,4 +1,4 @@
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_mint import NFTokenMint, NFTokenMintFlag
 from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountNFTs
@@ -39,9 +39,8 @@ mint_tx = NFTokenMint(
 )
 
 # Sign mint_tx using the issuer account
-mint_tx_signed = safe_sign_and_autofill_transaction(transaction=mint_tx, wallet=issuer_wallet, client=client)
-mint_tx_signed = send_reliable_submission(transaction=mint_tx_signed, client=client)
-mint_tx_result = mint_tx_signed.result
+mint_tx_response = submit_and_wait(transaction=mint_tx, client=client, wallet=issuer_wallet)
+mint_tx_result = mint_tx_response.result
 
 print(f"\n  Mint tx result: {mint_tx_result['meta']['TransactionResult']}")
 print(f"     Tx response: {mint_tx_result}")

--- a/content/_code-samples/non-fungible-token/py/mint-nft.py
+++ b/content/_code-samples/non-fungible-token/py/mint-nft.py
@@ -22,10 +22,10 @@ client = JsonRpcClient(JSON_RPC_URL)
 if seed == "":
     print("Requesting address from the Testnet faucet...")
     issuer_wallet = generate_faucet_wallet(client=client)
-    issuerAddr = issuer_wallet.classic_address
+    issuerAddr = issuer_wallet.address
 else:
     issuer_wallet = Wallet.from_seed(seed=seed)
-    issuerAddr = issuer_wallet.classic_address
+    issuerAddr = issuer_wallet.address
 
 print(f"\nIssuer Account: {issuerAddr}")
 print(f"          Seed: {issuer_wallet.seed}")

--- a/content/_code-samples/non-fungible-token/py/mint-nft.py
+++ b/content/_code-samples/non-fungible-token/py/mint-nft.py
@@ -24,7 +24,7 @@ if seed == "":
     issuer_wallet = generate_faucet_wallet(client=client)
     issuerAddr = issuer_wallet.classic_address
 else:
-    issuer_wallet = Wallet(seed=seed, sequence=0)
+    issuer_wallet = Wallet.from_seed(seed=seed)
     issuerAddr = issuer_wallet.classic_address
 
 print(f"\nIssuer Account: {issuerAddr}")

--- a/content/_code-samples/non-fungible-token/py/nft-general.py
+++ b/content/_code-samples/non-fungible-token/py/nft-general.py
@@ -38,13 +38,13 @@ client = JsonRpcClient(JSON_RPC_URL)
 # Get issuer, minter, buyer account credentials from the Testnet Faucet
 print("Requesting address from the Testnet faucet...")
 issuer_wallet = generate_faucet_wallet(client=client)
-issuerAddr = issuer_wallet.classic_address
+issuerAddr = issuer_wallet.address
 
 nftoken_minter_wallet = generate_faucet_wallet(client=client)
-minterAddr = nftoken_minter_wallet.classic_address
+minterAddr = nftoken_minter_wallet.address
 
 buyer_wallet = generate_faucet_wallet(client=client)
-buyerAddr = buyer_wallet.classic_address
+buyerAddr = buyer_wallet.address
 
 print(f"              Minter Account: {issuerAddr}"
       f"\n   Authorized Minter Account: {minterAddr}"

--- a/content/_code-samples/non-fungible-token/py/nft-general.py
+++ b/content/_code-samples/non-fungible-token/py/nft-general.py
@@ -3,7 +3,7 @@ from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_mint import NFTokenMint, NFTokenMintFlag
 from xrpl.models.transactions.nftoken_accept_offer import NFTokenAcceptOffer
 from xrpl.models.transactions.nftoken_cancel_offer import NFTokenCancelOffer
-from xrpl.models.transactions.account_set import AccountSet, AccountSetFlag
+from xrpl.models.transactions.account_set import AccountSet, AccountSetAsfFlag
 from xrpl.models.transactions.nftoken_burn import NFTokenBurn
 from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountNFTs
@@ -94,7 +94,7 @@ else:
 print(f"\n - Authorizing account {minterAddr} as a NFT minter on account {issuerAddr}...")
 authorize_minter_tx = AccountSet(
     account=issuerAddr,
-    set_flag=AccountSetFlag.ASF_AUTHORIZED_NFTOKEN_MINTER,
+    set_flag=AccountSetAsfFlag.ASF_AUTHORIZED_NFTOKEN_MINTER,
     nftoken_minter=minterAddr
 )
 

--- a/content/_code-samples/non-fungible-token/py/nft-general.py
+++ b/content/_code-samples/non-fungible-token/py/nft-general.py
@@ -1,5 +1,5 @@
 from xrpl.models.transactions.nftoken_create_offer import NFTokenCreateOffer, NFTokenCreateOfferFlag
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.models.transactions.nftoken_mint import NFTokenMint, NFTokenMintFlag
 from xrpl.models.transactions.nftoken_accept_offer import NFTokenAcceptOffer
 from xrpl.models.transactions.nftoken_cancel_offer import NFTokenCancelOffer
@@ -57,10 +57,9 @@ mint_tx = NFTokenMint(
     nftoken_taxon=0
 )
 
-# Sign mint_tx using issuer account
-mint_tx_signed = safe_sign_and_autofill_transaction(transaction=mint_tx, wallet=issuer_wallet, client=client)
-mint_tx_signed = send_reliable_submission(transaction=mint_tx_signed, client=client)
-mint_tx_result = mint_tx_signed.result
+# Sign and submit mint_tx using issuer account
+mint_tx_response = submit_and_wait(transaction=mint_tx, client=client, wallet=issuer_wallet)
+mint_tx_result = mint_tx_response.result
 print(f"\n Mint tx result: {mint_tx_result['meta']['TransactionResult']}"
       f"\n    Tx response: {mint_tx_result}")
 
@@ -81,9 +80,8 @@ burn_tx = NFTokenBurn(
 )
 
 # Sign burn_tx using issuer account
-burn_tx_signed = safe_sign_and_autofill_transaction(transaction=burn_tx, wallet=issuer_wallet, client=client)
-burn_tx_signed = send_reliable_submission(transaction=burn_tx_signed, client=client)
-burn_tx_result = burn_tx_signed.result
+burn_tx_response = submit_and_wait(transaction=burn_tx, client=client, wallet=issuer_wallet)
+burn_tx_result = burn_tx_response.result
 print(f"\n Burn tx result: {burn_tx_result['meta']['TransactionResult']}"
       f"\n    Tx response: {burn_tx_result}")
 
@@ -101,9 +99,8 @@ authorize_minter_tx = AccountSet(
 )
 
 # Sign authorize_minter_tx using issuer account
-authorize_minter_tx_signed = safe_sign_and_autofill_transaction(transaction=authorize_minter_tx, wallet=issuer_wallet, client=client)
-authorize_minter_tx_signed = send_reliable_submission(transaction=authorize_minter_tx_signed, client=client)
-authorize_minter_tx_result = authorize_minter_tx_signed.result
+authorize_minter_tx_response = submit_and_wait(transaction=authorize_minter_tx, client=client, wallet=issuer_wallet)
+authorize_minter_tx_result = authorize_minter_tx_response.result
 print(f"\n Authorize minter tx result: {authorize_minter_tx_result['meta']['TransactionResult']}"
       f"\n                Tx response: {authorize_minter_tx_result}")
 
@@ -125,9 +122,8 @@ mint_tx_1 = NFTokenMint(
 
 # Sign using previously authorized minter's account, this will result in the NFT's issuer field to be the Issuer Account
 # while the NFT's owner would be the Minter Account
-mint_tx_1_signed = safe_sign_and_autofill_transaction(transaction=mint_tx_1, wallet=nftoken_minter_wallet, client=client)
-mint_tx_1_signed = send_reliable_submission(transaction=mint_tx_1_signed, client=client)
-mint_tx_1_result = mint_tx_1_signed.result
+mint_tx_1_response = submit_and_wait(transaction=mint_tx_1, client=client, wallet=nftoken_minter_wallet)
+mint_tx_1_result = mint_tx_1_response.result
 print(f"\n Mint tx result: {mint_tx_1_result['meta']['TransactionResult']}"
       f"\n    Tx response: {mint_tx_1_result}")
 
@@ -154,10 +150,9 @@ sell_tx = NFTokenCreateOffer(
     flags=NFTokenCreateOfferFlag.TF_SELL_NFTOKEN,
 )
 
-# Sign sell_tx using minter account
-sell_tx_signed = safe_sign_and_autofill_transaction(transaction=sell_tx, wallet=nftoken_minter_wallet, client=client)
-sell_tx_signed = send_reliable_submission(transaction=sell_tx_signed, client=client)
-sell_tx_result = sell_tx_signed.result
+# Sign and submit sell_tx using minter account
+sell_tx_response = submit_and_wait(transaction=sell_tx, client=client, wallet=nftoken_minter_wallet)
+sell_tx_result = sell_tx_response.result
 print(f"\n Sell Offer tx result: {sell_tx_result['meta']['TransactionResult']}"
       f"\n          Tx response: {sell_tx_result}")
 
@@ -178,9 +173,8 @@ cancel_sell_offer_tx = NFTokenCancelOffer(
 )
 
 # Sign cancel_sell_offer_tx using minter account
-cancel_sell_offer_tx_signed = safe_sign_and_autofill_transaction(transaction=cancel_sell_offer_tx, wallet=nftoken_minter_wallet, client=client)
-cancel_sell_offer_tx_signed = send_reliable_submission(transaction=cancel_sell_offer_tx_signed, client=client)
-cancel_sell_offer_tx_result = cancel_sell_offer_tx_signed.result
+cancel_sell_offer_tx_response = submit_and_wait(transaction=cancel_sell_offer_tx, client=client, wallet=nftoken_minter_wallet)
+cancel_sell_offer_tx_result = cancel_sell_offer_tx_response.result
 print(f"\n Cancel Sell Offer tx result: {cancel_sell_offer_tx_result['meta']['TransactionResult']}"
       f"\n                 Tx response: {cancel_sell_offer_tx_result}")
 
@@ -193,10 +187,9 @@ sell_1_tx = NFTokenCreateOffer(
     flags=NFTokenCreateOfferFlag.TF_SELL_NFTOKEN,
 )
 
-# Sign sell_1_tx using minter account
-sell_1_tx_signed = safe_sign_and_autofill_transaction(transaction=sell_1_tx, wallet=nftoken_minter_wallet, client=client)
-sell_1_tx_signed = send_reliable_submission(transaction=sell_1_tx_signed, client=client)
-sell_1_tx_result = sell_1_tx_signed.result
+# Sign and submit sell_1_tx using minter account
+sell_1_tx_response = submit_and_wait(transaction=sell_1_tx, client=client, wallet=nftoken_minter_wallet)
+sell_1_tx_result = sell_1_tx_response.result
 print(f"\n Sell Offer tx result: {sell_1_tx_result['meta']['TransactionResult']}"
       f"\n          Tx response: {sell_1_tx_result}")
 
@@ -217,8 +210,7 @@ buy_tx = NFTokenAcceptOffer(
 )
 
 # Sign buy_tx using buyer account
-buy_tx_signed = safe_sign_and_autofill_transaction(transaction=buy_tx, wallet=buyer_wallet, client=client)
-buy_tx_signed = send_reliable_submission(transaction=buy_tx_signed, client=client)
-buy_tx_result = buy_tx_signed.result
+buy_tx_response = submit_and_wait(transaction=buy_tx, client=client, wallet=buyer_wallet)
+buy_tx_result = buy_tx_response.result
 print(f"\n Buy Offer result: {buy_tx_result['meta']['TransactionResult']}"
       f"\n      Tx response: {buy_tx_result}")

--- a/content/_code-samples/partial-payment/py/partial-payment.py
+++ b/content/_code-samples/partial-payment/py/partial-payment.py
@@ -21,11 +21,11 @@ wallet2 = generate_faucet_wallet(client, debug=True)
 
 # Create a TrustSet to issue an IOU `FOO` and set limit on it
 trust_set_tx = TrustSet(
-    account=wallet2.classic_address,
+    account=wallet2.address,
     limit_amount=IssuedCurrencyAmount(
         currency="FOO",
         value="10000000000",
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
 )
 
@@ -34,21 +34,21 @@ signed_trust_set_tx = submit_and_wait(trust_set_tx, client, wallet2)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances after trustline is claimed:")
-print("Balance of ${wallet1.classic_address} is:")
-print((client.request(AccountLines(account=wallet1.classic_address))).result["lines"])
-print("Balance of ${wallet2.classic_address} is:")
-print((client.request(AccountLines(account=wallet2.classic_address))).result["lines"])
+print("Balance of ${wallet1.address} is:")
+print((client.request(AccountLines(account=wallet1.address))).result["lines"])
+print("Balance of ${wallet2.address} is:")
+print((client.request(AccountLines(account=wallet2.address))).result["lines"])
 
 # Create a Payment to send 3840 FOO from wallet1 (issuer) to destination (wallet2)
 issue_quantity = "3840"
 payment_tx = Payment(
-    account=wallet1.classic_address,
+    account=wallet1.address,
     amount=IssuedCurrencyAmount(
         currency="FOO",
         value=issue_quantity,
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
-    destination=wallet2.classic_address,
+    destination=wallet2.address,
 )
 
 # Sign and autofill, then send transaction to the ledger
@@ -57,10 +57,10 @@ print("Initial Payment response: ", payment_response)
 
 # Issuer (wallet1) should have -3840 FOO and destination (wallet2) should have 3840 FOO
 print("Balances after wallet1 sends 3840 FOO to wallet2:")
-print("Balance of ${wallet1.classic_address} is:")
-print((client.request(AccountLines(account=wallet1.classic_address))).result["lines"])
-print("Balance of ${wallet2.classic_address} is:")
-print((client.request(AccountLines(account=wallet2.classic_address))).result["lines"])
+print("Balance of ${wallet1.address} is:")
+print((client.request(AccountLines(account=wallet1.address))).result["lines"])
+print("Balance of ${wallet2.address} is:")
+print((client.request(AccountLines(account=wallet2.address))).result["lines"])
 
 # Send money less than the amount specified on 2 conditions:
 # 1. Sender has less money than the amount specified in the payment Tx.
@@ -72,18 +72,18 @@ print((client.request(AccountLines(account=wallet2.classic_address))).result["li
 
 # Create Payment to send 4000 (of 3840) FOO from wallet2 to wallet1
 partial_payment_tx = Payment(
-    account=wallet2.classic_address,
+    account=wallet2.address,
     amount=IssuedCurrencyAmount(
         currency="FOO",
         value="4000",
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
-    destination=wallet1.classic_address,
+    destination=wallet1.address,
     flags=[PaymentFlag.TF_PARTIAL_PAYMENT],
     send_max=IssuedCurrencyAmount(
         currency="FOO",
         value="1000000",
-        issuer=wallet1.classic_address,
+        issuer=wallet1.address,
     ),
 )
 
@@ -93,7 +93,7 @@ print("Partial Payment response: ", partial_payment_response)
 
 # Tried sending 4000 of 3840 FOO -> wallet1 and wallet2 should have 0 FOO
 print("Balances after Partial Payment, when wallet2 tried to send 4000 FOOs")
-print("Balance of ${wallet1.classic_address} is:")
-print((client.request(AccountLines(account=wallet1.classic_address))).result["lines"])
-print("Balance of ${wallet2.classic_address} is:")
-print((client.request(AccountLines(account=wallet2.classic_address))).result["lines"])
+print("Balance of ${wallet1.address} is:")
+print((client.request(AccountLines(account=wallet1.address))).result["lines"])
+print("Balance of ${wallet2.address} is:")
+print((client.request(AccountLines(account=wallet2.address))).result["lines"])

--- a/content/_code-samples/partial-payment/py/partial-payment.py
+++ b/content/_code-samples/partial-payment/py/partial-payment.py
@@ -3,7 +3,7 @@ from xrpl.clients import JsonRpcClient
 from xrpl.models.amounts import IssuedCurrencyAmount
 from xrpl.models.requests import AccountLines
 from xrpl.models.transactions import Payment, PaymentFlag, TrustSet
-from xrpl.transaction import autofill_and_sign, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 # References
@@ -30,8 +30,7 @@ trust_set_tx = TrustSet(
 )
 
 # Sign and autofill, then send transaction to the ledger
-signed_trust_set_tx = autofill_and_sign(trust_set_tx, wallet2, client)
-send_reliable_submission(signed_trust_set_tx, client)
+signed_trust_set_tx = submit_and_wait(trust_set_tx, client, wallet2)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances after trustline is claimed:")
@@ -53,8 +52,7 @@ payment_tx = Payment(
 )
 
 # Sign and autofill, then send transaction to the ledger
-signed_payment_tx = autofill_and_sign(payment_tx, wallet1, client)
-payment_response = send_reliable_submission(signed_payment_tx, client)
+payment_response = submit_and_wait(payment_tx, client, wallet1)
 print("Initial Payment response: ", payment_response)
 
 # Issuer (wallet1) should have -3840 FOO and destination (wallet2) should have 3840 FOO
@@ -90,8 +88,7 @@ partial_payment_tx = Payment(
 )
 
 # Sign and autofill, then send transaction to the ledger
-signed_partial_payment_tx = autofill_and_sign(partial_payment_tx, wallet2, client)
-partial_payment_response = send_reliable_submission(signed_partial_payment_tx, client)
+partial_payment_response = submit_and_wait(partial_payment_tx, client, wallet2)
 print("Partial Payment response: ", partial_payment_response)
 
 # Tried sending 4000 of 3840 FOO -> wallet1 and wallet2 should have 0 FOO

--- a/content/_code-samples/paths/py/paths.py
+++ b/content/_code-samples/paths/py/paths.py
@@ -47,4 +47,4 @@ payment_tx = Payment(
     paths=paths,
 )
 
-print("signed: ", autofill_and_sign(payment_tx, wallet, client))
+print("signed: ", autofill_and_sign(payment_tx, client, wallet))

--- a/content/_code-samples/paths/py/paths.py
+++ b/content/_code-samples/paths/py/paths.py
@@ -27,7 +27,7 @@ destination_amount = IssuedCurrencyAmount(
 
 # Create a RipplePathFind request and have the client call it
 path_request = RipplePathFind(
-    source_account=wallet.classic_address,
+    source_account=wallet.address,
     source_currencies=[XRP()],
     destination_account=destination_account,
     destination_amount=destination_amount,
@@ -41,7 +41,7 @@ print(paths)
 
 # # Create a Payment to send money from wallet to destination_account using path
 payment_tx = Payment(
-    account=wallet.classic_address,
+    account=wallet.address,
     amount=destination_amount,
     destination=destination_account,
     paths=paths,

--- a/content/_code-samples/reliable-tx-submission/py/reliable_transaction-submission.py
+++ b/content/_code-samples/reliable-tx-submission/py/reliable_transaction-submission.py
@@ -20,14 +20,14 @@ wallet2 = generate_faucet_wallet(client, debug=True)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances of wallets before Payment tx")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))
 
 # Create a Payment transaction
 payment_tx = Payment(
-    account=wallet1.classic_address,
+    account=wallet1.address,
     amount="1000",
-    destination=wallet2.classic_address,
+    destination=wallet2.address,
 )
 
 # Autofill, sign, and submit the transaction
@@ -42,5 +42,5 @@ print("Validated:", tx_response.result["validated"])
 
 # Check balances after 1000 was sent from wallet1 to wallet2
 print("Balances of wallets after Payment tx:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))

--- a/content/_code-samples/reliable-tx-submission/py/reliable_transaction-submission.py
+++ b/content/_code-samples/reliable-tx-submission/py/reliable_transaction-submission.py
@@ -3,7 +3,7 @@ from xrpl.account import get_balance
 from xrpl.clients import JsonRpcClient
 from xrpl.models.requests import Tx
 from xrpl.models.transactions import Payment
-from xrpl.transaction import autofill_and_sign, send_reliable_submission
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 # References:
@@ -30,11 +30,8 @@ payment_tx = Payment(
     destination=wallet2.classic_address,
 )
 
-# Sign and autofill the transaction (prepares it to be ready to submit)
-signed_payment_tx = autofill_and_sign(payment_tx, wallet1, client)
-
-# Submits transaction and waits for response (validated or rejected)
-payment_response = send_reliable_submission(signed_payment_tx, client)
+# Autofill, sign, and submit the transaction
+payment_response = submit_and_wait(payment_tx, client, wallet1)
 print("Transaction was submitted")
 
 # Create a Transaction request to see transaction

--- a/content/_code-samples/require-destination-tags/py/require-destination-tags.py
+++ b/content/_code-samples/require-destination-tags/py/require-destination-tags.py
@@ -9,7 +9,7 @@ from xrpl.asyncio.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountInfo
 from xrpl.models.transactions import (
     AccountSet,
-    AccountSetFlag,
+    AccountSetAsfFlag,
 )
 
 
@@ -23,7 +23,7 @@ async def main() -> int:
         # Send AccountSet transaction -----------------------------------------------
         tx = AccountSet(
             account=wallet.address,
-            set_flag=AccountSetFlag.ASF_REQUIRE_DEST,
+            set_flag=AccountSetAsfFlag.ASF_REQUIRE_DEST,
         )
 
         # Sign and autofill the transaction (ready to submit)

--- a/content/_code-samples/require-destination-tags/py/require-destination-tags.py
+++ b/content/_code-samples/require-destination-tags/py/require-destination-tags.py
@@ -27,7 +27,7 @@ async def main() -> int:
         )
 
         # Sign and autofill the transaction (ready to submit)
-        signed_tx = await autofill_and_sign(tx, wallet, client)
+        signed_tx = await autofill_and_sign(tx, client, wallet)
         print("Transaction hash:", signed_tx.get_hash())
 
         # Submit the transaction and wait for response (validated or rejected)

--- a/content/_code-samples/require-destination-tags/py/require-destination-tags.py
+++ b/content/_code-samples/require-destination-tags/py/require-destination-tags.py
@@ -2,7 +2,7 @@ import asyncio
 
 from xrpl.asyncio.clients import AsyncWebsocketClient
 from xrpl.asyncio.transaction import (
-    safe_sign_and_autofill_transaction,
+    autofill_and_sign,
     submit_and_wait,
 )
 from xrpl.asyncio.wallet import generate_faucet_wallet
@@ -27,7 +27,7 @@ async def main() -> int:
         )
 
         # Sign and autofill the transaction (ready to submit)
-        signed_tx = await safe_sign_and_autofill_transaction(tx, wallet, client)
+        signed_tx = await autofill_and_sign(tx, wallet, client)
         print("Transaction hash:", signed_tx.get_hash())
 
         # Submit the transaction and wait for response (validated or rejected)

--- a/content/_code-samples/require-destination-tags/py/require-destination-tags.py
+++ b/content/_code-samples/require-destination-tags/py/require-destination-tags.py
@@ -22,7 +22,7 @@ async def main() -> int:
 
         # Send AccountSet transaction -----------------------------------------------
         tx = AccountSet(
-            account=wallet.classic_address,
+            account=wallet.address,
             set_flag=AccountSetFlag.ASF_REQUIRE_DEST,
         )
 
@@ -39,7 +39,7 @@ async def main() -> int:
         print("Requesting account information...")
         account_info = await client.request(
             AccountInfo(
-                account=wallet.classic_address,
+                account=wallet.address,
                 ledger_index="validated",
             )
         )
@@ -47,9 +47,9 @@ async def main() -> int:
         # Verify that the AccountRoot lsfRequireDestTag flag is set
         flags = account_info.result["account_data"]["Flags"]
         if flags & 0x00020000 != 0:
-            print(f"Require Destination Tag for account {wallet.classic_address} is enabled.")
+            print(f"Require Destination Tag for account {wallet.address} is enabled.")
         else:
-            print(f"Require Destination Tag for account {wallet.classic_address} is DISABLED.")
+            print(f"Require Destination Tag for account {wallet.address} is DISABLED.")
 
     # End main()
     return 0

--- a/content/_code-samples/require-destination-tags/py/require-destination-tags.py
+++ b/content/_code-samples/require-destination-tags/py/require-destination-tags.py
@@ -3,7 +3,7 @@ import asyncio
 from xrpl.asyncio.clients import AsyncWebsocketClient
 from xrpl.asyncio.transaction import (
     safe_sign_and_autofill_transaction,
-    send_reliable_submission,
+    submit_and_wait,
 )
 from xrpl.asyncio.wallet import generate_faucet_wallet
 from xrpl.models.requests import AccountInfo
@@ -32,7 +32,7 @@ async def main() -> int:
 
         # Submit the transaction and wait for response (validated or rejected)
         print("Submitting transaction...")
-        submit_result = await send_reliable_submission(signed_tx, client)
+        submit_result = await submit_and_wait(signed_tx, client)
         print("Submit result:", submit_result)
 
         # Confirm Account Settings --------------------------------------------------

--- a/content/_code-samples/secure-signing/py/sign-payment.py
+++ b/content/_code-samples/secure-signing/py/sign-payment.py
@@ -2,17 +2,23 @@
 import os  
 my_secret = os.getenv("MYSECRET")
 from xrpl.wallet import Wallet
-wallet = Wallet(seed=my_secret, sequence=16237283)
-print(wallet.classic_address) # "raaFKKmgf6CRZttTVABeTcsqzRQ51bNR6Q"
+wallet = Wallet.from_seed(seed=my_secret)
+print(wallet.classic_address)  # "raaFKKmgf6CRZttTVABeTcsqzRQ51bNR6Q"
+
+# For offline signing, you need to know your address's next Sequence number.
+# Alternatively, you could use a Ticket in place of the Sequence number.
+# This is useful when you need multiple signatures and may want to process transactions out-of-order.
+# For details, see: https://xrpl.org/tickets.html
+sequence = 0
 
 from xrpl.models.transactions import Payment
 from xrpl.utils import xrp_to_drops
 my_payment = Payment(
-    account=wallet.classic_address,
+    account=wallet.address,
     amount=xrp_to_drops(22),
     fee="10",
     destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
-    sequence=wallet.sequence, # this needs to be incremented upon every successful transaction
+    sequence=sequence,
 )
 print("Payment object:", my_payment)
 

--- a/content/_code-samples/secure-signing/py/sign-payment.py
+++ b/content/_code-samples/secure-signing/py/sign-payment.py
@@ -24,5 +24,5 @@ print("Payment object:", my_payment)
 
 # Sign transaction -------------------------------------------------------------
 import xrpl.transaction 
-signed = xrpl.transaction.safe_sign_transaction(my_payment, wallet)
+signed = xrpl.transaction.sign(my_payment, wallet)
 print("Signed transaction blob:", signed)

--- a/content/_code-samples/secure-signing/py/sign-payment.py
+++ b/content/_code-samples/secure-signing/py/sign-payment.py
@@ -3,7 +3,7 @@ import os
 my_secret = os.getenv("MYSECRET")
 from xrpl.wallet import Wallet
 wallet = Wallet.from_seed(seed=my_secret)
-print(wallet.classic_address)  # "raaFKKmgf6CRZttTVABeTcsqzRQ51bNR6Q"
+print(wallet.address)  # "raaFKKmgf6CRZttTVABeTcsqzRQ51bNR6Q"
 
 # For offline signing, you need to know your address's next Sequence number.
 # Alternatively, you could use a Ticket in place of the Sequence number.

--- a/content/_code-samples/send-a-memo/py/send-a-memo.py
+++ b/content/_code-samples/send-a-memo/py/send-a-memo.py
@@ -1,6 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import Payment, Memo
-from xrpl.transaction import safe_sign_and_autofill_transaction, submit_and_wait
+from xrpl.transaction import autofill_and_sign, submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 # This code sample validates and sends a transaction with a Memo attached
@@ -42,7 +42,7 @@ payment_tx = Payment(
 
 # Sign the transaction
 print("Submitting a payment transaction with our memo...")
-payment_tx_signed = safe_sign_and_autofill_transaction(payment_tx, wallet=test_wallet, client=client)
+payment_tx_signed = autofill_and_sign(payment_tx, wallet=test_wallet, client=client)
 print(f"\n  Encoded Transaction MEMO: {payment_tx_signed.memos}")
 
 # Send the transaction to the node

--- a/content/_code-samples/send-a-memo/py/send-a-memo.py
+++ b/content/_code-samples/send-a-memo/py/send-a-memo.py
@@ -1,6 +1,6 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import Payment, Memo
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
+from xrpl.transaction import safe_sign_and_autofill_transaction, submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 # This code sample validates and sends a transaction with a Memo attached
@@ -46,7 +46,7 @@ payment_tx_signed = safe_sign_and_autofill_transaction(payment_tx, wallet=test_w
 print(f"\n  Encoded Transaction MEMO: {payment_tx_signed.memos}")
 
 # Send the transaction to the node
-submit_tx_regular = send_reliable_submission(client=client, transaction=payment_tx_signed)
+submit_tx_regular = submit_and_wait(transaction=payment_tx_signed, client=client)
 submit_tx_regular = submit_tx_regular.result
 
 tx_MemoData = bytes.fromhex(submit_tx_regular['Memos'][0]['Memo']['MemoData']).decode('utf-8')

--- a/content/_code-samples/send-a-memo/py/send-a-memo.py
+++ b/content/_code-samples/send-a-memo/py/send-a-memo.py
@@ -42,7 +42,7 @@ payment_tx = Payment(
 
 # Sign the transaction
 print("Submitting a payment transaction with our memo...")
-payment_tx_signed = autofill_and_sign(payment_tx, wallet=test_wallet, client=client)
+payment_tx_signed = autofill_and_sign(payment_tx, client=client, wallet=test_wallet)
 print(f"\n  Encoded Transaction MEMO: {payment_tx_signed.memos}")
 
 # Send the transaction to the node

--- a/content/_code-samples/send-a-memo/py/send-a-memo.py
+++ b/content/_code-samples/send-a-memo/py/send-a-memo.py
@@ -14,7 +14,7 @@ client = JsonRpcClient(JSON_RPC_URL)
 # Get account credentials from the Testnet Faucet
 print("Requesting an account from the Testnet faucet...")
 test_wallet = generate_faucet_wallet(client=client)
-myAddr = test_wallet.classic_address
+myAddr = test_wallet.address
 
 memo_data = "Example Memo - 123 -=+"
 memo_type = "Text"

--- a/content/_code-samples/send-xrp/py/send-xrp.py
+++ b/content/_code-samples/send-xrp/py/send-xrp.py
@@ -26,7 +26,7 @@ print("Payment object:", my_payment)
 
 # Sign transaction -------------------------------------------------------------
 signed_tx = xrpl.transaction.autofill_and_sign(
-        my_payment, test_wallet, client)
+        my_payment, client, test_wallet)
 max_ledger = signed_tx.last_ledger_sequence
 tx_id = signed_tx.get_hash()
 print("Signed transaction:", signed_tx)

--- a/content/_code-samples/send-xrp/py/send-xrp.py
+++ b/content/_code-samples/send-xrp/py/send-xrp.py
@@ -1,6 +1,6 @@
 # Example Credentials ----------------------------------------------------------
 from xrpl.wallet import Wallet
-test_wallet = Wallet(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9", sequence=16237283)
+test_wallet = Wallet.from_seed(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9")
 print(test_wallet.classic_address) # "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH"
 
 # Connect ----------------------------------------------------------------------

--- a/content/_code-samples/send-xrp/py/send-xrp.py
+++ b/content/_code-samples/send-xrp/py/send-xrp.py
@@ -1,6 +1,7 @@
 # Example Credentials ----------------------------------------------------------
 from xrpl.wallet import Wallet
-test_wallet = Wallet.from_seed(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9")
+from xrpl.constants import CryptoAlgorithm
+test_wallet = Wallet.from_seed(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9", algorithm=CryptoAlgorithm.SECP256K1)
 print(test_wallet.address) # "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH"
 
 # Connect ----------------------------------------------------------------------

--- a/content/_code-samples/send-xrp/py/send-xrp.py
+++ b/content/_code-samples/send-xrp/py/send-xrp.py
@@ -35,12 +35,12 @@ print("Identifying hash:", tx_id)
 
 # Submit transaction -----------------------------------------------------------
 try:
-    tx_response = xrpl.transaction.send_reliable_submission(signed_tx, client)
+    tx_response = xrpl.transaction.submit_and_wait(signed_tx, client)
 except xrpl.transaction.XRPLReliableSubmissionException as e:
     exit(f"Submit failed: {e}")
 
 # Wait for validation ----------------------------------------------------------
-# send_reliable_submission() handles this automatically, but it can take 4-7s.
+# submit_and_wait() handles this automatically, but it can take 4-7s.
 
 # Check transaction results ----------------------------------------------------
 import json

--- a/content/_code-samples/send-xrp/py/send-xrp.py
+++ b/content/_code-samples/send-xrp/py/send-xrp.py
@@ -24,7 +24,7 @@ my_payment = xrpl.models.transactions.Payment(
 print("Payment object:", my_payment)
 
 # Sign transaction -------------------------------------------------------------
-signed_tx = xrpl.transaction.safe_sign_and_autofill_transaction(
+signed_tx = xrpl.transaction.autofill_and_sign(
         my_payment, test_wallet, client)
 max_ledger = signed_tx.last_ledger_sequence
 tx_id = signed_tx.get_hash()

--- a/content/_code-samples/send-xrp/py/send-xrp.py
+++ b/content/_code-samples/send-xrp/py/send-xrp.py
@@ -1,7 +1,7 @@
 # Example Credentials ----------------------------------------------------------
 from xrpl.wallet import Wallet
 test_wallet = Wallet.from_seed(seed="sn3nxiW7v8KXzPzAqzyHXbSSKNuN9")
-print(test_wallet.classic_address) # "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH"
+print(test_wallet.address) # "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH"
 
 # Connect ----------------------------------------------------------------------
 import xrpl
@@ -17,7 +17,7 @@ test_wallet = generate_faucet_wallet(client, debug=True)
 
 # Prepare transaction ----------------------------------------------------------
 my_payment = xrpl.models.transactions.Payment(
-    account=test_wallet.classic_address,
+    account=test_wallet.address,
     amount=xrpl.utils.xrp_to_drops(22),
     destination="rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
 )

--- a/content/_code-samples/set-regular-key/py/setRegularKey.py
+++ b/content/_code-samples/set-regular-key/py/setRegularKey.py
@@ -20,12 +20,12 @@ regular_key_wallet = generate_faucet_wallet(client, debug=True)
 
 # Both balances should be zero since nothing has been sent yet
 print("Balances before payment:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))
 
 # Assign key pair (regular_key_wallet) to wallet1 using SetRegularKey transaction
 tx = SetRegularKey(
-    account=wallet1.classic_address, regular_key=regular_key_wallet.classic_address
+    account=wallet1.address, regular_key=regular_key_wallet.address
 )
 
 set_regular_key_response = submit_and_wait(tx, client, wallet1)
@@ -36,8 +36,8 @@ print(set_regular_key_response)
 # Since regular_key_wallet is linked to wallet1,
 # walet1 can send payment to wallet2 and have regular_key_wallet sign it
 payment = Payment(
-    account=wallet1.classic_address,
-    destination=wallet2.classic_address,
+    account=wallet1.address,
+    destination=wallet2.address,
     amount="1000",
 )
 
@@ -48,5 +48,5 @@ print(payment_response)
 
 # Balance after sending 1000 from wallet1 to wallet2
 print("Balances after payment:")
-print(get_balance(wallet1.classic_address, client))
-print(get_balance(wallet2.classic_address, client))
+print(get_balance(wallet1.address, client))
+print(get_balance(wallet2.address, client))

--- a/content/_code-samples/set-regular-key/py/setRegularKey.py
+++ b/content/_code-samples/set-regular-key/py/setRegularKey.py
@@ -2,7 +2,7 @@
 from xrpl.account import get_balance
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import Payment, SetRegularKey
-from xrpl.transaction import autofill_and_sign, send_reliable_submission
+from xrpl.transaction import autofill_and_sign, submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 # References
@@ -28,8 +28,7 @@ tx = SetRegularKey(
     account=wallet1.classic_address, regular_key=regular_key_wallet.classic_address
 )
 
-signed_tx = autofill_and_sign(tx, wallet1, client)
-set_regular_key_response = send_reliable_submission(signed_tx, client)
+set_regular_key_response = submit_and_wait(tx, client, wallet1)
 
 print("Response for successful SetRegularKey tx:")
 print(set_regular_key_response)
@@ -42,8 +41,7 @@ payment = Payment(
     amount="1000",
 )
 
-signed_payment = autofill_and_sign(payment, regular_key_wallet, client)
-payment_response = send_reliable_submission(signed_payment, client)
+payment_response = submit_and_wait(payment, client, regular_key_wallet)
 
 print("Response for tx signed using Regular Key:")
 print(payment_response)

--- a/content/_code-samples/set-regular-key/py/setRegularKey.py
+++ b/content/_code-samples/set-regular-key/py/setRegularKey.py
@@ -2,7 +2,7 @@
 from xrpl.account import get_balance
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import Payment, SetRegularKey
-from xrpl.transaction import autofill_and_sign, submit_and_wait
+from xrpl.transaction import submit_and_wait
 from xrpl.wallet import generate_faucet_wallet
 
 # References

--- a/content/_code-samples/submit-and-verify/py/submit-and-verify.py
+++ b/content/_code-samples/submit-and-verify/py/submit-and-verify.py
@@ -1,7 +1,7 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import AccountSet
-from xrpl.transaction import safe_sign_and_autofill_transaction, send_reliable_submission
-from xrpl.wallet import Wallet, generate_faucet_wallet
+from xrpl.transaction import submit_and_wait
+from xrpl.wallet import generate_faucet_wallet
 
 # Connect to a testnet node
 JSON_RPC_URL = "https://s.altnet.rippletest.net:51234/"
@@ -16,10 +16,8 @@ tx = AccountSet(
     account=myAddr
 )
 
-# Sign the transaction locally
-my_tx_payment_signed = safe_sign_and_autofill_transaction(transaction=tx, wallet=test_wallet, client=client)
 # Submit transaction and verify its validity on the ledger
-response = send_reliable_submission(transaction=my_tx_payment_signed, client=client)
+response = submit_and_wait(transaction=tx, client=client, wallet=test_wallet)
 result = response.result["meta"]["TransactionResult"]
 
 print(f"Account: {myAddr}")

--- a/content/_code-samples/submit-and-verify/py/submit-and-verify.py
+++ b/content/_code-samples/submit-and-verify/py/submit-and-verify.py
@@ -9,7 +9,7 @@ client = JsonRpcClient(JSON_RPC_URL)
 
 # Generate a wallet and request faucet
 test_wallet = generate_faucet_wallet(client=client)
-myAddr = test_wallet.classic_address
+myAddr = test_wallet.address
 
 # Construct AccountSet transaction
 tx = AccountSet(

--- a/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
+++ b/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
@@ -64,7 +64,7 @@ async def main() -> int:
         print("Requesting orderbook information...")
         orderbook_info = await client.request(
             BookOffers(
-                taker=wallet.classic_address,
+                taker=wallet.address,
                 ledger_index="current",
                 taker_gets=we_want["currency"],
                 taker_pays=we_spend["currency"],
@@ -120,7 +120,7 @@ async def main() -> int:
             print("Requesting second orderbook information...")
             orderbook2_info = await client.request(
                 BookOffers(
-                    taker=wallet.classic_address,
+                    taker=wallet.address,
                     ledger_index="current",
                     taker_gets=we_spend["currency"],
                     taker_pays=we_want["currency"],
@@ -164,7 +164,7 @@ async def main() -> int:
         # hard-coded TakerGets and TakerPays amounts.
 
         tx = OfferCreate(
-            account=wallet.classic_address,
+            account=wallet.address,
             taker_gets=we_spend["value"],
             taker_pays=we_want["currency"].to_amount(we_want["value"]),
         )
@@ -225,18 +225,18 @@ async def main() -> int:
         print("Getting address balances as of validated ledger...")
         balances = await client.request(
             AccountLines(
-                account=wallet.classic_address,
+                account=wallet.address,
                 ledger_index="validated",
             )
         )
         pprint.pp(balances.result)
 
         # Check Offers --------------------------------------------------------------
-        print(f"Getting outstanding Offers from {wallet.classic_address} "
+        print(f"Getting outstanding Offers from {wallet.address} "
               f"as of validated ledger...")
         acct_offers = await client.request(
             AccountOffers(
-                account=wallet.classic_address,
+                account=wallet.address,
                 ledger_index="validated",
             )
         )

--- a/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
+++ b/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from xrpl.asyncio.clients import AsyncWebsocketClient
 from xrpl.asyncio.transaction import (
-    safe_sign_and_autofill_transaction,
+    autofill_and_sign,
     submit_and_wait,
 )
 from xrpl.asyncio.wallet import generate_faucet_wallet
@@ -170,7 +170,7 @@ async def main() -> int:
         )
 
         # Sign and autofill the transaction (ready to submit)
-        signed_tx = await safe_sign_and_autofill_transaction(tx, wallet, client)
+        signed_tx = await autofill_and_sign(tx, wallet, client)
         print("Transaction:", signed_tx)
 
         # Submit the transaction and wait for response (validated or rejected)

--- a/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
+++ b/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
@@ -170,7 +170,7 @@ async def main() -> int:
         )
 
         # Sign and autofill the transaction (ready to submit)
-        signed_tx = await autofill_and_sign(tx, wallet, client)
+        signed_tx = await autofill_and_sign(tx, client, wallet)
         print("Transaction:", signed_tx)
 
         # Submit the transaction and wait for response (validated or rejected)

--- a/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
+++ b/content/_code-samples/trade-in-the-decentralized-exchange/py/trade-in-the-dex.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from xrpl.asyncio.clients import AsyncWebsocketClient
 from xrpl.asyncio.transaction import (
     safe_sign_and_autofill_transaction,
-    send_reliable_submission,
+    submit_and_wait,
 )
 from xrpl.asyncio.wallet import generate_faucet_wallet
 from xrpl.models.currencies import (
@@ -175,7 +175,7 @@ async def main() -> int:
 
         # Submit the transaction and wait for response (validated or rejected)
         print("Sending OfferCreate transaction...")
-        result = await send_reliable_submission(signed_tx, client)
+        result = await submit_and_wait(signed_tx, client)
         if result.is_successful():
             print(f"Transaction succeeded: "
                   f"https://testnet.xrpl.org/transactions/{signed_tx.get_hash()}")

--- a/content/_code-samples/use-tickets/py/use-tickets-to-multisign.py
+++ b/content/_code-samples/use-tickets/py/use-tickets-to-multisign.py
@@ -21,7 +21,7 @@ client = JsonRpcClient(JSON_RPC_URL)
 
 # Generate a wallet and request faucet
 test_wallet = generate_faucet_wallet(client=client)
-myAddr = test_wallet.classic_address
+myAddr = test_wallet.address
 
 print("Setting up all the signers' accounts via the testnet faucet, this may take a while...")
 signer_1_wallet = generate_faucet_wallet(client=client)
@@ -30,9 +30,9 @@ signer_3_wallet = generate_faucet_wallet(client=client)
 
 # Set the list of accounts that are able to authorize transactions on behalf of our Account via a multi-sig transaction
 signers = [
-        SignerEntry(account=signer_1_wallet.classic_address, signer_weight=1),
-        SignerEntry(account=signer_2_wallet.classic_address, signer_weight=1),
-        SignerEntry(account=signer_3_wallet.classic_address, signer_weight=1)
+        SignerEntry(account=signer_1_wallet.address, signer_weight=1),
+        SignerEntry(account=signer_2_wallet.address, signer_weight=1),
+        SignerEntry(account=signer_3_wallet.address, signer_weight=1)
 ]
 
 # Display all the signers' account address

--- a/content/_code-samples/use-tickets/py/use-tickets-to-multisign.py
+++ b/content/_code-samples/use-tickets/py/use-tickets-to-multisign.py
@@ -1,5 +1,5 @@
 from xrpl.models.transactions import TicketCreate, AccountSet, SignerListSet, SignerEntry
-from xrpl.transaction import safe_sign_and_submit_transaction, autofill, multisign, sign
+from xrpl.transaction import sign_and_submit, autofill, multisign, sign
 from xrpl.models.requests.account_objects import AccountObjects, AccountObjectType
 from xrpl.models.requests.submit_multisigned import SubmitMultisigned
 from xrpl.wallet import generate_faucet_wallet
@@ -55,7 +55,7 @@ tx_set_signer_list = SignerListSet(
 
 # Sign transaction locally and submit
 print("Submitting a SignerListSet transaction to update our account to use our new Signers...")
-tx_set_signer_list_signed = safe_sign_and_submit_transaction(transaction=tx_set_signer_list, wallet=test_wallet, client=client)
+tx_set_signer_list_signed = sign_and_submit(transaction=tx_set_signer_list, wallet=test_wallet, client=client)
 
 # Construct a TicketCreate transaction, 3 tickets will be created
 tx_create_ticket = TicketCreate(
@@ -65,7 +65,7 @@ tx_create_ticket = TicketCreate(
 
 # Sign transaction locally and submit
 print("Submitting a TicketCreate transaction to get Ticket Sequences for future transactions...")
-tx_create_ticket_signed = safe_sign_and_submit_transaction(transaction=tx_create_ticket, wallet=test_wallet, client=client)
+tx_create_ticket_signed = sign_and_submit(transaction=tx_create_ticket, wallet=test_wallet, client=client)
 
 # Get a Ticket Sequence
 get_ticket_sequence = client.request(AccountObjects(

--- a/content/_code-samples/use-tickets/py/use-tickets-to-multisign.py
+++ b/content/_code-samples/use-tickets/py/use-tickets-to-multisign.py
@@ -55,7 +55,7 @@ tx_set_signer_list = SignerListSet(
 
 # Sign transaction locally and submit
 print("Submitting a SignerListSet transaction to update our account to use our new Signers...")
-tx_set_signer_list_signed = sign_and_submit(transaction=tx_set_signer_list, wallet=test_wallet, client=client)
+tx_set_signer_list_signed = sign_and_submit(transaction=tx_set_signer_list, client=client, wallet=test_wallet)
 
 # Construct a TicketCreate transaction, 3 tickets will be created
 tx_create_ticket = TicketCreate(
@@ -65,7 +65,7 @@ tx_create_ticket = TicketCreate(
 
 # Sign transaction locally and submit
 print("Submitting a TicketCreate transaction to get Ticket Sequences for future transactions...")
-tx_create_ticket_signed = sign_and_submit(transaction=tx_create_ticket, wallet=test_wallet, client=client)
+tx_create_ticket_signed = sign_and_submit(transaction=tx_create_ticket, client=client, wallet=test_wallet)
 
 # Get a Ticket Sequence
 get_ticket_sequence = client.request(AccountObjects(

--- a/content/_code-samples/use-tickets/py/use-tickets.py
+++ b/content/_code-samples/use-tickets/py/use-tickets.py
@@ -19,7 +19,7 @@ tx = TicketCreate(
 )
 
 # Sign transaction locally and submit
-my_tx_payment_signed = sign_and_submit(transaction=tx, wallet=test_wallet, client=client)
+my_tx_payment_signed = sign_and_submit(transaction=tx, client=client, wallet=test_wallet)
 
 # Get a Ticket Sequence
 get_ticket_sequence = AccountObjects(

--- a/content/_code-samples/use-tickets/py/use-tickets.py
+++ b/content/_code-samples/use-tickets/py/use-tickets.py
@@ -10,7 +10,7 @@ client = JsonRpcClient(JSON_RPC_URL)
 
 # Generate a wallet and request faucet
 test_wallet = generate_faucet_wallet(client=client)
-myAddr = test_wallet.classic_address
+myAddr = test_wallet.address
 
 # Construct a TicketCreate transaction, 2 ticket created for future use
 tx = TicketCreate(

--- a/content/_code-samples/use-tickets/py/use-tickets.py
+++ b/content/_code-samples/use-tickets/py/use-tickets.py
@@ -1,7 +1,7 @@
 from xrpl.clients import JsonRpcClient
 from xrpl.models.transactions import TicketCreate, AccountSet
-from xrpl.transaction import safe_sign_and_submit_transaction
-from xrpl.wallet import Wallet, generate_faucet_wallet
+from xrpl.transaction import sign_and_submit
+from xrpl.wallet import generate_faucet_wallet
 from xrpl.models.requests.account_objects import AccountObjects, AccountObjectType
 
 # Connect to a testnet node
@@ -19,7 +19,7 @@ tx = TicketCreate(
 )
 
 # Sign transaction locally and submit
-my_tx_payment_signed = safe_sign_and_submit_transaction(transaction=tx, wallet=test_wallet, client=client)
+my_tx_payment_signed = sign_and_submit(transaction=tx, wallet=test_wallet, client=client)
 
 # Get a Ticket Sequence
 get_ticket_sequence = AccountObjects(
@@ -48,7 +48,7 @@ tx_1 = AccountSet(
 )
 
 # Send transaction (w/ Ticket)
-tx_result = safe_sign_and_submit_transaction(transaction=tx_1, client=client, wallet=test_wallet)
+tx_result = sign_and_submit(transaction=tx_1, client=client, wallet=test_wallet)
 result = tx_result.result["engine_result"]
 
 print(f"Account: {myAddr}")

--- a/content/tutorials/build-apps/build-a-desktop-wallet-in-python.md
+++ b/content/tutorials/build-apps/build-a-desktop-wallet-in-python.md
@@ -418,7 +418,7 @@ You can now use your wallet to send XRP! You can even fund an entirely new accou
 
         import xrpl
         w = xrpl.wallet.Wallet.create()
-        print(w.classic_address)
+        print(w.address)
         print(w.seed)
         exit()
 

--- a/content/tutorials/get-started/get-started-using-python.md
+++ b/content/tutorials/get-started/get-started-using-python.md
@@ -112,19 +112,11 @@ To prepare the transaction:
 
 
 
-##### Sign
+##### Sign and submit
 
-To sign the transaction:
+To sign and submit the transaction:
 
-{{ include_code("_code-samples/get-started/py/prepare-payment.py", start_with="# Sign the transaction", end_before="# Print signed tx", language="py") }}
-
-
-
-##### Send
-
-To send the transaction:
-
-{{ include_code("_code-samples/get-started/py/prepare-payment.py", start_with="# Submit and send the transaction", end_before="# Print tx response", language="py") }}
+{{ include_code("_code-samples/get-started/py/prepare-payment.py", start_with="# Sign and submit the transaction", end_before="# Print tx response", language="py") }}
 
 
 ##### Derive an X-address

--- a/content/tutorials/get-started/get-started-using-python.md
+++ b/content/tutorials/get-started/get-started-using-python.md
@@ -121,7 +121,7 @@ To sign and submit the transaction:
 
 ##### Derive an X-address
 
-You can use `xrpl-py`'s [`xrpl.core.addresscodec`](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.core.addresscodec.html) module to derive an [X-address](https://xrpaddress.info/) from the `Wallet.classic_address` field:
+You can use `xrpl-py`'s [`xrpl.core.addresscodec`](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.core.addresscodec.html) module to derive an [X-address](https://xrpaddress.info/) from the `Wallet.address` field:
 
 {{ include_code("_code-samples/get-started/py/get-acct-info.py", start_with="# Derive an x-address from the classic address:", end_before="# Look up info about your account", language="py") }}
 

--- a/content/tutorials/get-started/send-xrp.ja.md
+++ b/content/tutorials/get-started/send-xrp.ja.md
@@ -262,7 +262,7 @@ _Python_
 ```py
 from xrpl.wallet import Wallet
 my_wallet = Wallet.create()
-print(my_wallet.classic_address) # Example: rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f
+print(my_wallet.address) # Example: rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f
 print(my_wallet.seed)            # Example: sp6JS7f14BuwFY8Mw6bTtLKWauoUs
 ```
 

--- a/content/tutorials/get-started/send-xrp.md
+++ b/content/tutorials/get-started/send-xrp.md
@@ -196,6 +196,7 @@ The result of the signing operation is a transaction object containing a signatu
 Now that you have a signed transaction, you can submit it to an XRP Ledger server, which relays it through the network. It's also a good idea to take note of the latest validated ledger index before you submit. The earliest ledger version that your transaction could get into as a result of this submission is one higher than the latest validated ledger when you submit it. Of course, if the same transaction was previously submitted, it could already be in a previous ledger. (It can't succeed a second time, but you may not realize it succeeded if you aren't looking in the right ledger versions.)
 
 - **JavaScript:** Use the [`submitAndWait()` method of the Client](https://js.xrpl.org/classes/Client.html#submitAndWait) to submit a signed transaction to the network and wait for the response, or use [`submitSigned()`](https://js.xrpl.org/classes/Client.html#submitSigned) to submit a transaction and get only the preliminary response.
+<!-- TODO: Update this to point to `submit_and_wait` once the refernce docs for submit_and_wait are live -->
 - **Python:** Use the [`xrpl.transaction.send_reliable_submission()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission) to submit a transaction to the network and wait for a response.
 - **Java:** Use the [`XrplClient.submit(SignedTransaction)` method](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#submit(org.xrpl.xrpl4j.crypto.signing.SignedTransaction)) to submit a transaction to the network. Use the [`XrplClient.ledger()`](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#ledger(org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams)) method to get the latest validated ledger index.
 
@@ -239,6 +240,7 @@ Most transactions are accepted into the next ledger version after they're submit
 
 - **JavaScript:**  If you used the [`.submitAndWait()` method](https://js.xrpl.org/classes/Client.html#submitAndWait), you can wait until the returned Promise resolves. Other, more asynchronous approaches are also possible.
 
+<!-- TODO: Update this to point to `submit_and_wait` once the reference docs for it go live -->
 - **Python:** If you used the [`xrpl.transaction.send_reliable_submission()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission), you can wait for the function to return. Other approaches, including asynchronous ones using the WebSocket client, are also possible.
 
 - **Java** Poll the [`XrplClient.transaction()` method](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#transaction(org.xrpl.xrpl4j.model.client.transactions.TransactionRequestParams,java.lang.Class)) to see if your transaction has a final result. Periodically check that the latest validated ledger index has not passed the `LastLedgerIndex` of the transaction using the [`XrplClient.ledger()`](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#ledger(org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams)) method.
@@ -272,7 +274,7 @@ To know for sure what a transaction did, you must look up the outcome of the tra
 
     **Tip:** In **TypeScript** you can pass a [`TxRequest`](https://js.xrpl.org/interfaces/TxRequest.html) to the [`Client.request()`](https://js.xrpl.org/classes/Client.html#request) method.
 
-- **Python:** Use the response from `send_reliable_submission()` or call the [`xrpl.transaction.get_transaction_from_hash()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash). (See the [tx method response format](tx.html#response-format) for a detailed reference of the fields this can contain.)
+- **Python:** Use the response from `submit_and_wait()` or call the [`xrpl.transaction.get_transaction_from_hash()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash). (See the [tx method response format](tx.html#response-format) for a detailed reference of the fields this can contain.)
 
 - **Java:** Use the [`XrplClient.transaction()`](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#transaction(org.xrpl.xrpl4j.model.client.transactions.TransactionRequestParams,java.lang.Class)) method to check the status of a transaction.
 

--- a/content/tutorials/get-started/send-xrp.md
+++ b/content/tutorials/get-started/send-xrp.md
@@ -328,7 +328,7 @@ _Python_
 ```py
 from xrpl.wallet import Wallet
 my_wallet = Wallet.create()
-print(my_wallet.classic_address) # Example: rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f
+print(my_wallet.address) # Example: rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f
 print(my_wallet.seed)            # Example: sp6JS7f14BuwFY8Mw6bTtLKWauoUs
 ```
 

--- a/content/tutorials/get-started/send-xrp.md
+++ b/content/tutorials/get-started/send-xrp.md
@@ -196,8 +196,7 @@ The result of the signing operation is a transaction object containing a signatu
 Now that you have a signed transaction, you can submit it to an XRP Ledger server, which relays it through the network. It's also a good idea to take note of the latest validated ledger index before you submit. The earliest ledger version that your transaction could get into as a result of this submission is one higher than the latest validated ledger when you submit it. Of course, if the same transaction was previously submitted, it could already be in a previous ledger. (It can't succeed a second time, but you may not realize it succeeded if you aren't looking in the right ledger versions.)
 
 - **JavaScript:** Use the [`submitAndWait()` method of the Client](https://js.xrpl.org/classes/Client.html#submitAndWait) to submit a signed transaction to the network and wait for the response, or use [`submitSigned()`](https://js.xrpl.org/classes/Client.html#submitSigned) to submit a transaction and get only the preliminary response.
-<!-- TODO: Update this to point to `submit_and_wait` once the refernce docs for submit_and_wait are live -->
-- **Python:** Use the [`xrpl.transaction.send_reliable_submission()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission) to submit a transaction to the network and wait for a response.
+- **Python:** Use the [`xrpl.transaction.submit_and_wait()` method](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.submit_and_wait) to submit a transaction to the network and wait for a response.
 - **Java:** Use the [`XrplClient.submit(SignedTransaction)` method](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#submit(org.xrpl.xrpl4j.crypto.signing.SignedTransaction)) to submit a transaction to the network. Use the [`XrplClient.ledger()`](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#ledger(org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams)) method to get the latest validated ledger index.
 
 <!-- MULTICODE_BLOCK_START -->
@@ -240,8 +239,7 @@ Most transactions are accepted into the next ledger version after they're submit
 
 - **JavaScript:**  If you used the [`.submitAndWait()` method](https://js.xrpl.org/classes/Client.html#submitAndWait), you can wait until the returned Promise resolves. Other, more asynchronous approaches are also possible.
 
-<!-- TODO: Update this to point to `submit_and_wait` once the reference docs for it go live -->
-- **Python:** If you used the [`xrpl.transaction.send_reliable_submission()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission), you can wait for the function to return. Other approaches, including asynchronous ones using the WebSocket client, are also possible.
+- **Python:** If you used the [`xrpl.transaction.submit_and_wait()` method](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.submit_and_wait), you can wait for the function to return. Other approaches, including asynchronous ones using the WebSocket client, are also possible.
 
 - **Java** Poll the [`XrplClient.transaction()` method](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#transaction(org.xrpl.xrpl4j.model.client.transactions.TransactionRequestParams,java.lang.Class)) to see if your transaction has a final result. Periodically check that the latest validated ledger index has not passed the `LastLedgerIndex` of the transaction using the [`XrplClient.ledger()`](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#ledger(org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams)) method.
 
@@ -274,7 +272,7 @@ To know for sure what a transaction did, you must look up the outcome of the tra
 
     **Tip:** In **TypeScript** you can pass a [`TxRequest`](https://js.xrpl.org/interfaces/TxRequest.html) to the [`Client.request()`](https://js.xrpl.org/classes/Client.html#request) method.
 
-- **Python:** Use the response from `submit_and_wait()` or call the [`xrpl.transaction.get_transaction_from_hash()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash). (See the [tx method response format](tx.html#response-format) for a detailed reference of the fields this can contain.)
+- **Python:** Use the response from [`submit_and_wait()`](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.submit_and_wait) or call the [`xrpl.transaction.get_transaction_from_hash()` method](https://xrpl-py.readthedocs.io/en/latest/source/xrpl.transaction.html#xrpl.transaction.get_transaction_from_hash). (See the [tx method response format](tx.html#response-format) for a detailed reference of the fields this can contain.)
 
 - **Java:** Use the [`XrplClient.transaction()`](https://javadoc.io/doc/org.xrpl/xrpl4j-client/latest/org/xrpl/xrpl4j/client/XrplClient.html#transaction(org.xrpl.xrpl4j.model.client.transactions.TransactionRequestParams,java.lang.Class)) method to check the status of a transaction.
 

--- a/content/tutorials/manage-account-settings/assign-a-regular-key-pair.md
+++ b/content/tutorials/manage-account-settings/assign-a-regular-key-pair.md
@@ -104,7 +104,7 @@ _Python_
 ```py
 keypair = xrpl.wallet.Wallet.create()
 print("seed:", keypair.seed)
-print("classic address:", keypair.classic_address)
+print("classic address:", keypair.address)
 ```
 
 _JavaScript_

--- a/content/tutorials/use-tokens/issue-a-fungible-token.md
+++ b/content/tutorials/use-tokens/issue-a-fungible-token.md
@@ -202,6 +202,7 @@ Most transactions are accepted into the next ledger version after they're submit
 The code samples in this tutorial use helper functions to wait for validation when submitting a transaction:
 
 - **JavaScript:** The `submit_and_verify()` function, as defined in the [submit-and-verify code sample](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/submit-and-verify).
+<!-- TODO: Update this to point to `submit_and_wait` once the reference docs for it go live -->
 - **Python:** The `send_reliable_submission()` [method of the xrpl-py library](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission).
 - **Java:** The `submitAndWaitForValidation()` method in the [sample Java class](https://github.com/XRPLF/xrpl-dev-portal/blob/master/content/_code-samples/issue-a-token/java/IssueToken.java).
 

--- a/content/tutorials/use-tokens/issue-a-fungible-token.md
+++ b/content/tutorials/use-tokens/issue-a-fungible-token.md
@@ -202,8 +202,7 @@ Most transactions are accepted into the next ledger version after they're submit
 The code samples in this tutorial use helper functions to wait for validation when submitting a transaction:
 
 - **JavaScript:** The `submit_and_verify()` function, as defined in the [submit-and-verify code sample](https://github.com/XRPLF/xrpl-dev-portal/tree/master/content/_code-samples/submit-and-verify).
-<!-- TODO: Update this to point to `submit_and_wait` once the reference docs for it go live -->
-- **Python:** The `send_reliable_submission()` [method of the xrpl-py library](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.send_reliable_submission).
+- **Python:** The `submit_and_wait()` [method of the xrpl-py library](https://xrpl-py.readthedocs.io/en/stable/source/xrpl.transaction.html#xrpl.transaction.submit_and_wait).
 - **Java:** The `submitAndWaitForValidation()` method in the [sample Java class](https://github.com/XRPLF/xrpl-dev-portal/blob/master/content/_code-samples/issue-a-token/java/IssueToken.java).
 
 **Tip:** Technically, you can configure the hot address in parallel with configuring the issuer address. For simplicity, this tutorial waits for each transaction one at a time.


### PR DESCRIPTION
In preparation for breaking changes to the xrpl-py library, this PR updates the code samples & tutorials in order to follow new best practices. 

This should NOT be merged until xrpl-py 2.0 is released. (This will be set as a draft PR until that point)

**This PR may be most digestible if read on a commit-by-commit basis. Most commits only migrate one of these breaking changes.**

## Breaking Changes

**Updates to function names for signing/submitting:**

* `send_reliable_submission` is now `submit_and_wait`
    * `submit_and_wait` can also handle the `autofill` and `sign` steps automatically (similar to how `submit_and_wait` works with xrpl.js)
* `submit_transaction` is now `submit`
* `safe_sign_and_submit_transaction` is now `sign_and_submit`
     * The `wallet` parameter here has been moved after `client` to be consistent with `submit_and_wait`
* `safe_sign_transaction` is now `sign`
* `safe_sign_and_autofill_transaction` is now `autofill_and_sign`
    * The `wallet` parameter here has been moved after `client` to be consistent with `submit_and_wait`

**`Wallet` Class**

* Removed `sequence` field
* Changed constructor to take in public and private key as required parameters
* Changed class methods to use the Ed25519 cryptographic algorithm by default
* Changed `classic_address` to `address` and made it read-only

`AccountSetFlags`
* `AccountSetAsfFlags` now contains Account Set Flags with the `ASF...` prefix.
* `AccountSetFlags` now is exclusively transaction flags.

**Core Keypairs**

* Changed the `generate_seed` method to take a hex string instead of a UTF-8 string
* Ed25519 key string is formatted with padded zeros if length is less than 32 bytes
* `sign` was made synchronous instead of asynchronous (moving a fee check out).