### PR TITLE
[JA] fix doc.html

### DIFF
--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -444,8 +444,7 @@ pages:
         html: docs.html
         parent: index.html
         template: page-docs.html.jinja
-        sidebar: disabled
-        top_nav_level: 1
+        sidebar: left_only
         top_nav_name: ドキュメント
         top_nav_shortcuts:
             # Programming Languages


### PR DESCRIPTION
Apply the settings of the English version to Japanese as well

before 
<img width="1443" alt="スクリーンショット 2023-10-03 14 26 35" src="https://github.com/XRPLF/xrpl-dev-portal/assets/69445828/524382c8-65ff-4800-a97e-9fe903ddccba">

after 
<img width="1441" alt="スクリーンショット 2023-10-03 14 26 48" src="https://github.com/XRPLF/xrpl-dev-portal/assets/69445828/20edba93-e243-49e8-87e6-1f0c5d46d0dc">
