### PR TITLE
Blog: unify nav with rest of site

### DIFF
--- a/@i18n/ja/translations.yaml
+++ b/@i18n/ja/translations.yaml
@@ -273,6 +273,7 @@ Create Payment Channel: Payment Channelを作成
 Send Issued Currency: トークンを送信
 Trust for: トラストラインの設定
 Security: セキュリティ
+Release Notes: リリースノート
 Custody: カストディ
 Infrastructure: インフラストラクチャ 
 Carbon Markets/Sustainability: 持続可能性

--- a/@theme/components/Navbar/Navbar.tsx
+++ b/@theme/components/Navbar/Navbar.tsx
@@ -8,10 +8,7 @@ import { Link } from "@portal/Link";
 import { ColorModeSwitcher } from "@theme/components/ColorModeSwitcher/ColorModeSwitcher";
 import { Search } from "@theme/components/Search/Search";
 
-import { useLocation } from "react-router-dom";
-
 // @ts-ignore
-// import navbar from '../../../top-nav.yaml';
 
 const alertBanner = {
   show: true,
@@ -52,31 +49,6 @@ export function Navbar(props) {
     }
   });
 
-  const { pathname } = useLocation();
-  const blogNavs = getBlogNavigationConfig();
-
-  const blogNavItems = [];
-  for (const blogNav of blogNavs) {
-    if (blogNav.type === "group") {
-      blogNavItems.push(
-        <NavDropdown
-          key={blogNav.index}
-          label={blogNav.label}
-          items={blogNav.items}
-          pathPrefix={pathPrefix}
-        />
-      );
-    } else {
-      blogNavItems.push(
-        <NavItem key={blogNav.index}>
-          <Link to={blogNav.link} className="nav-link">
-            {blogNav.label}
-          </Link>
-        </NavItem>
-      );
-    }
-  }
-
   React.useEffect(() => {
     // Turns out jQuery is necessary for firing events on Bootstrap v4
     // dropdowns. These events set classes so that the search bar and other
@@ -112,73 +84,36 @@ export function Navbar(props) {
     };
   }, []);
 
