### PR TITLE
Enable the "Edit Page" feature 

### DIFF
--- a/blog/2019/corrections-to-data-api-xrp-charts-metrics.md
+++ b/blog/2019/corrections-to-data-api-xrp-charts-metrics.md
@@ -1,3 +1,10 @@
+---
+category: 2020
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Corrections to Data API / XRP Charts Metrics for 2019-03-23
 
 The [Data API][], an open API that provides data to [XRP Charts][] and third-party tools, suffered gaps in data ingestion on 2019-03-23. As a result, several [metrics on XRP Charts](https://xrpcharts.ripple.com/#/metrics), including the number of ledgers closed per day, were overcounted. **During this time, the XRP Ledger did not experience any outages.** However, the Data API's ingestion service was unable to process ledgers with transactions containing the `tecKILLED` transaction response code. `tecKILLED` is a new response code added to the XRP Ledger by amendment [fix1578](https://developers.ripple.com/known-amendments.html#fix1578) on 2019-03-23. This necessitated changes to the [ripple-binary-codec library](https://github.com/ripple/ripple-binary-codec) used by the ingestion service, but [those changes](https://github.com/ripple/ripple-binary-codec/pull/27) were only partially deployed to the ingestion service. We have since reprocessed and corrected the metrics that were affected by this problem.

--- a/blog/2020/checks-enabled.md
+++ b/blog/2020/checks-enabled.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-06-17
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # The Checks Amendment is Now Enabled
 
 [As previously announced](https://xrpl.org/blog/2020/checks-expected.html), the Checks amendment [became enabled on the XRP Ledger](https://xrpcharts.ripple.com/#/transactions/D88F2DCDFB10023F9F6CBA8DF34C18E321D655CAC8FDB962387A5DB1540242A6) on 2020-06-18.

--- a/blog/2020/checks-expected.md
+++ b/blog/2020/checks-expected.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-06-11
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # The Checks Amendment is Expected 2020-06-18
 
 The Checks amendment to the XRP Ledger, introduced all the way back in [`rippled` v0.90.0](https://github.com/ripple/rippled/releases/tag/0.90.0), has [gained support from a majority of trusted validators](https://xrpcharts.ripple.com/#/transactions/F2CACEB0680626E8A4DE7EDA02DEC7438E1FB0D7C8736DD327074F85877E6D8E). Currently, it is expected to become enabled on 2020-06-18. As long as the Checks amendment continues to have the support of at least 80% of trusted validators continuously, it will become enabled on the scheduled date.

--- a/blog/2020/deletableaccounts-enabled.md
+++ b/blog/2020/deletableaccounts-enabled.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-05-08
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # DeletableAccounts is Now Enabled
 
 As previously announced, the DeletableAccounts amendment [became enabled on the XRP Ledger](https://livenet.xrpl.org/transactions/47B90519D31E0CB376B5FEE5D9359FA65EEEB2289F1952F2A3EB71D623B945DE) on **2020-05-08**.

--- a/blog/2020/deletableaccounts-expected.md
+++ b/blog/2020/deletableaccounts-expected.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-04-28
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # DeletableAccounts and Two Other Amendments Expected Soon
 
 Three amendments to the XRP Ledger protocol currently hold support of a majority of trusted validators, and are expected to become enabled on the following dates (in UTC):

--- a/blog/2020/developer-reflections-xrp-toolkit.md
+++ b/blog/2020/developer-reflections-xrp-toolkit.md
@@ -3,6 +3,10 @@ category: 2020
 date: 2020-07-17
 labels:
     - Developer Reflections
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: XRP Toolkit
 

--- a/blog/2020/developer-reflections-xrplorer.md
+++ b/blog/2020/developer-reflections-xrplorer.md
@@ -3,6 +3,10 @@ category: 2020
 date: 2020-05-30
 labels:
     - Developer Reflections
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Xrplorer
 

--- a/blog/2020/developer-reflections-xrpscan.md
+++ b/blog/2020/developer-reflections-xrpscan.md
@@ -3,7 +3,10 @@ category: 2020
 date: 2020-05-02
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: XRPScan
 

--- a/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected.md
+++ b/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-01-08
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Two Fix Amendments are Expected 2020-01-18
 
 On 2020-01-03, the [fixCheckThreading](https://xrpcharts.ripple.com/#/transactions/71460CE2DB7594C25A649C042D18BC3C027910CF02C60EC7F1E77660C9CAE1D2) and [fixPayChanRecipientOwnerDir](https://xrpcharts.ripple.com/#/transactions/4F5C639512B14BC6986026A2871CBF348C6092B1D4BE2DE9EE64D0F04E1EA5F7) amendments to the XRP Ledger gained support from a majority of trusted validators. These amendments were introduced in [`rippled` v1.4.0](https://github.com/ripple/rippled/releases/tag/1.4.0). Currently, they are expected to become enabled on 2020-01-18. Each amendment that continues to have the support of at least 80% of trusted validators continuously will become enabled on the scheduled date.

--- a/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority.md
+++ b/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-01-13
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # fixCheckThreading and fixPayChanRecipientOwnerDir Amendments Lost Majority
 
 On 2019-01-11, the fixCheckThreading and fixPayChanRecipientOwnerDir amendments lost the support of several validators, causing those amendments' support to fall below the 80% threshold for approval. (EnableAmendment LostMajority transactions: [fixCheckThreading](https://xrpcharts.ripple.com/#/transactions/3D10E846B1DA4BA07FA79BA1C13F802DD587F842F3810D997224C3693B120F51), [fixPayChanRecipientOwnerDir](https://xrpcharts.ripple.com/#/transactions/C848F96FDB815623753F27E8B5C83F4E38CFC8F50B28307142A6DFAC946EF070).) As a result, these amendments are no longer expected to become enabled on 2020-01-18, and their status depends on more validators to resume voting in favor of the amendments.

--- a/blog/2020/get-ready-for-deletable-accounts.md
+++ b/blog/2020/get-ready-for-deletable-accounts.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-05-06
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Get Ready for Deletable Accounts
 
 The XRP Ledger is currently [expected to enable](https://xrpl.org/blog/2020/deletableaccounts-expected.html) the deletion of on-ledger accounts for the first time, through the [DeletableAccounts Amendment](https://xrpl.org/known-amendments.html#deletableaccounts), on **2020-05-08 (UTC)**. This amendment comes with changes to some fairly fundamental details of the XRP Ledger protocol. If you use the XRP Ledger for your business, this is a good time to do a last check to make sure you're ready.

--- a/blog/2020/moving-devnet-to-vl.md
+++ b/blog/2020/moving-devnet-to-vl.md
@@ -3,6 +3,10 @@ category: 2020
 date: 2020-08-10
 labels:
     - Advisories
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Moving Devnet to a Validator List
 

--- a/blog/2020/requirefullycanonicalsig-expected.md
+++ b/blog/2020/requirefullycanonicalsig-expected.md
@@ -1,3 +1,14 @@
+---
+category: 2020
+date: 2020-06-24
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
+
 # The RequireFullyCanonicalSig Amendment is Expected 2020-07-03
 
 The RequireFullyCanonicalSig amendment to the XRP Ledger, introduced in [`rippled` v1.5.0](https://github.com/ripple/rippled/releases/tag/1.5.0), has [gained support from a majority of trusted validators](https://xrpcharts.ripple.com/#/transactions/4DF3E28D6920D917CE0A0A9E341BC5F792B3584E2DD5E679BD7679FE0875AEE6). Currently, it is expected to become enabled on 2020-07-03 (UTC). As long as the RequireFullyCanonicalSig amendment continues to have the support of at least 80% of trusted validators continuously, it will become enabled on the scheduled date.

--- a/blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled.md
+++ b/blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-08-04
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # RequireFullyCanonicalSig, fixQualityUpperBound, and FlowCross are Now Available
 
 [As previously announced](https://xrpl.org/blog/2020/requirefullycanonicalsig-expected.html), the **RequireFullyCanonicalSig** amendment [became enabled on the XRP Ledger](https://xrpcharts.ripple.com/#/transactions/94D8B158E948148B949CC3C35DD5DC4791D799E1FD5D3CE0E570160EDEF947D3) on 2020-07-03. Additionally, the **fixQualityUpperBound** amendment [became enabled](https://xrpcharts.ripple.com/#/transactions/5F8E9E9B175BB7B95F529BEFE3C84253E78DAF6076078EC450A480C861F6889E) on 2020-07-09 and the **FlowCross** amendment [became enabled](https://xrpcharts.ripple.com/#/transactions/44C4B040448D89B6C5A5DEC97C17FEDC2E590BA094BC7DB63B7FDC888B9ED78F) on 2020-08-04.

--- a/blog/2020/rippled-1.4.0-upgrade-advisory.md
+++ b/blog/2020/rippled-1.4.0-upgrade-advisory.md
@@ -1,3 +1,14 @@
+---
+category: 2020
+date: 2020-01-13
+labels:
+    - Advisories
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
+
 # XRP Ledger version 1.4.0 Upgrade Advisory
 
 Version 1.4.0 of the XRP Ledger core server (`rippled`) contains a change that can cause upgrades to take much longer than usual.
@@ -18,20 +29,26 @@ If needed, a workaround is possible. However, we do not recommend this procedure
 
 The following workaround can reduce `rippled`'s initial startup time after upgrading to version 1.4.0. It requires making changes to one of the SQL databases maintained by the server. Instead of deleting the unneeded data, this workaround renames the table. The old data continues to take up disk space on the server.
 
-**WARNING:** We do not recommend this procedure to anyone not familiar with sqlite3.
+{% admonition type="danger" name="WARNING" %}
+We do not recommend this procedure to anyone not familiar with sqlite3.
+{% /admonition %}
 
 1. Install the required tool: `sqlite3`. This is operating-system dependent.
     
     On Ubuntu you can use the following commands:
 
-        sudo apt-get update
-        sudo apt-get install sqlite3
+    ```sh
+    sudo apt-get update
+    sudo apt-get install sqlite3
+    ```
 
 2. Stop your `rippled` instance.
 
     This is operating-system dependent. On Linux, you can use the following commands:
 
-        sudo systemctl stop rippled.service
+    ```sh
+    sudo systemctl stop rippled.service
+    ```
 
 3. Read your configuration file and find the `[database_path]` stanza.
 
@@ -45,19 +62,27 @@ The following workaround can reduce `rippled`'s initial startup time after upgra
     
 5. Open the `ledger.db` file using the SQLite commandline:
     
-        sqlite3 ledger.db
+    ```sh
+    sqlite3 ledger.db
+    ```
     
 6. Execute the following command (the trailing semicolon is required):
 
-        ALTER TABLE Validations RENAME TO OldValidations;
+    ```sql
+    ALTER TABLE Validations RENAME TO OldValidations;
+    ```
     
 7. Execute the following command (the leading period is required):
 
-        .quit
+    ```text
+    .quit
+    ```
 
 8. You should now be able to start `rippled` without experiencing any delay.
 
-        sudo systemctl start rippled.service
+    ```sh
+    sudo systemctl start rippled.service
+    ```
 
 For general instructions on upgrading `rippled` on supported platforms, see [Install `rippled`](https://xrpl.org/install-rippled.html).
 

--- a/blog/2020/rippled-1.5.0.md
+++ b/blog/2020/rippled-1.5.0.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-04-10
+labels:
+    - Advisories
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Introducing XRP Ledger version 1.5.0
 
 **XRP Ledger (`rippled` server) version 1.5.0** has been released. The `rippled` 1.5.0 release introduces several improvements and new features, including support for gRPC API, API versioning, UNL propagation via the peer network, new RPC methods `validator_info` and `manifest`, augmented `submit` method, improved `tx` method, improved CLI parsing, improved protocol-level handshaking protocol, improved package building and various other minor bug fixes and improvements.

--- a/blog/2020/rippled-1.6.0.md
+++ b/blog/2020/rippled-1.6.0.md
@@ -3,6 +3,10 @@ category: 2020
 date: 2020-08-19
 labels:
     - rippled Release Notes
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.6.0
 

--- a/blog/2020/running-an-xrp-ledger-validator.md
+++ b/blog/2020/running-an-xrp-ledger-validator.md
@@ -3,6 +3,10 @@ category: 2020
 date: 2021-02-07
 labels:
     - Features
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Running an XRP Ledger Validator
 _by Mayur Bhandary, Software Engineer at Ripple_

--- a/blog/2020/testnet-amendments-rippled-1.5.0.md
+++ b/blog/2020/testnet-amendments-rippled-1.5.0.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-04-10
+labels:
+    - Advisories
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Postmortem: Testnet Amendments from rippled 1.5.0
 
 Like most new releases, version 1.5.0 of the XRP Ledger core server (`rippled`) contains new amendments which are not understood by earlier versions of the software.

--- a/blog/2020/two-fixes-enabled.md
+++ b/blog/2020/two-fixes-enabled.md
@@ -1,3 +1,13 @@
+---
+category: 2020
+date: 2020-05-01
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Two Fix Amendments Are Now Enabled
 
 As [previously announced](https://xrpl.org/blog/2020/deletableaccounts-expected.html), the [fixCheckThreading](https://xrpcharts.ripple.com/#/transactions/74AFEA8C17D25CA883D40F998757CA3B0DB1AC86794335BAA25FF20E00C2C30A) and [fixPayChanRecipientOwnerDir](https://xrpcharts.ripple.com/#/transactions/D2F8E457D08ACB185CDE3BB9BB1989A9052344678566785BACFB9DFDBDEDCF09) amendments became enabled on 2020-05-01.

--- a/blog/2021/community-spotlight-developing-wallet-protect.md
+++ b/blog/2021/community-spotlight-developing-wallet-protect.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2020-03-10
 labels:
     - Developer Reflections

--- a/blog/2021/five-upcoming-amendments.md
+++ b/blog/2021/five-upcoming-amendments.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-11-10
 labels:
     - Amendments

--- a/blog/2021/introducing-xrpl-js.md
+++ b/blog/2021/introducing-xrpl-js.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-10-20
 labels:
     - xrpl.js Release Notes

--- a/blog/2021/introducing-xrpl-py-for-pythonistas.md
+++ b/blog/2021/introducing-xrpl-py-for-pythonistas.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-04-06
 labels:
     - xrpl-py Release Notes

--- a/blog/2021/introducing-xrpl4j.md
+++ b/blog/2021/introducing-xrpl4j.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-05-20
 labels:
     - xrpl4j Release Notes

--- a/blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying.md
+++ b/blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-03-16
 labels:
     - Development

--- a/blog/2021/reserves-lowered.md
+++ b/blog/2021/reserves-lowered.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-09-21
 labels:
     - Advisories

--- a/blog/2021/ripple-lib-drops-lodash-browsers.md
+++ b/blog/2021/ripple-lib-drops-lodash-browsers.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-08-26
 labels:
     - xrpl.js Release Notes

--- a/blog/2021/rippled-1.7.0.md
+++ b/blog/2021/rippled-1.7.0.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-02-24
 labels:
     - rippled Release Notes

--- a/blog/2021/rippled-1.7.2.md
+++ b/blog/2021/rippled-1.7.2.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-05-24
 labels:
     - rippled Release Notes

--- a/blog/2021/rippled-1.7.3.md
+++ b/blog/2021/rippled-1.7.3.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-08-27
 labels:
     - rippled Release Notes

--- a/blog/2021/rippled-1.8.1.md
+++ b/blog/2021/rippled-1.8.1.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-12-02
 labels:
     - rippled Release Notes

--- a/blog/2021/rippled-1.8.2.md
+++ b/blog/2021/rippled-1.8.2.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-12-20
 labels:
     - rippled Release Notes

--- a/blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security.md
+++ b/blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-02-24
 labels:
     - rippled Release Notes

--- a/blog/2021/sidechain-engineering-preview.md
+++ b/blog/2021/sidechain-engineering-preview.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-09-30
 labels:
     - Development

--- a/blog/2021/three-amendments-expected.md
+++ b/blog/2021/three-amendments-expected.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-03-30
 labels:
     - Amendments

--- a/blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation.md
+++ b/blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-06-05
 labels:
     - Features

--- a/blog/2021/xrpl-node-configurator.md
+++ b/blog/2021/xrpl-node-configurator.md
@@ -1,5 +1,9 @@
 ---
 category: 2021
+theme:
+    markdown:
+        editPage:
+            hide: true
 date: 2021-04-14
 labels:
     - Development

--- a/blog/2022/clio-1.0.0.md
+++ b/blog/2022/clio-1.0.0.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-06-29
 labels:
     - Clio Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing Clio version 1.0.0
 

--- a/blog/2022/cryptoiso20022interop.md
+++ b/blog/2022/cryptoiso20022interop.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-11-15
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: CryptoIso20022 Interop
 

--- a/blog/2022/dev-reflections-relaunch.md
+++ b/blog/2022/dev-reflections-relaunch.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-10-26
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Get Your Project Featured on XRPL.org
 

--- a/blog/2022/expandedsignerlist-enabled-and-nfts-approaching.md
+++ b/blog/2022/expandedsignerlist-enabled-and-nfts-approaching.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-10-13
 labels:
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # ExpandedSignerList Enabled and NFTs Approaching
 

--- a/blog/2022/gemwallet.md
+++ b/blog/2022/gemwallet.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-11-23
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: GemWallet
 

--- a/blog/2022/get-ready-for-nfts.md
+++ b/blog/2022/get-ready-for-nfts.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-09-01
 labels:
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Get Ready for NFTs
 

--- a/blog/2022/introducing-clio.md
+++ b/blog/2022/introducing-clio.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-03-22
 labels:
     - Clio Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing Clio, an XRP Ledger API server, now in Beta
 

--- a/blog/2022/introducing-learning-portal.md
+++ b/blog/2022/introducing-learning-portal.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-10-03
 labels:
     - Features
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing the XRP Ledger Learning Portal
 

--- a/blog/2022/introducing-xrpl-py-2.0.0beta.md
+++ b/blog/2022/introducing-xrpl-py-2.0.0beta.md
@@ -3,7 +3,8 @@ category: 2022
 date: 2022-12-13
 labels:
     - xrpl-py Release Notes
-targets: [devblog]
+editPage:
+    hide: true
 ---
 # Introducing xrpl-py version 2.0.0-beta.0
 _by Team RippleX_

--- a/blog/2022/nft-devnet-reset.md
+++ b/blog/2022/nft-devnet-reset.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-03-01
 labels:
     - Advisories
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # The NFT-Devnet Has Been Reset
 

--- a/blog/2022/nftmaster.md
+++ b/blog/2022/nftmaster.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-12-14
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: NFTMASTER
 

--- a/blog/2022/non-fungible-tokens-are-now-available.md
+++ b/blog/2022/non-fungible-tokens-are-now-available.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-11-01
 labels:
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Non-Fungible Tokens Are Now Available
 

--- a/blog/2022/rippled-1.8.4.md
+++ b/blog/2022/rippled-1.8.4.md
@@ -3,6 +3,10 @@ category: 2022
 date: 2022-01-13
 labels:
     - rippled Release Notes
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.8.4
 

--- a/blog/2022/rippled-1.8.5.md
+++ b/blog/2022/rippled-1.8.5.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-02-08
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.8.5
 

--- a/blog/2022/rippled-1.9.0.md
+++ b/blog/2022/rippled-1.9.0.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-04-07
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.9.0
 

--- a/blog/2022/rippled-1.9.1.md
+++ b/blog/2022/rippled-1.9.1.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-05-23
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.9.1
 

--- a/blog/2022/rippled-1.9.2.md
+++ b/blog/2022/rippled-1.9.2.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-07-26
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.9.2
 

--- a/blog/2022/rippled-1.9.3.md
+++ b/blog/2022/rippled-1.9.3.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-08-26
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.9.3
 

--- a/blog/2022/rippled-1.9.4.md
+++ b/blog/2022/rippled-1.9.4.md
@@ -4,7 +4,10 @@ date: 2022-09-20
 labels:
     - rippled Release Notes
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.9.4
 

--- a/blog/2022/xpmarket.md
+++ b/blog/2022/xpmarket.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-12-07
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: XPmarket
 

--- a/blog/2022/ziggurat.md
+++ b/blog/2022/ziggurat.md
@@ -3,7 +3,10 @@ category: 2022
 date: 2022-11-30
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Ziggurat
 

--- a/blog/2023/aesthetes.md
+++ b/blog/2023/aesthetes.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-01-18
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Aesthetes
 

--- a/blog/2023/bei-api.md
+++ b/blog/2023/bei-api.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-03-01
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: BEI API
 

--- a/blog/2023/blockdaemon.md
+++ b/blog/2023/blockdaemon.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-08-29
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Blockdaemon
 

--- a/blog/2023/chispend.md
+++ b/blog/2023/chispend.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-04-05
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: ChiSpend
 

--- a/blog/2023/ciso.md
+++ b/blog/2023/ciso.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-06-07
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: CISO Integration for the XRP Ledger
 

--- a/blog/2023/clio-2.0.0.md
+++ b/blog/2023/clio-2.0.0.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-10-31
 labels:
     - Clio Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing Clio version 2.0.0
 

--- a/blog/2023/data-api-v2-deprecated.md
+++ b/blog/2023/data-api-v2-deprecated.md
@@ -4,7 +4,10 @@ date: 2023-10-05
 labels:
     - Advisories
     - Data API
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Data API v2 Shutdown
 

--- a/blog/2023/decommissioning-amm-devnet.md
+++ b/blog/2023/decommissioning-amm-devnet.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-12-05
 labels:
     - Advisories
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Decommissioning AMM-Devnet
 

--- a/blog/2023/devnet-reset-scheduled-sep-19-2023.md
+++ b/blog/2023/devnet-reset-scheduled-sep-19-2023.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-09-11
 labels:
     - Advisories
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Devnet Reset Scheduled for Tue, Sep 19, 2023
 _by Team RippleX_

--- a/blog/2023/disallowincoming-and-others-expected.md
+++ b/blog/2023/disallowincoming-and-others-expected.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-08-07
 labels:
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # DisallowIncoming and Others Expected 2023-08-21
 

--- a/blog/2023/edge.md
+++ b/blog/2023/edge.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-05-17
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Edge
 

--- a/blog/2023/fieldboss.md
+++ b/blog/2023/fieldboss.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-06-28
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: FieldBoss
 

--- a/blog/2023/gemwallet-update.md
+++ b/blog/2023/gemwallet-update.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-10-08
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: GemWallet (2023 Update)
 

--- a/blog/2023/mandla-money.md
+++ b/blog/2023/mandla-money.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-02-01
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Mandla Money
 

--- a/blog/2023/nft-devnet-decommission.md
+++ b/blog/2023/nft-devnet-decommission.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2022-01-27
 labels:
     - Advisories
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # The NFT-Devnet Decommissioned on January 31, 2023
 

--- a/blog/2023/rippled-1.10.0.md
+++ b/blog/2023/rippled-1.10.0.md
@@ -4,7 +4,10 @@ date: 2023-03-14
 labels:
     - rippled Release Notes
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.10.0
 

--- a/blog/2023/rippled-1.11.0.md
+++ b/blog/2023/rippled-1.11.0.md
@@ -4,7 +4,10 @@ date: 2023-06-21
 labels:
     - rippled Release Notes
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.11.0
 

--- a/blog/2023/rippled-1.12.0.md
+++ b/blog/2023/rippled-1.12.0.md
@@ -4,7 +4,10 @@ date: 2023-09-06
 labels:
     - rippled Release Notes
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 1.12.0
 

--- a/blog/2023/santiment.md
+++ b/blog/2023/santiment.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-10-06
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Santiment - Uncovering XRPL Metrics for Developers
 

--- a/blog/2023/stably.md
+++ b/blog/2023/stably.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-01-04
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Stably
 

--- a/blog/2023/summarizing-xrpl-docs-iav3.md
+++ b/blog/2023/summarizing-xrpl-docs-iav3.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-07-25
 labels:
     - Features
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Summarizing the Information Architecture v3 Updates (PR#1934)
 

--- a/blog/2023/upcoming-devnet-reset.md
+++ b/blog/2023/upcoming-devnet-reset.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-09-06
 labels:
     - Advisories
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Upcoming Devnet Reset
 _by Team RippleX_

--- a/blog/2023/xrp-toolkit.md
+++ b/blog/2023/xrp-toolkit.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-07-28
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: XRP Toolkit
 

--- a/blog/2023/xrpcafe.md
+++ b/blog/2023/xrpcafe.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-05-03
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: xrp.cafe
 

--- a/blog/2023/xrpl-py-2.0-release.md
+++ b/blog/2023/xrpl-py-2.0-release.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-07-05
 labels:
     - xrpl-py Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Migration Guide: Upgrading to xrpl-py Version 2.0.0
 _by Team RippleX_

--- a/blog/2023/zoetic.md
+++ b/blog/2023/zoetic.md
@@ -3,7 +3,10 @@ category: 2023
 date: 2023-02-15
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Zoetic
 

--- a/blog/2024/clio-2.1.0.md
+++ b/blog/2024/clio-2.1.0.md
@@ -3,7 +3,10 @@ category: 2024
 date: 2024-02-14
 labels:
     - Clio Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 
 # Introducing Clio version 2.1.0

--- a/blog/2024/get-ready-for-amm.md
+++ b/blog/2024/get-ready-for-amm.md
@@ -1,3 +1,13 @@
+---
+category: 2024
+date: 2024-03-21
+labels:
+    - Amendments
+theme:
+    markdown:
+        editPage:
+            hide: true
+---
 # Get Ready for AMM
 
 The [AMM Amendment](/resources/known-amendments#amm) to the XRP Ledger protocol, which adds Automated Market Maker functionality, is on track to become enabled on Mainnet on 2024-03-22. If it maintains support from a supermajority of validators and becomes enabled as expected, this represents the culmination of a 2-year project to bring AMM to the XRPL, starting from the XLS-30 draft specification proposed by Aanchal Malhotra and David Schwartz of Ripple and incorporating the work and feedback of numerous contributors in the XRPL community during that time.

--- a/blog/2024/how-to-mint-nfts.md
+++ b/blog/2024/how-to-mint-nfts.md
@@ -6,7 +6,10 @@ seo:
     description:  Learn the basics of minting an NFT on XRP Ledger and how you can get started quickly and easily today.
 labels:
     - Development
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # How to Mint an NFT on the XRP Ledger: A Step-by-Step Guide
 

--- a/blog/2024/rippled-2.0.0.md
+++ b/blog/2024/rippled-2.0.0.md
@@ -4,7 +4,10 @@ date: 2024-01-09
 labels:
     - rippled Release Notes
     - Amendments
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 2.0.0
 

--- a/blog/2024/rippled-2.0.1.md
+++ b/blog/2024/rippled-2.0.1.md
@@ -3,7 +3,10 @@ category: 2024
 date: 2024-01-29
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 2.0.1
 

--- a/blog/2024/rippled-2.1.0.md
+++ b/blog/2024/rippled-2.1.0.md
@@ -3,7 +3,10 @@ category: 2024
 date: 2024-02-20
 labels:
     - rippled Release Notes
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Introducing XRP Ledger version 2.1.0
 

--- a/blog/2024/verifyed.md
+++ b/blog/2024/verifyed.md
@@ -3,7 +3,10 @@ category: 2024
 date: 2024-03-14
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: VerifyEd - Empowering Credential Verification on XRP Ledger 
 

--- a/blog/2024/web3auth.md
+++ b/blog/2024/web3auth.md
@@ -3,7 +3,10 @@ category: 2024
 date: 2024-01-23
 labels:
     - Developer Reflections
-targets: [devblog]
+theme:
+    markdown:
+        editPage:
+            hide: true
 ---
 # Developer Reflections: Web3Auth
 

--- a/blog/index.page.tsx
+++ b/blog/index.page.tsx
@@ -103,7 +103,9 @@ export default function Index() {
                   </p>
                 </div>
                 <h4 className="mb-8 h2-sm font-weight-bold">
-                  {translate(`${heroPost.title}`)}
+                  <a href={`/blog/${heroPost.link}`}>
+                    {translate(`${heroPost.title}`)}
+                  </a>
                 </h4>
                 <p className="mb-4">{translate(`${heroPost.description}`)}</p>
                 <div className="d-lg-block">
@@ -215,7 +217,11 @@ export default function Index() {
                     <p id="card-date" className="mb-0">
                       {moment(translate(card.date)).format("MMM DD, YYYY")}
                     </p>
-                    <h5 className="mb-2-sm h3-sm">{translate(card.title)}</h5>
+                    <h5 className="mb-2-sm h3-sm">
+                      <a href={`/blog/${card.link}`}>
+                      {translate(card.title)}
+                      </a>
+                    </h5>
                   </div>
                   <div className="d-lg-block">
                     <p className="line-clamp">{translate(card.description)}</p>

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -59,6 +59,9 @@ theme:
       $ref: top-nav.yaml
   markdown:
     partialsFolders: ["docs/_snippets", "_code-samples", "_api-examples"]
+    editPage:
+      baseUrl: https://github.com/XRPLF/xrpl-dev-portal/tree/master/
+      hide: false
   footer:
     logo:
       hide: true


### PR DESCRIPTION
- Add missing metadata for "Get Ready for AMM" blog which was causing it not to appear in the right place.
- Enable the "Edit Page" feature on pages by default.
- Disable "Edit Page" on blogs from 2020-2024
- Fix metadata for blog 2020 blog posts, adding the correct post date and categories.
- Migrate some old md syntax in one old blog post.
- Make blog titles clickable links on the blog landing page.

See #2501 for some known issues that this PR does not address.