### PR TITLE
Shows that the translation of the content is out of date.

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -870,6 +870,7 @@ pages:
 
         # TODO: update translation. Some parts split into "ledger structure"
     -   md: concepts/ledgers/ledgers.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -1263,6 +1264,7 @@ pages:
 
         # TODO: update translation
     -   md: concepts/tokens/automated-market-makers.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -1281,6 +1283,7 @@ pages:
 
         #TODO: update translation. Mostly just the title has changed
     -   md: concepts/accounts/account-types.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -1310,6 +1313,7 @@ pages:
 
         # TODO: update translation based on latest English version
     -   md: concepts/accounts/cryptographic-keys.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -1807,6 +1811,7 @@ pages:
         # TODO: translate
     -   md: tutorials/get-started/get-started-using-java.md
         top_nav_grouping: 始めましょう
+        untranslated_warning: true
         targets:
             - ja
 
@@ -2073,6 +2078,7 @@ pages:
 
         # TODO: update translation to match English updates
     -   md: tutorials/use-specialized-payment-types/use-checks/use-checks.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2339,6 +2345,7 @@ pages:
 
         # TODO: update translation to add a table like in the English version
     -   md: references/protocol-reference/data-types/currency-formats.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2349,6 +2356,7 @@ pages:
         # TODO: update translation to use the term "sequence number" rather than
         # "dumb sequential"
     -   md: references/protocol-reference/data-types/nftoken.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2390,6 +2398,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0 & AMM
     -   md: references/protocol-reference/ledger-data/ledger-object-types/accountroot.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2407,6 +2416,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/ledger-data/ledger-object-types/amm.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2534,6 +2544,7 @@ pages:
 
         # TODO: update blurb translation based on English version
     -   md: references/protocol-reference/transactions/transaction-formats.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2543,6 +2554,7 @@ pages:
 
         # TODO: update translation with rippled 1.11.0 changes
     -   md: references/protocol-reference/transactions/transaction-common-fields.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2576,6 +2588,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/transactions/transaction-types/ammbid.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2585,6 +2598,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/transactions/transaction-types/ammcreate.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2600,6 +2614,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/transactions/transaction-types/ammdeposit.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2609,6 +2624,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/transactions/transaction-types/ammvote.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2618,6 +2634,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/transactions/transaction-types/ammwithdraw.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2859,6 +2876,7 @@ pages:
 
         # TODO: update translation
     -   md: references/protocol-reference/transactions/transaction-results/tel-codes.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2892,6 +2910,7 @@ pages:
 
         # TODO: update translation to latest English version
     -   md: references/protocol-reference/transactions/transaction-metadata.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -2910,6 +2929,7 @@ pages:
 
         # TODO: update translation with new/updated sections from the English version
     -   md: references/protocol-reference/serialization.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3134,6 +3154,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0
     -   md: references/http-websocket-apis/public-api-methods/account-methods/account_currencies.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3143,6 +3164,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0
     -   md: references/http-websocket-apis/public-api-methods/account-methods/account_info.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3152,6 +3174,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0
     -   md: references/http-websocket-apis/public-api-methods/account-methods/account_lines.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3169,6 +3192,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0
     -   md: references/http-websocket-apis/public-api-methods/account-methods/account_objects.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3178,6 +3202,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0
     -   md: references/http-websocket-apis/public-api-methods/account-methods/account_offers.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3340,6 +3365,7 @@ pages:
 
         # TODO: update translation
     -   md: references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3488,6 +3514,7 @@ pages:
 
         # TODO: update translation with reporting fields, ETL source object, corrected state_account.*.transitions field
     -   md: references/http-websocket-apis/public-api-methods/server-info-methods/server_info.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3497,6 +3524,7 @@ pages:
 
         # TODO: update translation with reporting fields, ETL source object, corrected state_account.*.transitions field
     -   md: references/http-websocket-apis/public-api-methods/server-info-methods/server_state.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -3869,6 +3897,7 @@ pages:
 
         # TODO: update translation for rippled v1.11.0
     -   md: references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/feature.ja.md
+        outdated_translation: true
         targets:
             - ja
 
@@ -4020,6 +4049,7 @@ pages:
 
         # TODO: update translation
     -   md: infrastructure/rippled/commandline-usage.ja.md
+        outdated_translation: true
         targets:
             - ja
 

--- a/template/pagetype-doc.html.jinja
+++ b/template/pagetype-doc.html.jinja
@@ -26,6 +26,12 @@
       <p class="mb-0">{% trans %}We are making an effort to offer the XRP Ledger Dev Portal in a variety of languages, but not all pages are available in all languages. If you'd like to help, <a href="https://github.com/XRPLF/xrpl-dev-portal/blob/master/CONTRIBUTING.md">please contribute!</a>{% endtrans %}</p>
     </div><!--/.devportal-callout-->
     {% endif %}
+    {% if target.lang != "en" and currentpage.outdated_translation %}
+    {# Add a "This translation is not up-to-date." banner. #}
+    <div class="mb-5 devportal-callout note"><strong>{% trans %}This page has the latest version, but it is not provided in this language.{% endtrans %}</strong>
+      <p class="mb-0">{% trans %}We are making an effort to offer the XRP Ledger Dev Portal in a variety of languages, but not all translated contents are up-to-date. If you'd like to help, <a href="https://github.com/XRPLF/xrpl-dev-portal/blob/master/CONTRIBUTING.md">please contribute!</a>{% endtrans %}</p>
+    </div><!--/.devportal-callout-->
+    {% endif %}
     <div class="content">
         {{ content }}
     </div>

--- a/template/pagetype-doc.html.jinja
+++ b/template/pagetype-doc.html.jinja
@@ -28,7 +28,7 @@
     {% endif %}
     {% if target.lang != "en" and currentpage.outdated_translation %}
     {# Add a "This translation is not up-to-date." banner. #}
-    <div class="mb-5 devportal-callout note"><strong>{% trans %}This page has the latest version, but it is not provided in this language.{% endtrans %}</strong>
+    <div class="mb-5 devportal-callout note"><strong>{% trans %}This translated page is not updated to match the latest changes in the English version.{% endtrans %}</strong>
       <p class="mb-0">{% trans %}We are making an effort to offer the XRP Ledger Dev Portal in a variety of languages, but not all translated contents are up-to-date. If you'd like to help, <a href="https://github.com/XRPLF/xrpl-dev-portal/blob/master/CONTRIBUTING.md">please contribute!</a>{% endtrans %}</p>
     </div><!--/.devportal-callout-->
     {% endif %}


### PR DESCRIPTION
This PR is a proposal for features related to internationalization. Feel free to comment on it.

---

- https://github.com/XRPLF/xrpl-dev-portal/issues/2084

Indicate that the translation of the content is out of date, just as if the content were untranslated


Specify `outdated_translation` in `dactyl-config.yml` to indicate that the translation is out of date.

In addition to adding in the comments that translations are needed in the future, it is required that `outdated_translation` be specified.