### PR TITLE
Add WARNING for fixNFTokenRemint: breaking change!

### DIFF
--- a/content/resources/known-amendments.md
+++ b/content/resources/known-amendments.md
@@ -688,6 +688,8 @@ Amendment `fixNFTokenRemint` would change the way NFT sequence numbers are const
 
 The amendment also introduces a new account deletion restriction. An account can only be deleted if `FirstNFTSequence` + `MintedNFTokens` + 256 is less than the current ledger sequence (256 was chosen as a heuristic restriction for account deletion and already exists in the account deletion constraint). Without this restriction, an NFT could still be re-minted under certain conditions.
 
+**Warning:** This is a **breaking change** for projects & tools relying on their own locally computed NFTokenID for minted tokens. As this fix changes the way a TokenID is calculated, without updating local code the wrong NFTokenIDs will be generated locally. A [well known reference implementation in JavaScript](https://gist.github.com/N3TC4T/a20fb528931ed009ebdd708be4938748?permalink_comment_id=4738760#gistcomment-4738760) can easily be patched with backwards compatibillity.
+
 
 ### fixNonFungibleTokensV1_2
 [fixNonFungibleTokensV1_2]: #fixnonfungibletokensv1_2

--- a/content/resources/known-amendments.md
+++ b/content/resources/known-amendments.md
@@ -688,7 +688,7 @@ Amendment `fixNFTokenRemint` would change the way NFT sequence numbers are const
 
 The amendment also introduces a new account deletion restriction. An account can only be deleted if `FirstNFTSequence` + `MintedNFTokens` + 256 is less than the current ledger sequence (256 was chosen as a heuristic restriction for account deletion and already exists in the account deletion constraint). Without this restriction, an NFT could still be re-minted under certain conditions.
 
-**Warning:** This is a **breaking change** for projects & tools relying on their own locally computed NFTokenID for minted tokens. As this fix changes the way a TokenID is calculated, without updating local code the wrong NFTokenIDs will be generated locally. A [well known reference implementation in JavaScript](https://gist.github.com/N3TC4T/a20fb528931ed009ebdd708be4938748?permalink_comment_id=4738760#gistcomment-4738760) can easily be patched with backwards compatibillity.
+**Warning:** This is a **breaking change** for projects & tools relying on their own locally computed NFTokenID for minted tokens. If you have code to calculate NFTokenIDs, you must update it to match the new fomula. For an example of how to do so with backwards compatibility, see this [well known reference implementation in JavaScript](https://gist.github.com/N3TC4T/a20fb528931ed009ebdd708be4938748?permalink_comment_id=4738760#gistcomment-4738760).
 
 
 ### fixNonFungibleTokensV1_2


### PR DESCRIPTION
Quote from: https://twitter.com/WietseWind/status/1717507250363760983

I was making a coffee last night while I suddenly realised that some info I read during the day about the fixNFTokenRemint amendment was actually more relevant than I thought.

It hit me that this is not just a fix, it is a breaking change. Talking to a few XLS20 devs made me realise most devs in the ecosystem do not realise it is a breaking change.

The fixNFTokenRemint amendment was close to reaching > 80% votes, but I just retracted our XRPL Labs validator vote to give the ecosystem more time to look into the changes, and how they affect their platforms.

What it comes down to is that, without code changes, NFT marketplaces, minting tools, etc. will most likely calculate the WRONG NFT ID if this amendment locks in.

Attached screenshot contains the mandatory changes to NFTokenID calculation. If your code calculates the minted NFTokenID, you need to update your code. 

Code example + my comment with changes to add to the example:
[https://gist.github.com/N3TC4T/a20fb528931ed009ebdd708be4938748?permalink_comment_id=4738760#gistcomment-4738760](https://t.co/wAqaZiXbNp)