### PR TITLE
include counters parameter in server_info command

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -49,7 +49,7 @@ An example of the request format:
 *Commandline*
 
 ```sh
-#Syntax: server_info
+#Syntax: server_info [counters]
 rippled server_info
 rippled server_info counters # for optional performance statistics
 ```

--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -21,6 +21,11 @@ An example of the request format:
 {
   "id": 1,
   "command": "server_info"
+},
+{
+  "id": 1,
+  "command": "server_info",
+  "counters": true
 }
 ```
 
@@ -32,6 +37,12 @@ An example of the request format:
     "params": [
         {}
     ]
+},
+{
+    "method": "server_info",
+    "params": [
+        {"counters" : true}
+    ]
 }
 ```
 
@@ -40,13 +51,14 @@ An example of the request format:
 ```sh
 #Syntax: server_info
 rippled server_info
+rippled server_info counters # for optional performance statistics
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
 [Try it! >](websocket-api-tool.html#server_info)
 
-The request does not take any parameters.
+The request takes in an optional `counters` parameter. It will render metrics pertaining to Job Queue, nodestore and RPC call counters.
 
 ## Response Format
 
@@ -129,6 +141,9 @@ The `info` object may have some arrangement of the following fields:
 | `validated_ledger.seq`              | Number          | The [ledger index][] of the latest validated ledger. |
 | `validation_quorum`                 | Number          | Minimum number of trusted validations required to validate a ledger version. Some circumstances may cause the server to require more validations. |
 | `validator_list_expires`            | String          | _(Admin only)_ Either the human readable time, in UTC, when the current validator list expires, the string `unknown` if the server has yet to load a published validator list or the string `never` if the server uses a static validator list. |
+| `counters`            | Object          | This object contains performance metrics pertaining to the RPC Calls (currently executing calls and the completed calls) and the JobQueue. It also contains the details of the nodestore like node_writes, node_reads_total, node_reads_hit, etc|
+| `current_activity`            | Object          | This field contains two arrays for `jobs` and `methods`. |
+
 
 **Note:** If the `closed_ledger` field is present and has a small `seq` value (less than 8 digits), that indicates `rippled` does not currently have a copy of the validated ledger from the peer-to-peer network. This could mean your server is still syncing. Typically, it takes about 5 minutes to sync with the network, depending on your connection speed and hardware specs.
 

--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -20,12 +20,8 @@ An example of the request format:
 ```json
 {
   "id": 1,
-  "command": "server_info"
-},
-{
-  "id": 1,
   "command": "server_info",
-  "counters": true
+  "counters": false
 }
 ```
 

--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -45,9 +45,9 @@ An example of the request format:
 *Commandline*
 
 ```sh
-#Syntax: server_info [counters]
+# Syntax: server_info [counters]
+# counters is an optional boolean value, it is used to display performance metrics
 rippled server_info
-rippled server_info counters # for optional performance statistics
 ```
 
 <!-- MULTICODE_BLOCK_END -->

--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -58,7 +58,7 @@ rippled server_info counters # for optional performance statistics
 
 [Try it! >](websocket-api-tool.html#server_info)
 
-The request takes in an optional `counters` parameter. It will render metrics pertaining to Job Queue, nodestore and RPC call counters.
+The request takes in an optional `counters` parameter. It will render metrics, including those that pertain to Job Queue, nodestore and RPC call counters.
 
 ## Response Format
 

--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -54,7 +54,11 @@ rippled server_info
 
 [Try it! >](websocket-api-tool.html#server_info)
 
-The request takes in an optional `counters` parameter. It will render metrics, including those that pertain to Job Queue, nodestore and RPC call counters.
+The request includes the following parameters:
+
+| Field                 | Type    | Required? | Description |
+|:----------------------|:--------|:----------|-------------|
+| `counters`            | Boolean | No        | If `true`, return metrics about the job queue, ledger store, and API method activity. The default is `false`. |
 
 ## Response Format
 

--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -31,13 +31,7 @@ An example of the request format:
 {
     "method": "server_info",
     "params": [
-        {}
-    ]
-},
-{
-    "method": "server_info",
-    "params": [
-        {"counters" : true}
+        {"counters" : false}
     ]
 }
 ```


### PR DESCRIPTION
Fix #4752 (https://github.com/XRPLF/rippled/issues/4752)
This PR attempts to document the usage of the counters parameter in the rippled server_info command.

@mtrippled please let me know if this change accurately reflects the intent of the command