### PR TITLE
Fix wallet address output in send-xrp.js example

### DIFF
--- a/content/_code-samples/send-xrp/js/send-xrp.js
+++ b/content/_code-samples/send-xrp/js/send-xrp.js
@@ -7,7 +7,7 @@ if (typeof module !== "undefined") {
 
 // Example credentials
 const wallet = xrpl.Wallet.fromSeed("sn3nxiW7v8KXzPzAqzyHXbSSKNuN9")
-console.log(wallet.address) // rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH
+console.log(wallet.address) // rLJmghXLb3Wvrc4oVqzXcNNPZ7WPjpvyJY
 
 // Connect -------------------------------------------------------------------
 async function main() {


### PR DESCRIPTION
The send-xrp.js example starts with code that imports a secret and outputs the corresponding wallet address to the console. The problem is the expected output (as indicated by the comment) is incorrect, this patch fixes this