### PR TITLE
Add PreviousFields to DeletedNode

### DIFF
--- a/docs/references/protocol/transactions/metadata.md
+++ b/docs/references/protocol/transactions/metadata.md
@@ -226,6 +226,7 @@ A `DeletedNode` object contains the following fields:
 | `LedgerEntryType` | String            | The [type of ledger entry](../ledger-data/ledger-entry-types/index.md) that was deleted.                                                                                                                                                                                             |
 | `LedgerIndex`     | String - [Hash][] | The [ID of this ledger entry](../ledger-data/common-fields.md) in the ledger's [state tree](../../../concepts/ledgers/index.md). **Note:** This is **not the same** as a [ledger index](../data-types/basic-data-types.md#ledger-index), even though the field name is very similar. |
 | `FinalFields`     | Object            | The content fields of the ledger entry immediately before it was deleted. Which fields are present depends on what type of ledger entry was created.                                                                                                                                 |
+| `PreviousFields` | Object             | Selected fields of the ledger entry before it was deleted. Which fields are present depends on what type of ledger entry was created. |
 
 
 ### ModifiedNode Fields

--- a/docs/references/protocol/transactions/metadata.md
+++ b/docs/references/protocol/transactions/metadata.md
@@ -226,7 +226,7 @@ A `DeletedNode` object contains the following fields:
 | `LedgerEntryType` | String            | The [type of ledger entry](../ledger-data/ledger-entry-types/index.md) that was deleted.                                                                                                                                                                                             |
 | `LedgerIndex`     | String - [Hash][] | The [ID of this ledger entry](../ledger-data/common-fields.md) in the ledger's [state tree](../../../concepts/ledgers/index.md). **Note:** This is **not the same** as a [ledger index](../data-types/basic-data-types.md#ledger-index), even though the field name is very similar. |
 | `FinalFields`     | Object            | The content fields of the ledger entry immediately before it was deleted. Which fields are present depends on what type of ledger entry was created.                                                                                                                                 |
-| `PreviousFields` | Object             | Selected fields of the ledger entry before it was deleted. Which fields are present depends on what type of ledger entry was created. |
+| `PreviousFields` | Object             | _(May be omitted)_ Selected fields of the ledger entry before it was deleted. Which fields are present depends on what type of ledger entry was created. |
 
 
 ### ModifiedNode Fields


### PR DESCRIPTION
Per issue #2533, include `PreviousFields` in the list of fields returned for a `DeletedNode`.