### PR TITLE
Update transaction source code links for rippled physical redesign

### DIFF
--- a/@l10n/es-ES/docs/concepts/networks-and-servers/peer-protocol.md
+++ b/@l10n/es-ES/docs/concepts/networks-and-servers/peer-protocol.md
@@ -18,7 +18,7 @@ El protocolo de pares es el modo principal de comunicación entre servidores en 
 - Solicitar datos de ledger de ledgers históricos, o proporcionar esos datos.
 - Proponer una conjunto de transacciones para el consenso, o compartir el resultado calculado de aplicar el conjunto de transacciones de consenso.
 
-Para establecer una conexión peer-to-peer, un servidor se conecta a otro usando HTTPS y solicita una [actualización HTTP](https://tools.ietf.org/html/rfc7230#section-6.7) para cambiar al protocolo `XRPL/2.0` (anteriormente `RTXP/1.2`). (Para más información, consultar el artículo [Red de superposición](https://github.com/XRPLF/rippled/blob/96bbabbd2ece106779bb544aa0e4ce174e99fdf6/src/ripple/overlay/README.md#handshake) en el [repositorio `rippled`](https://github.com/ripple/rippled).)
+Para establecer una conexión peer-to-peer, un servidor se conecta a otro usando HTTPS y solicita una [actualización HTTP](https://tools.ietf.org/html/rfc7230#section-6.7) para cambiar al protocolo `XRPL/2.0` (anteriormente `RTXP/1.2`). (Para más información, consultar el artículo [Red de superposición](https://github.com/XRPLF/rippled/blob/96bbabbd2ece106779bb544aa0e4ce174e99fdf6/src/ripple/overlay/README.md#handshake) en el [repositorio `rippled`](https://github.com/XRPLF/rippled).)
 
 ## Descubrimiento de pares
 

--- a/@l10n/ja/docs/concepts/networks-and-servers/peer-protocol.md
+++ b/@l10n/ja/docs/concepts/networks-and-servers/peer-protocol.md
@@ -18,7 +18,7 @@ XRP Ledgerのサーバは、XRP Ledgerピアプロトコル（RTXP）を使用�
 - 履歴レジャーへのレジャーデータのリクエスト、またはレジャーデータの提供。
 - コンセンサスのための一連のトランザクションの提示、またはコンセンサストランザクションセットの適用に関する算出結果の共有。
 
-ピアツーピア接続を確立するには、サーバどうしをHTTPSで接続し、一方のサーバはRTXPへの切り替えのために[HTTPアップグレード](https://tools.ietf.org/html/rfc7230#section-6.7)をリクエストします。（詳細は、[`rippled`リポジトリ](https://github.com/ripple/rippled)の[Overlay Network](https://github.com/XRPLF/rippled/blob/906ef761bab95f80b0a7e0cab3b4c594b226cf57/src/ripple/overlay/README.md#handshake)をご覧ください。）
+ピアツーピア接続を確立するには、サーバどうしをHTTPSで接続し、一方のサーバはRTXPへの切り替えのために[HTTPアップグレード](https://tools.ietf.org/html/rfc7230#section-6.7)をリクエストします。（詳細は、[`rippled`リポジトリ](https://github.com/XRPLF/rippled)の[Overlay Network](https://github.com/XRPLF/rippled/blob/906ef761bab95f80b0a7e0cab3b4c594b226cf57/src/ripple/overlay/README.md#handshake)をご覧ください。）
 
 ## ピアの検出
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/accountdelete.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/accountdelete.md
@@ -8,7 +8,7 @@ labels:
 ---
 # AccountDelete
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/DeleteAccount.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DeleteAccount.cpp "Source")
 
 _[DeletableAccounts Amendment](/resources/known-amendments.md#deletableaccounts)が必要です_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ammbid.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ammbid.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMBid
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMBid.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMBid.cpp "Source")
 
 _([AMM amendment][]により追加されました。)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ammcreate.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ammcreate.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMCreate
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMCreate.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMCreate.cpp "Source")
 
 _([AMM amendment][]により追加されました。)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ammdelete.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ammdelete.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMDelete
-[[ソース]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/AMMDelete.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMDelete.cpp "Source")
 
 _([AMM amendment][]により追加されました。)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ammdeposit.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ammdeposit.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMDeposit
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMDeposit.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMDeposit.cpp "Source")
 
 _([AMM amendment][]により追加されました。)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ammvote.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ammvote.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMVote
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMVote.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMVote.cpp "Source")
 
 _([AMM amendment][]により追加されました。)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ammwithdraw.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ammwithdraw.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMWithdraw
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMWithdraw.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMWithdraw.cpp "Source")
 
 _([AMM amendment][]により追加されました。)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/checkcancel.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/checkcancel.md
