### PR TITLE
Fix localized nav

### DIFF
--- a/@theme/components/Navbar/Navbar.tsx
+++ b/@theme/components/Navbar/Navbar.tsx
@@ -129,9 +129,9 @@ export function AlertBanner(props) {
           <p className="mb-0 apex-banner-text">{message}</p>
         </span>
         <span>
-          <a href={link} target="_blank" className="apex-btn">
+          <Link to={link} target="_blank" className="apex-btn">
             {button}
-          </a>
+          </Link>
         </span>
       </div>
     </div>
@@ -164,9 +164,9 @@ export function NavDropdown(props) {
           item2_href = pathPrefix + item2_href;
         }
         return (
-          <a key={index2} className={cls2} href={item2_href}>
+          <Link key={index2} className={cls2} to={item2_href}>
             {translate(item2.labelTranslationKey, item2.label)}
-          </a>
+          </Link>
         );
       });
 
@@ -195,18 +195,18 @@ export function NavDropdown(props) {
       const description = translate(splittranslationkey[1], splitlabel[1]); // splitlabel[1] might be undefined, that's ok
 
       return (
-        <a
+        <Link
           key={index}
           className="dropdown-item dropdown-hero"
           id={hero_id}
-          href={hero_href}
+          to={hero_href}
         >
           <img id={item.hero} alt={img_alt} src={item.icon} />
           <div className="dropdown-hero-text">
             <h4>{newlabel}</h4>
             <p>{description}</p>
           </div>
-        </a>
+        </Link>
       );
     } else {
       const cls = item.external
@@ -217,9 +217,9 @@ export function NavDropdown(props) {
         item_href = pathPrefix + item_href;
       }
       return (
-        <a key={index} className={cls} href={item_href}>
+        <Link key={index} className={cls} to={item_href}>
           {translate(item.labelTranslationKey, item.label)}
-        </a>
+        </Link>
       );
     }
   });
