### PR TITLE
Document `book_changes` APIs

### DIFF
--- a/_api-examples/book_changes/jsonrpc-response.json
+++ b/_api-examples/book_changes/jsonrpc-response.json
@@ -1,0 +1,71 @@
+{
+    "result" : {
+       "changes" : [
+          {
+             "close" : "277777.7777777778",
+             "currency_a" : "XRP_drops",
+             "currency_b" : "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/CNY",
+             "high" : "277777.7777777778",
+             "low" : "277777.7777777778",
+             "open" : "277777.7777777778",
+             "volume_a" : "44082741",
+             "volume_b" : "158.6978676"
+          },
+          {
+             "close" : "202999.9948135647",
+             "currency_a" : "XRP_drops",
+             "currency_b" : "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/XLM",
+             "high" : "202999.9948135647",
+             "low" : "202999.9948135647",
+             "open" : "202999.9948135647",
+             "volume_a" : "44191586",
+             "volume_b" : "217.6925474337355"
+          },
+          {
+             "close" : "80475.34586323083",
+             "currency_a" : "XRP_drops",
+             "currency_b" : "rf5YPb9y9P3fTjhxNaZqmrwaj5ar8PG1gM/47414C4100000000000000000000000000000000",
+             "high" : "80475.34586323083",
+             "low" : "80475.34586323083",
+             "open" : "80475.34586323083",
+             "volume_a" : "100000000",
+             "volume_b" : "1242.61659179386"
+          },
+          {
+             "close" : "231974.7481608686",
+             "currency_a" : "XRP_drops",
+             "currency_b" : "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz/534F4C4F00000000000000000000000000000000",
+             "high" : "231974.7481608686",
+             "low" : "231974.7481608686",
+             "open" : "231974.7481608686",
+             "volume_a" : "33734",
+             "volume_b" : "0.1454210006367"
+          },
+          {
+             "close" : "7.290000000001503",
+             "currency_a" : "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/CNY",
+             "currency_b" : "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/USD",
+             "high" : "7.290000000001503",
+             "low" : "7.290000000001503",
+             "open" : "7.290000000001503",
+             "volume_a" : "158.6978670792",
+             "volume_b" : "21.76925474337"
+          },
+          {
+             "close" : "0.1",
+             "currency_a" : "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/USD",
+             "currency_b" : "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/XLM",
+             "high" : "0.1",
+             "low" : "0.1",
+             "open" : "0.1",
+             "volume_a" : "21.76925474337355",
+             "volume_b" : "217.6925474337355"
+          }
+       ],
+       "ledger_hash" : "7AB08A2415C10E07201521F3260F77ADFF4902A528EA66378E259A07767A24B9",
+       "ledger_index" : 88530953,
+       "ledger_time" : 771100891,
+       "status" : "success",
+       "type" : "bookChanges"
+    }
+}

