### PR TITLE
fix: explainer videos autoplaying on first load of xrpl.org/docs.html

### DIFF
--- a/template/page-docs.html.jinja
+++ b/template/page-docs.html.jinja
@@ -110,17 +110,17 @@
       {
         "src": "./assets/img/backgrounds/docs-advanced-payment-features@2x.png",
         "title": "Advanced Payment Features",
-        "url": "https://www.youtube.com/embed/e2Iwsk37LMk?rel=0&amp;showinfo=0&amp;autoplay=1",
+        "url": "https://www.youtube.com/embed/e2Iwsk37LMk?rel=0&amp;showinfo=0",
       },
       {
         "src": "./assets/img/backgrounds/docs-governance@2x.png",
         "title": "Governance and the Amendment Process",
-        "url": "https://www.youtube.com/embed/4GbRdanHoR4?rel=0&amp;showinfo=0&amp;autoplay=1",
+        "url": "https://www.youtube.com/embed/4GbRdanHoR4?rel=0&amp;showinfo=0",
       },
       {
         "src": "./assets/img/backgrounds/docs-sidechains@2x.png",
         "title": "Federated Sidechains",
-        "url": "https://www.youtube.com/embed/NhH4LM8NxgY?rel=0&amp;showinfo=0&amp;autoplay=1",
+        "url": "https://www.youtube.com/embed/NhH4LM8NxgY?rel=0&amp;showinfo=0",
       },
     ]
   %}
@@ -189,22 +189,22 @@
     {
       "src": "./assets/img/backgrounds/docs-intro-to-XRP-ledger@2x.png",
       "title": "Intro to XRP Ledger",
-      "url": "https://www.youtube.com/embed/sVTybJ3cNyo?rel=0&amp;showinfo=0&amp;autoplay=1",
+      "url": "https://www.youtube.com/embed/sVTybJ3cNyo?rel=0&amp;showinfo=0",
     },
     {
       "src": "./assets/img/backgrounds/docs-accounts@2x.png",
       "title": "Accounts",
-      "url": "https://www.youtube.com/embed/eO8jE6PftX8?rel=0&amp;showinfo=0&amp;autoplay=1",
+      "url": "https://www.youtube.com/embed/eO8jE6PftX8?rel=0&amp;showinfo=0",
     },
     {
       "src": "./assets/img/backgrounds/docs-decentralized-exchange@2x.png",
       "title": "Decentralized Exchange",
-      "url": "https://www.youtube.com/embed/VWNrHBDfXvA?rel=0&amp;showinfo=0&amp;autoplay=1",
+      "url": "https://www.youtube.com/embed/VWNrHBDfXvA?rel=0&amp;showinfo=0",
     },
     {
       "src": "./assets/img/backgrounds/docs-tokenization@2x.png",
       "title": "Tokenization",
-      "url": "https://www.youtube.com/embed/Oj4cWOiWf4A?rel=0&amp;showinfo=0&amp;autoplay=1",
+      "url": "https://www.youtube.com/embed/Oj4cWOiWf4A?rel=0&amp;showinfo=0",
     },
     ]
   %}

--- a/template/page-docs.html.jinja
+++ b/template/page-docs.html.jinja
@@ -48,7 +48,6 @@
 
   {% macro videoCard(url, title, src)%}
     <div class="col float-up-on-hover">
-      <iframe id="video1" style="display:none;" src="{{url}}" title="{{title}}" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       <a href="{{url}}" id="playvideo" class="btn1" data-url={{url}}>
         <img
           class="get-started-img video-image"
@@ -110,17 +109,17 @@
       {
         "src": "./assets/img/backgrounds/docs-advanced-payment-features@2x.png",
         "title": "Advanced Payment Features",
-        "url": "https://www.youtube.com/embed/e2Iwsk37LMk?rel=0&amp;showinfo=0",
+        "url": "https://www.youtube.com/embed/e2Iwsk37LMk?rel=0&amp;showinfo=0&amp;autoplay=1",
       },
       {
         "src": "./assets/img/backgrounds/docs-governance@2x.png",
         "title": "Governance and the Amendment Process",
-        "url": "https://www.youtube.com/embed/4GbRdanHoR4?rel=0&amp;showinfo=0",
+        "url": "https://www.youtube.com/embed/4GbRdanHoR4?rel=0&amp;showinfo=0&amp;autoplay=1",
       },
       {
         "src": "./assets/img/backgrounds/docs-sidechains@2x.png",
         "title": "Federated Sidechains",
-        "url": "https://www.youtube.com/embed/NhH4LM8NxgY?rel=0&amp;showinfo=0",
+        "url": "https://www.youtube.com/embed/NhH4LM8NxgY?rel=0&amp;showinfo=0&amp;autoplay=1",
       },
     ]
   %}
@@ -189,22 +188,22 @@
     {
       "src": "./assets/img/backgrounds/docs-intro-to-XRP-ledger@2x.png",
       "title": "Intro to XRP Ledger",
-      "url": "https://www.youtube.com/embed/sVTybJ3cNyo?rel=0&amp;showinfo=0",
+      "url": "https://www.youtube.com/embed/sVTybJ3cNyo?rel=0&amp;showinfo=0&amp;autoplay=1",
     },
     {
       "src": "./assets/img/backgrounds/docs-accounts@2x.png",
       "title": "Accounts",
-      "url": "https://www.youtube.com/embed/eO8jE6PftX8?rel=0&amp;showinfo=0",
+      "url": "https://www.youtube.com/embed/eO8jE6PftX8?rel=0&amp;showinfo=0&amp;autoplay=1",
     },
     {
       "src": "./assets/img/backgrounds/docs-decentralized-exchange@2x.png",
       "title": "Decentralized Exchange",
-      "url": "https://www.youtube.com/embed/VWNrHBDfXvA?rel=0&amp;showinfo=0",
+      "url": "https://www.youtube.com/embed/VWNrHBDfXvA?rel=0&amp;showinfo=0&amp;autoplay=1",
     },
     {
       "src": "./assets/img/backgrounds/docs-tokenization@2x.png",
       "title": "Tokenization",
-      "url": "https://www.youtube.com/embed/Oj4cWOiWf4A?rel=0&amp;showinfo=0",
+      "url": "https://www.youtube.com/embed/Oj4cWOiWf4A?rel=0&amp;showinfo=0&amp;autoplay=1",
     },
     ]
   %}


### PR DESCRIPTION
This fixes an issue where if you went to https://xrpl.org/docs.html after enabling audio from auto-played videos, you'd hear every explainer video at the same time, which can be a rather jarring experience.

The fix was to turn off autoplay on the youtube videos.