@@ -231,7 +231,7 @@ export function NavDropdown(props) {
     <li className="nav-item dropdown">
       <a
         className="nav-link dropdown-toggle"
-        href="#"
+        to="#"
         id={toggler_id}
         role="button"
         data-toggle="dropdown"
@@ -286,13 +286,13 @@ export function GetStartedButton() {
   const { translate } = useTranslate();
 
   return (
-    <a
+    <Link
       className="btn btn-primary"
-      href={"/docs/tutorials"}
+      to={"/docs/tutorials"}
       style={{ height: "38px", paddingTop: "11px" }}
     >
       {translate("Get Started")}
-    </a>
+    </Link>
   );
 }
 
@@ -311,9 +311,9 @@ export function NavItem(props) {
 export function LogoBlock(props) {
   const { to, img, altText } = props;
   return (
-    <a className="navbar-brand" href="/">
+    <Link className="navbar-brand" to="/">
       <img className="logo" alt={"XRP LEDGER"} height="40" src="data:," />
-    </a>
+    </Link>
   );
 }
 

--- a/@theme/plugins/code-samples.js
+++ b/@theme/plugins/code-samples.js
@@ -43,6 +43,7 @@ export function codeSamples() {
 
         actions.createSharedData('code-samples', { codeSamples: sortedSamples, langs: Array.from(allLands) });
         actions.addRouteSharedData('/resources/code-samples/', 'code-samples', 'code-samples');
+        actions.addRouteSharedData('/ja/resources/code-samples/', 'code-samples', 'code-samples');
       } catch (e) {
         console.log(e);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.3.3",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "^0.78.6",
+        "@redocly/realm": "^0.82.4",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.1.tgz",
-      "integrity": "sha512-T9ko/35G+Bkl+win48GduaPlhSlOjjE5s1TeiEcD+QpxlLQnoEfb/nO/T+TQqkm+ipFwORn+rB8w14iJ/uD0bg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.5.tgz",
+      "integrity": "sha512-GWO0mgzNMLWaSYM4z4NVIuY0Cd1fl8cPnuetuddu5w/qGuvt5Y7oUi/kvvQGK9xgOkFJDQX2heIvTRn/OQ1XTg==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -1769,21 +1769,21 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.1.4.tgz",
-      "integrity": "sha512-OEdCW1HRpFiZaZNrXQq8LoBxX3APijZaa/Xyoc6r44LnyAPWkjQqvPoBxE7IRqSvMihf8bl+ZRc1gtc1KuFLHw=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.5.0.tgz",
+      "integrity": "sha512-oA1ezWPT2tSV9CLk0FtZlViaFKtp+id3iAVeKBme1DdP4xUCdxEdP8umB21iLKdc6leRd5uGa+T5Ox4nHBAXWg=="
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "0.6.39",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.6.39.tgz",
-      "integrity": "sha512-7zTIbo9RAOJIJM9//yHUzVr1XyXSrCFAF5/Po91QyQ006FDaDpd3BrnUSXdz2Aaa8OXCt7GZDPrqp3VmaBh9Ug==",
+      "version": "0.6.40",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.6.40.tgz",
+      "integrity": "sha512-ZOjMkhQSsIkrsQFScvt8hP7od0ksp8ErPOW51MDYwZ2xx+FQqXiuWCJXT4fhG1nrVkb0PTFvnfXuijdDbbhqhQ==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "history": "^4.10.1",
         "marked": "^4.0.15"
       },
       "peerDependencies": {
-        "@redocly/theme": "^0.35.0",
+        "@redocly/theme": "^0.36.0",
         "graphql": "^15.6.1",
         "prismjs": "^1.25.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -1834,12 +1834,12 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.10.4.tgz",
-      "integrity": "sha512-GzvAuoVtHk75q/HqaRNqRUTZWYKpZ16HCOWIrx2txAvZrMoWCUNRVsELY91W/ilH/Cepj6t/Nh+bpJ7o/mcN/g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.12.2.tgz",
+      "integrity": "sha512-dImBZaKws54a4/QdoAVsLDm4/gfVnzAVD68pSGFPMTLNM2AZINvevfUfOrbUNTXwHvG2UJkthUxDGQZLsp3Vaw==",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
-        "@redocly/config": "^0.1.1",
+        "@redocly/config": "^0.5.0",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
@@ -1890,16 +1890,15 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.0.0-alpha.88",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.0.0-alpha.88.tgz",
-      "integrity": "sha512-hi5kZmvgB5WXvQJxc0dlBp8xDLzTIGeY7yuTqvRa2/rQ8MLILDo/1A5+0532jQM9NCr0H3Z3XuYovSwe0/VHfg==",
+      "version": "3.0.0-alpha.91",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.0.0-alpha.91.tgz",
+      "integrity": "sha512-P8IwdaayUSJ3CYh4zapNwl6EzF78m5jpvh39gqCTqgHk5LPiGw2mWG8qfMJShu2WL1DkKPsR/ps8/8YBc/X+Zg==",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lint": "^6.4.2",
-        "@codemirror/state": "^6.4.1",
         "@lezer/highlight": "^1.1.6",
         "@markdoc/markdoc": "0.4.0",
-        "@redocly/openapi-core": "1.10.4",
+        "@redocly/openapi-core": "1.11.0",
         "@redocly/vscode-json-languageservice": "3.4.9",
         "@uiw/codemirror-theme-material": "^4.21.20",
         "@uiw/react-codemirror": "^4.21.24",
@@ -1944,37 +1943,154 @@
         "styled-components": "^4.1.1 || ^5.3.11"
       }
     },
-    "node_modules/@redocly/openapi-docs/node_modules/@codemirror/state": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
+    "node_modules/@redocly/openapi-docs/node_modules/@redocly/config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.2.0.tgz",
+      "integrity": "sha512-r0TqTPVXrxdvhpbOntWnJofOx0rC7u+A+tfC0KFwMtw38QCNb3pwodVjeLa7MT5Uu+fcPxfO119yLBj0QHvBuQ=="
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/@redocly/openapi-core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.11.0.tgz",
+      "integrity": "sha512-VH10SAkDu+jVW9tDFJWWYroFxHVY9N5VS4gorXw0cK8L+LydUOQ4KiZaKbTsTF2piWmZCxngZI7sNPHMiJ4Ftg==",
+      "dependencies": {
+        "@redocly/ajv": "^8.11.0",
+        "@redocly/config": "^0.2.0",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "lodash.isequal": "^4.5.0",
+        "minimatch": "^5.0.1",
+        "node-fetch": "^2.6.1",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=14.19.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@redocly/openapi-docs/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.1.9.tgz",
-      "integrity": "sha512-0zzZTKAJKZEVGfRL1a1uF32M/Kgz8ci3fZ9OM9zckReFrC7Wr8ioW7nwXCHyuRyE492YRYUYpKsJ9KVy6S3Nvg==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.1.17.tgz",
+      "integrity": "sha512-RbibwU4MdHP+Tp0kUasciv5Ma7XeYv0lQrWAjYI6M3ssoc1PSOpSrWd1hddugPaeAx8TbmboI3WToMrMveSykQ==",
       "dependencies": {
-        "@redocly/config": "0.1.4",
+        "@redocly/config": "0.5.0",
         "@redocly/mock-server": "0.0.8",
-        "@redocly/openapi-core": "1.10.4",
-        "@redocly/openapi-docs": "3.0.0-alpha.88"
+        "@redocly/openapi-core": "1.12.0",
+        "@redocly/openapi-docs": "3.0.0-alpha.91"
+      }
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/openapi-core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.12.0.tgz",
+      "integrity": "sha512-2Jfxv3iIk1JUwLSnLyewJ8GAsoxubROVieg13Sjo79TjuWaUBuI49j8GZqC08ljENqyEIp0JHReDjhKs4Snrhg==",
+      "dependencies": {
+        "@redocly/ajv": "^8.11.0",
+        "@redocly/config": "^0.2.0",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "lodash.isequal": "^4.5.0",
+        "minimatch": "^5.0.1",
+        "node-fetch": "^2.6.1",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=14.19.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.2.0.tgz",
+      "integrity": "sha512-r0TqTPVXrxdvhpbOntWnJofOx0rC7u+A+tfC0KFwMtw38QCNb3pwodVjeLa7MT5Uu+fcPxfO119yLBj0QHvBuQ=="
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@redocly/portal-plugin-mock-server/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.78.6",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.78.6.tgz",
-      "integrity": "sha512-Jq+Th1LSnKsRwO7ZJdsidpwDgWi/FZfMs1tbrbR2ntUUCdGr33+B46P6EvARCy2J8ME9C2bmDvrD0L+RveHT3w==",
+      "version": "0.82.4",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.82.4.tgz",
+      "integrity": "sha512-leziVcdgptFSc6XUMklNLja6NOKzcL+yjuFn3V8jjKR0Jd+2DknIxamB1ZRsyHiR4r0by9xeD2mhfz7m5Qb+qQ==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@cocalc/ansi-to-react": "7.0.0",
         "@markdoc/markdoc": "0.4.0",
         "@redocly/ajv": "^8.11.0",
-        "@redocly/config": "0.1.4",
-        "@redocly/graphql-docs": "0.6.39",
-        "@redocly/openapi-core": "1.10.4",
-        "@redocly/openapi-docs": "3.0.0-alpha.88",
-        "@redocly/portal-plugin-mock-server": "^0.1.9",
-        "@redocly/theme": "0.35.5",
+        "@redocly/config": "0.5.0",
+        "@redocly/graphql-docs": "0.6.40",
+        "@redocly/openapi-core": "1.12.2",
+        "@redocly/openapi-docs": "3.0.0-alpha.91",
+        "@redocly/portal-plugin-mock-server": "^0.1.17",
+        "@redocly/theme": "0.36.3",
         "@redocly/xml-crypto": "~3.0.1",
         "@tanstack/react-query": "4.0.5",
         "@wojtekmaj/react-datetimerange-picker": "^5.0.1",
@@ -1992,14 +2108,13 @@
         "fuse.js": "^6.6.2",
         "graphql": "^15.6.1",
         "gray-matter": "^4.0.3",
-        "hono": "~3.11.0",
+        "hono": "4.2.9",
         "htmlparser2": "^8.0.2",
         "i18next": "^22.4.12",
         "is-glob": "^4.0.3",
         "js-yaml": "^4.1.0",
         "lodash.throttle": "^4.1.1",
         "lru-cache": "^7.18.3",
-        "markdown-it": "12.3.2",
         "minimatch": "^7.4.2",
         "mri": "^1.2.0",
         "mustache": "^4.2.0",
@@ -2041,11 +2156,11 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.35.5",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.35.5.tgz",
-      "integrity": "sha512-3RAAJoFAqkcY7PfD5M/B7WcMrx1oO3Yv9UHwXtGXx6D3DWVVaPo5OPfGJ9e35pb+XtXvZDHJVq5fbT7KWZdCzA==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.36.3.tgz",
+      "integrity": "sha512-5dBiuOrOMBYI7eh5503dEp1x2ssbw7vbpy/bgIzti7QRUAtt/j3RuyTua7hdiispTFI52qwHohiijj0JP9TOag==",
       "dependencies": {
-        "@redocly/config": "0.1.4",
+        "@redocly/config": "0.5.0",
         "copy-to-clipboard": "^3.3.3",
         "highlight-words-core": "^1.2.2",
         "hotkeys-js": "^3.10.1",
@@ -2254,446 +2369,445 @@
       }
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.97.0.tgz",
-      "integrity": "sha512-KpPyC8x5ZrB4l9+jgl8FAhokedh+8b5VuBTTdTJKFf+x5uznMiBf/MZTWgvsIk8/9MtjkQYUN1qgVzEPiKWvHg==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-yYkW8OmNbZ1S1U7NA+YiALNMef/4BcJlrZEBZ8Iyqh/Rmty66qFf9/ZIS6RJ5a5OPQdB9Xn7V7WxfYdkrhOyQQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "unraw": "^3.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.97.0.tgz",
-      "integrity": "sha512-3LYlN0Cox0FBFNZqmgi7VyJ4MXppCmZoFjlurT+Y90ND1y2lCidcwjAthr3QpV8b+UCc7MG3APBGRfwqaYZ2IA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-zPHqGEcdRvD/xfRlJi367GSZ9VXFv7hoh+Ohado5JU/sA8DtVZEiQ+Vfusk3WBIpvvSVezh5Hxyl6P1bTsCLKw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@types/ramda": "~0.29.6",
+        "@swagger-api/apidom-ast": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "short-unique-id": "^5.0.2",
-        "stampit": "^4.3.2"
+        "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-0.97.0.tgz",
-      "integrity": "sha512-Y2YRnsJSXp+MdgwwMSCtidzJfy/bL6CZEpc+5aWUw1mphTjfLZC66uA4btUgUevyiT6mNHXm8tUmGomHA7Izdw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-AyaQQjpjBHPMQeVT1n5R92NRNEbTbbUGZYf1nEzPk9KEQm2y9K6HBbxg3htSrI3sgUj8LzxQocx8umEkDmj4FA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.97.0.tgz",
-      "integrity": "sha512-9vcgePgcYXUiYEqnvx8Ew04j8JtfenosysbSuGgRs93Ls8mQ/+ndIOklHaXJzNjBZZxqxS0p6QLFcj1jpUiojQ==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-Ev8dVTWUCnlS/yOePe4PLz9NdVfyNQB2QGlvtv0zys1AOzoHvxI/xaJCnbroHmHrBkvkyDXwccY2h/LzkMBoVQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.97.0.tgz",
-      "integrity": "sha512-uSTIEX4q9XWoP9TQq9nEtW5xG3hVQN2VD5spYoxvYlzUOtg12yxkVgu776eq0kVZd74acZhKIF7mn3uiqaQcHA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-bG16p1dY9WlNfSv4K5IUxILnl7GDiwp6Uoik8QGNpTbkSNW1Xky1DWyehmNUOG/P4A62E2aWuWO60WkJYHscSw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.97.0.tgz",
-      "integrity": "sha512-buEQSrXdtjoAkqIWSZ448HlvnareupthIoObYELp25LVuQwhxxVSY3NR0aCIR37GHgSchrmPBVcsvPMtXV96BA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-oKp4jY24dKeKY+rVQ76q84zmlcKcBtW+sHT3qx3AC0XZlSQRhrsv2x5/9r/MQoov7LLuGH8T6kI+HPMNPCuzDg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.97.0.tgz",
-      "integrity": "sha512-eBMIPxX4huNDGle6TOfSe1kKS1/HvL6w66GWWLFxZW2doCQHMADgjo7j/kVowrXiJtEoMgjBVp3W30WkcwBVug==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-gKmmTnmf4DGSfI6543Ajcqzf+epVW8ufxLkIMiSC1gUES2N9ncIyZ7VF5WKx3duWYokQ0abSnsIlCBDRYjFEWQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.97.0",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
-        "stampit": "^4.3.2"
+        "@swagger-api/apidom-ast": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.97.0.tgz",
-      "integrity": "sha512-tRbg3/b4aJGfcODc0HDngZDjBdhPAv8OZM1OZdsqI4EEIw3PI/wpd+b6b8a5udOjAdbUYqnYsq6gCylCDNBnzw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-4QSFBuSJQokozbyvOPrcwV8fL/abBcY+QYaF7d5Ft87M/+9HtUKyfon6WSLbhAFpaP8ZLhwvJl1kHFXfA/HenA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
-        "stampit": "^4.3.2"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.97.0.tgz",
-      "integrity": "sha512-0GITsoa6kVVkoKBUxyeODmh6vjGXuvDQZd3Vxs1nz0c/O6ZR+VBfBB3JW5wzhVr+WCXebaOJGDyWkxJMHKycxw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-/s9N8a+ronGXsD7uLfvOijnO/qqO5GWM0RYbAol7p8noYWN5ELg8iJScwn7CqjObRZyjMxrRGBSDAK0SquJnMQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
-        "stampit": "^4.3.2"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-0.97.0.tgz",
-      "integrity": "sha512-5gOA9FiO1J9OxJhcVBeXdm77kuh2cwPXG6Sh/DOlbk733Pz9v9W0aQgpLi5Ltsgagxe1sHhBqxJ1asw10QFzzw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-dUUFPf2LftBa/FSeRo2Me6HAJVziv0qHq5jX0jqFPTaTiIXaNHkO77W2a3308J5kdsejv7S/N8rbujdXFp+MoQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.97.0.tgz",
-      "integrity": "sha512-fbnN87SF0WN/4DcSpceuo+NUtkAGeicMIucEMF+LIIiCAF27Xi5d6Q823i9DgOEfJtifHKVj6Zhl/zSKAD2eyw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-Be1XDoy6YSyZWCuNDf5y6iYtOt40A/KWI57TEy+0Eao/SLbaupzTJmErtk96bf4/DhoRvlKiAgQkKt+9bqDZ9w==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.97.0.tgz",
-      "integrity": "sha512-DyvkTim+t7iVKyze6N3tITsfyElthmOwOcxwOjKj/3lySEy61DuY4X2FaPD5+owftVDxMs4Q6F9Chm7qv91a+Q==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-u87HFtYCtrqBthRp3y2a5YdCmiVTD7v8hv2hn6lGcUIjBB/1anqBejVbcWZa3tmknuUG+yIHROapq8HxKPkdcw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.97.0",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-ast": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-ns-workflows-1": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-0.97.0.tgz",
-      "integrity": "sha512-eIuoTRSITlUtMjpM3J0H9b2rVeEVu13i/Fv6+ZMPob0yHmQBWo9bnLjxxnfEZkpvp050worKULfNMdJV8NKBkA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-zMSXjWKtmHk+zl/tS3m/PCDJGh6+Gr9revPtxA0OAYvhmKTVhLNX4H8WtP4J+EGAUyjZKB7gussJUodqNR25uQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.97.0.tgz",
-      "integrity": "sha512-ZDzaiTHMEpz0kM0/iyHEjySTf0xoLKDJwJiSxKNuew141k0rakTVeVisxXeq+6JQi2eC6KuyS98DHMe7hEIVUw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-JbLcDtB9o/fblyKfYKJ+F2jVdcTPAvdbv1094qk9GCPl1JnU7A9SpkZKDdIF1WyUnJmDATUnSsDEib8gRfeGZw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.97.0.tgz",
-      "integrity": "sha512-5/BziPWqrHLr91VR+EC4pXt/fNToWMmvG+d7RVjksHinrjps2E6HA+oZOhqKqA2LRCLNjGhNUptXzRMDjjtenw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-T24Dq4qa/cngkfxUZ6eWULHjEscLutUTO6ltxnKDvyBlxkKURYw8FGBWRn4TSAmk9iK+UVrVg1NoFudtpfN6cQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.97.0.tgz",
-      "integrity": "sha512-XLD/YZifnhezRQY5ADQQAje5G5qtZ4GAbXk//1sRNe3R/qCk1pDxmRYr27yzt8w1XhfM+9VQmCTI21ZFpNFQOA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-gkpDw0+pf3B7MXxjk1nIo7WOKm/t9UvG4MGxDr4fB797v9Rt9fPDv2sMgsS/PFPqsa2zRhTrp2CPOKHCiOzW+A==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.97.0.tgz",
-      "integrity": "sha512-whyThDiGN4FoNirgY0XtXF7IJeU6NfsrBwjaxCkYBuSPslZBoWy4ojEQbfg+2HqNLbnHKJyvabh9/tSIxgB92A==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-1N2gF6qympDdIXaoCvT+B9P9yghYuGOyAWF91sN5kQLd6VtBlZi+jTnCPLxAd+rtl3h5WIIQyNed6qC/C884Mg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.97.0.tgz",
-      "integrity": "sha512-MPhAX77Z9Csti+Kljtbrl/ez2H610R4fQg0RnkNW40f4e6TXeOogT5tmceeWP+IKGAKX45HA1JpVPxdtSJn3ww==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-xNiA3OKGFdf8cHXsVfM2WdOhGDj838XjhXKjKEAbPK+LVe83/QUNRSSL0nxnr0Z6VNJG1J/5y/65Horf3fapow==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.97.0",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-ast": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "tree-sitter": "=0.20.4",
         "tree-sitter-json": "=0.20.2",
         "web-tree-sitter": "=0.20.3"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-0.97.0.tgz",
-      "integrity": "sha512-HtaoRN7wnVB2ilxs/RpLBR7+MwIfUqUcdCzC/EVV788CnSbutwj61W3jR2w9BRXeANJ4K2APcvU4W7WiI9Sugg==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-mbv+qcCRV6JpVOW2GEt0JjyeRD+lgbXmF5pcalDyr/+1Iuol8v3XLbwLHyEjR7FxMXj/DSjjfytnSKX1C+PwYA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.97.0.tgz",
-      "integrity": "sha512-psfxh7k671HukibaY53cems0fcsLQP8U5lQPzVDevEGJQoguAWHyV2C5kOr52XOJInmsN5E+COEn6oPzsIaDCg==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-aJIANKczHzVKUNihytvfVJFpUGiATWsiKtMgLxShx+i3JeN/DfkRGOBM4346mldjcEcUBA2zS8UDGvDGRz6oVQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.97.0.tgz",
-      "integrity": "sha512-PJpcLhS441ATFjbCHHhVUPd8K1JZaiFQJS7yfQEKQmA5MlBRh3w7mqCJAbZN49wuMkelTdB8qJJlVEGUDSxX5Q==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-QHcx9KltTmS0qEiLP2in391sQJDm7OYT9IFRH/Iy5mde2F7WNcQqY1D8o/YklDKvnkquHRIytDNx/IEjuYwwHQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-0.97.0.tgz",
-      "integrity": "sha512-X5saN/AElpS+LohbSjNPesUPWYOM8Wb19+OD7/WS1r6AVRIlj5gKLy3vO7BLBvaER5G73qYylfrPxCoUPlpZZg==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-gGlz/DV+uENk2KI3YRUbkw93Co/K47vMUIW+jFJ9BuiHJZ34LnylMGtxR/J+4o+4L1WQa3o/czg7NrYG5Xe9pQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.97.0.tgz",
-      "integrity": "sha512-kBW6atIN0rONf9kjNeE5eHkxb3amfby0vxKfk+9fiRdQbJVCg4UiWOFmU5rD9bc2smtLWSQNkjlMkKS3i2/4Wg==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-oOo6CybNEsTwxMsSUE9xjCoyw9H0MMMPGFxAatFbwxDlqyw32CvN3ydXXaQmu4TauhNDmplJLHtRlceKDzl7OQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.97.0.tgz",
-      "integrity": "sha512-cclRwQ9IQj6sFLUCDzqRbbbplQfKdt9xz8YONvtq4XBHZO6Ab8z5CF3A9eLiuW1TJZ3y0QU7xmI6h5jWwUrC9w==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-ePkENiU3HlYNOULgghjQr47UeNo8hXfI+mH7Iw25XGC8VHwt5X4PpXO63kcNu1pLsdscpLPyzVCTz9J3CxMmxg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-0.97.0.tgz",
-      "integrity": "sha512-UvnISzq5JDG43sTIJ2oE8u8qALHmBKbYMGncYgUdlHx7z5RgPAWxIRDWH40YFzUSuKSRNp4TI7eG/9MUd3RnGA==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-kM2Vmu13eEi+7nZLvLuNF3frZV8nSibD790sqDbtSQOym+cxGB/+iQ9PMeEIddPka7l4to4vDM5HaLW6EKGKAQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-workflows-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-0.97.0.tgz",
-      "integrity": "sha512-TTZS0YkFvy0X8Huom+fr3muZsCy8mtDpuUks45EvPqv6gjGLCBw3/AZ507CS0YxYvoERbXkYfAYqxW8lptwKuQ==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-3arbAoEiEQzz+YaDP6KX768GA0d3CbF8TxtpCnW2U0T2n8qou/kqSYUW2a58EoFDUhEsYyrB6+adwP9H5TSfdA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-ns-workflows-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.0.0"
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.97.0.tgz",
-      "integrity": "sha512-3f1ADjQyKyLnuRhPuoHMgWMW28o0ylohWCQwX4q69CMH0kqGxP7HnqIU/i0I2cxZdjGv72OCdiKwaR/OgHcmEw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-sDlW8XV4Q/MSJOr9aw9UwCoSAEyy4FFwi3IGqyLlgXWrh9ViaadwhCFLWxtn/stGyubXo29li+5taPuE3ETrqw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.97.0",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
+        "@swagger-api/apidom-ast": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
         "tree-sitter": "=0.20.4",
         "tree-sitter-yaml": "=0.5.0",
         "web-tree-sitter": "=0.20.3"
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.97.1.tgz",
-      "integrity": "sha512-Bs1U2VutmVpqbCxbCt4DTiL8v0s6osAJx+4v49BGrTcfFFh97K/EOAm48WgA8ViP7qHUNBhUF83rjbpEwOshFw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-iK8dyU3YsR23UuAHOlCB9OD9vKKsokyx0QGjYZpUP3EHu2gkTnn7m/NDuMpIC8MRHYlQNt42VKWZjQyC3z1nbw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.97.0",
-        "@types/ramda": "~0.29.6",
+        "@swagger-api/apidom-core": "^1.0.0-alpha.1",
+        "@types/ramda": "~0.30.0",
         "axios": "^1.4.0",
         "minimatch": "^7.4.3",
         "process": "^0.11.10",
-        "ramda": "~0.29.1",
-        "ramda-adjunct": "^4.1.1",
-        "stampit": "^4.3.2"
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-error": "^0.97.0",
-        "@swagger-api/apidom-json-pointer": "^0.97.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-2": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.97.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.97.0",
-        "@swagger-api/apidom-ns-workflows-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-workflows-json-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^0.97.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.97.0"
+        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+        "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-workflows-json-1": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.0"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -2832,9 +2946,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/linkify-it": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "optional": true
     },
     "node_modules/@types/lodash": {
@@ -2861,9 +2975,9 @@
       }
     },
     "node_modules/@types/mdurl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "optional": true
     },
     "node_modules/@types/node": {
@@ -2882,11 +2996,11 @@
       "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g=="
     },
     "node_modules/@types/ramda": {
-      "version": "0.29.11",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.11.tgz",
-      "integrity": "sha512-jm1+PmNOpE7aPS+mMcuB4a72VkCXUJqPSaQRu2YqR8MbsFfaowYXgKxc7bluYdDpRHNXT5Z+xu+Lgr3/ml6wSA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.0.tgz",
+      "integrity": "sha512-DQtfqUbSB18iM9NHbQ++kVUDuBWHMr6T2FpW1XTiksYRGjq4WnNPZLt712OEHEBJs7aMyJ68Mf2kGMOP1srVVw==",
       "dependencies": {
-        "types-ramda": "^0.29.9"
+        "types-ramda": "^0.30.0"
       }
     },
     "node_modules/@types/react": {
@@ -2973,20 +3087,20 @@
       }
     },
     "node_modules/@uiw/codemirror-theme-material": {
-      "version": "4.21.24",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.21.24.tgz",
-      "integrity": "sha512-Yn2M0O2MLdcvkznUDdGEQDvaYFaN6sPiJI1DyTgf+4x5WNCbTgI+bsIq291QPqM5SD/eDWfyqvrqL37Bfsj5GQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.22.1.tgz",
+      "integrity": "sha512-/omhOVgjINsP4BWjTzWRB8tsbW8nfEmq0NdQblvSkKAZjwEpxaWek84uP/PUFQXlvosZRCXfsTX3aKXh4c50MQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.24"
+        "@uiw/codemirror-themes": "4.22.1"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/@uiw/codemirror-theme-material/node_modules/@uiw/codemirror-themes": {
-      "version": "4.21.24",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.24.tgz",
-      "integrity": "sha512-InY24KWP8YArDBACWHKFZ6ZU+WCvRHf3ZB2cCVxMVN35P1ANUmRzpAP2ernZQ5OIriL1/A/kXgD0Zg3Y65PNgg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.22.1.tgz",
+      "integrity": "sha512-5TeB8wCc0aNd3YEhzOvgekpAFQfEm4fCTUcGmEIQqaRNgKAM83HYNpE1JF2j7x2oDFugdiO0yJynS6bo1zVOuw==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -3247,6 +3361,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/apg-lite": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.3.tgz",
+      "integrity": "sha512-lOoNkL7vN7PGdyQMFPey1aok2oVVqvs3n7UMFBRvQ9FoELSbKhgPc3rd7JptaGwCmo4125gLX9Cqb8ElvLCFaQ=="
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -4031,9 +4150,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
-      "integrity": "sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
       "hasInstallScript": true,
       "peer": true,
       "funding": {
@@ -4042,9 +4161,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.36.1.tgz",
-      "integrity": "sha512-NXCvHvSVYSrewP0L5OhltzXeWFJLo2AL2TYnj6iLV3Bw8mM62wAQMNgUCRI6EBu6hVVpbCxmOPlxh1Ikw2PfUA==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.37.1.tgz",
+      "integrity": "sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -4458,9 +4577,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.8.tgz",
-      "integrity": "sha512-O90eQdAQOiLZoE9pEgPz3JfqXh5yrhJHv0/LzOv3wWFLTWUqAKaISD1aWASQTLshLM+jziuSerbtUESKK8Jibw=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.3.tgz",
+      "integrity": "sha512-09uyBM2URzOfXMUAqGRnm9R9IUeSkzO9PktXc2eVQIsBmmJUqRmfL1xW2QPBxVJEtlEVs5d8ndrsIQsyAqs81g=="
     },
     "node_modules/domutils": {
       "version": "3.1.0",
@@ -5238,9 +5357,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hono": {
-      "version": "3.11.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-3.11.12.tgz",
-      "integrity": "sha512-TrxH75bc0m2UbvrhaXkoo32A9OhkJtvICAYgYWtxqLDOxBjRqSikyp4K7HTbnWkPeg9Z+2Q3nv0dN4o8kL6yLg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.2.9.tgz",
+      "integrity": "sha512-59FAv52UxDWUt/NlC0NzrRCjeVCThUnVlqlrKYm+k80XujBu6uJwBIa5gACKKZWobjA0MJ6Vds0I3URKf383Cw==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -7509,9 +7628,9 @@
       }
     },
     "node_modules/jotai": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.7.1.tgz",
