### PR TITLE
Fix {{use_network}} appearing in visible text

### DIFF
--- a/docs/tutorials/how-tos/use-tokens/trade-in-the-decentralized-exchange.md
+++ b/docs/tutorials/how-tos/use-tokens/trade-in-the-decentralized-exchange.md
@@ -67,7 +67,7 @@ For this tutorial, click the following button to connect:
 
 ### 2. Get Credentials
 
-To transact on the XRP Ledger, you need an address, a secret key, and some XRP. For development purposes, you can get these on the [{{use_network}}](../../../concepts/networks-and-servers/parallel-networks.md) using the following interface:
+To transact on the XRP Ledger, you need an address, a secret key, and some XRP. For development purposes, you can get these on the [Testnet](../../../concepts/networks-and-servers/parallel-networks.md) using the following interface:
 
 {% partial file="/docs/_snippets/interactive-tutorials/generate-step.md" /%}
 


### PR DESCRIPTION
Fix #2490.

This was a Dactyl variable that couldn't be directly translated to a Redocly variable. The fix is to hard-code it to a network name.