### PR TITLE
Fix image link to Code Flowchart

### DIFF
--- a/@i18n/ja/resources/contribute-code/index.md
+++ b/@i18n/ja/resources/contribute-code/index.md
@@ -86,7 +86,7 @@ XLSドラフトを作成した後、その変更にAmendmentが必要かどう�
 
 ## コードのフローチャート
 
-![コードのフローチャート](/docs/img/Contribute Code Flowchart.png)
+![コードのフローチャート](/docs/img/contribute-code-flowchart.png)
 
 
 ## 関連項目

--- a/resources/contribute-code/index.md
+++ b/resources/contribute-code/index.md
@@ -86,7 +86,7 @@ The general development path breaks down as follows:
 
 ## Code Flowchart
 
-![Code Flowchart](../../docs/img/contribute-code-flowchart.png)
+![Code Flowchart](/docs/img/contribute-code-flowchart.png)
 
 
 ## See Also


### PR DESCRIPTION
Fixed to the same format as other `/docs/img/....png` links