### PR TITLE
Bug fixes for Redocly WebSocket API page

### DIFF
--- a/content/resources/dev-tools/components/websocket-api/curl-modal.tsx
+++ b/content/resources/dev-tools/components/websocket-api/curl-modal.tsx
@@ -72,19 +72,22 @@ export const CurlModal: React.FC<CurlProps> = ({
 };
 
 export const CurlButton = ({selectedConnection, currentBody}: CurlButtonProps) => {
+  const [showCurlModal, setShowCurlModal] = useState(false);
+
   return <>
       <button
         className="btn btn-outline-secondary curl"
         data-toggle="modal"
         data-target="#wstool-1-curl"
         title="cURL syntax"
+        onClick={() => setShowCurlModal(true)}
       >
         <i className="fa fa-terminal"></i>
       </button>
-      <CurlModal
-        closeCurlModal={() => {}}
+      {showCurlModal && <CurlModal
+        closeCurlModal={() => setShowCurlModal(false)}
         currentBody={currentBody}
         selectedConnection={selectedConnection}
-      />
+      />}
   </>
 }

--- a/content/resources/dev-tools/components/websocket-api/right-sidebar.tsx
+++ b/content/resources/dev-tools/components/websocket-api/right-sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { useTranslate } from "@portal/hooks";
 import { Link } from "@portal/Link";
 import { slugify } from "./slugify";
@@ -22,8 +22,8 @@ export const RightSideBar: React.FC<RightSideBarProps> = ({
         <h4>{translate("API Methods")}</h4>
       </div>
       <ul className="command-list" id="command_list">
-        {commandList.map((list) => (
-          <>
+        {commandList.map((list, index) => (
+          <Fragment key={index}>
             <li className="separator">{list.group}</li>
             {list.methods.map((method) => (
               <li
@@ -46,7 +46,7 @@ export const RightSideBar: React.FC<RightSideBarProps> = ({
                 </Link>
               </li>
             ))}
-          </>
+          </Fragment>
         ))}
       </ul>
     </div>

--- a/content/resources/dev-tools/websocket-api-tool.page.tsx
+++ b/content/resources/dev-tools/websocket-api-tool.page.tsx
@@ -198,7 +198,7 @@ export function WebsocketApiTool() {
               </h3>
               {currentMethod.description && (
                 <p className="blurb">
-                  <div
+                  <span
                     dangerouslySetInnerHTML={{
                       __html: currentMethod.description,
                     }}

--- a/content/resources/dev-tools/websocket-api-tool.page.tsx
+++ b/content/resources/dev-tools/websocket-api-tool.page.tsx
@@ -197,13 +197,12 @@ export function WebsocketApiTool() {
                 </a>
               </h3>
               {currentMethod.description && (
-                <p className="blurb">
-                  <span
-                    dangerouslySetInnerHTML={{
-                      __html: currentMethod.description,
-                    }}
-                  />
-                </p>
+                <p
+                  className="blurb"
+                  dangerouslySetInnerHTML={{
+                    __html: currentMethod.description,
+                  }}
+                />
               )}
               {currentMethod.link && (
                 <a


### PR DESCRIPTION
Bug fixes for Redocly WebSocket API page:
- fix UL error
- toggle CurlModal to show/hide on button click
- < div > cannot appear as a descendant of < p >