### PR TITLE
Add Clio servers to list of public servers

### DIFF
--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -20,6 +20,9 @@ If you don't [run your own `rippled` server](../infrastructure/installation/inde
 | Ripple[¹][]   | Devnet      | `https://s.devnet.rippletest.net:51234/` | `wss://s.devnet.rippletest.net:51233/` | Devnet public server |
 | Ripple[¹][]   | Sidechain-Devnet | `https://sidechain-net2.devnet.rippletest.net:51234/` | `wss://sidechain-net2.devnet.rippletest.net:51233/` | Sidechain Devnet to test cross-chain bridge features. Devnet serves as the locking chain while this sidechain serves as the issuing chain. |
 | XRPL Labs     | Xahau Testnet | `https://xahau-test.net/` | `wss://xahau-test.net/` | [Hooks-enabled](https://hooks.xrpl.org/) Xahau Testnet |
+| Ripple[¹][]   | Testnet (Clio) | https://clio.altnet.rippletest.net:51234/	| wss://clio.altnet.rippletest.net:51233/ |
+| Ripple[¹][]   | Devnet (Clio)  | https://clio.devnet.rippletest.net:51234/	| wss://clio.devnet.rippletest.net:51233/ |
+
 
 [Network]: ../concepts/networks-and-servers/parallel-networks.md
 [¹]: #footnote-1

--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -17,11 +17,11 @@ If you don't [run your own `rippled` server](../infrastructure/installation/inde
 | Ripple[¹][]   | **Mainnet** | `https://s2.ripple.com:51234/` | `wss://s2.ripple.com/` | [Full-history server](../concepts/networks-and-servers/ledger-history.md#full-history) cluster |
 | Ripple[¹][]   | Testnet     | `https://s.altnet.rippletest.net:51234/` | `wss://s.altnet.rippletest.net:51233/` | Testnet public server |
 | XRPL Labs     | Testnet     | `https://testnet.xrpl-labs.com/` | `wss://testnet.xrpl-labs.com/` | Testnet public server with CORS support |
+| Ripple[¹][]   | Testnet (Clio) | `https://clio.altnet.rippletest.net:51234/`	| `wss://clio.altnet.rippletest.net:51233/` | Testnet public server with Clio |
 | Ripple[¹][]   | Devnet      | `https://s.devnet.rippletest.net:51234/` | `wss://s.devnet.rippletest.net:51233/` | Devnet public server |
+| Ripple[¹][]   | Devnet (Clio)  | `https://clio.devnet.rippletest.net:51234/`	| `wss://clio.devnet.rippletest.net:51233/` | Devnet public server with Clio |
 | Ripple[¹][]   | Sidechain-Devnet | `https://sidechain-net2.devnet.rippletest.net:51234/` | `wss://sidechain-net2.devnet.rippletest.net:51233/` | Sidechain Devnet to test cross-chain bridge features. Devnet serves as the locking chain while this sidechain serves as the issuing chain. |
 | XRPL Labs     | Xahau Testnet | `https://xahau-test.net/` | `wss://xahau-test.net/` | [Hooks-enabled](https://hooks.xrpl.org/) Xahau Testnet |
-| Ripple[¹][]   | Testnet (Clio) | `https://clio.altnet.rippletest.net:51234/`	| `wss://clio.altnet.rippletest.net:51233/` | Testnet public server with Clio |
-| Ripple[¹][]   | Devnet (Clio)  | `https://clio.devnet.rippletest.net:51234/`	| `wss://clio.devnet.rippletest.net:51233/` | Devnet public server with Clio |
 
 
 [Network]: ../concepts/networks-and-servers/parallel-networks.md

--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -20,8 +20,8 @@ If you don't [run your own `rippled` server](../infrastructure/installation/inde
 | Ripple[¹][]   | Devnet      | `https://s.devnet.rippletest.net:51234/` | `wss://s.devnet.rippletest.net:51233/` | Devnet public server |
 | Ripple[¹][]   | Sidechain-Devnet | `https://sidechain-net2.devnet.rippletest.net:51234/` | `wss://sidechain-net2.devnet.rippletest.net:51233/` | Sidechain Devnet to test cross-chain bridge features. Devnet serves as the locking chain while this sidechain serves as the issuing chain. |
 | XRPL Labs     | Xahau Testnet | `https://xahau-test.net/` | `wss://xahau-test.net/` | [Hooks-enabled](https://hooks.xrpl.org/) Xahau Testnet |
-| Ripple[¹][]   | Testnet (Clio) | https://clio.altnet.rippletest.net:51234/	| wss://clio.altnet.rippletest.net:51233/ |
-| Ripple[¹][]   | Devnet (Clio)  | https://clio.devnet.rippletest.net:51234/	| wss://clio.devnet.rippletest.net:51233/ |
+| Ripple[¹][]   | Testnet (Clio) | `https://clio.altnet.rippletest.net:51234/`	| `wss://clio.altnet.rippletest.net:51233/` | Testnet public server with Clio |
+| Ripple[¹][]   | Devnet (Clio)  | `https://clio.devnet.rippletest.net:51234/`	| `wss://clio.devnet.rippletest.net:51233/` | Devnet public server with Clio |
 
 
 [Network]: ../concepts/networks-and-servers/parallel-networks.md

--- a/resources/dev-tools/components/websocket-api/data/connections.json
+++ b/resources/dev-tools/components/websocket-api/data/connections.json
@@ -41,5 +41,19 @@
     "shortname": "Local server",
     "longname":
     "localhost:6006 (Local <code>rippled</code> Server on port 6006) <br/>\n              <small>(Requires that you <a href=\"install-rippled.html\">run <code>rippled</code></a> on this machine with default WebSocket settings)</small>"
+  },
+  {
+    "id": "connection-testnet-clio",
+    "ws_url": "wss://clio.altnet.rippletest.net:51233/",
+    "jsonrpc-url": "https://clio.altnet.rippletest.net:51234/",
+    "shortname": "Testnet-clio",
+    "longname": "clio.altnet.rippletest.net (Testnet Public Cluster with Clio)"
+  },
+  {
+    "id": "connection-devnet-clio",
+    "ws_url": "wss://clio.devnet.rippletest.net:51233/",
+    "jsonrpc-url": "https://clio.devnet.rippletest.net:51234/",
+    "shortname": "devnet-clio",
+    "longname": "clio.devnet.rippletest.net (Devnet Public Cluster with Clio)"
   }
 ]


### PR DESCRIPTION
Per https://github.com/XRPLF/xrpl-dev-portal/issues/2537, add clio servers to the list of public servers and to the list of available servers in the websocket API tool.