### PR TITLE
known-amendments: SHAMapV2, FlowV2, SusPay, Tickets are Obsolete

### DIFF
--- a/content/resources/known-amendments.md
+++ b/content/resources/known-amendments.md
@@ -87,9 +87,9 @@ The following is a list of [amendments](amendments.html) that are being develope
 
 **Tip:** This list is updated manually. If you're working on an amendment and have a private network to test the changes, you can edit this page to add your in-development amendment to this list. For more information on contributing to the XRP Ledger, see [Contribute Code to the XRP Ledger](contribute-code-flow.html).
 
-## Vetoed or Obsolete Amendments
+## Obsolete Amendments
 
-The following is a list of known [amendments](amendments.html) that have been vetoed and removed in a previous version, or are obsolete and have been marked for removal.
+The following is a list of known [amendments](amendments.html) that have been removed in a previous version, or are obsolete and have been marked for removal.
 
 | Name                              | Introduced | Status                        |
 |:----------------------------------|:-----------|:------------------------------|
@@ -97,10 +97,10 @@ The following is a list of known [amendments](amendments.html) that have been ve
 | [fixNFTokenDirV1][]               | v1.9.1     | [Obsolete: To Be Removed]( "BADGE_RED") |
 | [NonFungibleTokensV1][]           | v1.9.0     | [Obsolete: To Be Removed]( "BADGE_RED") |
 | [CryptoConditionsSuite][]         | v0.60.0    | [Obsolete: To Be Removed]( "BADGE_RED") |
-| [SHAMapV2][]                      | v0.32.1    | [Vetoed: Removed in v1.4.0](https://xrpl.org/blog/2019/rippled-1.4.0.html "BADGE_RED") |
-| [FlowV2][]                        | v0.32.1    | [Vetoed: Removed in v0.33.0](https://xrpl.org/blog/2016/flowv2-vetoed.html "BADGE_RED") |
-| [SusPay][]                        | v0.31.0    | [Vetoed: Removed in v0.60.0](https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features "BADGE_RED") |
-| [Tickets][]                       | v0.30.1    | [Vetoed: Removed in v0.90.0](https://xrpl.org/blog/2018/rippled-0.90.0.html "BADGE_RED") |
+| [SHAMapV2][]                      | v0.32.1    | [Obsolete: Removed in v1.4.0](https://xrpl.org/blog/2019/rippled-1.4.0.html "BADGE_RED") |
+| [FlowV2][]                        | v0.32.1    | [Obsolete: Removed in v0.33.0](https://xrpl.org/blog/2016/flowv2-vetoed.html "BADGE_RED") |
+| [SusPay][]                        | v0.31.0    | [Obsolete: Removed in v0.60.0](https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features "BADGE_RED") |
+| [Tickets][]                       | v0.30.1    | [Obsolete: Removed in v0.90.0](https://xrpl.org/blog/2018/rippled-0.90.0.html "BADGE_RED") |
 
 
 ## Details about Known Amendments


### PR DESCRIPTION
Maybe it's just me, but I don't really see the usefulness of distinguishing between Obsolete and "Vetoed", and I feel it could be a bit confusing given that `vetoed` is also [something that individual validators do](https://xrpl.org/feature.html).

What do we lose by just calling these Obsolete?