--- a/_api-examples/book_changes/ws-response.json
+++ b/_api-examples/book_changes/ws-response.json
@@ -1,0 +1,80 @@
+{
+    "result": {
+      "type": "bookChanges",
+      "ledger_hash": "7AB08A2415C10E07201521F3260F77ADFF4902A528EA66378E259A07767A24B9",
+      "ledger_index": 88530953,
+      "ledger_time": 771100891,
+      "validated": true,
+      "changes": [
+        {
+          "currency_a": "XRP_drops",
+          "currency_b": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/CNY",
+          "volume_a": "44082741",
+          "volume_b": "158.6978676",
+          "high": "277777.7777777778",
+          "low": "277777.7777777778",
+          "open": "277777.7777777778",
+          "close": "277777.7777777778"
+        },
+        {
+          "currency_a": "XRP_drops",
+          "currency_b": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/XLM",
+          "volume_a": "44191586",
+          "volume_b": "217.6925474337355",
+          "high": "202999.9948135647",
+          "low": "202999.9948135647",
+          "open": "202999.9948135647",
+          "close": "202999.9948135647"
+        },
+        {
+          "currency_a": "XRP_drops",
+          "currency_b": "rf5YPb9y9P3fTjhxNaZqmrwaj5ar8PG1gM/47414C4100000000000000000000000000000000",
+          "volume_a": "100000000",
+          "volume_b": "1242.61659179386",
+          "high": "80475.34586323083",
+          "low": "80475.34586323083",
+          "open": "80475.34586323083",
+          "close": "80475.34586323083"
+        },
+        {
+          "currency_a": "XRP_drops",
+          "currency_b": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz/534F4C4F00000000000000000000000000000000",
+          "volume_a": "33734",
+          "volume_b": "0.1454210006367",
+          "high": "231974.7481608686",
+          "low": "231974.7481608686",
+          "open": "231974.7481608686",
+          "close": "231974.7481608686"
+        },
+        {
+          "currency_a": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/CNY",
+          "currency_b": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/USD",
+          "volume_a": "158.6978670792",
+          "volume_b": "21.76925474337",
+          "high": "7.290000000001503",
+          "low": "7.290000000001503",
+          "open": "7.290000000001503",
+          "close": "7.290000000001503"
+        },
+        {
+          "currency_a": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/USD",
+          "currency_b": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/XLM",
+          "volume_a": "21.76925474337355",
+          "volume_b": "217.6925474337355",
+          "high": "0.1",
+          "low": "0.1",
+          "open": "0.1",
+          "close": "0.1"
+        }
+      ]
+    },
+    "id": "example_book_changes",
+    "status": "success",
+    "type": "response",
+    "warnings": [
+      {
+        "id": 2001,
+        "message": "This is a clio server. clio only serves validated data. If you want to talk to rippled, include 'ledger_index':'current' in your request"
+      }
+    ]
+  }