@@ -7,7 +7,7 @@ labels:
   - Checks
 ---
 # CheckCancel
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CancelCheck.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CancelCheck.cpp "Source")
 
 _（[Checks Amendment][]が必要です）_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/checkcash.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/checkcash.md
@@ -7,7 +7,7 @@ labels:
   - Checks
 ---
 # CheckCash
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CashCheck.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CashCheck.cpp "Source")
 
 _（[Checks Amendment][]が必要です）_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/checkcreate.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/checkcreate.md
@@ -7,7 +7,7 @@ labels:
   - Checks
 ---
 # CheckCreate
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateCheck.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateCheck.cpp "Source")
 
 _（[Checks Amendment][]が必要です）_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/clawback.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/clawback.md
@@ -8,7 +8,7 @@ labels:
 ---
 # Clawback
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Clawback.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Clawback.cpp "ソース")
 
 {% partial file="/@l10n/ja/docs/_snippets/clawback-disclaimer.md" /%}
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/depositpreauth.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/depositpreauth.md
@@ -7,7 +7,7 @@ labels:
   - セキュリティ
 ---
 # DepositPreauth
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DepositPreauth.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DepositPreauth.cpp "Source")
 
 _[DepositPreauth Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/diddelete.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/diddelete.md
@@ -8,7 +8,7 @@ labels:
 ---
 # DIDDelete
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DID.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DID.cpp "ソース")
 
 _([DID Amendment][])_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/didset.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/didset.md
@@ -8,7 +8,7 @@ labels:
 ---
 # DIDSet
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DID.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DID.cpp "ソース")
 
 _([DID Amendment][])_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/escrowcancel.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/escrowcancel.md
@@ -8,7 +8,7 @@ labels:
 ---
 # EscrowCancel
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Escrow.cpp "Source")
 
 _[Escrow Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/escrowcreate.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/escrowcreate.md
@@ -8,7 +8,7 @@ labels:
 ---
 # EscrowCreate
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Escrow.cpp "Source")
 
 _[Escrow Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/escrowfinish.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/escrowfinish.md
@@ -8,7 +8,7 @@ labels:
 ---
 # EscrowFinish
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Escrow.cpp "Source")
 
 _[Escrow Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/nftokenacceptoffer.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/nftokenacceptoffer.md
@@ -7,7 +7,7 @@ labels:
   - NFT, 非代替性トークン
 ---
 # NFTokenAcceptOffer
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenAcceptOffer.cpp "ソース")
 
 `NFTokenAcceptOffer`トランザクションは`NFToken`の購入または売却のオファーを受け入れるために使用されます。トランザクションは次のいずれかになります。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/nftokencreateoffer.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/nftokencreateoffer.md
@@ -7,7 +7,7 @@ labels:
   - 非代替性トークン, NFT
 ---
 # NFTokenCreateOffer
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenCreateOffer.cpp "ソース")
 
 トランザクションを送信するアカウントが所有する`NFToken`に対する新しい _売却_ オファー、または別のアカウントが所有する`NFToken`に対する新しい _購入_ オファーを作成します。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/nftokenmint.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/nftokenmint.md
@@ -7,7 +7,7 @@ labels:
   - 非代替性トークン, NFT
 ---
 # NFTokenMint
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenMint.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenMint.cpp "Source")
 
 `NFTokenMint`トランザクションは非代替性トークンを作成し、`NFTokenMinter`に紐付く[NFTokenPageオブジェクト][]に[NFToken][]オブジェクトとして追加します。このトランザクションは`NFTokenMinter`にとって、不変と定義されているトークンフィールド(例えば`Flags`)を設定することができる唯一の方法です。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/offercancel.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/offercancel.md
@@ -8,7 +8,7 @@ labels:
 ---
 # OfferCancel
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CancelOffer.cpp "Source")
 
 OfferCancelトランザクションは、XRP LedgerからOfferオブジェクトを削除します。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/offercreate.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/offercreate.md
@@ -8,7 +8,7 @@ labels:
 ---
 # OfferCreate
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateOffer.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateOffer.cpp "ソース")
 
 OfferCreateトランザクションは[分散型取引所](../../../../concepts/tokens/decentralized-exchange/index.md)で[注文](../../../../concepts/tokens/decentralized-exchange/offers.md)を作成します。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/oracledelete.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/oracledelete.md
@@ -8,7 +8,7 @@ labels:
 # OracleDelete
 _([PriceOracle Amendment][])_
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DeleteOracle.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DeleteOracle.cpp "ソース")
 
 既存の`Oracle`レジャーエントリを削除します。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/oracleset.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/oracleset.md
