### PR TITLE
AMMBid explain non-trading fee case

### DIFF
--- a/docs/references/protocol/transactions/types/ammbid.md
+++ b/docs/references/protocol/transactions/types/ammbid.md
@@ -11,7 +11,7 @@ labels:
 
 _(Requires the [AMM amendment][])_
 
-Bid on an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md)'s (AMM's) auction slot. If you win, you can trade against the AMM at a discounted fee until you are outbid or 24 hours have passed. If you are outbid before 24 hours have passed, you are refunded part of the cost of your bid based on how much time remains.
+Bid on an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md)'s (AMM's) auction slot. If you win, you can trade against the AMM at a discounted fee until you are outbid or 24 hours have passed. If you are outbid before 24 hours have passed, you are refunded part of the cost of your bid based on how much time remains. A Bid on AMM pool without trading fee set may result in sucessful transaction but will have no effect.
 
 You bid using the AMM's LP Tokens; the amount of a winning bid is returned to the AMM, decreasing the outstanding balance of LP Tokens.
 

--- a/docs/references/protocol/transactions/types/ammbid.md
+++ b/docs/references/protocol/transactions/types/ammbid.md
@@ -11,7 +11,7 @@ labels:
 
 _(Requires the [AMM amendment][])_
 
-Bid on an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md)'s (AMM's) auction slot. If you win, you can trade against the AMM at a discounted fee until you are outbid or 24 hours have passed. If you are outbid before 24 hours have passed, you are refunded part of the cost of your bid based on how much time remains. A Bid on AMM pool without trading fee set may result in sucessful transaction but will have no effect.
+Bid on an [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md)'s (AMM's) auction slot. If you win, you can trade against the AMM at a discounted fee until you are outbid or 24 hours have passed. If you are outbid before 24 hours have passed, you are refunded part of the cost of your bid based on how much time remains. If the AMM's trading fee is zero, you can still bid, but the auction slot provides no benefit unless the trading fee changes.
 
 You bid using the AMM's LP Tokens; the amount of a winning bid is returned to the AMM, decreasing the outstanding balance of LP Tokens.
 


### PR DESCRIPTION
Adds single sentence which addresses case when user bids on Pool which has not Trading fee yet set. For reference this is the transaction on XRPL Mainnet: A3A278DEEF3C5E06126526F948F31436BDDD96E61779E2E7A55090270017BD89