### PR TITLE
Bump Redocly/realm to version 0.70.0

### DIFF
--- a/content/@theme/markdoc/components.tsx
+++ b/content/@theme/markdoc/components.tsx
@@ -16,7 +16,7 @@ export function IndexPageItems() {
     return (
         <div className="children-display">
             <ul>
-              {data.map((item: any) => (
+              {data?.map((item: any) => (
                 <li className="level-1" key={item.slug}>
                   <Link to={item.slug}>{item.title}</Link>
                   <p className='class="blurb child-blurb'>{item.blurb}</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.3.3",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.69.4",
+        "@redocly/realm": "0.70.0",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "clsx": "^2.0.0",
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.69.4",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.69.4.tgz",
-      "integrity": "sha512-XXjQXglL1DuvQzqX1ap9sOseDFkrWsGEqoGnzVCwIM6D0h/mDctzb1lvFxGSXBSmfErLIVKVcgG1v/HRBrNdZg==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.70.0.tgz",
+      "integrity": "sha512-k+AYZyD6bdjyr/Y3ei6ZTdN5C5cwTv3Ldu2blzmSO2theBmWacxRTZJi55ETZdl5czVWxz3And4mhi9t8959WA==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@cocalc/ansi-to-react": "7.0.0",
@@ -2281,8 +2281,9 @@
         "@redocly/openapi-core": "1.2.0",
         "@redocly/openapi-docs": "3.0.0-alpha.82",
         "@redocly/portal-plugin-mock-server": "^0.1.0",
-        "@redocly/theme": "0.32.2",
+        "@redocly/theme": "0.32.3",
         "@redocly/xml-crypto": "~3.0.1",
+        "@tanstack/react-query": "4.0.5",
         "@wojtekmaj/react-datetimerange-picker": "^5.0.1",
         "@xmldom/xmldom": "^0.8.3",
         "babel-plugin-styled-components": "^2.0.7",
@@ -2298,7 +2299,7 @@
         "fuse.js": "^6.6.2",
         "graphql": "^15.6.1",
         "gray-matter": "^4.0.3",
-        "hono": "~2.1.0",
+        "hono": "~3.11.0",
         "htmlparser2": "^8.0.2",
         "i18next": "^22.4.12",
         "is-glob": "^4.0.3",
@@ -2321,7 +2322,6 @@
         "react-date-picker": "10.0.3",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
-        "react-query": "3.39.2",
         "react-router-dom": "^6.10.0",
         "react-select": "^5.7.0",
         "react-table": "^7.8.0",
@@ -2358,34 +2358,10 @@
         "@redocly/openapi-docs": "3.0.0-alpha.82"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/theme": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.32.2.tgz",
-      "integrity": "sha512-OPQwp5yHZrT2H2X69crM1zYvLwshB99cMeqgXCxKEkxEQKruqtRHiWXQGNi/RLtkGHHuYiK8MknHj1zZL5hdUQ==",
-      "dependencies": {
-        "@redocly/ajv": "^8.11.0",
-        "copy-to-clipboard": "^3.3.3",
-        "highlight-words-core": "^1.2.2",
-        "hotkeys-js": "^3.10.1",
-        "react-calendar": "4.2.1",
-        "react-date-picker": "10.0.3",
-        "timeago.js": "^4.0.2"
-      },
-      "peerDependencies": {
-        "lodash.throttle": "^4.1.1",
-        "prismjs": "^1.28.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.10.0",
-        "styled-components": "^4.1.1 || ^5.3.11",
-        "styled-system": "^5.1.5"
-      }
-    },
     "node_modules/@redocly/theme": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.32.0.tgz",
-      "integrity": "sha512-LWS+K8KvvCBAAzjag9Yv0Np5Jj/4sZuBUcxuz0+vxEy3QqpYj7SXxyM2KpWHpnExmS/Pz6VsXW08oWp3EJAp8A==",
-      "peer": true,
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.32.3.tgz",
+      "integrity": "sha512-Y+ZmdySW8J4+StDqsdlV3pEy1Pjn5mz6K5bpNgITmI1oPxpGpZFyWM84qFvSyAc+dj7BhH6Vby3HQ0H8c1XchQ==",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
         "copy-to-clipboard": "^3.3.3",
@@ -3016,6 +2992,42 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
+      "integrity": "sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.0.5.tgz",
+      "integrity": "sha512-tIggVlhoFevVpY/LkZroPmrERFHN8tw4aZLtgwSArzHmMJ03WQcaNvbbHy6GERidXtaMdUz+IeQryrE7cO7WPQ==",
+      "dependencies": {
+        "@tanstack/query-core": "^4.0.0-beta.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3209,6 +3221,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "peer": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -3824,14 +3841,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -3920,21 +3929,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browser-request": {
@@ -4267,7 +4261,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4649,11 +4644,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -5155,7 +5145,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5273,6 +5264,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5303,6 +5295,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5312,6 +5305,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5528,11 +5522,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hono": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-2.1.4.tgz",
-      "integrity": "sha512-x4mNdB7YoMBMHe8rDyXgKcAjK4/lerUY4PBaEYu+XCz1AilxtZAKLDtUer4ptaZ4T6RYreo5ksZuA3bQdOUEug==",
+      "version": "3.11.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-3.11.12.tgz",
+      "integrity": "sha512-TrxH75bc0m2UbvrhaXkoo32A9OhkJtvICAYgYWtxqLDOxBjRqSikyp4K7HTbnWkPeg9Z+2Q3nv0dN4o8kL6yLg==",
       "engines": {
-        "node": ">=11.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -5834,6 +5828,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7748,11 +7743,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8186,15 +8176,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -8223,11 +8204,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -8343,14 +8319,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
       "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "optional": true
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -8630,11 +8598,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8790,6 +8753,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9413,31 +9377,6 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "peer": true
     },
-    "node_modules/react-query": {
-      "version": "3.39.2",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.2.tgz",
-      "integrity": "sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-router": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
@@ -9653,11 +9592,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
       "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
-    },
     "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -9769,20 +9703,6 @@
       "peer": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ripple-address-codec": {
@@ -10910,15 +10830,6 @@
         "node": ">=14.0"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/unraw": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
@@ -11013,6 +10924,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.3.3",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.69.4",
+    "@redocly/realm": "0.70.0",
     "@uiw/react-codemirror": "^4.21.21",
     "@uiw/codemirror-themes": "4.21.21",
     "clsx": "^2.0.0",


### PR DESCRIPTION
This version includes several fixes we wanted, including for the issues with navigating in dev mode using Firefox. I also included a fix/workaround to prevent it from crashing on certain landing pages (concepts/tutorials/etc) although it doesn't fix the underlying issue with those pages' list of child pages being empty.