### PR TITLE
Clarify that accounts get 2 free TLs, reserves can be used for transaction fees

### DIFF
--- a/docs/concepts/accounts/reserves.md
+++ b/docs/concepts/accounts/reserves.md
@@ -14,6 +14,8 @@ The XRP Ledger applies _reserve requirements_, in XRP, to protect the shared glo
 
 To have an account, an address must hold a minimum amount of XRP in the shared global ledger. To fund a new address, you must receive enough XRP at that address to meet the reserve requirement. You cannot send the reserved XRP to others, but you can recover some of the XRP by [deleting the account](deleting-accounts.md).
 
+The XRP reserve is not dormant, however. You can use your reserves to pay transaction fees. Another way to look at your reserves is that you are pre-funding your account to handle your transaction fees.
+
 The reserve requirement changes from time to time due to the [Fee Voting](../consensus-protocol/fee-voting.md) process, where validators can agree to new reserve settings.
 
 ## Base Reserve and Owner Reserve
@@ -29,6 +31,8 @@ The current reserve requirements on Mainnet are:
 - Owner reserve: **2 XRP** per item
 
 Reserves on other networks may vary.
+
+An exception to the owner reserve is that you can create your first two trust lines on the XRPL without the required reserves of 2 XRP per trust line. Create your new account with the 10 XRP base reserve, then create your 2 trust lines and the reserves are not required. If you fund your account with more than 10 XRP, your account will be charged the normal reserve fees for your first two trust lines.
 
 ## Owner Reserves
 

--- a/docs/concepts/tokens/fungible-tokens/authorized-trust-lines.md
+++ b/docs/concepts/tokens/fungible-tokens/authorized-trust-lines.md
@@ -21,7 +21,7 @@ The transaction to authorize a trust line must be signed by the issuing address,
 
 ## Reserves
 
-Trust lines are ledger objects that require a reserve of 2 XRP each. To help new users get started, the reserve amoutns are waived for the first 2 trust lines you create for a new account. Fund your new account with 10 XRP and create your new trust lines. If you have more than 10 XRP in your account, up to 4 XRP are reserved for your first 2 trust lines. If you later remove the trust line, the reserves are freed up for future use.
+Trust lines are ledger objects that require a reserve of 2 XRP each. To help new users get started, the reserve amounts are waived for the first 2 trust lines you create for a new account. Fund your new account with 10 XRP and create your new trust lines. If you have more than 10 XRP in your account, up to 4 XRP are reserved for your first 2 trust lines. If you remove the trust line later, the reserves are freed up for future use.
 
 ## With Stablecoin Issuing
 

--- a/docs/concepts/tokens/fungible-tokens/authorized-trust-lines.md
+++ b/docs/concepts/tokens/fungible-tokens/authorized-trust-lines.md
@@ -19,6 +19,10 @@ The transaction to authorize a trust line must be signed by the issuing address,
 
 **Caution:** You can only enable Require Auth if your account has no trust lines and no Offers in the XRP Ledger, so you must decide whether or not to use it _before_ you start issuing tokens.
 
+## Reserves
+
+Trust lines are ledger objects that require a reserve of 2 XRP each. To help new users get started, the reserve amoutns are waived for the first 2 trust lines you create for a new account. Fund your new account with 10 XRP and create your new trust lines. If you have more than 10 XRP in your account, up to 4 XRP are reserved for your first 2 trust lines. If you later remove the trust line, the reserves are freed up for future use.
+
 ## With Stablecoin Issuing
 
 With a stablecoin on the XRP Ledger and use Authorized Trust Lines, the process of onboarding a new customer might look something like the following:
@@ -36,11 +40,10 @@ Even if you don't intend to use Authorized Trust Lines, you can enable the Requi
 
 
 ## Technical Details
-<!--{# TODO: split these off into one or more tutorials on using authorized trust lines, preferably with both JavaScript and Python code samples. #}-->
 
 ### Enabling Require Auth
 
-The following is an example of using a locally-hosted `rippled`'s [submit method][] to send an [AccountSet transaction][] that enables Require Auth using the `asfRequireAuth` flag. (This method works the same way regardless of whether the address is an issuing address, operational address, or standby address.)
+The following is an example of using a locally hosted `rippled`'s [submit method][] to send an [AccountSet transaction][] that enables Require Auth using the `asfRequireAuth` flag. (This method works the same way regardless of whether the address is an issuing address, operational address, or standby address.)
 
 Request:
 
@@ -78,7 +81,7 @@ If you are using the Authorized Trust Lines feature, others cannot hold balances
 
 To authorize a trust line, submit a [TrustSet transaction][] from your issuing address, with the user to trust as the `issuer` of the `LimitAmount`. Leave the `value` (the amount to trust them for) as **0**, and enable the [`tfSetfAuth`](../../../references/protocol/transactions/types/trustset.md#trustset-flags) flag for the transaction.
 
-The following is an example of using a locally-hosted `rippled`'s [submit method][] to send a TrustSet transaction authorizing the customer address `rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn` to hold USD issued by the address `rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW`:
+The following is an example of using a locally hosted `rippled`'s [submit method][] to send a TrustSet transaction authorizing the customer address `rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn` to hold USD issued by the address `rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW`:
 
 Request:
 


### PR DESCRIPTION
Clarify and add docs on 2 free trust lines and impact on reserves. Also characterize reserves as "pre-funding transaction fees" rather than dormant funds locked away.

Per Brett Mohlin.
https://github.com/XRPLF/xrpl-dev-portal/issues/2582