@@ -8,7 +8,7 @@ labels:
 # OracleSet
 _([PriceOracle Amendment][])_
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/SetOracle.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/SetOracle.cpp "ソース")
 
 Oracle Document ID を使用して、新しい`Oracle`レジャーエントリを作成するか、既存のフィールドを更新します。
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/paymentchannelclaim.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/paymentchannelclaim.md
@@ -7,7 +7,7 @@ labels:
   - Payment Channel
 ---
 # PaymentChannelClaim
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/PayChan.cpp "Source")
 
 _[PayChan Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/paymentchannelcreate.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/paymentchannelcreate.md
@@ -7,7 +7,7 @@ labels:
   - Payment Channel
 ---
 # PaymentChannelCreate
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "ソース")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/PayChan.cpp "ソース")
 
 _[PayChan Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/paymentchannelfund.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/paymentchannelfund.md
@@ -7,7 +7,7 @@ labels:
   - Payment Channel
 ---
 # PaymentChannelFund
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/PayChan.cpp "Source")
 
 _[PayChan Amendment][]により追加されました。_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/ticketcreate.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/ticketcreate.md
@@ -8,7 +8,7 @@ labels:
 ---
 # TicketCreate
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/CreateTicket.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateTicket.cpp "Source")
 
 _([TicketBatch amendment][]が必要です)_
 

--- a/@l10n/ja/docs/references/protocol/transactions/types/trustset.md
+++ b/@l10n/ja/docs/references/protocol/transactions/types/trustset.md
@@ -8,7 +8,7 @@ labels:
 ---
 # TrustSet
 
-[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/SetTrust.cpp "Source")
+[[ソース]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/SetTrust.cpp "Source")
 
 2つのアカウントをリンクする[トラストライン](../../../../concepts/tokens/fungible-tokens/index.md)を作成または変更します。
 

--- a/@l10n/ja/resources/contribute-code/create-custom-transactors.md
+++ b/@l10n/ja/resources/contribute-code/create-custom-transactors.md
@@ -21,8 +21,8 @@ _トランザクタ_ はトランザクションを処理し、XRP Ledgerを変�
 
 このチュートリアルでは、既存の`CreateCheck`トランザクションを例として使用します。ソースファイルはここで確認できます。
 
-- [ヘッダファイル](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateCheck.h)
-- [CPPファイル](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateCheck.cpp)
+- [ヘッダファイル](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateCheck.h)
+- [CPPファイル](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateCheck.cpp)
 
 
 ## ヘッダファイル

--- a/docs/references/protocol/transactions/pseudo-transaction-types/enableamendment.md
+++ b/docs/references/protocol/transactions/pseudo-transaction-types/enableamendment.md
@@ -1,29 +1,19 @@
 ---
-html: enableamendment.html
-parent: pseudo-transaction-types.html
 seo:
     description: Enable a change in transaction processing.
 labels:
   - Blockchain
 ---
 # EnableAmendment
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Change.cpp "Source")
 
-An `EnableAmendment` pseudo-transaction marks a change in the status of a proposed amendment when it:
+An `EnableAmendment` pseudo-transaction marks a change in the status of a proposed amendment. The possible status changes are:
 
-- Gains supermajority approval from validators.
-- Loses supermajority approval.
-- Is enabled on the XRP Ledger protocol.
+- The amendment gains supermajority approval from validators.
+- The amendment loses supermajority approval.
+- The amendment becomes enabled.
 
-<!-- TODO: Move to propose amendments tutorial.
-
-A server only enables amendments when these conditions are met:
-  
-- A previous ledger includes an `EnableAmendment` pseudo-transaction with the `tfGotMajority` flag enabled.
-- The previous ledger in question is an ancestor of the current ledger.
-- The previous ledger in question has a close time that is at least two weeks before the close time of the latest flag ledger.
-- There are no `EnableAmendment` pseudo-transactions for this amendment with the `tfLostMajority` flag enabled in the consensus ledgers between the `tfGotMajority` pseudo-transaction and the current ledger.
-
--->
+{% admonition type="info" name="Note" %}You cannot send a pseudo-transaction, but you may find one when processing ledgers.{% /admonition %}
 
 ## Example {% $frontmatter.seo.title %} JSON
 
@@ -41,7 +31,6 @@ A server only enables amendments when these conditions are met:
 
 
 {% partial file="/docs/_snippets/pseudo-tx-fields-intro.md" /%}
