### PR TITLE
Update ledger entry source links & some related edits for style

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -116,6 +116,11 @@
 [DepositPreauthエントリ]: /docs/references/protocol/transactions/types/depositpreauth.md
 [DepositPreauthオブジェクト]: /docs/references/protocol/transactions/types/depositpreauth.md
 [DepositPreauthトランザクション]: /docs/references/protocol/transactions/types/depositpreauth.md
+[DIDSet transaction]: /docs/references/protocol/transactions/types/didset.md
+[DIDSet transactions]: /docs/references/protocol/transactions/types/didset.md
+[DIDSet トランザクション]: /docs/references/protocol/transactions/types/didset.md
+[DIDSet]: /docs/references/protocol/transactions/types/didset.md
+[DIDSetトランザクション]: /docs/references/protocol/transactions/types/didset.md
 [DirectoryNode entry]: /docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
 [DirectoryNode object]: /docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
 [DirectoryNode エントリ]: /docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
@@ -367,8 +372,23 @@
 [UNLModify pseudo-transactions]: /docs/references/protocol/transactions/pseudo-transaction-types/unlmodify.md
 [UNLModify]: /docs/references/protocol/transactions/pseudo-transaction-types/unlmodify.md
 [UNLModify疑似トランザクション]: /docs/references/protocol/transactions/pseudo-transaction-types/unlmodify.md
+[XChainAddAccountCreateAttestation transaction]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
+[XChainAddAccountCreateAttestation transactions]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
+[XChainAddAccountCreateAttestation トランザクション]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
+[XChainAddAccountCreateAttestation]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
+[XChainAddAccountCreateAttestationトランザクション]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
 [XChainBridge amendment]: /resources/known-amendments.md#xchainbridge
 [XChainBridgeの修正]: /resources/known-amendments.md#xchainbridge
+[XChainCreateBridge transaction]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
+[XChainCreateBridge transactions]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
+[XChainCreateBridge トランザクション]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
+[XChainCreateBridge]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
+[XChainCreateBridgeトランザクション]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
+[XChainCreateClaimID transaction]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
+[XChainCreateClaimID transactions]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
+[XChainCreateClaimID トランザクション]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
+[XChainCreateClaimID]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
+[XChainCreateClaimIDトランザクション]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
 [XRP, in drops]: /docs/references/protocol/data-types/basic-data-types.md#specifying-currency-amounts
 [XRPFees amendment]: /resources/known-amendments.md#xrpfees
 [XRPFeesの修正]: /resources/known-amendments.md#xrpfees

--- a/docs/references/protocol/ledger-data/ledger-entry-types/accountroot.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/accountroot.md
@@ -1,6 +1,4 @@
 ---
-html: accountroot.html
-parent: ledger-entry-types.html
 seo:
     description: The settings, XRP balance, and other metadata for one account.
 labels:
@@ -8,9 +6,9 @@ labels:
   - XRP
 ---
 # AccountRoot
-[[Source]](https://github.com/XRPLF/rippled/blob/264280edd79b7f764536e02459f33f66a59c0531/src/ripple/protocol/impl/LedgerFormats.cpp#L36-L60 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L136-L158 "Source")
 
-An `AccountRoot` ledger entry type describes a single [account](../../../../concepts/accounts/index.md), its settings, and XRP balance.
+An `AccountRoot` ledger entry type describes a single [account](../../../../concepts/accounts/index.md), its settings, and XRP balance. You can create a new account by sending a [Payment transaction][] with enough XRP to a mathematically-valid address.
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/amendments.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/amendments.md
@@ -1,13 +1,11 @@
 ---
-html: amendments-object.html #amendments.html is taken by the concept page
-parent: ledger-entry-types.html
 seo:
     description: Singleton ledger entry with status of enabled and pending amendments.
 labels:
   - Blockchain
 ---
 # Amendments
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L138-L144 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L187-L192 "Source")
 
 The `Amendments` ledger entry type contains a list of [Amendments](../../../../concepts/networks-and-servers/amendments.md) that are currently active. Each ledger version contains **at most one** `Amendments` entry.
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/amm.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/amm.md
@@ -1,17 +1,15 @@
 ---
-html: amm.html
-parent: ledger-entry-types.html
 seo:
     description: The definition and details of an Automated Market Maker (AMM) instance.
 labels:
   - AMM
 ---
 # AMM
