### PR TITLE
Update latest amendment status & related fixes

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -503,6 +503,8 @@
 [fixNFTokenRemintの修正]: /resources/known-amendments.md#fixnftokenremint
 [fixPayChanRecipientOwnerDir amendment]: /resources/known-amendments.md#fixpaychanrecipientownerdir
 [fixPayChanRecipientOwnerDirの修正]: /resources/known-amendments.md#fixpaychanrecipientownerdir
+[fixPreviousTxnID amendment]: /resources/known-amendments.md#fixprevioustxnid
+[fixPreviousTxnIDの修正]: /resources/known-amendments.md#fixprevioustxnid
 [fixQualityUpperBound amendment]: /resources/known-amendments.md#fixqualityupperbound
 [fixQualityUpperBoundの修正]: /resources/known-amendments.md#fixqualityupperbound
 [fixRemoveNFTokenAutoTrustLine amendment]: /resources/known-amendments.md#fixremovenftokenautotrustline

--- a/docs/references/protocol/ledger-data/ledger-entry-types/amendments.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/amendments.md
@@ -15,36 +15,47 @@ The `Amendments` ledger entry type contains a list of [Amendments](../../../../c
 
 ```json
 {
-    "Majorities": [
-        {
-            "Majority": {
-                "Amendment": "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146",
-                "CloseTime": 535589001
-            }
-        }
-    ],
     "Amendments": [
         "42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE",
         "4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373",
-        "6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC",
-        "740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11"
+        // (... Long list of enabled amendment IDs ...)
+        "03BDC0099C4E14163ADA272C1B6F6FABB448CC3E51F522F978041E4B57D9158C",
+        "35291ADD2D79EB6991343BDA0912269C817D0F094B02226C1C14AD2858962ED4"
     ],
     "Flags": 0,
     "LedgerEntryType": "Amendments",
+    "Majorities": [
+    {
+        "Majority": {
+            "Amendment": "7BB62DC13EC72B775091E9C71BF8CF97E122647693B50C5E87A80DFD6FCFAC50",
+            "CloseTime": 779561310
+        }
+    },
+    {
+        "Majority": {
+            "Amendment": "755C971C29971C9F20C6F080F2ED96F87884E40AD19554A5EBECDCEC8A1F77FE",
+            "CloseTime": 779561310
+        }
+    }
+    ],
     "index": "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"
 }
 ```
+
+<!-- Note: At time of writing (2024-10-15) fixPreviousTxnID is the most recently enabled amendment, which means that the last time the Amendments entry changed was when it became enabled. Amendments' changes don't apply until the next ledger, so fixPreviousTxnID was not in effect at the time. The PreviousTxnID and PreviousTxnLgrSeq fields will be added to the Amendments entry the next time any amendment gains supermajority support. -->
 
 ## {% $frontmatter.seo.title %} Fields
 
 In addition to the [common fields](../common-fields.md), the {% code-page-name /%} ledger entry has the following fields:
 
-| Name              | JSON Type | [Internal Type][] | Required? | Description |
-|-------------------|-----------|-------------------|-----------|-------------|
-| `Amendments`      | Array     | Vector256         | No        | Array of 256-bit [amendment IDs](../../../../concepts/networks-and-servers/amendments.md) for all currently enabled amendments. If omitted, there are no enabled amendments. |
-| `Flags`           | Number    | UInt32            | Yes       | A bit-map of boolean flags enabled for this object. Currently, the protocol defines no flags for `Amendments` objects. The value is always `0`. |
-| `LedgerEntryType` | String    | UInt16            | Yes       | The value `0x0066`, mapped to the string `Amendments`, indicates that this object describes the status of amendments to the XRP Ledger. |
-| `Majorities`      | Array     | STArray           | No        | Array of objects describing the status of amendments that have majority support but are not yet enabled. If omitted, there are no pending amendments with majority support. |
+| Name                | JSON Type | [Internal Type][] | Required? | Description |
+|---------------------|-----------|-------------------|-----------|-------------|
+| `Amendments`        | Array     | Vector256         | No        | Array of 256-bit [amendment IDs](../../../../concepts/networks-and-servers/amendments.md) for all currently enabled amendments. If omitted, there are no enabled amendments. |
+| `Flags`             | Number    | UInt32            | Yes       | A bit-map of boolean flags enabled for this object. Currently, the protocol defines no flags for `Amendments` objects. The value is always `0`. |
+| `LedgerEntryType`   | String    | UInt16            | Yes       | The value `0x0066`, mapped to the string `Amendments`, indicates that this object describes the status of amendments to the XRP Ledger. |
+| `Majorities`        | Array     | STArray           | No        | Array of objects describing the status of amendments that have majority support but are not yet enabled. If omitted, there are no pending amendments with majority support. |
+| `PreviousTxnID`     | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
 
 Each member of the `Majorities` field, if it is present, is an object with one field, `Majority`, whose contents are a nested object with the following fields:
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/amm.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/amm.md
@@ -18,52 +18,44 @@ An `AMM` ledger entry describes a single [Automated Market Maker](../../../../co
 
 ```json
 {
-    "Account" : "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
-    "Asset" : {
-      "currency" : "XRP"
+    "Account": "rBp3UDRuEteeJqp4rEk5kxMe7BGWNYrF9A",
+    "Asset": {
+      "currency": "XRP"
     },
-    "Asset2" : {
-      "currency" : "TST",
-      "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+    "Asset2": {
+      "currency": "NEX",
+      "issuer": "rQGiPFWhaTDdue1xHX7cVpxGqPQK54zng1"
     },
-    "AuctionSlot" : {
-      "Account" : "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
-      "AuthAccounts" : [
-          {
-            "AuthAccount" : {
-                "Account" : "rMKXGCbJ5d8LbrqthdG46q3f969MVK2Qeg"
-            }
-          },
-          {
-            "AuthAccount" : {
-                "Account" : "rBepJuTLFJt3WmtLXYAxSjtBWAeQxVbncv"
-            }
-          }
-      ],
-      "DiscountedFee" : 60,
-      "Expiration" : 721870180,
-      "Price" : {
-          "currency" : "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
-          "issuer" : "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
-          "value" : "0.8696263565463045"
+    "AuctionSlot": {
+      "Account": "r3ZGQZw1NCbBp5AEGkMDE9NgNpzw91aofD",
+      "Expiration": 778576560,
+      "Price": {
+        "currency": "03DC324562A8915B7C65E9D31B93D62D02BC491C",
+        "issuer": "rBp3UDRuEteeJqp4rEk5kxMe7BGWNYrF9A",
+        "value": "0"
       }
     },
-    "Flags" : 0,
-    "LPTokenBalance" : {
-      "currency" : "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
-      "issuer" : "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
-      "value" : "71150.53584131501"
+    "Flags": 0,
+    "LPTokenBalance": {
+      "currency": "03DC324562A8915B7C65E9D31B93D62D02BC491C",
+      "issuer": "rBp3UDRuEteeJqp4rEk5kxMe7BGWNYrF9A",
+      "value": "5509581.299648495"
     },
-    "TradingFee" : 600,
-    "VoteSlots" : [
+    "LedgerEntryType": "AMM",
+    "OwnerNode": "0",
+    "PreviousTxnID": "9E8E9B8FD27391C818525BFF6A29452F7A9888F31622BEF6FC36064D05CF6436",
+    "PreviousTxnLgrSeq": 91448830,
+    "TradingFee": 1,
+    "VoteSlots": [
       {
-          "VoteEntry" : {
-            "Account" : "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
-            "TradingFee" : 600,
-            "VoteWeight" : 100000
-          }
+        "VoteEntry": {
+          "Account": "r3ZGQZw1NCbBp5AEGkMDE9NgNpzw91aofD",
+          "TradingFee": 1,
+          "VoteWeight": 100000
+        }
       }
-    ]
+    ],
+    "index": "F490627BACE2D0AA744514A640B4999D50E495DD1677550D8B10E2D20FBB15C3"
 }
 ```
 
@@ -78,8 +70,11 @@ In addition to the [common fields](../common-fields.md), {% code-page-name /%} e
 | `Account`     | String              | AccountID         | Yes       | The address of the [special account](accountroot.md#special-amm-accountroot-entries) that holds this AMM's assets. |
 | `AuctionSlot`    | Object              | STObject          | No        | Details of the current owner of the auction slot, as an [Auction Slot object](#auction-slot-object). |
 | `LPTokenBalance` | [Currency Amount][] | Amount            | Yes       | The total outstanding balance of liquidity provider tokens from this AMM instance. The holders of these tokens can vote on the AMM's trading fee in proportion to their holdings, or redeem the tokens for a share of the AMM's assets which grows with the trading fees collected. |
+| `PreviousTxnID`     | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
 | `TradingFee`     | Number              | UInt16            | Yes       | The percentage fee to be charged for trades against this AMM instance, in units of 1/100,000. The maximum value is 1000, for a 1% fee. |
 | `VoteSlots`      | Array               | STArray           | No        | A list of vote objects, representing votes on the pool's trading fee. |
+
 
 ### Auction Slot Object
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
@@ -23,18 +23,20 @@ There are three kinds of directory:
 {% tab label="Offer Directory" %}
 ```json
 {
-    "ExchangeRate": "4F069BA8FF484000",
+    "ExchangeRate": "4e133c40576f7c00",
     "Flags": 0,
     "Indexes": [
-        "AD7EAE148287EF12D213A251015F86E6D4BD34B3C4A0A1ED9A17198373F908AD"
+        "353E55E7A0B0E82D16DF6E748D48BDAFE4C56045DF5A8B0ED723FF3C38A4787A"
     ],
     "LedgerEntryType": "DirectoryNode",
-    "RootIndex": "1BBEF97EDE88D40CEE2ADE6FEF121166AFE80D99EBADB01A4F069BA8FF484000",
+    "PreviousTxnID": "0F79E60C8642A23658ECB29D939499EA0F28D804077B7EE16613BE0C813A2DD6",
+    "PreviousTxnLgrSeq": 91448326,
+    "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E133C40576F7C00",
     "TakerGetsCurrency": "0000000000000000000000000000000000000000",
     "TakerGetsIssuer": "0000000000000000000000000000000000000000",
-    "TakerPaysCurrency": "0000000000000000000000004A50590000000000",
-    "TakerPaysIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
-    "index": "1BBEF97EDE88D40CEE2ADE6FEF121166AFE80D99EBADB01A4F069BA8FF484000"
+    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+    "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+    "index": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E133C40576F7C00"
 }
 ```
 {% /tab %}
@@ -43,14 +45,29 @@ There are three kinds of directory:
 ```json
 {
     "Flags": 0,
+    "IndexNext": "0",
+    "IndexPrevious": "0",
     "Indexes": [
-        "AD7EAE148287EF12D213A251015F86E6D4BD34B3C4A0A1ED9A17198373F908AD",
-        "E83BBB58949A8303DF07172B16FB8EFBA66B9191F3836EC27A4568ED5997BAC5"
+        "1192C0191D1B8861AA6F5A84A575E0CBE4B97574A5E8B3D7B7AD64643EE38CA7",
+        "16A0674079229DB47EDDF4FD83AFEA59ADAC944DD5F16EA5D9C989ED8F918AE0",
+        "1F65776E640C97B76E365763E97E5B59B6C4CDBB46FB7C8869D1712528985E6D",
+        "35D6A9F578E63C875EDB6348E55EFADBD300A0817290276D8CC3DD3587FAD4B3",
+        "36B236D80688C2975A5D24935020B75BEB4B26F5115D71943356E86CCD3B8CE4",
+        "39E8F12D519E5C6C1AC36434D7340281C362508B7D5BC863166C8FE8621A124C",
+        "4DF14053E1BD697C5B4A4A1A7BA8988BD802F0CD5DB6ED9C2AC74AD8A7B91A35",
+        "5E2D97ABAB0D2BE1948F275823096597E3359DD0696CF2938A712169394236BE",
+        "678CE03A2F8157FBF7D5EFDED2D55D127F60EC26BC4F51DBC8FB05DF370B248E",
+        "8250CE37F6495903C1F7D16E072E8823ECE06FA73F011A0F8D79D5626BF581BB",
+        "C353DA9F84EB02B4206D6F5166A9277916559115EEDF7B841C38E4473084A010",
+        "CB2D979DE863A7AF792A12D6C4518E2B299EF782E361705DE7F1D0077521D521",
+        "DFA7CB434A3D9D782C2FACEB95F431476D3AAAD62078C0FBE8C115E00039C6F5"
     ],
     "LedgerEntryType": "DirectoryNode",
-    "Owner": "rpR95n1iFkTqpoy1e878f4Z1pVHVtWKMNQ",
-    "RootIndex": "193C591BF62482468422313F9D3274B5927CA80B4DD3707E42015DD609E39C94",
-    "index": "193C591BF62482468422313F9D3274B5927CA80B4DD3707E42015DD609E39C94"
+    "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+    "PreviousTxnID": "CB802FC111C4C03B1E1D762E813D3F1F47347E57C68D00B5F92822C417C2484C",
+    "PreviousTxnLgrSeq": 91448329,
+    "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3",
+    "index": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
 }
 ```
 {% /tab %}
@@ -58,22 +75,16 @@ There are three kinds of directory:
 {% tab label="NFT Offer Directory" %}
 ```json
 {
-   "result": {
-      "index": "CC45A27DAF06BFA45E8AFC92801AD06A06B7004DAD0F7022E439B3A2F6FA5B5A",
-      "ledger_current_index": 310,
-      "node": {
-         "Flags": 2,
-         "Indexes": [
-            "83C81AC39F9771DDBCD66F6C225FC76EFC0971384EC6148BAFA5BD18019FC495"
-         ],
-         "LedgerEntryType": "DirectoryNode",
-         "NFTokenID": "000800009988C43C563A7BB35AF34D642990CDF089F11B445EB3DCCD00000132",
-         "RootIndex": "CC45A27DAF06BFA45E8AFC92801AD06A06B7004DAD0F7022E439B3A2F6FA5B5A",
-         "index": "CC45A27DAF06BFA45E8AFC92801AD06A06B7004DAD0F7022E439B3A2F6FA5B5A"
-      },
-      "status": "success",
-      "validated": false
-   }
+    "Flags": 1,
+    "Indexes": [
+        "68227B203065DED9EEB8B73FC952494A1DA6A69CEABEAA99923836EB5E77C95A"
+    ],
+    "LedgerEntryType": "DirectoryNode",
+    "NFTokenID": "000822603EA060FD1026C04B2D390CC132D07D600DA9B082CB5CE9AC0487E50B",
+    "PreviousTxnID": "EF8A9AD51E7CC6BBD219C3C980EC3145C7B0814ED3184471FD952D9D23A1918D",
+    "PreviousTxnLgrSeq": 91448417,
+    "RootIndex": "0EC5802BD1AB56527A9DE524CCA2A2BA25E1085CCE7EA112940ED115FFF91EE2",
+    "index": "0EC5802BD1AB56527A9DE524CCA2A2BA25E1085CCE7EA112940ED115FFF91EE2"
 }
 ```
 {% /tab %}
@@ -90,18 +101,27 @@ There are three kinds of directory:
 | `IndexNext`         | Number    | UInt64            | No        | If this directory consists of multiple pages, this ID links to the next object in the chain, wrapping around at the end. |
 | `IndexPrevious`     | Number    | UInt64            | No        | If this directory consists of multiple pages, this ID links to the previous object in the chain, wrapping around at the beginning. |
 | `LedgerEntryType`   | String    | UInt16            | Yes       | The value `0x0064`, mapped to the string `DirectoryNode`, indicates that this object is part of a directory. |
-| `NFTokenID`         | String    | Hash25            | No       |(NFT offer directories only) ID of the NFT in a buy or sell offer. |
+| `NFTokenID`         | String    | Hash256           | No        | (NFT offer directories only) ID of the NFT in a buy or sell offer. |
 | `Owner`             | String    | AccountID         | No        | (Owner directories only) The address of the account that owns the objects in this directory. |
+| `PreviousTxnID`     | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
 | `RootIndex`         | String    | Hash256           | Yes       | The ID of root object for this directory. |
 | `TakerGetsCurrency` | String    | Hash160           | No        | (Offer directories only) The currency code of the `TakerGets` amount from the offers in this directory. |
 | `TakerGetsIssuer`   | String    | Hash160           | No        | (Offer directories only) The issuer of the `TakerGets` amount from the offers in this directory. |
-| `TakerPaysCurrency` | String    | Hash160           | No        |(Offer directories only) The currency code of the `TakerPays` amount from the offers in this directory. |
+| `TakerPaysCurrency` | String    | Hash160           | No        | (Offer directories only) The currency code of the `TakerPays` amount from the offers in this directory. |
 | `TakerPaysIssuer`   | String    | Hash160           | No        | (Offer directories only) The issuer of the `TakerPays` amount from the offers in this directory. |
 
 
 ## {% $frontmatter.seo.title %} Flags
 
-There are no flags defined for {% code-page-name /%} entries.
+{% code-page-name /%} entries can have the following values in the `Flags` field:
+
+| Flag Name              | Hex Value    | Decimal Value | Description |
+|:-----------------------|:-------------|:--------------|:------------|
+| `lsfNFTokenBuyOffers`  | `0x00000001` | 1             | This directory contains NFT buy offers. |
+| `lsfNFTokenSellOffers` | `0x00000002` | 2             | This directory contains NFT sell offers. |
+
+Owner directories and offer directories for fungible tokens do not use flags; their `Flags` value is always 0.
 
 
 ## {% $frontmatter.seo.title %} Reserve

--- a/docs/references/protocol/ledger-data/ledger-entry-types/feesettings.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/feesettings.md
@@ -37,6 +37,8 @@ In addition to the [common fields](../common-fields.md), the {% code-page-name /
 | `ReferenceFeeUnits` | Number    | UInt32            | Yes       | The `BaseFee` translated into "fee units". |
 | `ReserveBase`       | Number    | UInt32            | Yes       | The [base reserve](../../../../concepts/accounts/reserves.md#base-reserve-and-owner-reserve) for an account in the XRP Ledger, as drops of XRP. |
 | `ReserveIncrement`  | Number    | UInt32            | Yes       | The incremental [owner reserve](../../../../concepts/accounts/reserves.md#base-reserve-and-owner-reserve) for owning objects, as drops of XRP. |
+| `PreviousTxnID`     | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
 
 {% admonition type="danger" name="Warning" %}The JSON format for this ledger entry type is unusual. The `BaseFee`, `ReserveBase`, and `ReserveIncrement` indicate drops of XRP but ***not*** in the usual format for [specifying XRP][Currency Amount].{% /admonition %}
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/negativeunl.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/negativeunl.md
@@ -18,17 +18,19 @@ Each ledger version contains **at most one** `NegativeUNL` entry. If no validato
 
 ```json
 {
-  "DisabledValidators": [
-    {
-      "DisabledValidator": {
-        "FirstLedgerSequence": 1609728,
-        "PublicKey": "ED6629D456285AE3613B285F65BBFF168D695BA3921F309949AFCD2CA7AFEC16FE"
+    "DisabledValidators": [
+      {
+        "DisabledValidator": {
+          "FirstLedgerSequence": 91371264,
+          "PublicKey": "ED58F6770DB5DD77E59D28CB650EC3816E2FC95021BB56E720C9A12DA79C58A3AB"
+        }
       }
-    }
-  ],
-  "Flags": 0,
-  "LedgerEntryType": "NegativeUNL",
-  "index": "2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244"
+    ],
+    "Flags": 0,
+    "LedgerEntryType": "NegativeUNL",
+    "PreviousTxnID": "8D47FFE664BE6C335108DF689537625855A6A95160CC6D351341B92624D9C5E3",
+    "PreviousTxnLgrSeq": 91442944,
+    "index": "2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244"
 }
 ```
 
@@ -40,6 +42,8 @@ In addition to the [common fields](../common-fields.md), the {% code-page-name /
 |:----------------------|:----------|:------------------|:----------|:---------------------|
 | `DisabledValidators`  | Array     | Array             | No        | A list of `DisabledValidator` objects (see below), each representing a trusted validator that is currently disabled. |
 | `LedgerEntryType`     | String    | UInt16            | Yes       | The value `0x004E`, mapped to the string `NegativeUNL`, indicates that this entry is the Negative UNL. |
+| `PreviousTxnID`     | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
 | `ValidatorToDisable`  | String    | Blob              | No        | The public key of a trusted validator that is scheduled to be disabled in the next flag ledger. |
 | `ValidatorToReEnable` | String    | Blob              | No        | The public key of a trusted validator in the Negative UNL that is scheduled to be re-enabled in the next flag ledger. |
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -17,13 +17,13 @@ This list is updated manually. For a live view of amendment voting, see the Amen
 
 | Name                              | Introduced | Status                        |
 |:----------------------------------|:-----------|:------------------------------|
-| [fixAMMv1_1][]                    | v2.2.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.2.0" %}Open for Voting: 2024-06-04{% /badge %} |
-| [fixEmptyDID][]                   | v2.2.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.2.0" %}Open for Voting: 2024-06-04{% /badge %} |
-| [fixPreviousTxnID][]              | v2.2.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.2.0" %}Open for Voting: 2024-06-04{% /badge %} |
 | [fixXChainRewardRounding][]       | v2.2.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.2.0" %}Open for Voting: 2024-06-04{% /badge %} |
 | [PriceOracle][]                   | v2.2.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.2.0" %}Open for Voting: 2024-06-04{% /badge %} |
 | [DID][]                           | v2.0.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.0.0.html" %}Open for Voting: 2024-01-09{% /badge %} |
 | [XChainBridge][]                  | v2.0.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.0.0.html" %}Open for Voting: 2024-01-09{% /badge %} |
+| [fixEmptyDID][]                   | v2.2.0     | {% badge href="https://livenet.xrpl.org/transactions/A858AE8832981D77A4C5038D633CC9CBD54C9764BD2A3F8CA174E02D1736F472" %}Enabled: 2024-09-27{% /badge %} |
+| [fixPreviousTxnID][]              | v2.2.0     | {% badge href="https://livenet.xrpl.org/transactions/C7A9804E1F499ABBF38D791BAD25B1479DB1CEA4E9B6C5C08D6D4EF13F41E171" %}Enabled: 2024-09-27{% /badge %} |
+| [fixAMMv1_1][]                    | v2.2.0     | {% badge href="https://livenet.xrpl.org/transactions/8C8F5566464097BF1BAF7C645BB9E1762986844A052BBA3B9769F6564EEFAB71" %}Enabled: 2024-09-24{% /badge %} |
 | [fixNFTokenReserve][]             | v2.1.0     | {% badge href="https://livenet.xrpl.org/transactions/D708CF1799A27CB982F16FCE4762DD12738737A61E5850480BA51400280E06C4" %}Enabled: 2024-04-12{% /badge %} |
 | [fixAMMOverflowOffer][]           | v2.1.1     | {% badge href="https://livenet.xrpl.org/transactions/64144409D991726D108B89D79F9305438D61928A322EF1CD14DC3A5F24CE64BC" %}Enabled: 2024-04-11{% /badge %} |
 | [fixDisallowIncomingV1][]         | v2.0.0     | {% badge href="https://livenet.xrpl.org/transactions/50286B4B9C95331A48D3AD517E1FD3299308C6B696C85E096A73A445E9EB1BFB" %}Enabled: 2024-04-11{% /badge %} |
@@ -103,6 +103,7 @@ The following is a list of [amendments](../docs/concepts/networks-and-servers/am
 This list is updated manually. If you're working on an amendment and have a private network to test the changes, you can edit this page to add your in-development amendment to this list. For more information on contributing to the XRP Ledger, see [Contribute Code to the XRP Ledger](contribute-code/index.md).
 {% /admonition %}
 
+
 ## Obsolete Amendments
 
 The following is a list of known [amendments](../docs/concepts/networks-and-servers/amendments.md) that have been removed in a previous version, or are obsolete and have been marked for removal.
@@ -113,14 +114,13 @@ The following is a list of known [amendments](../docs/concepts/networks-and-serv
 | [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [CryptoConditionsSuite][]         | v0.60.0    | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [SHAMapV2][]                      | v0.32.1    | {% badge href="https://xrpl.org/blog/2019/rippled-1.4.0.html" %}Obsolete: Removed in v1.4.0{% /badge %} |
 | [FlowV2][]                        | v0.32.1    | {% badge href="https://xrpl.org/blog/2016/flowv2-vetoed.html" %}Obsolete: Removed in v0.33.0{% /badge %} |
+| [SHAMapV2][]                      | v0.32.1    | {% badge href="https://xrpl.org/blog/2019/rippled-1.4.0.html" %}Obsolete: Removed in v1.4.0{% /badge %} |
 | [SusPay][]                        | v0.31.0    | {% badge href="https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features" %}Obsolete: Removed in v0.60.0{% /badge %} |
 | [Tickets][]                       | v0.30.1    | {% badge href="https://xrpl.org/blog/2018/rippled-0.90.0.html" %}Obsolete: Removed in v0.90.0{% /badge %} |
 
 
 ## Details about Known Amendments
-
 
 ### AMM
 [AMM]: #amm
@@ -230,7 +230,6 @@ Although this amendment is enabled, it has no effect unless the [SusPay](#suspay
 This amendment was intended to add support for several types of crypto-conditions from the official [crypto-conditions specification](https://tools.ietf.org/html/draft-thomas-crypto-conditions-03) for use in [EscrowCreate][] and [EscrowFinish][] transactions.
 
 However, the amendment was added to `rippled` v0.60.0 before implementation was complete. As a result, this amendment ID refers to incomplete code which does almost nothing. Modifying the existing amendment to add support for other crypto-conditions would cause a conflict with old versions of the amendment already in released software. If a future release adds support for additional crypto-conditions, it must use a new and different amendment ID.
-
 
 
 ### DeletableAccounts
@@ -654,7 +653,7 @@ This amendment fixes the improper handling of large synthetic AMM offers in the 
 | Amendment    | fixAMMv1_1 |
 |:-------------|:-----------|
 | Amendment ID | 35291ADD2D79EB6991343BDA0912269C817D0F094B02226C1C14AD2858962ED4 |
-| Status       | Open for Voting |
+| Status       | Enabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -706,7 +705,7 @@ This amendment has no effect unless the [DisallowIncoming][] amendment is enable
 | Amendment    | fixEmptyDID |
 |:-------------|:------------|
 | Amendment ID | 755C971C29971C9F20C6F080F2ED96F87884E40AD19554A5EBECDCEC8A1F77FE |
-| Status       | Open for Voting |
+| Status       | Enabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -717,7 +716,6 @@ With this amendment, if a transaction would create an empty DID, it returns the 
 Without this amendment, an empty DID can be created, which takes up space and counts towards the owner reserve but does nothing useful.
 
 This amendment has no effect unless the [DID][] amendment is enabled.
-
 
 
 ### fixFillOrKill
@@ -738,7 +736,6 @@ This amendment has no effect unless the [FlowCross][] amendment is enabled.
 
 
 ### fixInnerObjTemplate
-
 [fixInnerObjTemplate]: #fixinnerobjtemplate
 
 | Amendment    | fixInnerObjTemplate |
@@ -822,7 +819,6 @@ The amendment also introduces a new account deletion restriction. An account can
 
 
 ### fixNFTokenReserve
-
 [fixNFTokenReserve]: #fixnftokenreserve
 
 | Amendment    | fixNFTokenReserve |
@@ -897,7 +893,7 @@ This change prevents accounts from being deleted if they are the recipient for o
 | Amendment    | fixPreviousTxnID |
 |:-------------|:-----------------|
 | Amendment ID | 7BB62DC13EC72B775091E9C71BF8CF97E122647693B50C5E87A80DFD6FCFAC50 |
-| Status       | Open for Voting |
+| Status       | Enabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1491,5 +1487,7 @@ Simplifies transaction cost calculations to use XRP directly rather than calcula
 - Updates the SetFee transaction type. Replaces `BaseFee`, `ReferenceFeeUnits`, `ReserveBase`, `ReserveIncrement` fields with `BaseFeeDrops`, `ReserveBaseDrops`, `ReserveIncrementDrops`.
 
 Without this amendment, the format of the transaction and ledger entry are the same.
+
+
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -114,8 +114,8 @@ The following is a list of known [amendments](../docs/concepts/networks-and-serv
 | [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [CryptoConditionsSuite][]         | v0.60.0    | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [FlowV2][]                        | v0.32.1    | {% badge href="https://xrpl.org/blog/2016/flowv2-vetoed.html" %}Obsolete: Removed in v0.33.0{% /badge %} |
 | [SHAMapV2][]                      | v0.32.1    | {% badge href="https://xrpl.org/blog/2019/rippled-1.4.0.html" %}Obsolete: Removed in v1.4.0{% /badge %} |
+| [FlowV2][]                        | v0.32.1    | {% badge href="https://xrpl.org/blog/2016/flowv2-vetoed.html" %}Obsolete: Removed in v0.33.0{% /badge %} |
 | [SusPay][]                        | v0.31.0    | {% badge href="https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features" %}Obsolete: Removed in v0.60.0{% /badge %} |
 | [Tickets][]                       | v0.30.1    | {% badge href="https://xrpl.org/blog/2018/rippled-0.90.0.html" %}Obsolete: Removed in v0.90.0{% /badge %} |
 


### PR DESCRIPTION
- fixPreviousTxnID, fixAMMv1_1, and fixEmptyDID went live.
- Added PreviousTxnID, PreviousTxnLgrSeq fields to ledger entry types that had them added by the fixPreviousTxnID amendment.
- Updated ledger entry examples for several of those entry types.
- Documented DirectoryNode flags for NFT offer directories. (These were missing, because they weren't mentioned in the XLS-20 spec, but have been around since NFTs went live.)