### PR TITLE
IAv3: Fix incomplete 'Ledgers' blurb

### DIFF
--- a/content/concepts/ledgers/ledgers.md
+++ b/content/concepts/ledgers/ledgers.md
@@ -1,7 +1,7 @@
 ---
 html: ledgers.html
 parent: concepts.html
-blurb: The history of 
+blurb: Ledgers are the data structure that holds data in the shared XRP Ledger network. A chain of ledgers records the history of transactions and state changes.
 labels:
   - Blockchain
   - Data Retention


### PR DESCRIPTION
The blurb for the "Ledgers" concept was an incomplete fragment.