-[[Source]](https://github.com/XRPLF/rippled/blob/89780c8e4fd4d140fcb912cf2d0c01c1b260539e/src/ripple/protocol/impl/LedgerFormats.cpp#L272-L284 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L369-L380 "Source")
+
+An `AMM` ledger entry describes a single [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md) (AMM) instance. This is always paired with a [special AccountRoot entry](accountroot.md#special-amm-accountroot-entries). You can create an AMM by sending an [AMMCreate transaction][].
 
 _(Added by the [AMM amendment][])_
-
-An `AMM` ledger entry describes a single [Automated Market Maker](../../../../concepts/tokens/decentralized-exchange/automated-market-makers.md) (AMM) instance. This is always paired with a [special AccountRoot entry](accountroot.md#special-amm-accountroot-entries).
 
 
 ## Example AMM JSON

--- a/docs/references/protocol/ledger-data/ledger-entry-types/bridge.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/bridge.md
@@ -1,6 +1,4 @@
 ---
-html: bridge.html
-parent: ledger-entry-types.html
 seo:
     description: A `bridge` object represents a single cross-chain bridge that connects and enables value to move efficiently between two blockchains. 
 labels:
@@ -8,12 +6,11 @@ labels:
 status: not_enabled
 ---
 # Bridge
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L212-L223 "Source")
+
+The `Bridge` ledger entry represents a single cross-chain bridge that connects the XRP Ledger with another blockchain, such as its sidechain, and enables value in the form of XRP and other tokens (IOUs) to move efficiently between the two blockchains. You can create a bridge by sending an [XChainCreateBridge transaction][].
+
 _(Requires the [XChainBridge amendment][] {% not-enabled /%})_
-
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L286-L300 "Source")
-
-The `Bridge` ledger entry represents a single cross-chain bridge that connects the XRP Ledger with another blockchain, such as its sidechain, and enables value in the form of XRP and other tokens (IOUs) to move efficiently between the two blockchains.
-
 
 ## Example Bridge JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/check.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/check.md
@@ -1,17 +1,15 @@
 ---
-html: check.html
-parent: ledger-entry-types.html
 seo:
     description: A check that can be redeemed for money by its destination.
 labels:
   - Checks
 ---
 # Check
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L157-L170 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L50-L63 "Source")
+
+A `Check` entry describes a [check](../../../../concepts/payment-types/checks.md), similar to a paper personal check, which can be cashed by its destination to get money from its sender. You can create a check by sending a [CheckCreate transaction][].
 
 _(Added by the [Checks amendment][].)_
-
-A `Check` entry describes a [check](../../../../concepts/payment-types/checks.md), similar to a paper personal check, which can be cashed by its destination to get money from its sender.
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth.md
@@ -1,15 +1,13 @@
 ---
-html: depositpreauth-object.html #depositpreauth.html is taken by the tx type
-parent: ledger-entry-types.html
 seo:
     description: A record of preauthorization for sending payments to an account that requires authorization.
 labels:
   - Security
 ---
 # DepositPreauth
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L172-L178 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L246-L253 "Source")
 
-A `DepositPreauth` entry tracks a preauthorization from one account to another. [DepositPreauth transactions][] create these entries.
+A `DepositPreauth` entry tracks a preauthorization from one account to another. You can create a preauthorization by sending a [DepositPreauth transaction][].
 
 This has no effect on processing of transactions unless the account that provided the preauthorization requires [Deposit Authorization](../../../../concepts/accounts/depositauth.md). In that case, the account that was preauthorized can send payments and other transactions directly to the account that provided the preauthorization. Preauthorizations are one-directional, and have no effect on payments going the opposite direction.
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/did.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/did.md
@@ -1,18 +1,15 @@
 ---
-html: did.html
-parent: ledger-entry-types.html
 seo:
     description: The definition and details of a Decentralized Identifier (DID).
 labels:
   - DID
 ---
 # DID
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L330-L341 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L69-L77 "Source")
 
-_(Requires the [DID amendment][])_
+A `DID` ledger entry holds references to, or data associated with, a single [Decentralized Identifier (DID)](../../../../concepts/decentralized-storage/decentralized-identifiers.md). You can create or modify a DID by sending a [DIDSet transaction][].
 
-A `DID` ledger entry holds references to, or data associated with, a single [DID](../../../../concepts/decentralized-storage/decentralized-identifiers.md).
-
+_(Added by the [DID amendment][])_
 
 ## Example DID JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
@@ -6,7 +6,7 @@ labels:
   - Decentralized Exchange
 ---
 # DirectoryNode
