### PR TITLE
change limit description for all API's required

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_channels.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_channels.md
@@ -61,7 +61,7 @@ The request includes the following parameters:
 | `destination_account` | String - [Address][] | No        | A second account; if provided, filter results to payment channels whose destination is this account. |
 | `ledger_hash`         | String               | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index`        | Number or String     | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`               | Number               | No        | Limit the number of transactions to retrieve. Cannot be less than 10 or more than 400. Values outside this range are replaced with the closest valid option. The default is 200. |
+| `limit`               | Number               | No        | Limit the number of transactions to retrieve. Cannot be less than 10 or more than 400. Positive values outside this range are replaced with the closest valid option. The default is 200. |
 | `marker`              | [Marker][]           | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 ## Response Format

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_channels.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_channels.md
@@ -61,7 +61,7 @@ The request includes the following parameters:
 | `destination_account` | String - [Address][] | No        | A second account; if provided, filter results to payment channels whose destination is this account. |
 | `ledger_hash`         | String               | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index`        | Number or String     | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`               | Number               | No        | Limit the number of transactions to retrieve. Cannot be less than 10 or more than 400. The default is 200. |
+| `limit`               | Number               | No        | Set transaction retrieval limit between 10 and 400. Invalid numbers are replaced with the closest valid option. Default is 200.|
 | `marker`              | [Marker][]           | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 ## Response Format

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_channels.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_channels.md
@@ -61,7 +61,7 @@ The request includes the following parameters:
 | `destination_account` | String - [Address][] | No        | A second account; if provided, filter results to payment channels whose destination is this account. |
 | `ledger_hash`         | String               | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index`        | Number or String     | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`               | Number               | No        | Set transaction retrieval limit between 10 and 400. Invalid numbers are replaced with the closest valid option. Default is 200.|
