### PR TITLE
Update LastUpdateTime description in oracleset.md

### DIFF
--- a/docs/references/protocol/transactions/types/oracleset.md
+++ b/docs/references/protocol/transactions/types/oracleset.md
@@ -46,7 +46,7 @@ Creates a new `Oracle` ledger entry or updates the fields of an existing one, us
 | `OracleDocumentID` | Number    | UInt32        | Yes       | A unique identifier of the price oracle for the `Account`. |
 | `Provider`         | String    | Blob          | Variable  | An arbitrary value that identifies an oracle provider, such as Chainlink, Band, or DIA. This field is a string, up to 256 ASCII hex encoded characters (0x20-0x7E). This field is required when creating a new `Oracle` ledger entry, but is optional for updates. |
 | `URI`              | String    | Blob          | No        | An optional Universal Resource Identifier to reference price data off-chain. This field is limited to 256 bytes. |
-| `LastUpdateTime`   | Number    | UInt32        | Yes       | The time the data was last updated, in [seconds since the Ripple Epoch][]. |
+| `LastUpdateTime`   | Number    | UInt32        | Yes       | The time the data was last updated, in seconds since the UNIX Epoch. |
 | `AssetClass`       | String    | Blob          | Variable  | Describes the type of asset, such as "currency", "commodity", or "index". This field is a string, up to 16 ASCII hex encoded characters (0x20-0x7E). This field is required when creating a new `Oracle` ledger entry, but is optional for updates. |
 | `PriceDataSeries`  | Array     | Array         | Yes       | An array of up to 10 `PriceData` objects, each representing the price information for a token pair. More than five `PriceData` objects require two owner reserves. |
 


### PR DESCRIPTION
Updated description for `LastUpdateTime` field as per the [PriceOracle PR comments](https://github.com/XRPLF/rippled/pull/4789#pullrequestreview-1771165140). This field accepts UNIX time instead of Ripple time because it must integrate with third party systems that may not measure time in Ripple time.