### PR TITLE
Add XRPLExplorer amendments dashboard page link

### DIFF
--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -12,7 +12,7 @@ labels:
 The following is a comprehensive list of all known [amendments](../docs/concepts/networks-and-servers/amendments.md) and their status on the production XRP Ledger:
 
 {% admonition type="success" name="Tip" %}
-This list is updated manually. For a live view of amendment voting, see the [XRPScan Amendments Dashboard](https://xrpscan.com/amendments).
+This list is updated manually. For a live view of amendment voting, see the Amendments Dashboards: [XRPScan](https://xrpscan.com/amendments), [XRPLExplorer](https://xrplexplorer.com/amendments).
 {% /admonition %}
 
 | Name                              | Introduced | Status                        |


### PR DESCRIPTION
xrplexplorer.com is a new domain for Bithomp's XRPL explorer for mainnet