### PR TITLE
account_tx only returns validated transactions

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
+++ b/content/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
@@ -1,7 +1,7 @@
 ---
 html: account_tx.html
 parent: account-methods.html
-blurb: Get info about an account's transactions.
+blurb: Get a list of transactions affecting an account.
 labels:
   - Payments
   - Accounts
@@ -9,7 +9,7 @@ labels:
 # account_tx
 [[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/rpc/handlers/AccountTx.cpp "Source")
 
-The `account_tx` method retrieves a list of transactions that involved the specified account.
+The `account_tx` method retrieves a list of validated transactions that involve a given account.
 
 ## Request Format
 


### PR DESCRIPTION
Per https://github.com/XRPLF/rippled/pull/4775#discussion_r1380587801 this command only returns transactions from validated ledgers, so this clarifies that detail