-      "integrity": "sha512-bsaTPn02nFgWNP6cBtg/htZhCu4s0wxqoklRHePp6l/vlsypR9eLn7diRliwXYWMXDpPvW/LLA2afI8vwgFFaw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.0.tgz",
+      "integrity": "sha512-yZNMC36FdLOksOr8qga0yLf14miCJlEThlp5DeFJNnqzm2+ZG7wLcJzoOyij5K6U6Xlc5ljQqPDlJRgqW0Y18g==",
       "engines": {
         "node": ">=12.20.0"
       },
@@ -7773,14 +7892,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
-    "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -7930,29 +8041,6 @@
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
-    "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -7963,11 +8051,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/memoize-one": {
       "version": "6.0.0",
@@ -8138,9 +8221,9 @@
       "peer": true
     },
     "node_modules/node-abi": {
-      "version": "3.56.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
-      "integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
+      "version": "3.62.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
       "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -8409,10 +8492,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-path-templating": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-1.5.1.tgz",
+      "integrity": "sha512-kgRHToVP571U1YzUnaZnWaUIygon2itg5g96kwaFIi8bnpsw4oXYOk7k59Ivn+ley1iQnMENe/1HSovpPVZuXA==",
+      "dependencies": {
+        "apg-lite": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/openapi-sampler": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.4.0.tgz",
-      "integrity": "sha512-3FKJQCHAMG9T7RsRy9u5Ft4ERPq1QQmn77C8T3OSofYL9uur59AqychvQ0YQKijrqRwIkAbzkh+nQnAE3gjMVA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.5.1.tgz",
+      "integrity": "sha512-tIWIrZUKNAsbqf3bd9U1oH6JEXo8LNYuDlXw26By67EygpjT+ArFnsxxyTMjFWRfbqo5ozkvgSQDK69Gd8CddA==",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
         "json-pointer": "0.6.2"
@@ -8867,18 +8961,18 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz",
-      "integrity": "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.0.tgz",
+      "integrity": "sha512-13Y0iMhIQuAm/wNGBL/9HEqIfRGmNmjKnTPlKWfA9f7dnDkr8d45wQ+S7+ZLh/Pq9PdcGxkqKUEA7ySu1QSd9Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/ramda-adjunct": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-4.1.1.tgz",
-      "integrity": "sha512-BnCGsZybQZMDGram9y7RiryoRHS5uwx8YeGuUeDKuZuvK38XO6JJfmK85BwRWAKFA6pZ5nZBO/HBFtExVaf31w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.0.0.tgz",
+      "integrity": "sha512-iEehjqp/ZGjYZybZByDaDu27c+79SE7rKDcySLdmjAwKWkz6jNhvGgZwzUGaMsij8Llp9+1N1Gy0drpAq8ZSyA==",
       "engines": {
         "node": ">=0.10.3"
       },
@@ -8887,7 +8981,7 @@
         "url": "https://opencollective.com/ramda-adjunct"
       },
       "peerDependencies": {
-        "ramda": ">= 0.29.0"
+        "ramda": ">= 0.30.0"
       }
     },
     "node_modules/rc": {
@@ -9152,9 +9246,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.51.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.1.tgz",
-      "integrity": "sha512-ifnBjl+kW0ksINHd+8C/Gp6a4eZOdWyvRv0UBaByShwU8JbVx5hTcTWEcd5VdybvmPTATkVVXk9npXArHmo56w==",
+      "version": "7.51.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.4.tgz",
+      "integrity": "sha512-V14i8SEkh+V1gs6YtD0hdHYnoL4tp/HX/A45wWQN15CYr9bFRmmRdYStSO5L65lCCZRF+kYiSKhm9alqbcdiVA==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -9689,9 +9783,9 @@
       }
     },
     "node_modules/short-unique-id": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.0.3.tgz",