-<!--{# fix md highlighting_ #}-->
 
 | Field            | JSON Type | [Internal Type][] | Description               |
 |:-----------------|:----------|:------------------|:--------------------------|

--- a/docs/references/protocol/transactions/pseudo-transaction-types/setfee.md
+++ b/docs/references/protocol/transactions/pseudo-transaction-types/setfee.md
@@ -58,7 +58,7 @@ This transaction has two formats, depending on whether the [XRPFees amendment][]
 
 ## {% $frontmatter.seo.title %} Fields
 
-The fields of a SetFee pseudo-transaction depend on whether the [XRPFees amendment][] was enabled at the time. In addition to the [common fields](../references/protocol/transactions/pseudo-transaction-types/pseudo-transaction-types.md), they can use the following:
+The fields of a SetFee pseudo-transaction depend on whether the [XRPFees amendment][] was enabled at the time. In addition to the [common fields](./pseudo-transaction-types.md), they can use the following:
 
 {% tabs %}
 {% tab label="Current Format" %}

--- a/docs/references/protocol/transactions/pseudo-transaction-types/setfee.md
+++ b/docs/references/protocol/transactions/pseudo-transaction-types/setfee.md
@@ -1,12 +1,11 @@
 ---
-html: setfee.html
-parent: pseudo-transaction-types.html
 seo:
     description: Change global reserve and transaction cost settings.
 labels:
   - Fees
 ---
 # SetFee
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Change.cpp "Source")
 
 A `SetFee` [pseudo-transaction](pseudo-transaction-types.md) marks a change in [transaction cost](../../../../concepts/transactions/transaction-cost.md) or [reserve requirements](../../../../concepts/accounts/reserves.md) as a result of [Fee Voting](../../../../concepts/consensus-protocol/fee-voting.md).
 
