### PR TITLE
fix: get-acct-info.js should use wss

### DIFF
--- a/content/_code-samples/get-started/js/get-acct-info.js
+++ b/content/_code-samples/get-started/js/get-acct-info.js
@@ -5,7 +5,7 @@ const xrpl = require("xrpl")
 async function main() {
 
   // Define the network client
-  const SERVER_URL = "https://s.altnet.rippletest.net:51234/"
+  const SERVER_URL = "wss://s.altnet.rippletest.net:51233/"
   const client = new xrpl.Client(SERVER_URL)
   await client.connect()
 


### PR DESCRIPTION
Using https would result in:

```
(node) UnhandledPromiseRejectionWarning: ValidationError: server URI must start with `wss://`, `ws://`, `wss+unix://`, or `ws+unix://`.
    at new Client (index.js:88:19)
```

- Testnet WebSocket URL from https://xrpl.org/xrp-testnet-faucet.html