### PR TITLE
Fix typo in auto-bridging blurb

### DIFF
--- a/content/concepts/tokens/autobridging.md
+++ b/content/concepts/tokens/autobridging.md
@@ -1,7 +1,7 @@
 ---
 html: autobridging.html
 parent: decentralized-exchange.html
-blurb: Autobriding automatically connects order books using XRP as an intermediary when it reduces costs.
+blurb: Auto-bridging automatically connects order books using XRP as an intermediary when it reduces costs.
 labels:
   - XRP
   - Decentralized Exchange


### PR DESCRIPTION
Reported on Slack.

Unrelated, I haven't figured out why the sidebar for this page is partly buried under the header. It seems the styles are exactly the same as the one on pages that don't have problems...