### PR TITLE
Fix ammbid error inaccuracy; make ammendment requirement consistent with other enabled amendments

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info.md
+++ b/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info.md
@@ -13,7 +13,7 @@ labels:
 
 The {% code-page-name /%} method gets information about an Automated Market Maker (AMM) instance.
 
-_(Requires the [AMM amendment][])_
+_(Added by the [AMM amendment][])_
 
 
 ### Request Format

--- a/docs/references/protocol/transactions/types/ammbid.md
+++ b/docs/references/protocol/transactions/types/ammbid.md
@@ -62,8 +62,6 @@ You bid using the AMM's LP Tokens; the amount of a winning bid is returned to th
 | `BidMax`       | [Currency Amount][] | Amount            | No        | Pay at most this amount for the slot. If the cost to win the bid is higher than this amount, the transaction fails. If omitted, pay as much as necessary to win the bid. |
 | `AuthAccounts` | Array               | STArray           | No        | A list of up to 4 additional accounts that you allow to trade at the discounted fee. This cannot include the address of the transaction sender. Each of these objects should be an [Auth Account object](#auth-account-objects). |
 
-You cannot specify both `BidMin` and `BidMax`.
-
 ### Auth Account Objects
 
 Each member of the `AuthAccounts` array must be an object with the following field:
@@ -76,7 +74,7 @@ Like other "inner objects" that can appear in arrays, the JSON representation of
 
 ## Auction Slot Price
 
-If successful, the transaction automatically outbids the previous slot owner and debits the bid price from the sender's LP Tokens. The price to win the auction decreases over time, divided into 20 intervals of 72 minutes each. If the sender does not have enough LP Tokens to win the bid, or the price of the bid is higher than the transaction's `BidMax` value, the transaction fails with a `tecAMM_FAILED_BID` result.
+If successful, the transaction automatically outbids the previous slot owner and debits the bid price from the sender's LP Tokens. The price to win the auction decreases over time, divided into 20 intervals of 72 minutes each. If the sender does not have enough LP Tokens to win the bid, or the price of the bid is higher than the transaction's `BidMax` value, the transaction fails with a `tecAMM_INVALID_TOKENS` result.
 
 - If the auction slot is currently empty, expired, or in its last interval, the **minimum bid** is **0.001% of the AMM's total LP Tokens balance**.
 

--- a/docs/references/protocol/transactions/types/ammbid.md
+++ b/docs/references/protocol/transactions/types/ammbid.md
@@ -9,7 +9,7 @@ labels:
 # AMMBid
 [[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMBid.cpp "Source")
 
-_(Requires the [AMM amendment][])_
+_(Added by the [AMM amendment][])_
 
 Bid on an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md)'s (AMM's) auction slot. If you win, you can trade against the AMM at a discounted fee until you are outbid or 24 hours have passed. If you are outbid before 24 hours have passed, you are refunded part of the cost of your bid based on how much time remains.
 

--- a/docs/references/protocol/transactions/types/ammcreate.md
+++ b/docs/references/protocol/transactions/types/ammcreate.md
@@ -9,7 +9,7 @@ labels:
 # AMMCreate
 [[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMCreate.cpp "Source")
 
-_(Requires the [AMM amendment][])_
+_(Added by the [AMM amendment][])_
 
 Create a new [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md) (AMM) instance for trading a pair of assets ([fungible tokens](../../../../concepts/tokens/index.md) or [XRP](../../../../introduction/what-is-xrp.md)).
 

--- a/docs/references/protocol/transactions/types/ammdelete.md
+++ b/docs/references/protocol/transactions/types/ammdelete.md
@@ -9,7 +9,7 @@ labels:
 # AMMDelete
 [[Source]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/AMMDelete.cpp "Source")
 
-_(Requires the [AMM amendment][])_
+_(Added by the [AMM amendment][])_
 
 Delete an empty [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md) (AMM) instance that could not be fully deleted automatically.
 

--- a/docs/references/protocol/transactions/types/ammdeposit.md
+++ b/docs/references/protocol/transactions/types/ammdeposit.md
@@ -9,7 +9,7 @@ labels:
 # AMMDeposit
 [[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMDeposit.cpp "Source")
 
-_(Requires the [AMM amendment][])_
+_(Added by the [AMM amendment][])_
 
 Deposit funds into an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md) (AMM) instance and receive the AMM's liquidity provider tokens (_LP Tokens_) in exchange. You can deposit one or both of the assets in the AMM's pool.
 

--- a/docs/references/protocol/transactions/types/ammwithdraw.md
+++ b/docs/references/protocol/transactions/types/ammwithdraw.md
@@ -9,7 +9,7 @@ labels:
 # AMMWithdraw
 [[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMWithdraw.cpp "Source")
 
-_(Requires the [AMM amendment][])_
+_(Added by the [AMM amendment][])_
 
 Withdraw assets from an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md) (AMM) instance by returning the AMM's liquidity provider tokens (LP Tokens).
 


### PR DESCRIPTION
Not sure how to word the corresponding section in [error cases section](https://xrpl.org/docs/references/protocol/transactions/types/ammbid/#error-cases) which says basically the same thing as `tecAMM_INVALID_TOKENS`

> `tecAMM_FAILED`	This transaction could not win the auction, 
> either because the sender does not hold enough LP Tokens to pay the necessary bid or because the price 
> to win the auction was higher than the transaction's specified BidMax value.
> `tecAMM_INVALID_TOKENS` The sender of this transaction does not hold enough LP Tokens to meet the slot price.