### PR TITLE
Add Clio release notes to blog sidebar navigation.

### DIFF
--- a/blog/2024/clio-2.1.0.md
+++ b/blog/2024/clio-2.1.0.md
@@ -5,30 +5,34 @@ labels:
     - Clio Release Notes
 targets: [devblog]
 ---
+
 # Introducing Clio version 2.1.0
 
 Version 2.1.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds new features, bug fixes, and amendment support.
 
 ## Notable New Features
-* [Prometheus metrics collection](https://github.com/XRPLF/clio?tab=readme-ov-file#prometheus-metrics-collection)
-* [Admin password configuration for admin rights](https://github.com/XRPLF/clio?tab=readme-ov-file#admin-rights-for-requests)
-* [New subscription manager](https://github.com/XRPLF/clio/pull/1071)
-* [amm_info API](https://xrpl.org/amm_info.html#amm_info)
-  * Version 2.0.0 of Clio supported [AMM](https://xrpl.org/known-amendments.html#amm) amendment transaction model changes but did not include this API
-  * If the [AMM](https://xrpl.org/known-amendments.html#amm) amendment is enabled and you have not upgraded Clio to 2.1.0 or newer, this API would not be supported
+
+- [Prometheus metrics collection](https://github.com/XRPLF/clio?tab=readme-ov-file#prometheus-metrics-collection)
+- [Admin password configuration for admin rights](https://github.com/XRPLF/clio?tab=readme-ov-file#admin-rights-for-requests)
+- [New subscription manager](https://github.com/XRPLF/clio/pull/1071)
+- [amm_info API](https://xrpl.org/amm_info.html#amm_info)
+  - Version 2.0.0 of Clio supported [AMM](https://xrpl.org/known-amendments.html#amm) amendment transaction model changes but did not include this API
+  - If the [AMM](https://xrpl.org/known-amendments.html#amm) amendment is enabled and you have not upgraded Clio to 2.1.0 or newer, this API would not be supported
 
 ## Amendment Support
+
 The following amendments have been introduced since Clio 2.0.0 and have transaction model changes.  Clio 2.1.0 is built with `libxrpl` 2.0.0, which supports these amendments.
 
-* [XChainBridge](https://xrpl.org/known-amendments.html#xchainbridge)
-* [DID](https://xrpl.org/known-amendments.html#did)
+- [XChainBridge](https://xrpl.org/known-amendments.html#xchainbridge)
+- [DID](https://xrpl.org/known-amendments.html#did)
 
 If these amendments are enabled and you have not upgraded Clio to 2.1.0 or newer, the ETL will be amendment blocked and new ledgers will not be processed.
 
 To check the current voting status of these amendments on Mainnet, see the [XRPScan Amendments Dashboard](https://xrpscan.com/amendments).
 
 ## Database Migration
-If you are currently running Clio 1.0.4 or earlier and upgrading, you must perform a database migration to properly support NFT data.  Instructions for the migration are described https://github.com/XRPLF/clio/tree/clio_migrator%402.0.0
+
+If you are currently running Clio 1.0.4 or earlier and upgrading, you must perform a database migration to properly support NFT data. Instructions for the migration are described [here](https://github.com/XRPLF/clio/tree/clio_migrator%402.0.0).
 
 ## Install / Upgrade
 

--- a/blog/sidebars.yaml
+++ b/blog/sidebars.yaml
@@ -5,6 +5,7 @@
     - group: '2024'
       expanded: false
       items:
+        - page: 2024/clio-2.1.0.md
         - page: 2024/rippled-2.0.1.md
         - page: 2024/web3auth.md
         - page: 2024/rippled-2.0.0.md


### PR DESCRIPTION
Small change: I missed adding the latest Clio release notes file to the blog sidebar navigation. Plus some minor formatting fixes.