### PR TITLE
Improve install-rippled-on-ubuntu.md

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
+++ b/content/tutorials/manage-the-rippled-server/installation/install-rippled-on-ubuntu.md
@@ -31,23 +31,22 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
         sudo mkdir /usr/local/share/keyrings/
         wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | gpg --dearmor > ripple-key.gpg
-        sudo mv ripple-key.gpg /usr/local/share/keyrings
+        sudo mv ripple-key.gpg /usr/local/share/keyrings/
 
 
 4. Check the fingerprint of the newly-added key:
 
-        gpg /usr/local/share/keyrings/ripple-key.gpg
+        gpg --import --import-options show-only /usr/local/share/keyrings/ripple-key.gpg
 
     The output should include an entry for Ripple such as the following:
 
-        gpg: WARNING: no command supplied.  Trying to guess what you mean ...
         pub   rsa3072 2019-02-14 [SC] [expires: 2026-02-17]
             C0010EC205B35A3310DC90DE395F97FFCCAFD9A2
         uid           TechOps Team at Ripple <techops+rippled@ripple.com>
         sub   rsa3072 2019-02-14 [E] [expires: 2026-02-17]
 
 
-    In particular, make sure that the fingerprint matches. (In the above example, the fingerprint is on the third line, starting with `C001`.)
+    In particular, make sure that the fingerprint matches. (In the above example, the fingerprint is on the second line, starting with `C001`.)
 
 4. Add the appropriate Ripple repository for your operating system version:
 


### PR DESCRIPTION
Minor improvements:

- `mv` will rename the file (instead of moving it into a destination directory) if the destination directory does not exist. By providing the `/`, we are being explicit that we want the file to be moved.
  - If the earlier `mkdir` command was skipped or failed, we want `mv`  to report an error, instead of silently renaming the key file to `keyrings`, which would not make sense.
- Supplying a command to `gpg` prevents the warning which was previously shown in the gpg output.