-  // Render a different top nav for the Blog site.
-  if (pathname.includes("blog")) {
-    return (
-      <>
-        <AlertBanner
-          show={alertBanner.show}
-          message={alertBanner.message}
-          button={alertBanner.button}
-          link={alertBanner.link}
-        />
-        <NavWrapper belowAlertBanner={true}>
-          <LogoBlock to={href} img={logo} alt={altText} />
-          <NavControls>
-            <MobileMenuIcon />
-          </NavControls>
-          <TopNavCollapsible>
-            <NavItems>
-              {blogNavItems}
-              <div id="topnav-search" className="nav-item search">
-                <Search className="topnav-search" />
-              </div>
-              <div id="topnav-button" className="nav-item">
-                <GetStartedButton />
-              </div>
-              <div id="topnav-language" className="nav-item">
-                <LanguagePicker onChangeLanguage={changeLanguage} onlyIcon />
-              </div>
-              <div id="topnav-theme" className="nav-item">
-                <StyledColorModeSwitcher />
-              </div>
-            </NavItems>
-          </TopNavCollapsible>
-        </NavWrapper>
-      </>
-    );
-  } else {
-    return (
-      <>
-        <AlertBanner
-          show={alertBanner.show}
-          message={alertBanner.message}
-          button={alertBanner.button}
-          link={alertBanner.link}
-        />
-        <NavWrapper belowAlertBanner={true}>
-          <LogoBlock to={href} img={logo} alt={altText} />
-          <NavControls>
-            <MobileMenuIcon />
-          </NavControls>
-          <TopNavCollapsible>
-            <NavItems>
-              {navItems}
-              <div id="topnav-search" className="nav-item search">
-                <Search className="topnav-search" />
-              </div>
-              <div id="topnav-language" className="nav-item">
-                <LanguagePicker onChangeLanguage={changeLanguage} onlyIcon />
-              </div>
-              <div id="topnav-theme" className="nav-item">
-                <StyledColorModeSwitcher />
-              </div>
-            </NavItems>
-          </TopNavCollapsible>
-        </NavWrapper>
-      </>
-    );
-  }
+  return (
+    <>
+      <AlertBanner
+        show={alertBanner.show}
+        message={alertBanner.message}
+        button={alertBanner.button}
+        link={alertBanner.link}
+      />
+      <NavWrapper belowAlertBanner={true}>
+        <LogoBlock to={href} img={logo} alt={altText} />
+        <NavControls>
+          <MobileMenuIcon />
+        </NavControls>
+        <TopNavCollapsible>
+          <NavItems>
+            {navItems}
+            <div id="topnav-search" className="nav-item search">
+              <Search className="topnav-search" />
+            </div>
+            <div id="topnav-language" className="nav-item">
+              <LanguagePicker onChangeLanguage={changeLanguage} onlyIcon />
+            </div>
+            <div id="topnav-theme" className="nav-item">
+              <StyledColorModeSwitcher />
+            </div>
+          </NavItems>
+        </TopNavCollapsible>
+      </NavWrapper>
+    </>
+  );
 }
 
 const StyledColorModeSwitcher = styled(ColorModeSwitcher)`
@@ -440,132 +375,4 @@ export class ThemeToggle extends React.Component {
   componentDidMount() {
     this.auto_update_theme();
   }
-}
-
-function getBlogNavigationConfig() {
-  const { translate } = useTranslate();
-
-  return [
-    {
-      index: "0",
-      label: translate("Learn"),
-      type: "group",
-      items: [
-        {
-          type: "group",
-          label: translate("XRP Ledger"),
-          items: [
-            {
-              type: "link",
-              fsPath: "about/index.page.tsx",
-              label: translate("Overview"),
-              link: "/about/",
-            },
-            {
-              type: "link",
-              fsPath: "about/uses.page.tsx",
-              label: translate("Uses"),
-              link: "/about/uses",
-            },
-            {
-              type: "link",
-              fsPath: "about/history.page.tsx",
-              label: translate("History"),
-              link: "/about/history",
-            },
-            {
-              type: "link",
-              fsPath: "about/impact.page.tsx",
-              label: translate("Impact"),
-              link: "/about/impact",
-            },
-            {
-              type: "link",
-              fsPath: "about/impact.page.tsx",
-              label: translate("Carbon Calculator"),
-              link: "/about/impact",
-            },
-          ],
-        },
-      ],
-      pathPrefix: "",
-    },
-    {
-      index: "1",
-      label: translate("Explore"),
-      type: "group",
-      items: [
-        {
-          type: "group",
-          label: translate("Explore the XRP Ledger"),
-          items: [
-            {
-              type: "link",
-              fsPath: "/docs/introduction/crypto-wallets.md",
-              label: translate("Wallets"),
-              link: "/docs/introduction/crypto-wallets",
-            },
-            {
-              type: "link",
-              fsPath: "about/xrp.page.tsx",
-              label: translate("Exchanges"),
-              link: "/about/xrp",
-            },
-            {
-              type: "link",
-              fsPath: "about/uses.page.tsx",
-              label: translate("Businesses"),
-              link: "/about/uses",
-            },
-            {
-              type: "link",
-              fsPath: "",
-              label: translate("Ledger Explorer"),
-              link: "https://livenet.xrpl.org/",
-            },
-          ],
-        },
-      ],
-      pathPrefix: "",
-    },
-    {
-      index: "2",
-      label: translate("Build"),
-      type: "group",
-      items: [
-        {
-          type: "group",
-          label: translate("Build with XRPL"),
-          items: [
-            {
-              type: "link",
-              fsPath: "/docs/index.page.tsx",
-              label: translate("Docs"),
-              link: "/docs/",
-            },
-            {
-              type: "link",
-              fsPath: "/resources/dev-tools/index.page.tsx",
-              label: translate("Dev Tools"),
-              link: "/resources/dev-tools/",
-            },
-            {
-              type: "link",
-              fsPath: "/blog/index.page.tsx",
-              label: translate("Dev Blog"),
-              link: "/blog/",
-            },
-          ],
-        },
-      ],
-      pathPrefix: "",
-    },
-    {
-      index: "3",
-      type: "link",
-      fsPath: "community/index.page.tsx",
-      label: translate("Contribute"),
-      link: "/community",
-    },
-  ];
 }

--- a/@theme/plugins/blog-posts.js
+++ b/@theme/plugins/blog-posts.js
@@ -44,6 +44,7 @@ export function blogPosts() {
 
         actions.createSharedData('blog-posts', { blogPosts: sortedPosts });
         actions.addRouteSharedData('/blog/', 'blog-posts', 'blog-posts');
+        actions.addRouteSharedData('/ja/blog/', 'blog-posts', 'blog-posts');
       } catch (e) {
         console.log(e);
       }

--- a/blog/index.page.tsx
+++ b/blog/index.page.tsx
@@ -124,7 +124,7 @@ export default function Index() {
         {/* Other Blog Posts*/}
         <section className="container-new py-26">
           <div className="row w-100 mx-auto px-2">
-            <div className="row-cols-lg-2 m-0 p-0 mt-2">
+            <div className="col-lg-4 m-0 p-0 mt-2">
               {/* Filters Desktop*/}
               <div className="p-3 category_sidebar d-none d-lg-block">
                 <p className="mb-2 category-header">Filter by Category:</p>


### PR DESCRIPTION
As noted in #2501, the top nav for the blog was not intentionally different from the rest of the site but rather had fallen out of date when the main site got updated and the old blog hadn't. When we migrated to Redocly, we re-created the outdated blog top nav, but this was unnecessary.

The dropdowns include links to numerous moved or deprecated pages and are best served by replacing them entirely with the standard site-wide navigation.

Also, I fixed a bug that was causing xrpl.org/ja/blog/ to throw an error instead of showing the list of blog posts.