### PR TITLE
Add footer and frontmatter for custom pages

### DIFF
--- a/content/about/history.page.tsx
+++ b/content/about/history.page.tsx
@@ -1,6 +1,13 @@
 import * as React from "react";
 import { useTranslate } from "@portal/hooks";
 
+export const frontmatter = {
+  seo: {
+    title: 'History',
+    description: "The history of the XRP Ledger (XRPL), launched in 2012 as a faster, scalable, more sustainable blockchain.",
+  }
+};
+
 export default function History() {
   const { translate } = useTranslate();
   const [openSections, setOpenSections] = React.useState({});

--- a/content/about/impact.page.tsx
+++ b/content/about/impact.page.tsx
@@ -5,6 +5,13 @@ import mapLight from "../static/js/impact/mapLight.json";
 import { useLottie } from "lottie-react";
 import { useThemeFromClassList } from "../@theme/helpers";
 
+export const frontmatter = {
+  seo: {
+    title: 'Impact',
+    description: "Learn how the XRP Ledger helps move money around the world faster, cheaper and more sustainably than any other currency available today.",
+  }
+};
+
 export default function Impact() {
   const theme = useThemeFromClassList(['dark', 'light'])
   const { translate } = useTranslate();

--- a/content/about/index.page.tsx
+++ b/content/about/index.page.tsx
@@ -1,6 +1,13 @@
 import * as React from "react";
 import { useTranslate } from "@portal/hooks";
 
+export const frontmatter = {
+  seo: {
+    title: 'XRP Ledger Overview',
+    description: "An introduction to the key benefits and features of the XRP Ledger, a public blockchain driven by the XRPL developer community.",
+  }
+};
+
 const faqs = [
   {
     question: "Is XRPL a private blockchain, owned by Ripple?",

--- a/content/about/uses.page.tsx
+++ b/content/about/uses.page.tsx
@@ -4,6 +4,13 @@ import numLight from "../static/js/ecosystem/numbers-animation-light.json";
 import numDark from "../static/js/ecosystem/numbers-animation.json";
 import arrow from "../static/js/ecosystem/arrow-animation.json";
 
+export const frontmatter = {
+  seo: {
+    title: 'Use Cases & Featured Projects',
+    description: "Here’s how the XRP Ledger is used to power innovative technology across the payments and public blockchain landscape.",
+  }
+};
+
 import { useLottie } from "lottie-react";
 import { useThemeFromClassList } from "../@theme/helpers";
 

--- a/content/community/ambassadors.page.tsx
+++ b/content/community/ambassadors.page.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { useTranslate } from '@portal/hooks';
 
+export const frontmatter = {
+  seo: {
+    title: 'Ambassadors',
+    description: "The XRPL Campus Ambassador program connects and empowers student champions of the XRPL.",
+  }
+};
+
 false
 
 const target= {prefix: ''}; // TODO: fixme

--- a/content/community/developer-funding.page.tsx
+++ b/content/community/developer-funding.page.tsx
@@ -1,6 +1,13 @@
 import * as React from "react";
 import { useTranslate } from "@portal/hooks";
 
+export const frontmatter = {
+  seo: {
+    title: 'Developer Funding',
+    description: "If you’re a software developer or team looking to build your next project or venture on the XRP Ledger (XRPL), there are a number of opportunities to fund your next innovation.",
+  }
+};
+
 false;
 
 const target = { prefix: "" }; // TODO: fixme

--- a/content/community/events.page.tsx
+++ b/content/community/events.page.tsx
@@ -3,6 +3,13 @@ import * as React from "react";
 import { useTranslate } from "@portal/hooks";
 const moment = require("moment");
 
+export const frontmatter = {
+  seo: {
+    title: 'Events',
+    description: "Find the XRPL Community around the world and join these events to see what's happening.",
+  }
+};
+
 function categorizeDates(arr) {
   const past = [];
   const upcoming = [];

--- a/content/community/index.page.tsx
+++ b/content/community/index.page.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { useTranslate } from "@portal/hooks";
 import moment from "moment";
+
+export const frontmatter = {
+  seo: {
+    title: 'Community',
+    description: "The XRP Ledger (XRPL) is a community-driven public blockchain. Here’s how you can get involved.",
+  }
+};
+
 const findNearestUpcomingEvent = (events) => {
   let nearestEvent = null;
   let nearestDateDiff = Infinity;

--- a/content/docs.page.tsx
+++ b/content/docs.page.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { useTranslate } from '@portal/hooks';
 
+export const frontmatter = {
+  seo: {
+    title: 'Documentation',
+    description: "Explore XRP Ledger documentation and everything you need to know to start building and integrating with the ledger.",
+  }
+};
+
 const recommendedPages = [
   {
     description: 'rippled API Reference',

--- a/content/redocly.yaml
+++ b/content/redocly.yaml
@@ -40,26 +40,63 @@ theme:
       $ref: top-nav.yaml
   markdown:
     partialsFolders: ["_snippets", "_code-samples", "_api-examples"]
-  # footer:
-  #   # hide:
-  #   copyrightText: © 2022-2023, Redocly Inc. All right reserved.
-  #   items:
-  #     - group: Legal
-  #       items:
-  #         - label: Terms of Use
-  #           href: 'https://redocly.com/subscription-agreement/'
-  #         - label: Privacy Notice
-  #           href: 'https://redocly.com/privacy-policy/'
-  #         - label: Cookie Notice
-  #           href: 'https://redocly.com/privacy-policy/'
-  #     - group: Social
-  #       items:
-  #         - label: Facebook
-  #           href: 'https://www.facebook.com/redocly/'
-  #         - label: Youtube
-  #           href: 'https://www.youtube.com/channel/UCxYbPjnpqmHCmwg9iWf7wtQ'
-  #         - label: Twitter
-  #           href: 'https://twitter.com/Redocly'
+  footer:
+    copyrightText: © 2024 XRP Ledger. Open Source.
+    items:
+      - group: About
+        items:
+          - page: about/index.page.tsx
+          - page: about/uses.page.tsx
+          - page: about/history.page.tsx
+          - page: about/impact.page.tsx
+          - label: XRPL Foundation
+            href: https://foundation.xrpl.org/
+            external: true
+          - page: about/faq.md
+          - page: about/privacy-policy.md
+      - group: Docs
+        items:
+          - page: docs.page.tsx
+          - page: introduction/index.md
+          - page: use-cases/index.md
+          - page: concepts/index.md
+          ## TODO: uncomment the following when the pages have been added
+          # - page: tutorials/index.md
+          # - page: references/index.md
+          - page: infrastructure/index.md
+      - group: Resources
+        items:
+          - page: resources/code-samples.page.tsx
+          - page: resources/dev-tools/index.page.tsx
+          - label: XRPL Learning Portal
+            href: https://learn.xrpl.org/
+            external: true
+          - label: XRPL Brand Kit
+            href: https://xrpl.org/XRPL_Brand_Kit.zip
+            external: true
+          - label: Ledger Explorer
+            href: https://livenet.xrpl.org/
+            external: true
+          - page: resources/known-amendments.md
+          - page: resources/contribute-code/contribute-code.md
+          - page: resources/contribute-documentation/index.md
+      - group: Community
+        items:
+          - page: community/index.page.tsx
+          - page: community/events.page.tsx
+          - page: community/ambassadors.page.tsx
+          - page: community/developer-funding.page.tsx
+          - label: XRPL Jobs
+            href: https://jobs.xrpl.org/
+            external: true
+          - page: blog/index.md
+          - label: XRPL Grants
+            href: https://xrplgrants.org/
+            external: true
+          - label: GitHub
+            href: https://github.com/XRPLF/
+            external: true
+          - page: community/report-a-scam.md
   # sidebar:
   #   hide:
   # search:

--- a/content/resources/code-samples.page.tsx
+++ b/content/resources/code-samples.page.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { usePageSharedData, useTranslate } from '@portal/hooks';
 
+export const frontmatter = {
+  seo: {
+    title: 'Code Samples',
+    description: "Browse sample code for building common use cases on the XRP Ledger.",
+  }
+};
+
 const langIcons = {
   cli: require('../static/img/logos/cli.svg'),
   go: require('../static/img/logos/golang.svg'),

--- a/content/resources/dev-tools/index.page.tsx
+++ b/content/resources/dev-tools/index.page.tsx
@@ -1,5 +1,13 @@
 import * as React from "react";
 import { useTranslate } from "@portal/hooks";
+
+export const frontmatter = {
+  seo: {
+    title: 'Dev Tools',
+    description: "Use these tools to explore, build, and test XRP Ledger technology.",
+  }
+};
+
 const explorers_tools = [
   {
     id: "xrp-explorer",


### PR DESCRIPTION
- Use the default Redocly footer (we can probably re-style this to look a lot like the current XRPL.org footer)
- Add frontmatter to all the custom pages that are in the footer, which more or less fixes #2330 (the individual dev tools might still need it)