-[[Source]](https://github.com/XRPLF/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L44 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L165-L179 "Source")
 
 The `DirectoryNode` ledger entry type provides a list of links to other entries in the ledger's state data. A single conceptual _Directory_ takes the form of a doubly linked list, with one or more DirectoryNode entries each containing up to 32 [IDs of other entries](../common-fields.md). The first DirectoryNode entry is called the root of the directory, and all entries other than the root can be added or deleted as necessary.
 
@@ -15,6 +15,8 @@ There are three kinds of directory:
 * _Owner directories_ list other entries owned by an account, such as [`RippleState` (trust line)](ripplestate.md) or [`Offer`](offer.md) entries.
 * _Offer directories_ list the offers available in the [decentralized exchange](../../../../concepts/tokens/decentralized-exchange/index.md). A single Offer directory contains all the offers that have the same exchange rate for the same token (currency code and issuer).
 * _NFT Offer directories_ list buy and sell offers for NFTs. Each NFT has up to two directories, one for buy offers, the other for sell offers.
+
+All types of directories are automatically updated by the protocol as necessary.
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/escrow.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/escrow.md
@@ -1,17 +1,15 @@
 ---
-html: escrow-object.html #escrow.html is taken by the concept page
-parent: ledger-entry-types.html
 seo:
     description: Contains XRP held for a conditional payment.
 labels:
   - Escrow
 ---
 # Escrow
-[[Source]](https://github.com/XRPLF/rippled/blob/c6b6d82a754fe449cc533e18659df483c10a5c98/src/ripple/protocol/impl/LedgerFormats.cpp#L90-L101 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L329-L342 "Source")
+
+An `Escrow` ledger entry represents an [escrow](../../../../concepts/payment-types/escrow.md), which holds XRP until specific conditions are met. You can create an escrow by sending an [EscrowCreate transaction][].
 
 _(Added by the [Escrow amendment][].)_
-
-An `Escrow` ledger entry represents an [escrow](../../../../concepts/payment-types/escrow.md), which holds XRP until specific conditions are met.
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/feesettings.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/feesettings.md
@@ -1,13 +1,11 @@
 ---
-html: feesettings.html
-parent: ledger-entry-types.html
 seo:
     description: Singleton object with consensus-approved base transaction cost and reserve requirements.
 labels:
   - Fees
 ---
 # FeeSettings
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L115-L120 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L297-L309 "Source")
 
 The `FeeSettings` entry contains the current base [transaction cost](../../../../concepts/transactions/transaction-cost.md) and [reserve amounts](../../../../concepts/accounts/reserves.md) as determined by [fee voting](../../../../concepts/consensus-protocol/fee-voting.md). Each ledger version contains **at most one** `FeeSettings` entry.
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes.md
@@ -1,26 +1,24 @@
 ---
-html: ledgerhashes.html
-parent: ledger-entry-types.html
 seo:
     description: Lists of prior ledger versions' hashes for history lookup.
 labels:
   - Blockchain
 ---
 # LedgerHashes
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L104-L108 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L202-L206 "Source")
 
-(Not to be confused with the ["ledger hash" string data type][Hash], which uniquely identifies a ledger version. This section describes the `LedgerHashes` ledger object type.)
+(Not to be confused with the ["ledger hash" string data type][Hash], which uniquely identifies a ledger version. This page describes the `LedgerHashes` ledger entry type.)
 
