### PR TITLE
Create build-for-linux-macos-windows.md

### DIFF
--- a/content/tutorials/manage-the-rippled-server/installation/build-for-linux-macos-windows.md
+++ b/content/tutorials/manage-the-rippled-server/installation/build-for-linux-macos-windows.md
@@ -1,0 +1,39 @@
+---
+html: build-for-linux-macos-windows.html
+parent: install-rippled.html
+blurb: Build rippled binary on Linux, macOS, or Windows.
+labels:
+  - Core Server
+---
+# Build rippled on Linux, macOS, or Windows
+
+This page links to the build instructions for `rippled`. You can build `rippled` for testing, development, and/or production.
+
+- [Build instructions for `rippled` on GitHub](https://github.com/XRPLF/rippled/blob/develop/BUILD.md)
+
+
+## Next Steps
+
+{% include '_snippets/post-rippled-install.md' %}
+<!--_ -->
+
+
+## See Also
+
+- **Concepts:**
+    - [The `rippled` Server](xrpl-servers.html)
+    - [Introduction to Consensus](intro-to-consensus.html)
+- **Tutorials:**
+    - [Configure rippled](configure-rippled.html)
+    - [Troubleshoot rippled](troubleshoot-the-rippled-server.html)
+    - [Get Started with the rippled API](get-started-using-http-websocket-apis.html)
+- **References:**
+    - [rippled API Reference](http-websocket-apis.html)
+        - [`rippled` Commandline Usage](commandline-usage.html)
+        - [server_info method][]
+
+
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}
+{% include '_snippets/tx-type-links.md' %}
+{% include '_snippets/rippled_versions.md' %}


### PR DESCRIPTION
It is currently difficult/impossible to find the rippled build instructions on xrpl.org. This PR aims to make those instructions easier to find.