### PR TITLE
Add JS libs: xrpl-client, xrpl-accountlib

### DIFF
--- a/content/references/client-libraries.md
+++ b/content/references/client-libraries.md
@@ -13,6 +13,8 @@ For other programming languages, you can access the XRP Ledger through the [HTTP
 |---------------------------------|---------------------------|-------------|--------------|-------------|
 | **Python**                      | `xrpl-py`                 | [Get Started Using Python](get-started-using-python.html) | [API Reference](https://xrpl-py.readthedocs.io/) | [Repo](https://github.com/XRPLF/xrpl-py) |
 | **JavaScript** / **TypeScript** | `xrpl.js`                 | [Get Started](get-started-using-javascript.html) |  [API Reference](https://js.xrpl.org/) | [Repo](https://github.com/XRPLF/xrpl.js) |
+| **JavaScript** / **TypeScript** | `xrpl-client`             | [Get Started](https://jsfiddle.net/WietseWind/35az6p1b/) |  [NPM Reference](https://www.npmjs.com/package/xrpl-client) | [Repo](https://github.com/XRPL-Labs/xrpl-client) |
+| **JavaScript** / **TypeScript** | `xrpl-accountlib`         | [Get Started](https://jsfiddle.net/WietseWind/gkefpnu0/) |  [NPM Reference](https://www.npmjs.com/package/xrpl-accountlib) | [Repo](https://github.com/WietseWind/xrpl-accountlib) |
 | **C++**                         | `rippled` Signing Library | [Get Started](https://github.com/XRPLF/rippled/tree/develop/Builds/linux#signing-library) |  | (Part of [`rippled`](https://github.com/XRPLF/rippled/)) |
 | **Java**                        | `xrpl4j`                  | [Get Started Using Java](get-started-using-java.html) | [API Reference](https://javadoc.io/doc/org.xrpl/) | [Repo](https://github.com/XRPLF/xrpl4j) |
 | **PHP**                         | `XRPL_PHP`                | [Get Started Using PHP](get-started-using-php.html) | [XRPL_PHP Docs](https://alexanderbuzz.github.io/xrpl-php-docs/) | [Repo](https://github.com/AlexanderBuzz/xrpl-php) |


### PR DESCRIPTION
While `xrpl.js` is most convenient for most and properly documented, the XRPL Labs libs. `xrpl-client` and `xrpl-accountlib` work well in certain environments, and are thus used in several of our own and third party projects.

It could (would?) make sense to add them to the table as well, as they are actively maintained:
- https://www.npmjs.com/package/xrpl-client
- https://www.npmjs.com/package/xrpl-accountlib