--- a/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
+++ b/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
@@ -59,7 +59,7 @@ The request includes the following parameters:
 There are several known issue with this method in `rippled`.
 
 - You must specify the `ledger_index` or `ledger_hash` explicitly instead of using a default or a shortcut string. ([Issue #5034](https://github.com/XRPLF/rippled/issues/5034))
-- The response may be missing the `validated` field even when querying validated ledgers. ([#5035](https://github.com/XRPLF/rippled/issues/5035))
+- JSON-RPC API responses may be missing the `validated` field even when querying validated ledgers. ([#5035](https://github.com/XRPLF/rippled/issues/5035))
 - When querying a recently-closed ledger, a successful response may sometimes return a Ledger Request Object instead of the intended data. ([#5033](https://github.com/XRPLF/rippled/issues/5033))
 - When querying data from older ledgers, the server may take a long time (over 30 seconds) to respond. ([#5036](https://github.com/XRPLF/rippled/issues/5036))
 

--- a/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
+++ b/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
@@ -1,0 +1,125 @@
+---
+seo:
+    description: Get information on 
+labels:
+  - Decentralized Exchange
+  - Cross-Currency
+---
+# book_changes
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/rpc/handlers/AMMInfo.cpp "Source")
+
+The {% code-page-name /%} method reports information about changes to the order books in the [decentralized exchange (DEX)](../../../../concepts/tokens/decentralized-exchange/index.md) compared with the previous ledger version. This may be useful for building "candlestick" charts.
+
+### Request Format
+
+An example of the request format:
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+    "id": "example_book_changes",
+    "command": "book_changes",
+    "ledger_index": 88530953
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+    "method": "{% $frontmatter.seo.title %}",
+    "params": [{
+      "ledger_index": 88530953
+    }]
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```sh
+#Syntax: book_changes [<ledger hash|id>]
+rippled book_changes 88530953
+```
+{% /tab %}
+
+{% /tabs %}
+
+[Try it! >](/resources/dev-tools/websocket-api-tool#book_changes)
+
+The request includes the following parameters:
+
+| Field          | Type             | Required? | Description |
+|:---------------|:-----------------|:----------|-------------|
+| `ledger_hash`  | [Hash][]         | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
+| `ledger_index` | [Ledger Index][] | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
+
+{% admonition type="warning" name="Known Issues" %}
+There are several known issue with this method in `rippled`.
+
+- You must specify the `ledger_index` or `ledger_hash` explicitly instead of using a default or a shortcut string. ([Issue #5034](https://github.com/XRPLF/rippled/issues/5034))
+- The response may be missing the `validated` field even when querying validated ledgers. ([#5035](https://github.com/XRPLF/rippled/issues/5035))
+- When querying a recently-closed ledger, a successful response may sometimes return a Ledger Request Object instead of the intended data. ([#5033](https://github.com/XRPLF/rippled/issues/5033))
+- When querying data from older ledgers, the server may take a long time (over 30 seconds) to respond. ([#5036](https://github.com/XRPLF/rippled/issues/5036))
+
+These bugs do not apply to Clio servers.
+{% /admonition %}
+
+## Response Format
+
+An example of a successful response:
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+{% code-snippet file="/_api-examples/book_changes/ws-response.json" language="json" /%}
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+{% code-snippet file="/_api-examples/book_changes/jsonrpc-response.json" language="json" prefix="200 OK\n\n" /%}
+{% /tab %}
+
+{% tab label="Commandline" %}
+{% code-snippet file="/_api-examples/book_changes/jsonrpc-response.json" language="json" prefix="Loading: \"/etc/opt/ripple/rippled.cfg\"\n2024-Jun-07 18:41:45.257772761 UTC HTTPClient:NFO Connecting to 127.0.0.1:5005\n\n" /%}
+{% /tab %}
+
+{% /tabs %}
+
+The response follows the [standard format][], with a successful result containing the following fields:
+
+| Field          | Type             | Description             |
+|:---------------|:-----------------|:------------------------|
+| `changes`      | Array            | List of [Book Update Objects](#book-update-objects), containing one entry for each order book that was updated in this ledger version. The array is empty if no order books were updated. |
+| `ledger_hash`  | [Hash][]         | The identifying hash of the ledger version that was used when retrieving this data. |
+| `ledger_index` | [Ledger Index][] | The ledger index of the ledger version that was used when retrieving this data. |
+| `ledger_time`  | Number           | The official close time of the ledger that was used when retrieving this data, in [seconds since the Ripple Epoch][]. |
+| `type`         | String           | The string `bookChanges`, which indicates that this is an order book update message. |
+| `validated`    | Boolean          | _(May be omitted)_ If `true`, the information comes from a validated ledger version. |
+
+### Book Update Objects
+
+A Book Update Object represents the changes to a single order book in a single ledger version, and contains the following fields:
+
+| Field          | Type             | Description             |
+|:---------------|:-----------------|:------------------------|
+| `currency_a`   | String | An identifier for the first of the two currencies in the order book. For XRP, this is the string `XRP_drops`. For [tokens](../../../../concepts/tokens/index.md), this is formatted as the address of the issuer in [base58][], followed by a forward-slash (`/`), followed by the [Currency Code][] for the token, which can be a 3-character standard code or a 20-character hexadecimal code. |
+| `currency_b`   | String | An identifier for the second of two currencies in the order book. This is in the same format as `currency_a`, except `currency_b` can never be XRP. 
+| `volume_a`     | String - Number | The total amount, or _volume_, of the first currency (that is, `currency_a`) that moved as a result of trades through this order book in this ledger. |
+| `volume_b`     | String - Number | The volume of the second currency (that is, `currency_b`) that moved as a result of trades through this order book in this ledger. |
+| `high`         | String - Number | The highest exchange rate among all offers matched in this ledger, as a ratio of the first currency to the second currency. (In other words, `currency_a : currency_b`.) |
+| `low`          | String - Number | The lowest exchange rate among all offers matched in this ledger, as a ratio of the first currency to the second currency. |
+| `open`         | String - Number | The exchange rate at the top of this order book before processing the transactions in this ledger, as a ratio of the first currency to the second currency. |
+| `close`        | String - Number | The exchange rate at the top of this order book after processing the transactions in this ledger, as a ratio of the first currency to the second currency. |
+
+For XRP-token order books, XRP is always `currency_a`. For token-token order books, the currencies are sorted alphabetically by the issuer and then currency code.
+
+Exchange rates involving XRP are always calculated using [drops of XRP][]. For example, if the rate from XRP to FOO is 1.0 XRP to 1 FOO, the rate reported by the API is `1000000` (1 million drops of XRP per 1 FOO).
+
+## Possible Errors
+
+* Any of the [universal error types][].
+* `lgrNotFound` - The ledger specified by the `ledger_hash` or `ledger_index` does not exist, or it does exist but the server does not have it.
+* `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
+++ b/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
@@ -6,7 +6,7 @@ labels:
   - Cross-Currency
 ---
 # book_changes
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/rpc/handlers/AMMInfo.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/rpc/BookChanges.h "Source")
 
 The {% code-page-name /%} method reports information about changes to the order books in the [decentralized exchange (DEX)](../../../../concepts/tokens/decentralized-exchange/index.md) compared with the previous ledger version. This may be useful for building "candlestick" charts.
 
@@ -52,7 +52,7 @@ The request includes the following parameters:
 
 | Field          | Type             | Required? | Description |
 |:---------------|:-----------------|:----------|-------------|
-| `ledger_hash`  | [Hash][]         | No        | A 20-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
+| `ledger_hash`  | [Hash][]         | No        | A 32-byte hex string for the ledger version to use. (See [Specifying Ledgers][]) |
 | `ledger_index` | [Ledger Index][] | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. (See [Specifying Ledgers][]) |
 
 {% admonition type="warning" name="Known Issues" %}

--- a/docs/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
+++ b/docs/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
@@ -684,7 +684,7 @@ The fields from a Book Changes stream message are as follows:
 
 | Field          | Value            | Description                             |
 |:---------------|:-----------------|:----------------------------------------|
-| `type`         | String           | The value `bookChanges` this is from the Book Changes stream. |
+| `type`         | String           | The value `bookChanges` indicates this is from the Book Changes stream. |
 | `ledger_index` | [Ledger Index][] | The ledger index of the ledger with these changes. |
 | `ledger_hash`  | [Hash][]         | The identifying hash of the ledger with these changes. |
 | `ledger_time`  | Number           | The official close time of the ledger with these changes, in [seconds since the Ripple Epoch][]. |
@@ -706,7 +706,7 @@ The fields from a consensus stream message are as follows:
 
 | Field       | Type   | Description                |
 |:------------|:-------|:---------------------------|
-| `type`      | String | `consensusPhase` indicates this is from the consensus stream |
+| `type`      | String | The value `consensusPhase` indicates this is from the consensus stream |
 | `consensus` | String | The new consensus phase the server is in. Possible values are `open`, `establish`, and `accepted`. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
+++ b/docs/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe.md
@@ -80,6 +80,7 @@ The following parameters are deprecated and may be removed without further notic
 
 The `streams` parameter provides access to the following default streams of information:
 
+- `book_changes` - Sends a message with order book changes whenever the consensus process declares a new validated ledger.
 - `consensus` - Sends a message whenever the server changes phase in the consensus cycle.
 - `ledger` - Sends a message whenever the consensus process declares a new validated ledger.
 - `manifests` - Sends a message whenever the server receives an update to a validator's ephemeral signing key.
@@ -547,14 +548,150 @@ Example order book stream message:
 
 The format of an order book stream message is the same as that of [transaction stream messages](#transaction-streams), except that `OfferCreate` transactions also contain the following field:
 
-| `Field`                   | Value  | Description                             |
+| Field                     | Value  | Description                             |
 |:--------------------------|:-------|:----------------------------------------|
 | `transaction.owner_funds` | String | Numeric amount of the `TakerGets` currency that the `Account` sending this OfferCreate transaction has after executing this transaction. This does not check whether the currency amount is [frozen](../../../../concepts/tokens/fungible-tokens/freezes.md). |
 
 
-## Consensus Stream
+## Book Changes Stream
 
-{% badge href="https://github.com/XRPLF/rippled/releases/tag/1.4.0" %}New in: rippled 1.4.0{% /badge %}
+The `book_changes` stream sends `bookChanges` messages whenever a new ledger is validated. This message contains a summary of all changes to order books in the decentralized exchange that occurred in that ledger.
+
+Example `bookChanges` message:
+
+```json
+{
+  "type": "bookChanges",
+  "ledger_index": 88530525,
+  "ledger_hash": "E2F24290E1714C842D34A1057E6D6B7327C7DDD310263AFBC67CA8EFED7A331B",
+  "ledger_time": 771099232,
+  "changes": [
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/USD",
+      "volume_a": "23020993",
+      "volume_b": "11.51049687275246",
+      "high": "1999999.935232603",
+      "low": "1999999.935232603",
+      "open": "1999999.935232603",
+      "close": "1999999.935232603"
+    },
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rRbiKwcueo6MchUpMFDce9XpDwHhRLPFo/43525950544F0000000000000000000000000000",
+      "volume_a": "28062",
+      "volume_b": "0.000643919229004",
+      "high": "43580000.00000882",
+      "low": "43580000.00000882",
+      "open": "43580000.00000882",
+      "close": "43580000.00000882"
+    },
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu/5553444300000000000000000000000000000000",
+      "volume_a": "147797392",
+      "volume_b": "70.41143840513008",
+      "high": "2099053.724049922",
+      "low": "2099053.724049922",
+      "open": "2099053.724049922",
+      "close": "2099053.724049922"
+    },
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V/LTC",
+      "volume_a": "350547165",
+      "volume_b": "2.165759976556748",
+      "high": "162573356.3100158",
+      "low": "160134763.7403094",
+      "open": "162573356.3100158",
+      "close": "160134763.7403094"
+    },
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL/BTC",
+      "volume_a": "352373535",
+      "volume_b": "0.00249291478138912",
+      "high": "1413500174054660e-4",
+      "low": "1413499999999996e-4",
+      "open": "1413500174054660e-4",
+      "close": "1413499999999996e-4"
+    },
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq/5553445400000000000000000000000000000000",
+      "volume_a": "8768045",
+      "volume_b": "4.193604075536",
+      "high": "2090813.734932601",
+      "low": "2090813.734932601",
+      "open": "2090813.734932601",
+      "close": "2090813.734932601"
+    },
+    {
+      "currency_a": "XRP_drops",
+      "currency_b": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq/USD",
+      "volume_a": "28113",
+      "volume_b": "0.013405652999",
+      "high": "2097100.380123005",
+      "low": "2097100.380123005",
+      "open": "2097100.380123005",
+      "close": "2097100.380123005"
+    },
+    {
+      "currency_a": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe/58434F5245000000000000000000000000000000",
+      "currency_b": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D/434F524500000000000000000000000000000000",
+      "volume_a": "75.626516003375",
+      "volume_b": "63.022096669479",
+      "high": "1.200000000000003",
+      "low": "1.200000000000003",
+      "open": "1.200000000000003",
+      "close": "1.200000000000003"
+    },
+    {
+      "currency_a": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/CNY",
+      "currency_b": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y/USD",
+      "volume_a": "83.9115222024",
+      "volume_b": "11.51049687275",
+      "high": "7.290000000004561",
+      "low": "7.290000000004561",
+      "open": "7.290000000004561",
+      "close": "7.290000000004561"
+    },
+    {
+      "currency_a": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V/LTC",
+      "currency_b": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL/BTC",
+      "volume_a": "0.64167647147626",
+      "volume_b": "0.00073047551165797",
+      "high": "878.4366638381051",
+      "low": "878.4366638381051",
+      "open": "878.4366638381051",
+      "close": "878.4366638381051"
+    },
+    {
+      "currency_a": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq/USD",
+      "currency_b": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/USD",
+      "volume_a": "0.013432464305",
+      "volume_b": "0.013566788948",
+      "high": "0.9900990099046391",
+      "low": "0.9900990099046391",
+      "open": "0.9900990099046391",
+      "close": "0.9900990099046391"
+    }
+  ]
+}
+```
+
+The fields from a Book Changes stream message are as follows:
+
+| Field          | Value            | Description                             |
+|:---------------|:-----------------|:----------------------------------------|
+| `type`         | String           | The value `bookChanges` this is from the Book Changes stream. |
+| `ledger_index` | [Ledger Index][] | The ledger index of the ledger with these changes. |
+| `ledger_hash`  | [Hash][]         | The identifying hash of the ledger with these changes. |
+| `ledger_time`  | Number           | The official close time of the ledger with these changes, in [seconds since the Ripple Epoch][]. |
+| `changes`      | Array            | List of [Book Update Objects](../path-and-order-book-methods/book_changes.md#book-update-objects), containing one entry for each order book that was updated in this ledger version. The array is empty if no order books were updated. |
+
+
+## Consensus Stream
 
 The `consensus` stream sends `consensusPhase` messages when [the consensus process](../../../../concepts/consensus-protocol/index.md) changes phase. The message contains the new phase of consensus the server is in.
 
@@ -567,9 +704,9 @@ The `consensus` stream sends `consensusPhase` messages when [the consensus proce
 
 The fields from a consensus stream message are as follows:
 
-| `Field`             | Type                      | Description                |
-|:--------------------|:--------------------------|:---------------------------|
-| `type`              | String                    | `consensusPhase` indicates this is from the consensus stream |
-| `consensus`         | String                    | The new consensus phase the server is in. Possible values are `open`, `establish`, and `accepted`. |
+| Field       | Type   | Description                |
+|:------------|:-------|:---------------------------|
+| `type`      | String | `consensusPhase` indicates this is from the consensus stream |
+| `consensus` | String | The new consensus phase the server is in. Possible values are `open`, `establish`, and `accepted`. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/resources/dev-tools/components/websocket-api/data/command-list.json
+++ b/resources/dev-tools/components/websocket-api/data/command-list.json
@@ -7,7 +7,6 @@
         "description": "Returns information about an account's <a href='/docs/concepts/payment-types/payment-channels/'>payment channels</a>.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_channels",
         "body": {
-          "id": 1,
           "command": "account_channels",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "destination_account": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
@@ -29,7 +28,6 @@
         "description": "Retrieves information about an account, its activity, and its XRP balance.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_info",
         "body": {
-          "id": 2,
           "command": "account_info",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "ledger_index": "current",
@@ -41,7 +39,6 @@
         "description": "Retrieves information about an account's trust lines, including balances for all non-XRP currencies and assets.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines",
         "body": {
-          "id": 2,
           "command": "account_lines",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "ledger_index": "validated"
@@ -62,7 +59,6 @@
         "description": "Returns the raw ledger format for all objects owned by an account.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects",
         "body": {
-          "id": 1,
           "command": "account_objects",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "ledger_index": "validated",
@@ -75,7 +71,6 @@
         "description": "Retrieves a list of offers made by a given account that are outstanding as of a particular ledger version.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_offers",
         "body": {
-          "id": 2,
           "command": "account_offers",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
         }
@@ -85,7 +80,6 @@
         "description": "Retrieves a list of transactions that affected the specified account.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx",
         "body": {
-          "id": 2,
           "command": "account_tx",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "ledger_index_min": -1,
@@ -115,7 +109,6 @@
         "description": "Compares an account's Default Ripple and No Ripple flags to the recommended settings.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/noripple_check",
         "body": {
-          "id": 0,
           "command": "noripple_check",
           "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "role": "gateway",
@@ -134,7 +127,6 @@
         "description": "Retrieves information about the public ledger.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger",
         "body": {
-          "id": 14,
           "command": "ledger",
           "ledger_index": "validated",
           "full": false,
@@ -149,7 +141,6 @@
         "description": "Returns the unique identifiers of the most recently closed ledger. (This ledger is not necessarily validated and immutable yet.)",
         "link": "/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_closed",
         "body": {
-          "id": 2,
           "command": "ledger_closed"
         }
       },
@@ -158,7 +149,6 @@
         "description": "Returns the unique identifiers of the current in-progress ledger.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_current",
         "body": {
-          "id": 2,
           "command": "ledger_current"
         }
       },
@@ -167,7 +157,6 @@
         "description": "Retrieves contents of the specified ledger.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data",
         "body": {
-          "id": 2,
           "ledger_hash": "842B57C1CC0613299A686D3E9F310EC0422C84D3911E5056389AA7E5808A93C8",
           "command": "ledger_data",
           "limit": 5,
@@ -233,7 +222,6 @@
         "description": "Retrieves information on a single transaction from a specific ledger version.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/transaction-methods/transaction_entry",
         "body": {
-          "id": 4,
           "command": "transaction_entry",
           "tx_hash": "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7",
           "ledger_index": 348734
@@ -244,7 +232,6 @@
         "description": "Retrieves information on a single transaction.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/transaction-methods/tx",
         "body": {
-          "id": 1,
           "command": "tx",
           "transaction": "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7",
           "binary": false
@@ -259,7 +246,6 @@
         "name": "amm_info",
         "description": "Looks up info on an Automated Market Maker instance.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info",
-        "status": "not_enabled",
         "body": {
           "command": "amm_info",
           "asset": {
@@ -272,11 +258,19 @@
         }
       },
       {
+        "name": "book_changes",
+        "description": "Reports changes to the order books that occurred in a specific ledger version.",
+        "link": "/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes/",
+        "body": {
+          "command": "book_changes",
+          "ledger_index": 88530953
+        }
+      },
+      {
         "name": "book_offers",
         "description": "Retrieves a list of offers, also known as the order book, between two currencies.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_offers/",
         "body": {
-          "id": 4,
           "command": "book_offers",
           "taker": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "taker_gets": {
@@ -294,7 +288,6 @@
         "description": "Checks whether one account is authorized to send payments directly to another.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/deposit_authorized",
         "body": {
-          "id": 1,
           "command": "deposit_authorized",
           "source_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "destination_account": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
@@ -327,7 +320,6 @@
         "link": "/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/path_find",
         "ws_only": true,
         "body": {
-          "id": 8,
           "command": "path_find",
           "subcommand": "create",
           "source_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -344,7 +336,6 @@
         "description": "Searches one time for a payment path.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/ripple_path_find",
         "body": {
-          "id": 8,
           "command": "ripple_path_find",
           "source_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
           "source_currencies": [
@@ -424,7 +415,6 @@
         "description": "Checks the validity of a signature that can be used to redeem a specific amount of XRP from a payment channel.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify",
         "body": {
-          "id": 1,
           "command": "channel_verify",
           "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
           "signature": "304402204EF0AFB78AC23ED1C472E74F4299C0C21F1B21D07EFC0A3838A420F76D783A400220154FB11B6F54320666E4C36CA7F686C16A3A0456800BBC43746F34AF50290064",
@@ -486,7 +476,6 @@
         "description": "Returns an SDK-compatible definitions.json, generated from the rippled server being queried.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions",
         "body": {
-          "id": 1,
           "command": "server_definitions"
         }
       },
@@ -495,7 +484,6 @@
         "description": "Reports a human-readable version of various information about the rippled server being queried.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_info",
         "body": {
-          "id": 1,
           "command": "server_info"
         }
       },
@@ -512,7 +500,6 @@
         "description": "Reports a machine-readable version of various information about the rippled server being queried.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_state",
         "body": {
-          "id": 1,
           "command": "server_state"
         }
       }
@@ -526,7 +513,6 @@
         "description": "Checks that the connection is working.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/utility-methods/ping",
         "body": {
-          "id": 1,
           "command": "ping"
         }
       },
@@ -535,7 +521,6 @@
         "description": "Provides a random number, which may be a useful source of entropy for clients.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/utility-methods/random",
         "body": {
-          "id": 1,
           "command": "random"
         }
       }

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -459,6 +459,7 @@
                   expanded: false
                   items:
                     - page: docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info.md
+                    - page: docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_changes.md
                     - page: docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_offers.md
                     - page: docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/deposit_authorized.md
                     - page: docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers.md


### PR DESCRIPTION
Documents the `book_changes` API method and subscription stream, which were added to `rippled` a few versions ago by https://github.com/XRPLF/rippled/pull/4212

- [x] Add `book_changes` API method docs
- [x] Add `book_changes` subscription stream docs
- [x] Add websocket tool example for `book_changes` method
- [x] Remove extraneous numerical IDs from other WebSocket tool examples

Not in scope:
- #2617