-      "integrity": "sha512-yhniEILouC0s4lpH0h7rJsfylZdca10W9mDJRAFh3EpcSUanCHGb0R7kcFOIUCZYSAPo0PUD5ZxWQdW0T4xaug==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.2.0.tgz",
+      "integrity": "sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg==",
       "bin": {
         "short-unique-id": "bin/short-unique-id",
         "suid": "bin/short-unique-id"
@@ -9992,11 +10086,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stampit": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stampit/-/stampit-4.3.2.tgz",
-      "integrity": "sha512-pE2org1+ZWQBnIxRPrBM2gVupkuDD0TTNIo1H6GdT/vO82NXli2z8lRE8cu/nBIHrcOCXFBAHpb9ZldrB2/qOA=="
-    },
     "node_modules/stickyfill": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
@@ -10196,16 +10285,16 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.26.0.tgz",
-      "integrity": "sha512-1yFR/S2V3v5DwgmNePoHEjq2dZJxDx1leDQ53r5M4hZs+dozm9VnznlSl9a1V5iTYw4UsS4PQuBRQsmBH21ViA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.28.0.tgz",
+      "integrity": "sha512-uEi5wm30241FU4ngFJQzrHuWGPMgbbg6foGiAVuR8S8wS/Iwp2f7vbaTWJOpHwqlxedtg2WX/+PSb/BwVnw/Kw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
-        "@swagger-api/apidom-core": ">=0.97.0 <1.0.0",
-        "@swagger-api/apidom-error": ">=0.97.0 <1.0.0",
-        "@swagger-api/apidom-json-pointer": ">=0.97.0 <1.0.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=0.97.0 <1.0.0",
-        "@swagger-api/apidom-reference": ">=0.97.0 <1.0.0",
+        "@swagger-api/apidom-core": ">=1.0.0-alpha.1 <1.0.0-beta.0",
+        "@swagger-api/apidom-error": ">=1.0.0-alpha.1 <1.0.0-beta.0",
+        "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.1 <1.0.0-beta.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.1 <1.0.0-beta.0",
+        "@swagger-api/apidom-reference": ">=1.0.0-alpha.1 <1.0.0-beta.0",
         "cookie": "~0.6.0",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
