### PR TITLE
Make Mac build instructions easier to find

### DIFF
--- a/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
+++ b/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
@@ -9,7 +9,7 @@ top_nav_grouping: Popular Pages
 ---
 # Build `rippled` on Linux, Mac, or Windows
 
-Building `rippled` across various platforms requires a C++ development environment. You will need tools like Git, Python, Conan, CMake, and a suitable C++ compiler.
+Building `rippled` across various platforms such as Windows, Linux, or macOS requires a C++ development environment. You will need tools like Git, Python, Conan, CMake, and a suitable C++ compiler.
 
 To continue, proceed to [the latest `rippled` build instructions on GitHub](https://github.com/XRPLF/rippled/blob/develop/BUILD.md).
 

--- a/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
+++ b/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
@@ -1,0 +1,19 @@
+---
+html: build-on-linux-mac-windows.md
+parent: install-rippled.html
+blurb: Build rippled on Linux, Mac (macOS), or Windows
+labels:
+  - Core Server
+  - Blockchain
+top_nav_grouping: Popular Pages
+---
+# Build `rippled` on Linux, Mac, or Windows
+
+Building `rippled` across various platforms requires a C++ development environment. You will need tools like Git, Python, Conan, CMake, and a suitable C++ compiler. Familiarity with Conan and CMake will be helpful.
+
+To continue, proceed to [the latest `rippled` build instructions on GitHub](https://github.com/XRPLF/rippled/blob/develop/BUILD.md).
+
+<!--{# common link defs #}--> 
+{% include '_snippets/rippled-api-links.md' %} 
+{% include '_snippets/tx-type-links.md' %} 
+{% include '_snippets/rippled_versions.md' %}

--- a/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
+++ b/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
@@ -9,7 +9,7 @@ top_nav_grouping: Popular Pages
 ---
 # Build `rippled` on Linux, Mac, or Windows
 
-Building `rippled` across various platforms requires a C++ development environment. You will need tools like Git, Python, Conan, CMake, and a suitable C++ compiler. Familiarity with Conan and CMake will be helpful.
+Building `rippled` across various platforms requires a C++ development environment. You will need tools like Git, Python, Conan, CMake, and a suitable C++ compiler.
 
 To continue, proceed to [the latest `rippled` build instructions on GitHub](https://github.com/XRPLF/rippled/blob/develop/BUILD.md).
 

--- a/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
+++ b/content/infrastructure/rippled/installation/build-on-linux-mac-windows.md
@@ -1,5 +1,5 @@
 ---
-html: build-on-linux-mac-windows.md
+html: build-on-linux-mac-windows.html
 parent: install-rippled.html
 blurb: Build rippled on Linux, Mac (macOS), or Windows
 labels:
@@ -7,13 +7,13 @@ labels:
   - Blockchain
 top_nav_grouping: Popular Pages
 ---
-# Build `rippled` on Linux, Mac, or Windows
+# Build rippled on Linux, Mac, or Windows
 
 Building `rippled` across various platforms such as Windows, Linux, or macOS requires a C++ development environment. You will need tools like Git, Python, Conan, CMake, and a suitable C++ compiler.
 
 To continue, proceed to [the latest `rippled` build instructions on GitHub](https://github.com/XRPLF/rippled/blob/develop/BUILD.md).
 
-<!--{# common link defs #}--> 
-{% include '_snippets/rippled-api-links.md' %} 
-{% include '_snippets/tx-type-links.md' %} 
+<!--{# common link defs #}-->
+{% include '_snippets/rippled-api-links.md' %}
+{% include '_snippets/tx-type-links.md' %}
 {% include '_snippets/rippled_versions.md' %}

--- a/dactyl-config.yml
+++ b/dactyl-config.yml
@@ -3879,11 +3879,17 @@ pages:
         targets:
             - ja
 
+    # TODO: translate
+    -   md: infrastructure/rippled/installation/build-on-linux-mac-windows.md
+        targets:
+            - en
+            - ja
+
         # Redirect to build instructions on rippled repo.
     -   name: Build and Run rippled on Ubuntu
         html: build-run-rippled-ubuntu.html
         template: pagetype-redirect.html.jinja
-        redirect_url: https://github.com/XRPLF/rippled/blob/release/BUILD.md
+        redirect_url: build-on-linux-mac-windows.html
         targets:
             - en
             - ja
@@ -3892,7 +3898,7 @@ pages:
     -   name: Build and Run rippled on macOS
         html: build-run-rippled-macos.html
         template: pagetype-redirect.html.jinja
-        redirect_url: https://github.com/XRPLF/rippled/blob/release/BUILD.md
+        redirect_url: build-on-linux-mac-windows.html
         targets:
             - en
             - ja


### PR DESCRIPTION
I hope this (automatically?) adds a link to https://xrpl.org/install-rippled.html