### PR TITLE
Update setregularkey.md

### DIFF
--- a/content/references/protocol/transactions/types/setregularkey.md
+++ b/content/references/protocol/transactions/types/setregularkey.md
@@ -11,7 +11,7 @@ labels:
 
 A `SetRegularKey` transaction assigns, changes, or removes the regular key pair associated with an account.
 
-You can protect your account by assigning a regular key pair to it and using it instead of the master key pair to sign transactions whenever possible. If your regular key pair is compromised, but your master key pair is not, you can use a `SetRegularKey` transaction to regain control of your account.
+You can protect your account by assigning a regular key pair to it and using it instead of the private key pair to sign transactions whenever possible. If your regular key pair is compromised, but your private key pair is not, you can use a `SetRegularKey` transaction to regain control of your account.
 
 ## Example {{currentpage.name}} JSON
 


### PR DESCRIPTION
Replacing `master key` by `private key`.
I think we should be clear on private key or seed here.
`master key` doesn't seem to be a standard word here. A master key could be as well a 'password' you use to encrypt data. Here the context is about a private key.
Also to keep consistent with this page within the doc: https://xrpl.org/assign-a-regular-key-pair.html?utm_source=gemwallet.app I would rather use the term `private key`.
Also following this schema: https://xrpl.org/img/cryptographic-keys.svg
If we want to mention the seed, I would rather use seed or rather passphrase.

Let me know if this makes sense :) Happy to comment more about it.