### PR TITLE
Remove MPT-Devnet faucet, which has been shut down; use APIv1 for Faucets

### DIFF
--- a/resources/dev-tools/faucets.json
+++ b/resources/dev-tools/faucets.json
@@ -25,14 +25,6 @@
             "desc": "Hooks (L1 smart contracts) enabled Xahau testnet."
         },
         {
-            "id": "faucet-select-mpt-devnet",
-            "wsUrl": "wss://mpt.devnet.rippletest.net:51233/",
-            "jsonRpcUrl": "https://mpt.devnet.rippletest.net:51234/",
-            "faucetHost": "mptfaucet.devnet.rippletest.net",
-            "shortName": "MPT-Devnet",
-            "desc": "Preview of XLS-33d Multi-Purpose Tokens amendment."
-        },
-        {
             "id": "faucet-select-batch-devnet",
             "wsUrl": "wss://batch.nerdnest.xyz",
             "jsonRpcUrl": "https://batch.rpc.nerdnest.xyz",

--- a/resources/dev-tools/xrp-faucets.page.tsx
+++ b/resources/dev-tools/xrp-faucets.page.tsx
@@ -133,6 +133,7 @@ async function generateFaucetCredentialsAndUpdateUI(
   const wallet = Wallet.generate()
   
   const client = new Client(selectedFaucet.wsUrl)
+  client.apiVersion = 1 // Workaround for networks that don't support APIv2
   await client.connect()
 
   try {


### PR DESCRIPTION
- MPTs are available on the regular Devnet so the MPT-Devnet (including faucet) has been shut down.
- Xahau network doesn't support APIv2, so explicitly specify APIv1 in the Faucet code. (The other networks' public servers support both API versions and we don't need anything from APIv2 here, so this is purely restoring functionality in this case.)
- Known issue: the Batch faucet still doesn't work; it appears to be broken on the server side.