### PR TITLE
Add core dump config; update key adding; add Bookworm to supported OSs

### DIFF
--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -29,14 +29,14 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 3. Add Ripple's package-signing GPG key to your list of trusted keys:
 
-        sudo mkdir /usr/local/share/keyrings/
-        wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | gpg --dearmor > ripple-key.gpg
-        sudo mv ripple-key.gpg /usr/local/share/keyrings/
+        sudo install -m 0755 -d /etc/apt/keyrings && \
+            wget -qO- https://repos.ripple.com/repos/api/gpg/key/public | \
+            sudo gpg --dearmor -o /etc/apt/keyrings/ripple.gpg
 
 
 4. Check the fingerprint of the newly-added key:
 
-        gpg --import --import-options show-only /usr/local/share/keyrings/ripple-key.gpg
+        gpg --show-keys /etc/apt/keyrings/ripple.gpg
 
     The output should include an entry for Ripple such as the following:
 
@@ -50,14 +50,15 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 5. Add the appropriate Ripple repository for your operating system version:
 
-        echo "deb [signed-by=/usr/local/share/keyrings/ripple-key.gpg] https://repos.ripple.com/repos/rippled-deb focal stable" | \
+        echo "deb [signed-by=/etc/apt/keyrings/ripple.gpg] https://repos.ripple.com/repos/rippled-deb focal stable" | \
             sudo tee -a /etc/apt/sources.list.d/ripple.list
 
     The above example is appropriate for **Ubuntu 20.04 Focal Fossa**. For other operating systems, replace the word `focal` with one of the following:
 
-    - `bionic` for **Ubuntu 18.04 Bionic Beaver**
     - `buster` for **Debian 10 Buster**
     - `bullseye` for **Debian 11 Bullseye**
+    - `bookworm` for **Debian 12 Bookworm**
+    - `bionic` for **Ubuntu 18.04 Bionic Beaver**
     - `jammy` for **Ubuntu 22.04 Jammy Jellyfish**
 
     If you want access to development or pre-release versions of `rippled`, use one of the following instead of `stable`:
@@ -67,15 +68,12 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
     **Warning:** Unstable and nightly builds may be broken at any time. Do not use these builds for production servers.
 
-6. Fetch the Ripple repository.
+6. Update the package index to include Ripple's repo and install `rippled`.
 
-        sudo apt -y update
+        sudo apt -y update && sudo apt -y install rippled
 
-7. Install the `rippled` software package:
 
-        sudo apt -y install rippled
-
-8. Check the status of the `rippled` service:
+7. Check the status of the `rippled` service:
 
         systemctl status rippled.service
 
@@ -84,11 +82,33 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
         sudo systemctl start rippled.service
 
 
-9. Optional: allow `rippled` to bind to privileged ports.
+8. Optional: allow `rippled` to bind to privileged ports.
 
     This allows you to serve incoming API requests on port 80 or 443. (If you want to do so, you must also update the config file's port settings.)
 
         sudo setcap 'cap_net_bind_service=+ep' /opt/ripple/bin/rippled
+
+
+9. Optional: configure core dumps
+
+    By default Ubuntu is not configured to produce core files useful for debuggin crashes. 
+    First run:
+    
+            ulimit -c unlimited
+    
+    Now run `sudo systemctl edit rippled`. An editor will open and add 
+
+        [Service]
+        LimitCORE=infinity
+
+    This creates `/etc/systemd/system/rippled.service.d/override.conf` saving core dumps while not interfering 
+    with the service file provided by the `rippled` package.
+    Core dumps appearing in `/var/lib/apport/coredump/` can be loaded into `gdb` with
+
+        gdb <path_to_rippled> <path_to_core_file>
+
+    provided the `rippled-dbgsym` package has been installed. 
+    You will need permission to read files in the core dump directory.
 
 
 ## Next Steps

--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -103,7 +103,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
     This creates the file `/etc/systemd/system/rippled.service.d/override.conf` and configures the OS to save core dumps, without changing the service file provided by the `rippled` package. If your server crashes, you can find the core dump in `/var/lib/apport/coredump/`. To load the core dump for inspection, use a command such as the following:
 
-        gdb <path_to_rippled> <path_to_core_file>
+        gdb /opt/ripple/bin/rippled /var/lib/apport/coredump/core
 
     **Note:** To debug a core file this way, you must have the `rippled-dbgsym` package installed, and you need permission to read files in the core dump directory.
 

--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -94,7 +94,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
     By default Ubuntu is not configured to produce core files useful for debugging crashes.
     First run:
     
-            ulimit -c unlimited
+        ulimit -c unlimited
     
     Now run `sudo systemctl edit rippled`. The default editor should open and add
 

--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -107,8 +107,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
         gdb <path_to_rippled> <path_to_core_file>
 
-    provided the `rippled-dbgsym` package has been installed. 
-    You will need permission to read files in the core dump directory.
+    **Note:** To debug a core file this way, you must have the `rippled-dbgsym` package installed, and you need permission to read files in the core dump directory.
 
 
 ## Next Steps

--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -101,9 +101,7 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
         [Service]
         LimitCORE=infinity
 
-    This creates `/etc/systemd/system/rippled.service.d/override.conf` saving core dumps while not interfering 
-    with the service file provided by the `rippled` package.
-    Core dumps appearing in `/var/lib/apport/coredump/` can be loaded into `gdb` with
+    This creates the file `/etc/systemd/system/rippled.service.d/override.conf` and configures the OS to save core dumps, without changing the service file provided by the `rippled` package. If your server crashes, you can find the core dump in `/var/lib/apport/coredump/`. To load the core dump for inspection, use a command such as the following:
 
         gdb <path_to_rippled> <path_to_core_file>
 

--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -91,12 +91,12 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 9. Optional: configure core dumps
 
-    By default Ubuntu is not configured to produce core files useful for debuggin crashes. 
+    By default Ubuntu is not configured to produce core files useful for debugging crashes. 
     First run:
     
             ulimit -c unlimited
     
-    Now run `sudo systemctl edit rippled`. An editor will open and add 
+    Now run `sudo systemctl edit rippled`. The default editor should open and add 
 
         [Service]
         LimitCORE=infinity

--- a/content/infrastructure/installation/install-rippled-on-ubuntu.md
+++ b/content/infrastructure/installation/install-rippled-on-ubuntu.md
@@ -91,12 +91,12 @@ Before you install `rippled`, you must meet the [System Requirements](system-req
 
 9. Optional: configure core dumps
 
-    By default Ubuntu is not configured to produce core files useful for debugging crashes. 
+    By default Ubuntu is not configured to produce core files useful for debugging crashes.
     First run:
     
             ulimit -c unlimited
     
-    Now run `sudo systemctl edit rippled`. The default editor should open and add 
+    Now run `sudo systemctl edit rippled`. The default editor should open and add
 
         [Service]
         LimitCORE=infinity


### PR DESCRIPTION
Add instructions to enable core dumps on Ubuntu.
Update adding Ripple's gpg key.
Add new Debian to supported Linux distros.