-The `LedgerHashes` object type contains a history of prior ledgers that led up to this ledger version, in the form of their hashes. Objects of this ledger type are modified automatically when closing a ledger. (This is one of the only times a ledger's state data is modified without a [transaction](../../../../concepts/transactions/index.md) or [pseudo-transaction](../../transactions/pseudo-transaction-types/pseudo-transaction-types.md).) The `LedgerHashes` objects exist to make it possible to look up a previous ledger's hash with only the current ledger version and at most one lookup of a previous ledger version.
+The `LedgerHashes` ledger entry type contains a history of prior ledgers that led up to this ledger version, in the form of their hashes. Entries of this type are modified automatically when closing a ledger. (This is one of the only times a ledger's state data is modified without a [transaction](../../../../concepts/transactions/index.md) or [pseudo-transaction](../../transactions/pseudo-transaction-types/pseudo-transaction-types.md).) The `LedgerHashes` entries exist to make it possible to look up a previous ledger's hash with only the current ledger version and at most one lookup of a previous ledger version.
 
-There are two kinds of `LedgerHashes` object. Both types have the same fields. Each ledger version contains:
+There are two kinds of `LedgerHashes` entry. Both types have the same fields. Each ledger version contains:
 
-- Exactly one "recent history" `LedgerHashes` object
-- A number of "previous history" `LedgerHashes` objects based on the current ledger index (that is, the length of the ledger history). Specifically, the XRP Ledger adds a new "previous history" object every 65536 ledger versions. <!-- STYLE_OVERRIDE: a number of -->
+- Exactly one "recent history" `LedgerHashes` entry.
+- A number of "previous history" `LedgerHashes` entries based on the current ledger index (that is, the length of the ledger history). Specifically, the XRP Ledger adds a new "previous history" object every 65536 ledger versions.
 
 {% admonition type="info" name="Note" %}As an exception, a new genesis ledger has no `LedgerHashes` objects at all, because it has no ledger history.{% /admonition %}
 
-Example `LedgerHashes` object (trimmed for length):
+Example `LedgerHashes` entry (trimmed for length):
 
 ```json
 {
@@ -54,16 +52,16 @@ In addition to the [common fields](../common-fields.md), {% code-page-name /%} e
 
 ## Recent History LedgerHashes
 
-There is exactly one `LedgerHashes` object of the "recent history" sub-type in every ledger after the genesis ledger. This object contains the identifying hashes of the most recent 256 ledger versions (or fewer, if the ledger history has less than 256 ledgers total) in the `Hashes` array. Whenever a new ledger is closed, part of the process of closing it involves updating the "recent history" object with the hash of the previous ledger version this ledger version is derived from (also known as this ledger version's _parent ledger_). When there are more than 256 hashes, the oldest one is removed.
+There is exactly one `LedgerHashes` entry of the "recent history" sub-type in every ledger after the genesis ledger. This entry contains the identifying hashes of the most recent 256 ledger versions (or fewer, if the ledger history has less than 256 ledgers total) in the `Hashes` array. Whenever a new ledger is closed, part of the process of closing it involves updating the "recent history" entry with the hash of the previous ledger version this ledger version is derived from (also known as this ledger version's _parent ledger_). When there are more than 256 hashes, the oldest one is removed.
 
-Using the "recent history" `LedgerHashes` object of a given ledger, you can get the hash of any ledger index within the 256 ledger versions before the given ledger version.
+Using the "recent history" `LedgerHashes` entry of a given ledger, you can get the hash of any of the 256 ledger versions before it.
 
 
 ## Previous History LedgerHashes
 
-The "previous history" `LedgerHashes` entries collectively contain the hash of every 256th ledger version (also called "flag ledgers") in the full history of the ledger. When the child of a flag ledger closes, the flag ledger's hash is added to the `Hashes` array of the newest "previous history" `LedgerHashes` object. Every 65536 ledgers, `rippled` creates a new `LedgerHashes` object, so that each "previous history" object has the hashes of 256 flag ledgers.
+The "previous history" `LedgerHashes` entries collectively contain the hash of every 256th ledger version (also called "flag ledgers") in the full history of the ledger. When the child of a flag ledger closes, the flag ledger's hash is added to the `Hashes` array of the newest "previous history" `LedgerHashes` entry. Every 65536 ledgers, `rippled` creates a new `LedgerHashes` entry, so that each "previous history" entry has the hashes of 256 flag ledgers.
 
-{% admonition type="info" name="Note" %}The oldest "previous history" `LedgerHashes` object contains only 255 entries because the genesis ledger has ledger index 1, not 0.{% /admonition %}
+{% admonition type="info" name="Note" %}The oldest "previous history" `LedgerHashes` entry contains only 255 hashes because the genesis ledger has ledger index 1, not 0.{% /admonition %}
 
 The "previous history" `LedgerHashes` objects act as a [skip list](https://en.wikipedia.org/wiki/Skip_list) so you can get the hash of any historical flag ledger from its index. From there, you can use that flag ledger's "recent history" object to get the hash of any other ledger.
 
@@ -76,15 +74,15 @@ There are no flags defined for {% code-page-name /%} entries.
 ## LedgerHashes ID Formats
 [[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/Indexes.cpp#L26-L42)
 
-There are two formats for `LedgerHashes` object IDs, depending on whether the object is a "recent history" sub-type or a "previous history" sub-type.
+There are two formats for `LedgerHashes` ledger entry IDs, depending on whether the entry is a "recent history" sub-type or a "previous history" sub-type.
 
-The **"recent history"** `LedgerHashes` object has an ID that is the [SHA-512Half][] of the `LedgerHashes` space key (`0x0073`). In other words, the "recent history" always has the ID `B4979A36CDC7F3D3D5C31A4EAE2AC7D7209DDA877588B9AFC66799692AB0D66B`.
+The **"recent history"** `LedgerHashes` entry has an ID that is the [SHA-512Half][] of the `LedgerHashes` space key (`0x0073`). In other words, the "recent history" always has the ID `B4979A36CDC7F3D3D5C31A4EAE2AC7D7209DDA877588B9AFC66799692AB0D66B`.
 
-The **"previous history"** `LedgerHashes` objects have an ID that is the [SHA-512Half][] of the following values, concatenated in order:
+Each **"previous history"** `LedgerHashes` entry has an ID that is the [SHA-512Half][] of the following values, concatenated in order:
 
 - The `LedgerHashes` space key (`0x0073`)
 - The 32-bit [Ledger Index][] of a flag ledger in the object's `Hashes` array, divided by 65536.
 
-    {% admonition type="success" name="Tip" %}Dividing by 65536 keeps the most significant 16 bits, which are the same for all the flag ledgers listed in a "previous history" object, and only those ledgers. You can use this fact to look up the `LedgerHashes` object that contains the hash of any flag ledger.{% /admonition %}
+    {% admonition type="success" name="Tip" %}Dividing by 65536 keeps the most significant 16 bits, which are the same for all the flag ledgers listed in a "previous history" entry, and only those ledgers. You can use this fact to look up the `LedgerHashes` entry that contains the hash of any flag ledger.{% /admonition %}
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/negativeunl.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/negativeunl.md
@@ -1,12 +1,11 @@
 ---
-html: negativeunl.html
-parent: ledger-entry-types.html
 seo:
     description: List of validators currently believed to be offline.
 labels:
   - Blockchain
 ---
 # NegativeUNL
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L85-L91 "Source")
 
 _(Added by the [NegativeUNL amendment][].)_
 
@@ -42,8 +41,8 @@ In addition to the [common fields](../common-fields.md), the {% code-page-name /
 |:----------------------|:----------|:------------------|:----------|:---------------------|
 | `DisabledValidators`  | Array     | Array             | No        | A list of `DisabledValidator` objects (see below), each representing a trusted validator that is currently disabled. |
 | `LedgerEntryType`     | String    | UInt16            | Yes       | The value `0x004E`, mapped to the string `NegativeUNL`, indicates that this entry is the Negative UNL. |
-| `PreviousTxnID`     | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
-| `PreviousTxnLgrSeq` | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnID`       | String    | Hash256           | No        | The identifying hash of the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
+| `PreviousTxnLgrSeq`   | Number    | UInt32            | No        | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this entry. _(Added by the [fixPreviousTxnID amendment][].)_ |
 | `ValidatorToDisable`  | String    | Blob              | No        | The public key of a trusted validator that is scheduled to be disabled in the next flag ledger. |
 | `ValidatorToReEnable` | String    | Blob              | No        | The public key of a trusted validator in the Negative UNL that is scheduled to be re-enabled in the next flag ledger. |
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/nftokenoffer.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/nftokenoffer.md
@@ -1,14 +1,13 @@
 ---
-html: nftokenoffer.html
-parent: ledger-entry-types.html
 seo:
     description: Create offers to buy or sell NFTs.
 labels:
  - Non-fungible Tokens, NFTs
 ---
 # NFTokenOffer
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L34-L44 "Source")
 
-An `NFTokenOffer` entry represents an offer to buy, sell or transfer an [NFT](../../../../concepts/tokens/nfts/index.md).
+An `NFTokenOffer` entry represents an offer to buy, sell or transfer an [NFT](../../../../concepts/tokens/nfts/index.md). You can create an NFT buy or sell offer by sending an [NFTokenCreateOffer transaction][].
 
 _(Added by the [NonFungibleTokensV1_1 amendment][].)_
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/nftokenpage.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/nftokenpage.md
@@ -1,14 +1,13 @@
 ---
-html: nftokenpage.html
-parent: ledger-entry-types.html
 seo:
     description: Ledger structure for recording NFTokens.
 labels:
  - Non-fungible Tokens, NFTs
 ---
 # NFTokenPage
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L97-L103 "Source")
 
