### PR TITLE
[JA] update Clawback

### DIFF
--- a/content/_snippets/clawback-disclaimer.ja.md
+++ b/content/_snippets/clawback-disclaimer.ja.md
@@ -1,0 +1,1 @@
+_[Clawback amendment](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-39d-clawback)が必要です。_

--- a/content/concepts/tokens/clawing-back-tokens.ja.md
+++ b/content/concepts/tokens/clawing-back-tokens.ja.md
@@ -1,0 +1,42 @@
+---
+html: clawing-back-tokens.html
+parent: tokens.html
+blurb: 発行者は、トークンを発行する前にClawback機能を有効にすると、規制遵守の目的でトークンを取り戻すことができます。
+labels:
+  - トークン
+---
+# トークンの回収
+
+{% include '_snippets/clawback-disclaimer.ja.md' %}
+
+規制上の目的から、トークンがアカウントに送信された後にトークンを回収する機能を必要とする発行者が存在します。例えば、トークンが違法行為で制裁を受けたアカウントに送られたことが発覚した場合、発行者はその資金を「回収」することができます。
+
+発行者は、発行アカウントで**Allow Clawback**フラグを有効にすることで、トークンを回収する権限を得ることができます。発行者がすでにトークンを発行している場合、このフラグを有効にすることはできません。
+
+**注記:** アカウント自身が発行したトークンのみを回収することができます。この方法でXRPを回収することはできません。
+
+Clawback機能はデフォルトで無効になっています。使用するには、[AccountSetトランザクション][]を送信して、**Allow Trust Line Clawback**設定を有効にする必要があります。**既存のトークンを持つ発行者はClawback機能を有効にすることはできません**。**Allow Trust Line Clawback**を有効にできるのは、所有者ディレクトリが完全に空の場合のみです。つまり、トラストライン、オファー、エスクロー、ペイメントチャネル、チェック、または署名者リストを設定する前に有効にする必要があります。
+
+`lsfNoFreeze`が設定されているときに`lsfAllowTrustLineClawback`を設定しようとすると、トランザクションは`tecNO_PERMISSION`を返します。
+逆に、`lsfAllowTrustLineClawback`が設定されている時に`lsfNoFreeze`を設定しようとすると、トランザクションは`tecNO_PERMISSION`を返します。
+
+## Clawbackトランザクションの例
+
+```json
+{
+  "TransactionType": "Clawback",
+  "Account": "rp6abvbTbjoce8ZDJkT6snvxTZSYMBCC9S",
+  "Amount": {
+      "currency": "FOO",
+      "issuer": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+      "value": "314.159"
+    }
+}
+```
+
+このトランザクションが成功した場合、rp6abvbTbjoce8ZDJkT6snvxTZSYMBCC9Sが発行し、rsA2LpzuawewSBQXkiju3YQTMzW13pAAdWが保有する最大314.159FOOを回収することになります。
+
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}			
+{% include '_snippets/tx-type-links.md' %}			
+{% include '_snippets/rippled_versions.md' %}

--- a/content/concepts/tokens/clawing-back-tokens.md
+++ b/content/concepts/tokens/clawing-back-tokens.md
@@ -4,7 +4,6 @@ parent: tokens.html
 blurb: Issuers can claw back their tokens for compliance purposes if they enable the Clawback feature before issuing tokens.
 labels:
   - Tokens
-status: not_enabled
 ---
 # Clawing Back Tokens
 

