### PR TITLE
2571 - Update Rippling definition to clarify issuer's role in the process

### DIFF
--- a/docs/concepts/tokens/fungible-tokens/rippling.md
+++ b/docs/concepts/tokens/fungible-tokens/rippling.md
@@ -9,7 +9,7 @@ labels:
 ---
 # Rippling
 
-In the XRP Ledger, "rippling" describes a process of atomic net settlement between multiple connected parties who have [trust lines](index.md) for the same token. Rippling is essential, because it allows users who hold tokens to send those to each other with the issuer as a passive intermediary. In a sense, rippling is like a passive, two-way [exchange order](../decentralized-exchange/offers.md) with no limit and a 1:1 exchange rate for two tokens with the same currency code but different issuers.
+In the XRP Ledger, "rippling" describes a process of atomic net settlement between multiple connected parties who have [trust lines](index.md) for the same token. Rippling is essential, because it enables token holders to transfer funds directly to each other, without any issuer involvement in the debiting and crediting process. In a sense, rippling is like a passive, two-way [exchange order](../decentralized-exchange/offers.md) with no limit and a 1:1 exchange rate for two tokens with the same currency code but different issuers.
 
 Rippling only occurs along the [paths](paths.md) of a payment. [Direct XRP-to-XRP payments](../../payment-types/direct-xrp-payments.md) do not involve rippling.
 


### PR DESCRIPTION
```
Rippling is essential, because it allows users who hold tokens to send those to each other with the issuer as a passive intermediary.
```

Issue: https://github.com/XRPLF/xrpl-dev-portal/issues/2571