-The `NFTokenPage` object represents a collection of [NFTs](../../../../concepts/tokens/nfts/index.md) owned by the same account. An account can have multiple `NFTokenPage` entries, which form a doubly linked list.
+An `NFTokenPage` entry represents a collection of [NFTs](../../../../concepts/tokens/nfts/index.md) owned by the same account. An account can have multiple `NFTokenPage` entries, which form a doubly linked list. NFT directories are automatically updated when an account mints, burns, buys, or sells NFTs.
 
 _(Added by the [NonFungibleTokensV1_1 amendment][].)_
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/offer.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/offer.md
@@ -1,15 +1,13 @@
 ---
-html: offer.html
-parent: ledger-entry-types.html
 seo:
     description: An order to make a currency trade.
 labels:
   - Decentralized Exchange
 ---
 # Offer
-[[Source]](https://github.com/XRPLF/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L57 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L229-L240 "Source")
 
-The `Offer` ledger entry describes an [Offer](../../../../concepts/tokens/decentralized-exchange/offers.md) to exchange currencies in the XRP Ledger's [decentralized exchange](../../../../concepts/tokens/decentralized-exchange/index.md). (In finance, this is more traditionally known as an _order_.) An [OfferCreate transaction][] only creates an `Offer` entry in the ledger when the Offer cannot be fully executed immediately by consuming other Offers already in the ledger.
+An `Offer` ledger entry describes an [Offer](../../../../concepts/tokens/decentralized-exchange/offers.md) to exchange currencies in the XRP Ledger's [decentralized exchange](../../../../concepts/tokens/decentralized-exchange/index.md). (In finance, this is more traditionally known as an _order_.) You an create a new Offer entry by sending an [OfferCreate transaction][] that is not fully executed immediately.
 
 An Offer can become unfunded through other activities in the network, while remaining in the ledger. When processing transactions, the network automatically removes any unfunded Offers that those transactions come across. (Otherwise, unfunded Offers remain, because _only_ transactions can change the ledger state.)
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/oracle.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/oracle.md
@@ -1,17 +1,15 @@
+---
+seo:
+    description: A ledger entry to publish price information about currency pairs.
+labels:
+  - Decentralized Exchange
+---
 # Oracle
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L385-L395 "Source")
 