--- a/content/references/protocol-reference/transactions/transaction-types/clawback.ja.md
+++ b/content/references/protocol-reference/transactions/transaction-types/clawback.ja.md
@@ -1,0 +1,55 @@
+---
+html: clawback.html
+parent: transaction-types.html
+blurb: 発行したトークンを取り戻します。
+labels:
+  - トークン
+---
+# Clawback
+
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Clawback.cpp "ソース")
+
+{% include '_snippets/clawback-disclaimer.ja.md' %}
+
+あなたのアカウントが発行したトークンを回収します。
+
+Clawback機能はデフォルトで無効になっています。使用するには、[AccountSetトランザクション][]を送信して**Allow Trust Line Clawback**設定を有効にする必要があります。既存のトークンを持つ発行者はClawback機能を有効にできません。つまり、トラストライン、オファー、エスクロー、ペイメントチャネル、チェック、または署名者リストを設定する前に行う必要があります。Clawback機能を有効にした後、元に戻すことはできません：アカウントは永久にトラストラインで発行された資産を回収する権限を得ます。
+
+## {{currentpage.name}} JSONの例
+
+```json
+{
+  "TransactionType": "Clawback",
+  "Account": "rp6abvbTbjoce8ZDJkT6snvxTZSYMBCC9S",
+  "Amount": {
+      "currency": "FOO",
+      "issuer": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+      "value": "314.159"
+    }
+}
+```
+
+{% include '_snippets/tx-fields-intro.ja.md' %}
+
+| フィールド　         | JSONの型   | [内部の型][] | 説明       |
+|:-------------------|:----------|:------------|:----------|
+| `Amount`           | [通貨額][] | Amount      | 回収する金額と、その金額を回収する相手を表します。`value`サブフィールドの回収する数量はゼロであってはなりません。これが現在の残高より多い場合、トランザクションは全残高を回収します。サブフィールド`Amount`内の`issuer`はトークン所有者のアカウントを表します。|
+
+このトランザクションを実行するアカウントは、回収する資産の発行者でなければなりません。XRP Ledgerでは、トラストラインは双方向であり、設定によっては双方が資産の*発行者*とみなされることに注意してください。この仕様において、*発行者*という用語は、未払い残高がある(つまり、発行された資産に"債務がある")トラストラインの側が、その資産を回収することを意味します。
+
+
+## エラーケース
+
+すべてのトランザクションで発生する可能性のあるエラーに加えて、{{currentpage.name}}トランザクションでは、次の[トランザクション結果コード](transaction-results.html)が発生する可能性があります。
+
+| エラーコード | 説明 |
+|:-----------|:------------|
+| `temDISABLED` | [Clawback amendment](known-amendments.html#clawback)が有効ではありません。 |
+| `temBAD_AMOUNT` | 保有者の残高が0です。回収しようとする金額が保有者の残高を超えていてもエラーにはなりません。また、`Amount`に記載されている相手がこのトランザクションを発行している`Account`と同じ場合にもエラーが発生します。 |
+| `tecNO-LINE` | 取引相手とのトラストラインがない、またはトラストラインの残高が0です。 |
+| `tecNO-PERMISSION` | `lsfNoFreeze`が設定されているときに`lsfAllowTrustlineClawback`を設定、または`lsfAllowTrustLineClawback`が設定されているときに`lsfNoFreeze`を設定しようとしています。 |
+
+<!-- {# common link defs #} -->
+{% include '_snippets/rippled-api-links.md' %}
+{% include '_snippets/tx-type-links.md' %}
+{% include '_snippets/rippled_versions.md' %}

--- a/content/references/protocol-reference/transactions/transaction-types/clawback.md
+++ b/content/references/protocol-reference/transactions/transaction-types/clawback.md
@@ -4,7 +4,6 @@ parent: transaction-types.html
 blurb: Claw back tokens you've issued.
 labels:
   - Tokens
-status: not_enabled
 ---
 # Clawback
 
@@ -16,7 +15,7 @@ Claw back tokens issued by your account.
 
 Clawback is disabled by default. To use clawback, you must send an [AccountSet transaction][] to enable the **Allow Trust Line Clawback** setting. An issuer with any existing tokens cannot enable Clawback. You can only enable **Allow Trust Line Clawback** if you have a completely empty owner directory, meaning you must do so before you set up any trust lines, offers, escrows, payment channels, checks, or signer lists.  After you enable Clawback, it cannot reverted: the account permanently gains the ability to claw back issued assets on trust lines.
 
-## Example Clawback JSON
+## Example {{currentpage.name}} JSON
 
 ```json
 {
@@ -29,8 +28,6 @@ Clawback is disabled by default. To use clawback, you must send an [AccountSet t
     }
 }
 ```
-
-## Clawback Fields
 
 {% include '_snippets/tx-fields-intro.md' %}
 

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -1227,10 +1227,14 @@ pages:
         targets:
             - ja
 
-# TODO - Translate
     -   md: concepts/tokens/clawing-back-tokens.md
+        status: not_enabled
         targets:
             - en
+
+    -   md: concepts/tokens/clawing-back-tokens.ja.md
+        status: not_enabled
+        targets:
             - ja
 
     -   md: concepts/tokens/freezes.md
@@ -2751,10 +2755,14 @@ pages:
         targets:
             - ja
 
-# TODO: Translate
     -   md: references/protocol-reference/transactions/transaction-types/clawback.md
+        status: not_enabled
         targets:
             - en
+
+    -   md: references/protocol-reference/transactions/transaction-types/clawback.ja.md
+        status: not_enabled
+        targets:
             - ja
 
     -   md: references/protocol-reference/transactions/transaction-types/depositpreauth.md


### PR DESCRIPTION
Moved `status: not_enabled` to config so that it is easy to see that it needs to be removed in multiple languages after enabling Clawback.