### PR TITLE
[ja] fix broken link to Clio amendment blocked servers

### DIFF
--- a/content/@i18n/ja/concepts/networks-and-servers/amendments.md
+++ b/content/@i18n/ja/concepts/networks-and-servers/amendments.md
@@ -66,9 +66,7 @@ AmendmentブロックはXRP Ledgerデータの正確性を守るためのセキ�
 ### AmendmentブロックされたClioサーバ
 <a id="amendment-blocked-clio-servers"></a>
 
-<!-- TODO: translate section -->
-
-The Clio server can become amendment blocked if it encounters an unknown field type while loading ledger data. This occurs if the field is newer than the `libxrpl` dependency that was used when building Clio. To unblock your Clio server, upgrade to a newer Clio release that was built with a compatible `libxrpl`.
+Clioサーバが台帳データのロード中に未知のフィールドに遭遇した場合、Amendmentブロックが発生することがあります。これは、Clioのビルド時に使用された`libxrpl`の依存ファイルにそれらのフィールドが存在しない場合に発生します。Amendmentブロックを解除するには、互換性のある`libxrpl`でビルドされた新しいClioリリースにアップグレードしてください。
 
 ## Amendmentの削除
 

--- a/content/@i18n/ja/concepts/networks-and-servers/amendments.md
+++ b/content/@i18n/ja/concepts/networks-and-servers/amendments.md
@@ -63,6 +63,13 @@ AmendmentブロックはXRP Ledgerデータの正確性を守るためのセキ�
 最新バージョンの`rippled`にアップグレードすることで、Amendmentブロックされたサーバーのブロックを解除することができます。
 
 
+### AmendmentブロックされたClioサーバ
+<a id="amendment-blocked-clio-servers"></a>
+
+<!-- TODO: translate section -->
+
+The Clio server can become amendment blocked if it encounters an unknown field type while loading ledger data. This occurs if the field is newer than the `libxrpl` dependency that was used when building Clio. To unblock your Clio server, upgrade to a newer Clio release that was built with a compatible `libxrpl`.
+
 ## Amendmentの削除
 
 Amendmentを有効にすると、修正前の動作のソースコードは`rippled`に残ります。検証のためにレジャーの結果を再構築するなど、古いコードを保持するユースケースはありますが、Amendmentとレガシーコードの追跡は時間の経過とともに複雑さを増していきます。

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -773,7 +773,6 @@ pages:
             - en
 
     -   md: "@i18n/ja/concepts/networks-and-servers/amendments.md"
-        outdated_translation: true
         targets:
             - ja
 


### PR DESCRIPTION
Fixes the broken link in master caused by linking to a section that hasn't been added to the Japanese translation of the amendments page.