-_(Requires the [PriceOracle amendment][])_
+An `Oracle` ledger entry holds data associated with a single [price oracle](../../../../concepts/decentralized-storage/price-oracles.md), which can store information on up to 10 asset pairs. You can create or modify a price oracle with an [OracleSet transaction][].
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/impl/LedgerFormats.cpp#L353-L366 "Source")
-
-An `Oracle` ledger entry holds data associated with a single price oracle object.
-
-{% admonition type="info" name="Note" %}
-
-A price oracle object can store information for up to 10 token pairs.
-
-{% /admonition %}
-
+_(Added by the [PriceOracle amendment][])_
 
 ## Example Oracle JSON
 
@@ -42,12 +40,12 @@ A price oracle object can store information for up to 10 token pairs.
 
 | Field               | JSON Type | Internal Type | Required? | Description |
 |---------------------|-----------|---------------|-----------|-------------|
-| `Owner`             | String    | AccountID     | Yes       | The XRPL account with update and delete privileges for the oracle. It's recommended to set up [multi-signing](../../../../tutorials/how-tos/manage-account-settings/set-up-multi-signing.md) on this account. |
-| `Provider`          | String    | Blob          | Yes       | An arbitrary value that identifies an oracle provider, such as Chainlink, Band, or DIA. This field is a string, up to 256 ASCII hex encoded characters (0x20-0x7E). |
-| `PriceDataSeries`   | Array     | Array         | Yes       | An array of up to 10 `PriceData` objects, each representing the price information for a token pair. More than five `PriceData` objects require two owner reserves. |
-| `LastUpdateTime`    | Number    | UInt32        | Yes       | The time the data was last updated, represented in Unix time. |
+| `Owner`             | String    | AccountID     | Yes       | The [account](../../../../concepts/accounts/index.md) with update and delete privileges for the oracle. It's recommended to set up [multi-signing](../../../../tutorials/how-tos/manage-account-settings/set-up-multi-signing.md) on this account. |
+| `Provider`          | String    | Blob          | Yes       | An arbitrary value that identifies an oracle provider, such as Chainlink, Band, or DIA. This field is a string, up to 256 ASCII hex encoded characters (`0x20`-`0x7E`). |
+| `PriceDataSeries`   | Array     | Array         | Yes       | An array of up to 10 `PriceData` objects, each representing the price information for an asset pair. More than five `PriceData` objects require two owner reserves. |
+| `LastUpdateTime`    | Number    | UInt32        | Yes       | The time the data was last updated, represented in Unix time. (**Note:** Unlike many other time values on the XRP Ledger, this value does not use the Ripple Epoch.) |
 | `URI`               | String    | Blob          | No        | An optional Universal Resource Identifier to reference price data off-chain. This field is limited to 256 bytes. |
-| `AssetClass`        | String    | Blob          | Yes       | Describes the type of asset, such as "currency", "commodity", or "index". This field is a string, up to 16 ASCII hex encoded characters (0x20-0x7E). |
+| `AssetClass`        | String    | Blob          | Yes       | Describes the type of asset, such as "currency", "commodity", or "index". This field is a string, up to 16 ASCII hex encoded characters (`0x20`-`0x7E`). |
 | `OwnerNode`         | String    | UInt64        | Yes       | A hint indicating which page of the oracle owner's owner directory links to this entry, in case the directory consists of multiple pages. |
 | `PreviousTxnID`     | String    | UInt256       | Yes       | The hash of the previous transaction that modified this entry. |
 | `PreviousTxnLgrSeq` | String    | UInt32        | Yes       | The ledger index that this object was most recently modified or created in. |

--- a/docs/references/protocol/ledger-data/ledger-entry-types/oracle.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/oracle.md
@@ -45,7 +45,7 @@ _(Added by the [PriceOracle amendment][])_
 | `PriceDataSeries`   | Array     | Array         | Yes       | An array of up to 10 `PriceData` objects, each representing the price information for an asset pair. More than five `PriceData` objects require two owner reserves. |
 | `LastUpdateTime`    | Number    | UInt32        | Yes       | The time the data was last updated, represented in Unix time. (**Note:** Unlike many other time values on the XRP Ledger, this value does not use the Ripple Epoch.) |
 | `URI`               | String    | Blob          | No        | An optional Universal Resource Identifier to reference price data off-chain. This field is limited to 256 bytes. |