@@ -14,6 +13,28 @@ A `SetFee` [pseudo-transaction](pseudo-transaction-types.md) marks a change in [
 
 ## Example {% $frontmatter.seo.title %} JSON
 
+This transaction has two formats, depending on whether the [XRPFees amendment][] was enabled at the time:
+
+{% tabs %}
+{% tab label="Current Format" %}
+```json
+{
+    "Account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+    "BaseFeeDrops": "10",
+    "Fee": "0",
+    "LedgerSequence": 92508417,
+    "ReserveBaseDrops": "1000000",
+    "ReserveIncrementDrops": "200000",
+    "Sequence": 0,
+    "SigningPubKey": "",
+    "TransactionType": "SetFee",
+    "date": 786494751,
+    "ledger_index": 92508417
+}
+```
+{% /tab %}
+
+{% tab label="Legacy Format" %}
 ```json
 {
     "Account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
@@ -30,28 +51,35 @@ A `SetFee` [pseudo-transaction](pseudo-transaction-types.md) marks a change in [
     "ledger_index": 3721729,
 }
 ```
+{% /tab %}
+{% /tabs %}
 
 {% partial file="/docs/_snippets/pseudo-tx-fields-intro.md" /%}
-<!--{# fix md highlighting_ #}-->
 
-| Field               | JSON Type        | [Internal Type][] | Description     |
-|:--------------------|:-----------------|:------------------|:----------------|
-| `BaseFee`           | String           | UInt64            | The charge, in drops of XRP, for the reference transaction, as hex. (This is the [transaction cost](../../../../concepts/transactions/transaction-cost.md) before scaling for load.) |
-| `ReferenceFeeUnits` | Unsigned Integer | UInt32            | The cost, in fee units, of the reference transaction |
-| `ReserveBase`       | Unsigned Integer | UInt32            | The base reserve, in drops |
-| `ReserveIncrement`  | Unsigned Integer | UInt32            | The incremental reserve, in drops |
-| `LedgerSequence`    | Number           | UInt32            | _(Omitted for some historical `SetFee` pseudo-transactions)_ The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
+## {% $frontmatter.seo.title %} Fields
 
+The fields of a SetFee pseudo-transaction depend on whether the [XRPFees amendment][] was enabled at the time. In addition to the [common fields](../references/protocol/transactions/pseudo-transaction-types/pseudo-transaction-types.md), they can use the following:
 
-If the _[XRPFees amendment][]_ is enabled, `SetFee` pseudo-transactions use these fields instead:
-
+{% tabs %}
+{% tab label="Current Format" %}
 | Field                   | JSON Type | [Internal Type][] | Description     |
 |:------------------------|:----------|:------------------|:----------------|
 | `BaseFeeDrops`          | String    | Amount            | The charge, in drops of XRP, for the reference transaction. (This is the [transaction cost](../../../../concepts/transactions/transaction-cost.md) before scaling for load.) |
-| `ReserveBaseDrops`      | String    | Amount            | The base reserve, in drops |
-| `ReserveIncrementDrops` | String    | Amount            | The incremental reserve, in drops |
+| `ReserveBaseDrops`      | String    | Amount            | The base reserve, in drops. |
+| `ReserveIncrementDrops` | String    | Amount            | The incremental reserve, in drops. |
 | `LedgerSequence`        | Number    | UInt32            | _(Omitted for some historical `SetFee` pseudo-transactions)_ The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
+{% /tab %}
 
+{% tab label="Legacy Format" %}
+| Field               | JSON Type | [Internal Type][] | Description     |
+|:--------------------|:----------|:------------------|:----------------|
+| `BaseFee`           | String    | UInt64            | The charge, in drops of XRP, for the reference transaction, as hex. (This is the [transaction cost](../../../../concepts/transactions/transaction-cost.md) before scaling for load.) |
+| `ReferenceFeeUnits` | Number    | UInt32            | The cost, in fee units, of the reference transaction. |
+| `ReserveBase`       | Number    | UInt32            | The base reserve, in drops. |
+| `ReserveIncrement`  | Number    | UInt32            | The incremental reserve, in drops |
+| `LedgerSequence`    | Number    | UInt32            | _(Omitted for some historical `SetFee` pseudo-transactions)_ The index of the ledger version where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other occurrences of the same change. |
+{% /tab %}
+{% /tabs %}
 
 {% raw-partial file="/docs/_snippets/setfee_uniqueness_note.md" /%}
 

--- a/docs/references/protocol/transactions/pseudo-transaction-types/unlmodify.md
+++ b/docs/references/protocol/transactions/pseudo-transaction-types/unlmodify.md
@@ -7,6 +7,7 @@ labels:
   - Blockchain
 ---
 # UNLModify
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Change.cpp "Source")
 
 _(Added by the [NegativeUNL amendment][].)_
 

--- a/docs/references/protocol/transactions/types/accountdelete.md
+++ b/docs/references/protocol/transactions/types/accountdelete.md
@@ -1,6 +1,4 @@
 ---
-html: accountdelete.html
-parent: transaction-types.html
 seo:
     description: Delete an account.
 labels:
@@ -8,9 +6,9 @@ labels:
 ---
 # AccountDelete
 
-[[Source]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/DeleteAccount.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DeleteAccount.cpp "Source")
 
-_Added by the [DeletableAccounts amendment](/resources/known-amendments.md#deletableaccounts)_
+_Added by the [DeletableAccounts amendment][]_
 
 An AccountDelete transaction deletes an [account](../../ledger-data/ledger-entry-types/accountroot.md) and any objects it owns in the XRP Ledger, if possible, sending the account's remaining XRP to a specified destination account. See [Deleting Accounts](../../../../concepts/accounts/deleting-accounts.md) for the requirements to delete an account.
 
@@ -31,12 +29,12 @@ An AccountDelete transaction deletes an [account](../../ledger-data/ledger-entry
 [Query example transaction. >](/resources/dev-tools/websocket-api-tool?server=wss%3A%2F%2Fxrplcluster.com%2F&req=%7B%22id%22%3A%22example_AccountDelete%22%2C%22command%22%3A%22tx%22%2C%22transaction%22%3A%221AF19BF9717DA0B05A3BFC5007873E7743BA54C0311CCCCC60776AAEAC5C4635%22%2C%22binary%22%3Afalse%7D)
 
 {% raw-partial file="/docs/_snippets/tx-fields-intro.md" /%}
-<!--{# fix md highlighting_ #}-->
 
-| Field            | JSON Type        | [Internal Type][] | Description        |
-|:-----------------|:-----------------|:------------------|:-------------------|
-| `Destination`    |  String - [Address][] | AccountID    | The address of an account to receive any leftover XRP after deleting the sending account. Must be a funded account in the ledger, and must not be the sending account. |
-| `DestinationTag` | Number           | UInt32            | _(Optional)_ Arbitrary [destination tag](../../../../concepts/transactions/source-and-destination-tags.md) that identifies a hosted recipient or other information for the recipient of the deleted account's leftover XRP. |
+| Field            | JSON Type        | [Internal Type][] | Required? | Description |
+|:-----------------|:-----------------|:------------------|:----------|:------------|
+| `Destination`    |  String - [Address][] | AccountID    | Yes       | The address of an account to receive any leftover XRP after deleting the sending account. Must be a funded account in the ledger, and must not be the sending account. |
+| `DestinationTag` | Number           | UInt32            | No        | Arbitrary [destination tag](../../../../concepts/transactions/source-and-destination-tags.md) that identifies a hosted recipient or other information for the recipient of the deleted account's leftover XRP. |
+
 
 ## Special Transaction Cost
 
@@ -57,7 +55,7 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecNO_DST` | Occurs if the `Destination` account is not a funded account in the ledger. |
 | `tecNO_PERMISSION` | Occurs if the `Destination` account requires [deposit authorization](../../../../concepts/accounts/depositauth.md) and the sender is not preauthorized. |
 | `tecTOO_SOON` | Occurs if the sender's `Sequence` number is too high. The transaction's `Sequence` number plus 256 must be less than the current [Ledger Index][]. This prevents replay of old transactions if this account is resurrected after it is deleted. |
-| `tecHAS_OBLIGATIONS` | Occurs if the account to be deleted is connected to objects that cannot be deleted in the ledger. (This includes objects created by other accounts, such as [escrows](../../../../concepts/payment-types/escrow.md) and for example [NFT's minted](nftokenmint.md), [even if owned by another account](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/DeleteAccount.cpp#L197).) |
+| `tecHAS_OBLIGATIONS` | Occurs if the account to be deleted is connected to objects that cannot be deleted in the ledger. (This includes objects created by other accounts, such as [escrows](../../../../concepts/payment-types/escrow.md) and for example [NFT's minted](nftokenmint.md), [even if owned by another account](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DeleteAccount.cpp#L197).) |
 | `tefTOO_BIG` | Occurs if the sending account is linked to more than 1000 objects in the ledger. The transaction could succeed on retry if some of those objects were deleted separately first. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/accountset.md
+++ b/docs/references/protocol/transactions/types/accountset.md
@@ -1,6 +1,4 @@
 ---
-html: accountset.html
-parent: transaction-types.html
 seo:
     description: Set options on an account.
 labels:
@@ -8,7 +6,7 @@ labels:
 ---
 # AccountSet
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/SetAccount.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/SetAccount.cpp "Source")
 
 An AccountSet transaction modifies the properties of an [account in the XRP Ledger](../../ledger-data/ledger-entry-types/accountroot.md).
 

--- a/docs/references/protocol/transactions/types/ammbid.md
+++ b/docs/references/protocol/transactions/types/ammbid.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMBid
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMBid.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMBid.cpp "Source")
 
 _(Added by the [AMM amendment][])_
 

--- a/docs/references/protocol/transactions/types/ammcreate.md
+++ b/docs/references/protocol/transactions/types/ammcreate.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMCreate
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMCreate.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMCreate.cpp "Source")
 
 _(Added by the [AMM amendment][])_
 

--- a/docs/references/protocol/transactions/types/ammdelete.md
+++ b/docs/references/protocol/transactions/types/ammdelete.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMDelete
-[[Source]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/AMMDelete.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMDelete.cpp "Source")
 
 _(Added by the [AMM amendment][])_
 

--- a/docs/references/protocol/transactions/types/ammdeposit.md
+++ b/docs/references/protocol/transactions/types/ammdeposit.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMDeposit
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMDeposit.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMDeposit.cpp "Source")
 
 _(Added by the [AMM amendment][])_
 

--- a/docs/references/protocol/transactions/types/ammvote.md
+++ b/docs/references/protocol/transactions/types/ammvote.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMVote
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMVote.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMVote.cpp "Source")
 
 _(Added by the [AMM amendment][])_
 

--- a/docs/references/protocol/transactions/types/ammwithdraw.md
+++ b/docs/references/protocol/transactions/types/ammwithdraw.md
@@ -7,7 +7,7 @@ labels:
   - AMM
 ---
 # AMMWithdraw
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/AMMWithdraw.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/AMMWithdraw.cpp "Source")
 
 _(Added by the [AMM amendment][])_
 

--- a/docs/references/protocol/transactions/types/checkcancel.md
+++ b/docs/references/protocol/transactions/types/checkcancel.md
@@ -7,7 +7,7 @@ labels:
   - Checks
 ---
 # CheckCancel
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CancelCheck.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CancelCheck.cpp "Source")
 
 _(Added by the [Checks amendment][].)_
 

--- a/docs/references/protocol/transactions/types/checkcash.md
+++ b/docs/references/protocol/transactions/types/checkcash.md
@@ -7,7 +7,7 @@ labels:
   - Checks
 ---
 # CheckCash
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CashCheck.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CashCheck.cpp "Source")
 
 _(Added by the [Checks amendment][].)_
 

--- a/docs/references/protocol/transactions/types/checkcreate.md
+++ b/docs/references/protocol/transactions/types/checkcreate.md
@@ -7,7 +7,7 @@ labels:
   - Checks
 ---
 # CheckCreate
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateCheck.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateCheck.cpp "Source")
 
 _(Added by the [Checks amendment][].)_
 

--- a/docs/references/protocol/transactions/types/clawback.md
+++ b/docs/references/protocol/transactions/types/clawback.md
@@ -8,7 +8,7 @@ labels:
 ---
 # Clawback
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Clawback.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Clawback.cpp "Source")
 
 {% partial file="/docs/_snippets/clawback-disclaimer.md" /%}
 

--- a/docs/references/protocol/transactions/types/depositpreauth.md
+++ b/docs/references/protocol/transactions/types/depositpreauth.md
@@ -7,7 +7,7 @@ labels:
   - Security
 ---
 # DepositPreauth
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DepositPreauth.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DepositPreauth.cpp "Source")
 
 _Added by the [DepositPreauth amendment][]._
 

--- a/docs/references/protocol/transactions/types/diddelete.md
+++ b/docs/references/protocol/transactions/types/diddelete.md
@@ -8,7 +8,7 @@ labels:
 ---
 # DIDDelete
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DID.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DID.cpp "Source")
 
 _(Requires the [DID amendment][])_
 

--- a/docs/references/protocol/transactions/types/didset.md
+++ b/docs/references/protocol/transactions/types/didset.md
@@ -8,7 +8,7 @@ labels:
 ---
 # DIDSet
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DID.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DID.cpp "Source")
 
 _(Requires the [DID amendment][])_
 

--- a/docs/references/protocol/transactions/types/escrowcancel.md
+++ b/docs/references/protocol/transactions/types/escrowcancel.md
@@ -8,7 +8,7 @@ labels:
 ---
 # EscrowCancel
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Escrow.cpp "Source")
 
 _Added by the [Escrow amendment][]._
 

--- a/docs/references/protocol/transactions/types/escrowcreate.md
+++ b/docs/references/protocol/transactions/types/escrowcreate.md
@@ -8,7 +8,7 @@ labels:
 ---
 # EscrowCreate
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Escrow.cpp "Source")
 
 _Added by the [Escrow amendment][]._
 

--- a/docs/references/protocol/transactions/types/escrowfinish.md
+++ b/docs/references/protocol/transactions/types/escrowfinish.md
@@ -8,7 +8,7 @@ labels:
 ---
 # EscrowFinish
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/Escrow.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/Escrow.cpp "Source")
 
 _Added by the [Escrow amendment][]._
 

--- a/docs/references/protocol/transactions/types/nftokenacceptoffer.md
+++ b/docs/references/protocol/transactions/types/nftokenacceptoffer.md
@@ -7,7 +7,7 @@ labels:
   - NFTs, Non-fungible Tokens
 ---
 # NFTokenAcceptOffer
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenAcceptOffer.cpp "Source")
 
 The `NFTokenAcceptOffer` transaction is used to accept offers to `buy` or `sell` an `NFToken`. It can either:
 

--- a/docs/references/protocol/transactions/types/nftokenburn.md
+++ b/docs/references/protocol/transactions/types/nftokenburn.md
@@ -7,7 +7,7 @@ labels:
   - Non-fungible Tokens, NFTs
 ---
 # NFTokenBurn
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenBurn.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenBurn.cpp "Source")
 
 The `NFTokenBurn` transaction is used to remove a `NFToken` object from the `NFTokenPage` in which it is being held, effectively removing the token from the ledger (_burning_ it).
 

--- a/docs/references/protocol/transactions/types/nftokencanceloffer.md
+++ b/docs/references/protocol/transactions/types/nftokencanceloffer.md
@@ -7,7 +7,7 @@ labels:
   - NFTs, Non-fungible Tokens
 ---
 # NFTokenCancelOffer
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenCancelOffer.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenCancelOffer.cpp "Source")
 
 The `NFTokenCancelOffer` transaction can be used to cancel existing token offers created using `NFTokenCreateOffer`.
 

--- a/docs/references/protocol/transactions/types/nftokencreateoffer.md
+++ b/docs/references/protocol/transactions/types/nftokencreateoffer.md
@@ -7,7 +7,7 @@ labels:
  - Non-fungible Tokens, NFTs
 ---
 # NFTokenCreateOffer
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenCreateOffer.cpp "Source")
 
 Creates either a new _Sell_ offer for an `NFToken` owned by the account executing the transaction, or a new _Buy_ offer for an `NFToken` owned by another account.
 

--- a/docs/references/protocol/transactions/types/nftokenmint.md
+++ b/docs/references/protocol/transactions/types/nftokenmint.md
@@ -7,7 +7,7 @@ labels:
   - Non-fungible Tokens, NFTs
 ---
 # NFTokenMint
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/NFTokenMint.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/NFTokenMint.cpp "Source")
 
 The `NFTokenMint` transaction creates a non-fungible token and adds it to the relevant [NFTokenPage object][] of the `NFTokenMinter` as an [NFToken][] object. This transaction is the only opportunity the `NFTokenMinter` has to specify any token fields that are defined as immutable (for example, the `TokenFlags`).
 

--- a/docs/references/protocol/transactions/types/offercancel.md
+++ b/docs/references/protocol/transactions/types/offercancel.md
@@ -8,7 +8,7 @@ labels:
 ---
 # OfferCancel
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CancelOffer.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CancelOffer.cpp "Source")
 
 An OfferCancel transaction removes an Offer object from the XRP Ledger.
 

--- a/docs/references/protocol/transactions/types/offercreate.md
+++ b/docs/references/protocol/transactions/types/offercreate.md
@@ -8,7 +8,7 @@ labels:
 ---
 # OfferCreate
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateOffer.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateOffer.cpp "Source")
 
 An OfferCreate transaction places an [Offer](../../../../concepts/tokens/decentralized-exchange/offers.md) in the [decentralized exchange](../../../../concepts/tokens/decentralized-exchange/index.md).
 

--- a/docs/references/protocol/transactions/types/oracledelete.md
+++ b/docs/references/protocol/transactions/types/oracledelete.md
@@ -8,7 +8,7 @@ labels:
 # OracleDelete
 _(Requires the [PriceOracle amendment][])_
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/DeleteOracle.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/DeleteOracle.cpp "Source")
 
 Delete an `Oracle` ledger entry.
 

--- a/docs/references/protocol/transactions/types/oracleset.md
+++ b/docs/references/protocol/transactions/types/oracleset.md
@@ -8,7 +8,7 @@ labels:
 # OracleSet
 _(Requires the [PriceOracle amendment][])_
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/SetOracle.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/SetOracle.cpp "Source")
 
 Creates a new `Oracle` ledger entry or updates the fields of an existing one, using the Oracle Document ID.
 

--- a/docs/references/protocol/transactions/types/paymentchannelclaim.md
+++ b/docs/references/protocol/transactions/types/paymentchannelclaim.md
@@ -7,7 +7,7 @@ labels:
   - Payment Channels
 ---
 # PaymentChannelClaim
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/PayChan.cpp "Source")
 
 _Added by the [PayChan amendment][]._
 

--- a/docs/references/protocol/transactions/types/paymentchannelcreate.md
+++ b/docs/references/protocol/transactions/types/paymentchannelcreate.md
@@ -7,7 +7,7 @@ labels:
   - Payment Channels
 ---
 # PaymentChannelCreate
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/PayChan.cpp "Source")
 
 _Added by the [PayChan amendment][]._
 

--- a/docs/references/protocol/transactions/types/paymentchannelfund.md
+++ b/docs/references/protocol/transactions/types/paymentchannelfund.md
@@ -7,7 +7,7 @@ labels:
   - Payment Channels
 ---
 # PaymentChannelFund
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/PayChan.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/PayChan.cpp "Source")
 
 _Added by the [PayChan amendment][]._
 

--- a/docs/references/protocol/transactions/types/signerlistset.md
+++ b/docs/references/protocol/transactions/types/signerlistset.md
@@ -8,7 +8,7 @@ labels:
 ---
 # SignerListSet
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/SetSignerList.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/SetSignerList.cpp "Source")
 
 The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to [multi-sign](../../../../concepts/accounts/multi-signing.md) a transaction. This transaction type was introduced by the [MultiSign amendment][].
 

--- a/docs/references/protocol/transactions/types/ticketcreate.md
+++ b/docs/references/protocol/transactions/types/ticketcreate.md
@@ -8,7 +8,7 @@ labels:
 ---
 # TicketCreate
 
-[[Source]](https://github.com/XRPLF/rippled/blob/develop/src/ripple/app/tx/impl/CreateTicket.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateTicket.cpp "Source")
 
 _(Added by the [TicketBatch amendment][].)_
 

--- a/docs/references/protocol/transactions/types/trustset.md
+++ b/docs/references/protocol/transactions/types/trustset.md
@@ -8,7 +8,7 @@ labels:
 ---
 # TrustSet
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/SetTrust.cpp "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/SetTrust.cpp "Source")
 
 Create or modify a [trust line](../../../../concepts/tokens/fungible-tokens/index.md) linking two accounts.
 

--- a/resources/contribute-code/create-custom-transactors.md
+++ b/resources/contribute-code/create-custom-transactors.md
@@ -21,8 +21,8 @@ Transactors follow a basic order of operations:
 
 This tutorial uses the existing `CreateCheck` transactor as an example. You can view the source files here:
 
-- [Header File](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateCheck.h)
-- [CPP File](https://github.com/XRPLF/rippled/blob/master/src/ripple/app/tx/impl/CreateCheck.cpp)
+- [Header File](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateCheck.h)
+- [CPP File](https://github.com/XRPLF/rippled/blob/master/src/xrpld/app/tx/detail/CreateCheck.cpp)
 
 
 ## Header File


### PR DESCRIPTION
The 2.3.0 release of `rippled` moved a bunch of the furniture, so this updates links in the transaction docs to point to the current source code location. Applies to EN, ES, and JA files.