### PR TITLE
Update search language filtering

### DIFF
--- a/@theme/components/Navbar/AlgoliaSearch.tsx
+++ b/@theme/components/Navbar/AlgoliaSearch.tsx
@@ -4,9 +4,6 @@ import { useThemeHooks } from '@redocly/theme/core/hooks';
 export function AlgoliaSearch() {
     const { useL10n } = useThemeHooks()
     let { lang } = useL10n()
-    if (lang == "en-US") {
-        lang = "en"
-    }
     return (
             <DocSearch
                 appId="R39QY3MZC7"

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2779,13 +2779,13 @@ code_of_conduct.ja:
     to: /ja/docs/concepts/tokens/
     type: 301
 /ja/federated-sidechains.html:
-    to: /jahttps://opensource.ripple.com/docs/xls-38d-cross-chain-bridge/cross-chain-bridges/
+    to: https://opensource.ripple.com/docs/xls-38d-cross-chain-bridge/cross-chain-bridges/
     type: 301
 /ja/xrpl-interoperability.html:
-    to: /jahttps://opensource.ripple.com/docs/xls-38d-cross-chain-bridge/cross-chain-bridges/
+    to: https://opensource.ripple.com/docs/xls-38d-cross-chain-bridge/cross-chain-bridges/
     type: 301
 /ja/intro-to-evm-sidechain.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
+    to: https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
     type: 301
 /ja/the-rippled-server.html:
     to: /ja/docs/concepts/networks-and-servers/
@@ -3076,22 +3076,22 @@ code_of_conduct.ja:
     to: /ja/docs/concepts/transactions/finality-of-results/canceling-a-transaction
     type: 301
 /ja/evm-sidechains.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
+    to: https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
     type: 301
 /ja/get-started-evm-sidechain.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/get-started-evm-sidechain/
+    to: https://opensource.ripple.com/docs/evm-sidechain/get-started-evm-sidechain/
     type: 301
 /ja/connect-metamask-to-xrpl-evm-sidechain.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/connect-metamask-to-xrpl-evm-sidechain/
+    to: https://opensource.ripple.com/docs/evm-sidechain/connect-metamask-to-xrpl-evm-sidechain/
     type: 301
 /ja/join-evm-sidechain-devnet.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/join-evm-sidechain-devnet/
+    to: https://opensource.ripple.com/docs/evm-sidechain/join-evm-sidechain-devnet/
     type: 301
 /ja/evm-sidechain-validator-security.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-validator-security/
+    to: https://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-validator-security/
     type: 301
 /ja/evm-sidechain-run-a-validator-node.html:
-    to: /jahttps://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-run-a-validator-node/
+    to: https://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-run-a-validator-node/
     type: 301
 /ja/use-xrpl-sidechains.html:
     to: /ja/docs/tutorials/how-tos/use-xrpl-sidechains/
@@ -3382,7 +3382,7 @@ code_of_conduct.ja:
     to: /ja/docs/references/client-libraries
     type: 301
 /ja/rippleapi-reference.html:
-    to: /jahttps://js.xrpl.org/
+    to: https://js.xrpl.org/
     type: 301
 /ja/xrpljs2-migration-guide.html:
     to: /ja/docs/references/xrpljs2-migration-guide
@@ -3700,7 +3700,7 @@ code_of_conduct.ja:
     to: /ja/docs/references/http-websocket-apis/peer-port-methods/validator-list
     type: 301
 /ja/xrp-api.html:
-    to: /jahttps://xpring-eng.github.io/xrp-api/
+    to: https://xpring-eng.github.io/xrp-api/
     type: 301
 /ja/data-api.html:
     to: /ja/docs/references/data-api


### PR DESCRIPTION
After re-indexing the site, there were two problems that caused search to return no results:

- DocSearch was no longer configured with `lang` as a filterable attribute. We fixed this in the Algolia interface.
- The language tag on pages changed from `en` to `en-US`. This PR removes the special case that we previously needed to get results for English, which is now causing results not to appear for English.

This PR also fixes a number of typos in the `redirects.yaml` file that were discovered while investigating the search problems.