### PR TITLE
Fix broken link in desktop wallet readme

### DIFF
--- a/content/_code-samples/build-a-desktop-wallet/js/README.md
+++ b/content/_code-samples/build-a-desktop-wallet/js/README.md
@@ -2,7 +2,7 @@
 
 Build a non-custodial XRP Ledger wallet application in JavaScript that runs on the desktop using Electron.
 
-For the full documentation, refer to the [Build a Wallet in JavaScript tutorial](build-a-wallet-in-javascript.html).
+For the full documentation, refer to the [Build a Wallet in JavaScript tutorial](https://xrpl.org/build-a-wallet-in-javascript.html).
 
 ## TL;DR
 


### PR DESCRIPTION
This README is meant to be viewed from GitHub, so it doesn't work to use a relative link to the site.

(Caught because Redocly was throwing an error even though it shouldn't be using the file.)