@@ -10213,14 +10302,16 @@
         "js-yaml": "^4.1.0",
         "node-abort-controller": "^3.1.1",
         "node-fetch-commonjs": "^3.3.2",
+        "openapi-path-templating": "^1.5.1",
         "qs": "^6.10.2",
-        "traverse": "~0.6.6"
+        "ramda-adjunct": "^5.0.0",
+        "traverse": "=0.6.8"
       }
     },
     "node_modules/swagger-client/node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -10629,9 +10720,9 @@
       }
     },
     "node_modules/types-ramda": {
-      "version": "0.29.9",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.9.tgz",
-      "integrity": "sha512-B+VbLtW68J4ncG/rccKaYDhlirKlVH/Izh2JZUfaPJv+3Tl2jbbgYsB1pvole1vXKSgaPlAe/wgEdOnMdAu52A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.0.tgz",
+      "integrity": "sha512-oVPw/KHB5M0Du0txTEKKM8xZOG9cZBRdCVXvwHYuNJUVkAiJ9oWyqkA+9Bj2gjMsHgkkhsYevobQBWs8I2/Xvw==",
       "dependencies": {
         "ts-toolbelt": "^9.6.0"
       }
@@ -10648,11 +10739,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/unraw": {
       "version": "3.0.0",
@@ -10724,9 +10810,9 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/url/node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dependencies": {
         "side-channel": "^1.0.6"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.3.3",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "^0.78.6",
+    "@redocly/realm": "^0.82.4",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",


### PR DESCRIPTION
- Bump Redocly to the latest version to get various bug fixes. (Without the update, the other changes don't fix the dropdowns.)
- Fix a bug where using the dropdowns from the Japanese version of the site would take you to a mixed-up half-translated version of the site
- Fix a bug where the Code Samples page showed an error page if you tried to view it in the Japanese version of the site.