-| `AssetClass`        | String    | Blob          | Yes       | Describes the type of asset, such as "currency", "commodity", or "index". This field is a string, up to 16 ASCII hex encoded characters (`0x20`-`0x7E`). |
+| `AssetClass`        | String    | Blob          | Yes       | Arbitrary string to describe the type of asset, such as _currency_, _commodity_, or _index_. Must be formatted as hexadecimal representing ASCII characters (`0x20`-`0x7E`), maximum 16 bytes. |
 | `OwnerNode`         | String    | UInt64        | Yes       | A hint indicating which page of the oracle owner's owner directory links to this entry, in case the directory consists of multiple pages. |
 | `PreviousTxnID`     | String    | UInt256       | Yes       | The hash of the previous transaction that modified this entry. |
 | `PreviousTxnLgrSeq` | String    | UInt32        | Yes       | The ledger index that this object was most recently modified or created in. |

--- a/docs/references/protocol/ledger-data/ledger-entry-types/paychannel.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/paychannel.md
@@ -1,18 +1,15 @@
 ---
-html: paychannel.html
-parent: ledger-entry-types.html
 seo:
     description: A channel for asynchronous XRP payments.
 labels:
   - Payment Channels
 ---
 # PayChannel
-[[Source]](https://github.com/XRPLF/rippled/blob/c0a0b79d2d483b318ce1d82e526bd53df83a4a2c/src/ripple/protocol/impl/LedgerFormats.cpp#L180-L198 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L348-L363 "Source")
+
+A `PayChannel` entry represents a [payment channel](../../../../concepts/payment-types/payment-channels.md). You can create a payment channel with a [PaymentChannelCreate transaction][].
 
 _(Added by the [PayChan amendment][].)_
-
-A `PayChannel` entry represents a [payment channel](../../../../concepts/payment-types/payment-channels.md).
-
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate.md
@@ -1,15 +1,13 @@
 ---
-html: ripplestate.html
-parent: ledger-entry-types.html
 seo:
     description: This entry represents a trust line, tracking the net balance of tokens between them.
 labels:
   - Tokens
 ---
 # RippleState
-[[Source]](https://github.com/XRPLF/rippled/blob/5d2d88209f1732a0f8d592012094e345cbe3e675/src/ripple/protocol/impl/LedgerFormats.cpp#L70 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L277-L289 "Source")
 
-A `RippleState` ledger entry represents a [trust line](../../../../concepts/tokens/fungible-tokens/index.md) between two accounts. Each account can change its own limit and other settings, but the balance is a single shared value. A trust line that is entirely in its default state is considered the same as a trust line that does not exist and is automatically deleted.
+A `RippleState` ledger entry represents a [trust line](../../../../concepts/tokens/fungible-tokens/index.md) between two accounts. Each account can change its own limit and other settings, but the balance is a single shared value. A trust line that is entirely in its default state is considered the same as a trust line that does not exist and is automatically deleted. You can create or modify a trust line with a [TrustSet transaction][].
 
 ## High vs. Low Account
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/signerlist.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/signerlist.md
@@ -1,18 +1,15 @@
 ---
-html: signerlist.html
-parent: ledger-entry-types.html
 seo:
     description: A list of addresses for multi-signing transactions.
 labels:
   - Security
 ---
 # SignerList
-[[Source]](https://github.com/XRPLF/rippled/blob/6d2e3da30696bd10e3bb11a5ff6d45d2c4dae90f/src/ripple/protocol/impl/LedgerFormats.cpp#L127 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L111-L118 "Source")
+
+A `SignerList` entry represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account by [multi-signing](../../../../concepts/accounts/multi-signing.md). You can create, replace, or remove a signer list using a [SignerListSet transaction][].
 
 _(Added by the [MultiSign amendment][].)_
-
-A `SignerList` entry represents a list of parties that, as a group, are authorized to sign a transaction in place of an individual account. You can create, replace, or remove a signer list using a [SignerListSet transaction][].
-
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/ticket.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/ticket.md
@@ -7,12 +7,12 @@ labels:
   - Transaction Sending
 ---
 # Ticket
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L124-L130 "Source")
 
-[[Source]](https://github.com/XRPLF/rippled/blob/76a6956138c4ecd156c5c408f136ed3d6ab7d0c1/src/ripple/protocol/impl/LedgerFormats.cpp#L155-L164)
+A `Ticket` entry type represents a [Ticket](../../../../concepts/accounts/tickets.md), which tracks an account [sequence number][Sequence Number] that has been set aside for future use. You can create new tickets with a [TicketCreate transaction][].
 
 _(Added by the [TicketBatch amendment][].)_
 
-A `Ticket` entry type represents a [Ticket](../../../../concepts/accounts/tickets.md), which tracks an account [sequence number][Sequence Number] that has been set aside for future use. You can create new tickets with a [TicketCreate transaction][].
 
 ## Example {% $frontmatter.seo.title %} JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid.md
@@ -10,7 +10,7 @@ status: not_enabled
 
 An `XChainOwnedClaimID` entry represents *one* cross-chain transfer of value and includes information of the account on the source chain that locks or burns the funds on the source chain.
 
-The `XChainOwnedClaimID` entry must be acquired on the destination chain before submitting a `XChainCommit` on the source chain. Its purpose is to prevent transaction replay attacks and is also used as a place to collect attestations from witness servers.
+The `XChainOwnedClaimID` entry must be acquired on the destination chain before submitting a `XChainCommit` on the source chain. Its purpose is to prevent transaction replay attacks. It is also used as a place to collect attestations from witness servers.
 
 You can create a new `XChainOwnedClaimID` by sending an [XChainCreateClaimID transaction][]. An `XChainOwnedClaimID` is destroyed when the funds are successfully claimed on the destination chain.
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid.md
@@ -1,6 +1,4 @@
 ---
-html: xchainownedclaimid.html
-parent: ledger-entry-types.html
 seo:
     description: An `XChainOwnedClaimID` object represents *one* cross-chain transfer of value. 
 labels:
@@ -8,15 +6,15 @@ labels:
 status: not_enabled
 ---
 # XChainOwnedClaimID
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L259-L269 "Source")
+
+An `XChainOwnedClaimID` entry represents *one* cross-chain transfer of value and includes information of the account on the source chain that locks or burns the funds on the source chain.
+
+The `XChainOwnedClaimID` entry must be acquired on the destination chain before submitting a `XChainCommit` on the source chain. Its purpose is to prevent transaction replay attacks and is also used as a place to collect attestations from witness servers.
+
+You can create a new `XChainOwnedClaimID` by sending an [XChainCreateClaimID transaction][]. An `XChainOwnedClaimID` is destroyed when the funds are successfully claimed on the destination chain.
+
 _(Requires the [XChainBridge amendment][] {% not-enabled /%})_
-
-[[Source]](https://github.com/seelabs/rippled/blob/xbridge/src/ripple/protocol/impl/LedgerFormats.cpp#L281-L293 "Source")
-
-An `XChainOwnedClaimID` object represents *one* cross-chain transfer of value and includes information of the account on the source chain that locks or burns the funds on the source chain.
-
-The `XChainOwnedClaimID` object must be acquired on the destination chain before submitting a `XChainCommit` on the source chain. Its purpose is to prevent transaction replay attacks and is also used as a place to collect attestations from witness servers.
-
-An `XChainCreateClaimID` transaction is used to create a new `XChainOwnedClaimID`. The ledger object is destroyed when the funds are successfully claimed on the destination chain.
 
 
 ## Example XChainOwnedClaimID JSON

--- a/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid.md
@@ -1,6 +1,4 @@
 ---
-html: xchainownedcreateaccountclaimid.html
-parent: ledger-entry-types.html
 seo:
     description: The `XChainOwnedCreateAccountClaimID` ledger object is used to collect attestations for creating an account via a cross-chain transfer. 
 labels:
@@ -8,15 +6,15 @@ labels:
 status: not_enabled
 ---
 # XChainOwnedCreateAccountClaimID
+[[Source]](https://github.com/XRPLF/rippled/blob/f64cf9187affd69650907d0d92e097eb29693945/include/xrpl/protocol/detail/ledger_entries.macro#L315-L323 "Source")
+
+An `XChainOwnedCreateAccountClaimID` ledger entry collects attestations for creating an account via a cross-chain transfer.
+
+You can create a new `XChainOwnedCreateAccountClaimID` entry by sending an [XChainAddAccountCreateAttestation transaction][] with a signed attestation of a relevant transaction occurring on another chain.
+
+An `XChainOwnedCreateAccountClaimID` ledger entry is destroyed when all the attestations have been received and the funds have transferred to the new account.
+
 _(Requires the [XChainBridge amendment][] {% not-enabled /%})_
-
-[[Source]](https://github.com/seelabs/rippled/blob/xbridge/src/ripple/protocol/impl/LedgerFormats.cpp#L296-L306 "Source")
-
-The `XChainOwnedCreateAccountClaimID` ledger object is used to collect attestations for creating an account via a cross-chain transfer.
-
-It is created when an `XChainAddAccountCreateAttestation` transaction adds a signature attesting to a `XChainAccountCreateCommit` transaction and the `XChainAccountCreateCount` is greater than or equal to the current `XChainAccountClaimCount` on the `Bridge` ledger object.
-
-The ledger object is destroyed when all the attestations have been received and the funds have transferred to the new account.
 
 
 ## Example XChainOwnedCreateAccountClaimID JSON


### PR DESCRIPTION
Continuation of #2903, but for ledger entry reference docs this time.

While I was there editing basically every ledger entry page, I made them a little bit more internally consistent, like using a "Required?" column in the field list and having the opening description mention which type of transaction creates these entries.

