### PR TITLE
Note that `fee_ref` will be removed if XRPFees is enabled

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
+++ b/content/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
@@ -169,7 +169,7 @@ The fields from a ledger stream message are as follows:
 |:--------------------|:--------------------------|:---------------------------|
 | `type`              | String                    | `ledgerClosed` indicates this is from the ledger stream |
 | `fee_base`          | Number                    | The [reference transaction cost](transaction-cost.html#reference-transaction-cost) as of this ledger version, in [drops of XRP][]. If this ledger version includes a [SetFee pseudo-transaction](setfee.html) the new transaction cost applies starting with the following ledger version. |
-| `fee_ref`           | Number                    | _(May be omitted)_ The [reference transaction cost](transaction-cost.html#reference-transaction-cost) in "fee units". If the _[XRPFees amendment][]_ is enabled, it is permanently omitted, as it will no longer be relevant. |
+| `fee_ref`           | Number                    | _(May be omitted)_ The [reference transaction cost](transaction-cost.html#reference-transaction-cost) in "fee units". If the _[XRPFees amendment][]_ is enabled, this field is permanently omitted as it will no longer be relevant. |
 | `ledger_hash`       | String - [Hash][]         | The identifying hash of the ledger version that was closed. |
 | `ledger_index`      | Number - [Ledger Index][] | The ledger index of the ledger that was closed. |
 | `ledger_time`       | Number                    | The time this ledger was closed, in [seconds since the Ripple Epoch][] |

--- a/content/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
+++ b/content/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
@@ -169,7 +169,7 @@ The fields from a ledger stream message are as follows:
 |:--------------------|:--------------------------|:---------------------------|
 | `type`              | String                    | `ledgerClosed` indicates this is from the ledger stream |
 | `fee_base`          | Number                    | The [reference transaction cost](transaction-cost.html#reference-transaction-cost) as of this ledger version, in [drops of XRP][]. If this ledger version includes a [SetFee pseudo-transaction](setfee.html) the new transaction cost applies starting with the following ledger version. |
-| `fee_ref`           | Number                    | _(May be omitted)_ The [reference transaction cost](transaction-cost.html#reference-transaction-cost) in "fee units".  Will be permanently omitted if the _[XRPFees amendment][]_ is enabled, because it will no longer have any meaning. |
+| `fee_ref`           | Number                    | _(May be omitted)_ The [reference transaction cost](transaction-cost.html#reference-transaction-cost) in "fee units". If the _[XRPFees amendment][]_ is enabled, it is permanently omitted, as it will no longer be relevant. |
 | `ledger_hash`       | String - [Hash][]         | The identifying hash of the ledger version that was closed. |
 | `ledger_index`      | Number - [Ledger Index][] | The ledger index of the ledger that was closed. |
 | `ledger_time`       | Number                    | The time this ledger was closed, in [seconds since the Ripple Epoch][] |

--- a/content/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
+++ b/content/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
@@ -169,7 +169,7 @@ The fields from a ledger stream message are as follows:
 |:--------------------|:--------------------------|:---------------------------|
 | `type`              | String                    | `ledgerClosed` indicates this is from the ledger stream |
 | `fee_base`          | Number                    | The [reference transaction cost](transaction-cost.html#reference-transaction-cost) as of this ledger version, in [drops of XRP][]. If this ledger version includes a [SetFee pseudo-transaction](setfee.html) the new transaction cost applies starting with the following ledger version. |
-| `fee_ref`           | Number                    | The [reference transaction cost](transaction-cost.html#reference-transaction-cost) in "fee units". |
+| `fee_ref`           | Number                    | _(May be omitted)_ The [reference transaction cost](transaction-cost.html#reference-transaction-cost) in "fee units".  Will be permanently omitted if the _[XRPFees amendment][]_ is enabled, because it will no longer have any meaning. |
 | `ledger_hash`       | String - [Hash][]         | The identifying hash of the ledger version that was closed. |
 | `ledger_index`      | Number - [Ledger Index][] | The ledger index of the ledger that was closed. |
 | `ledger_time`       | Number                    | The time this ledger was closed, in [seconds since the Ripple Epoch][] |


### PR DESCRIPTION
https://github.com/XRPLF/rippled/pull/4247 removed the `fee_ref` field from the Ledger subscription stream if `XRPFees` is enabled. This is because `XRPFees` removes the concept of fee levels from rippled, and that's what `fee_ref` returned, so it doesn't make any sense to include anymore.