### PR TITLE
Clarify partial-payments.md

### DIFF
--- a/content/concepts/payment-types/partial-payments.md
+++ b/content/concepts/payment-types/partial-payments.md
@@ -8,7 +8,7 @@ labels:
 ---
 # Partial Payments
 
-The sender of any Payment can enable the "Partial Payment" flag and send a payment which delivers less than the `Amount` field indicates. When processing any Payment, use [the `delivered_amount` metadata field](#the-delivered_amount-field), not the `Amount` field. The `delivered_amount` is the amount a payment actually delivered.
+The sender of any Payment can enable the "Partial Payment" flag and send a payment which delivers less than the `Amount` field indicates. When processing any Payment, use the `delivered_amount` metadata field, not the `Amount` field. The `delivered_amount` is the amount a payment actually delivered.
 
 If a Payment does not enable the Partial Payment flag, the `Amount` field of a [Payment transaction][] in the XRP Ledger specifies the amount to deliver after charging for exchange rates and [transfer fees](transfer-fees.html). The Partial Payment flag ([`tfPartialPayment`](payment.html#payment-flags)) allows a payment to succeed by reducing the amount received instead of increasing the amount sent. Partial payments are useful for [returning payments](become-an-xrp-ledger-gateway.html#bouncing-payments) without incurring additional costs to oneself.
 

--- a/content/concepts/payment-types/partial-payments.md
+++ b/content/concepts/payment-types/partial-payments.md
@@ -8,7 +8,7 @@ labels:
 ---
 # Partial Payments
 
-The sender of any Payment can enable the "Partial Payment" flag and send a payment which delivers less than the `Amount` field indicates. When processing any Payment, use the `delivered_amount` metadata field, not the `Amount` field. The `delivered_amount` is the amount a payment actually delivered.
+The sender of any [Payment transaction][] can enable the ["Partial Payment" flag](payment.html#payment-flags) and send a payment which delivers less than the `Amount` field indicates. When processing any Payment, use the `delivered_amount` metadata field, not the `Amount` field. The `delivered_amount` is the amount a payment actually delivered.
 
 If a Payment does not enable the Partial Payment flag, the `Amount` field of a [Payment transaction][] in the XRP Ledger specifies the amount to deliver after charging for exchange rates and [transfer fees](transfer-fees.html). The Partial Payment flag ([`tfPartialPayment`](payment.html#payment-flags)) allows a payment to succeed by reducing the amount received instead of increasing the amount sent. Partial payments are useful for [returning payments](become-an-xrp-ledger-gateway.html#bouncing-payments) without incurring additional costs to oneself.
 

--- a/content/concepts/payment-types/partial-payments.md
+++ b/content/concepts/payment-types/partial-payments.md
@@ -8,9 +8,11 @@ labels:
 ---
 # Partial Payments
 
-In the default case, the `Amount` field of a [Payment transaction][] in the XRP Ledger specifies the exact amount to deliver, after charging for exchange rates and [transfer fees](transfer-fees.html). The "Partial Payment" flag ([`tfPartialPayment`](payment.html#payment-flags)) allows a payment to succeed by reducing the amount received instead of increasing the amount sent. Partial payments are useful for [returning payments](become-an-xrp-ledger-gateway.html#bouncing-payments) without incurring additional costs to oneself.
+The sender of any Payment can enable the "Partial Payment" flag and send a payment which delivers less than the `Amount` field indicates. When processing any Payment, use [the `delivered_amount` metadata field](#the-delivered_amount-field), not the `Amount` field. The `delivered_amount` is the amount a payment actually delivered.
 
-The amount of XRP used for the [transaction cost](transaction-cost.html) is always deducted from the sender’s account, regardless of the type of transaction.
+If a Payment does not enable the Partial Payment flag, the `Amount` field of a [Payment transaction][] in the XRP Ledger specifies the amount to deliver after charging for exchange rates and [transfer fees](transfer-fees.html). The Partial Payment flag ([`tfPartialPayment`](payment.html#payment-flags)) allows a payment to succeed by reducing the amount received instead of increasing the amount sent. Partial payments are useful for [returning payments](become-an-xrp-ledger-gateway.html#bouncing-payments) without incurring additional costs to oneself.
+
+The amount of XRP used for the [transaction cost](transaction-cost.html) is always deducted from the sender’s account, regardless of the type of transaction. This transaction cost, or fee, is not included in the `Amount`.
 
 Partial payments can be used to exploit naive integrations with the XRP Ledger to steal money from exchanges and gateways. The [Partial Payments Exploit](#partial-payments-exploit) section of this document describes how this exploit works and how you can avoid it.
 


### PR DESCRIPTION
- Clarify that the sender of any Payment can enable the Partial Payment flag (it's not something that recipients control).
- Avoid burying the lede. Remind people to use delivered_amount. It can't be repeated too much.
- Clarify that the transaction cost is separate from the Amount.