### PR TITLE
public-servers: divide table in two

### DIFF
--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -18,7 +18,7 @@ If you don't [run your own `rippled` server](../infrastructure/installation/inde
 | Ripple[¹][]   | **Mainnet** | `https://s1.ripple.com:51234/` | `wss://s1.ripple.com/` | General purpose server cluster |
 | Ripple[¹][]   | **Mainnet** | `https://s2.ripple.com:51234/` | `wss://s2.ripple.com/` | [Full-history server](../concepts/networks-and-servers/ledger-history.md#full-history) cluster |
 
-## Other Networks
+## Test Networks
 
 | Operator  | [Network][] | JSON-RPC URL | WebSocket URL | Notes                |
 |:----------|:------------|:-------------|:--------------|:---------------------|

--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -10,11 +10,18 @@ labels:
 
 If you don't [run your own `rippled` server](../infrastructure/installation/index.md), you can use the following public servers to submit transactions or read data from the ledger.
 
+## Mainnet
+
 | Operator  | [Network][] | JSON-RPC URL | WebSocket URL | Notes                |
 |:----------|:------------|:-------------|:--------------|:---------------------|
 | XRP Ledger Foundation | **Mainnet** | `https://xrplcluster.com/` <br> `https://xrpl.ws/` [²][] | `wss://xrplcluster.com/` <br>  `wss://xrpl.ws/` [²][] | Full history server cluster with CORS support. |
 | Ripple[¹][]   | **Mainnet** | `https://s1.ripple.com:51234/` | `wss://s1.ripple.com/` | General purpose server cluster |
 | Ripple[¹][]   | **Mainnet** | `https://s2.ripple.com:51234/` | `wss://s2.ripple.com/` | [Full-history server](../concepts/networks-and-servers/ledger-history.md#full-history) cluster |
+
+## Other Networks
+
+| Operator  | [Network][] | JSON-RPC URL | WebSocket URL | Notes                |
+|:----------|:------------|:-------------|:--------------|:---------------------|
 | Ripple[¹][]   | Testnet     | `https://s.altnet.rippletest.net:51234/` | `wss://s.altnet.rippletest.net:51233/` | Testnet public server |
 | XRPL Labs     | Testnet     | `https://testnet.xrpl-labs.com/` | `wss://testnet.xrpl-labs.com/` | Testnet public server with CORS support |
 | Ripple[¹][]   | Testnet (Clio) | `https://clio.altnet.rippletest.net:51234/`	| `wss://clio.altnet.rippletest.net:51233/` | Testnet public server with Clio |
@@ -28,7 +35,7 @@ If you don't [run your own `rippled` server](../infrastructure/installation/inde
 [¹]: #footnote-1
 [²]: #footnote-2
 
-<a id="footnote-1"></a>¹ Ripple's public servers are not for sustained or business use, and they may become unavailable at any time. For regular use, you should run your own `rippled` server or contract someone you trust to do so. Ripple includes [Reporting Mode][] servers in its public clusters.
+<a id="footnote-1"></a>¹ Ripple's public servers are not for sustained or business use, and they may become unavailable at any time. For regular use, you should [run your own `rippled` server](../concepts/networks-and-servers/) or contract someone you trust to do so. Ripple includes [Clio servers](../concepts/networks-and-servers/the-clio-server/) (the successor to [Reporting Mode][]) in its public clusters.
 
 <a id="footnote-2"></a>² `xrpl.ws` is an alias for `xrplcluster.com`. However, the `.ws` top-level domain's reliability may be unsuitable for production uses.
 


### PR DESCRIPTION
As this table has grown, I believe Mainnet deserves its own table here.