+| `limit`               | Number               | No        | Limit the number of transactions to retrieve. Cannot be less than 10 or more than 400. Values outside this range are replaced with the closest valid option. The default is 200. |
 | `marker`              | [Marker][]           | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 ## Response Format

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_lines.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_lines.md
@@ -50,7 +50,7 @@ rippled account_lines r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59
 
 [Try it! >](websocket-api-tool.html#account_lines)
 
-The request accepts the following parameters:
+The request accepts the following parameters: /Users/peterchen/xrpl-dev-portal/content/references/http-websocket-apis/public-api-methods/account-methods/account_lines.md
 
 | `Field`        | Type                 | Description    |
 |:---------------|:---------------------|:---------------|
@@ -58,7 +58,7 @@ The request accepts the following parameters:
 | `ledger_hash`  | String               | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | Number or String     | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 | `peer`         | String - [Address][] | _(Optional)_ A second account; if provided, filter results to trust lines connecting the two accounts. |
-| `limit`        | Number               | _(Optional)_ Limit the number of trust lines to retrieve. The server may return less than the specified limit, even if there are more pages of results. Must be within the inclusive range 10 to 400. The default is 200. |
+| `limit`        | Number               | _(Optional)_ Limit the number of trust lines to retrieve. The server may return less than the specified limit, even if there are more pages of results. Must be within the inclusive range 10 to 400.  Positive values outside this range are replaced with the closest valid option. The default is 200. |
 | `marker`       | [Marker][]           | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 The following parameters are deprecated and may be removed without further notice: `ledger` and `peer_index`.

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_nfts.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_nfts.md
@@ -52,7 +52,7 @@ The request includes the following parameters:
 | `account`      | String           | The unique identifier of an account, typically the account's [Address][]. The request returns a list of NFTs owned by this account. |
 | `ledger_hash`  | String           | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Number | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`        | Integer          | _(Optional)_ Limit the number of [token pages][NFTokenPage object] to retrieve. Each page can contain up to 32 NFTs. The `limit` value cannot be lower than 20 or more than 400. Values outside this range are replaced with the closest valid option. The default is 100. |
+| `limit`        | Integer          | _(Optional)_ Limit the number of [token pages][NFTokenPage object] to retrieve. Each page can contain up to 32 NFTs. The `limit` value cannot be lower than 20 or more than 400. Positive values outside this range are replaced with the closest valid option. The default is 100. |
 | `marker`       | [Marker][]       | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_nfts.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_nfts.md
@@ -52,7 +52,7 @@ The request includes the following parameters:
 | `account`      | String           | The unique identifier of an account, typically the account's [Address][]. The request returns a list of NFTs owned by this account. |
 | `ledger_hash`  | String           | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Number | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`        | Integer          | _(Optional)_ Limit the number of [token pages][NFTokenPage object] to retrieve. Each page can contain up to 32 NFTs. The `limit` value cannot be lower than 20 or more than 400. The default is 100. |
+| `limit`        | Integer          | _(Optional)_ Limit the number of [token pages][NFTokenPage object] to retrieve. Each page can contain up to 32 NFTs. The `limit` value cannot be lower than 20 or more than 400. Values outside this range are replaced with the closest valid option. The default is 100. |
 | `marker`       | [Marker][]       | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_offers.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_offers.md
@@ -57,7 +57,7 @@ A request can include the following parameters:
 | `account`      | String - [Address][] | Yes       | Look up Offers placed by this account. |
 | `ledger_hash`  | String               | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | Number or String     | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`        | Number               | No        | Limit the number of Offers to retrieve. The server may return fewer than this number of results. Must be within the inclusive range 10 to 400. The default is 200. |
+| `limit`        | Number               | No        | Limit the number of Offers to retrieve. The server may return fewer than this number of results. Must be within the inclusive range 10 to 400. Values outside this range are replaced with the closest valid option.The default is 200. |
 | `marker`       | [Marker][]           | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 The following parameters are deprecated should not be provided: `ledger`, `strict`.

--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_offers.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_offers.md
@@ -57,7 +57,7 @@ A request can include the following parameters:
 | `account`      | String - [Address][] | Yes       | Look up Offers placed by this account. |
 | `ledger_hash`  | String               | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | Number or String     | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`        | Number               | No        | Limit the number of Offers to retrieve. The server may return fewer than this number of results. Must be within the inclusive range 10 to 400. Values outside this range are replaced with the closest valid option.The default is 200. |
+| `limit`        | Number               | No        | Limit the number of Offers to retrieve. The server may return fewer than this number of results. Must be within the inclusive range 10 to 400. Positive values outside this range are replaced with the closest valid option.The default is 200. |
 | `marker`       | [Marker][]           | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 The following parameters are deprecated should not be provided: `ledger`, `strict`.

--- a/content/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data.md
+++ b/content/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data.md
@@ -55,7 +55,7 @@ A request can include the following fields:
 | `ledger_hash`  | [Hash][]         | No        | A 20-byte hex string identifying the ledger version to use. |
 | `ledger_index` | [Ledger Index][] | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 | `binary`       | Boolean          | No        | If `true`, return ledger entries as hexadecimal strings instead of JSON. The default is `false`. |
-| `limit`        | Number           | No        | Limit the number of ledger entries to retrieve. The server may return fewer than this number of entries. Cannot be more than 2048 (when requesting binary) or 256 (when requesting JSON). The default is the maximum. |
+| `limit`        | Number           | No        | Limit the number of ledger entries to retrieve. The server may return fewer than this number of entries. Cannot be more than 2048 (when requesting binary) or 256 (when requesting JSON). Values outside this range are replaced with the closest valid option. The default is the maximum. |
 | `marker`       | [Marker][]       | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 | `type`         | String           | No        | Filter results to a specific type of ledger entry. {% include '_snippets/lowercase-types.md' %} |
 

--- a/content/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data.md
+++ b/content/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data.md
@@ -55,7 +55,7 @@ A request can include the following fields:
 | `ledger_hash`  | [Hash][]         | No        | A 20-byte hex string identifying the ledger version to use. |
 | `ledger_index` | [Ledger Index][] | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 | `binary`       | Boolean          | No        | If `true`, return ledger entries as hexadecimal strings instead of JSON. The default is `false`. |
-| `limit`        | Number           | No        | Limit the number of ledger entries to retrieve. The server may return fewer than this number of entries. Cannot be more than 2048 (when requesting binary) or 256 (when requesting JSON). Values outside this range are replaced with the closest valid option. The default is the maximum. |
+| `limit`        | Number           | No        | Limit the number of ledger entries to retrieve. The server may return fewer than this number of entries. Cannot be more than 2048 (when requesting binary) or 256 (when requesting JSON). Positive values outside this range are replaced with the closest valid option. The default is the maximum. |
 | `marker`       | [Marker][]       | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
 | `type`         | String           | No        | Filter results to a specific type of ledger entry. {% include '_snippets/lowercase-types.md' %} |
 

--- a/content/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers.md
+++ b/content/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers.md
@@ -52,7 +52,7 @@ The request includes the following parameters:
 | `nft_id`       | String           | The unique identifier of a [NFToken][] object. |
 | `ledger_hash`  | String           | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Number | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`        | Integer          | _(Optional)_ Limit the number of NFT buy offers to retrieve. This value cannot be lower than 50 or more than 500. The default is 250. |
+| `limit`        | Integer          | _(Optional)_ Limit the number of NFT buy offers to retrieve. This value cannot be lower than 50 or more than 500. Values outside this range are replaced with the closest valid option. The default is 250. |
 | `marker`       | [Marker][]       | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 

--- a/content/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers.md
+++ b/content/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers.md
@@ -52,7 +52,7 @@ The request includes the following parameters:
 | `nft_id`       | String           | The unique identifier of a [NFToken][] object. |
 | `ledger_hash`  | String           | _(Optional)_ A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | String or Number | _(Optional)_ The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
-| `limit`        | Integer          | _(Optional)_ Limit the number of NFT buy offers to retrieve. This value cannot be lower than 50 or more than 500. Values outside this range are replaced with the closest valid option. The default is 250. |
+| `limit`        | Integer          | _(Optional)_ Limit the number of NFT buy offers to retrieve. This value cannot be lower than 50 or more than 500. Positive values outside this range are replaced with the closest valid option. The default is 250. |
 | `marker`       | [Marker][]       | _(Optional)_ Value from a previous paginated response. Resume retrieving data where that response left off. |
 
 


### PR DESCRIPTION
The description of "limit" field will need to be changed for many of the API's to help clarify that values below 10 will be set to 10 and values above 400 will be set to 400. More information can be found here: https://github.com/XRPLF/xrpl-dev-portal/issues/1985 

I will change the rest of the api's that has the "limit" field to the new description once approved/changed. 