### PR TITLE
Fix ledger_entry formatting issues

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
+++ b/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
@@ -808,6 +808,107 @@ rippled json ledger_entry '{ "nft_page": "255DD86DDF59D778081A06D02701E9B2C9F4F0
 
 [Try it! >](/resources/dev-tools/websocket-api-tool#ledger_entry-nft-page)
 
+### Get MPT Issuance Object
+
+_(Requires the [MPToken amendment][] {% not-enabled /%})_
+
+Return an `MPTokenIssuance` object.
+
+| Field          | Type   | Description           |
+|:---------------|:-------|:----------------------|
+| `mpt_issuance` | String | The 192-bit `MPTokenIssuanceID` that's associated with the MPTokenIssuance, as hexadecimal. |
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+    "id": "example_get_mpt_issuance",
+    "command": "ledger_entry",
+    "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E",
+    "ledger_index": "validated"
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+  "method": "ledger_entry",
+  "params": [{
+    "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E",
+    "ledger_index": "validated"
+  }]
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```sh
+rippled json ledger_entry '{ "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E", "ledger_index": "validated" }'
+```
+{% /tab %}
+{% /tabs %}
+
+<!-- TODO: add try-it for MPT issuance
+[Try it! >](/resources/dev-tools/websocket-api-tool#ledger_entry-mpt_issuance)
+-->
+
+### Get MPToken Object
+
+_(Requires the [MPToken amendment][] {% not-enabled /%})_
+
+Return an `MPToken` object.
+
+| Field                     | Type             | Description |
+|:--------------------------|:-----------------|:------------|
+| `mptoken`                 | ️Object or String | If a string, interpret as ledger entry ID of the MPToken to retrieve. If an object, requires the sub-fields `account` and `mpt_issuance_id` to unique identify the MPToken. |
+| `mptoken.mpt_issuance_id` | String           | (Required if the `MPToken` is specified as an object) The 192-bit MPTokenIssuanceID that's associated with the MPTokenIssuance. |
+| `mptoken.account` ️        | String           | (Required if the `MPToken` is specified as an object) The account that owns the MPToken. |
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+    "id": "example_get_mpt_issuance",
+    "command": "ledger_entry",
+    "mptoken": {
+      "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D",
+      "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"
+    }
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+            "mptoken":{
+                "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D",
+                "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"
+            } 
+        }
+    ]
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```sh
+rippled json ledger_entry '{ "mptoken": {"mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D", "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"} }'
+```
+{% /tab %}
+{% /tabs %}
+
+<!-- TODO: make a try-it link for MPT object
+[Try it! >](/resources/dev-tools/websocket-api-tool#ledger_entry-mptoken)
+ -->
+
+
 ## Response Format
 
 The response follows the [standard format][], with a successful result containing the following fields:
@@ -922,210 +1023,6 @@ An example of a successful response:
 {% /tab %}
 
 {% /tabs %}
-
-### Get MPT Issuance Object
-
-_(Requires the [MPToken amendment][] {% not-enabled /%})_
-
-Return an `MPTokenIssuance` object.
-
-| Field                   | Type                       | Description           |
-|:------------------------|:---------------------------|:----------------------|
-| `mpt_issuance`              | String | The 192-bit `MPTokenIssuanceID` that's associated with the MPTokenIssuance. |
-
-<!-- MULTICODE_BLOCK_START -->
-
-*WebSocket*
-
-```json
-{
-    "id": "example_get_mpt_issuance",
-    "command": "ledger_entry",
-    "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E",
-    "ledger_index": "validated"
-}
-```
-
-*JSON-RPC*
-
-```json
-{
-  "method": "ledger_entry",
-  "params": [{
-    "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E",
-    "ledger_index": "validated"
-  }]
-}
-```
-*Commandline*
-
-```sh
-rippled json ledger_entry '{ "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E", "ledger_index": "validated" }'
-```
-
-[Try it! >](/resources/dev-tools/websocket-api-tool#ledger_entry-mpt_issuance)
-
-### Get MPToken Object
-
-_(Requires the [MPToken amendment][] {% not-enabled /%})_
-
-Return an `MPToken` object.
-
-| Field                   | Type                       | Description           |
-|:------------------------|:---------------------------|:----------------------|
-| `mptoken`               | ️Object or String          | If a string, interpret as ledger entry ID of the MPToken to retrieve. If an object, requires the sub-fields account and mpt_issuance_id to unique identify the MPToken. |
-| mptoken.mpt_issuance_id |	️String                      |	(Required if the `MPToken` is specified as an object) The 192-bit MPTokenIssuanceID that's associated with the MPTokenIssuance. |
-| mptoken.account	️         | String	                    | (Required if the `MPToken` is specified as an object) The account that owns the MPToken. |
-
-<!-- MULTICODE_BLOCK_START -->
-
-*WebSocket*
-
-```json
-{
-    "id": "example_get_mpt_issuance",
-    "command": "ledger_entry",
-    "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D",
-    "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"
-}
-```
-
-*JSON-RPC*
-
-```json
-{
-    "method": "ledger_entry",
-    "params": [
-        {
-            "mptoken":{
-                "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D",
-                "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"
-            } 
-        }
-    ]
-}
-```
-*Commandline*
-
-```sh
-rippled json ledger_entry '{ "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D", "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"}'
-```
-<!-- MULTICODE_BLOCK_END -->
-[Try it! >](/resources/dev-tools/websocket-api-tool#ledger_entry-mptissuance)
-
-## Response Format
-
-The response follows the [standard format][], with a successful result containing the following fields:
-
-| Field          | Type             | Description                              |
-|:---------------|:-----------------|:-----------------------------------------|
-| `index`        | String           | The unique ID of this [ledger entry](../../../protocol/ledger-data/ledger-entry-types/index.md). |
-| `ledger_index` | Unsigned Integer | The [ledger index](../../../protocol/data-types/basic-data-types.md#ledger-index) of the ledger that was used when retrieving this data. |
-| `node`         | Object           | _(Omitted if `"binary": true` specified.)_ Object containing the data of this ledger entry, according to the [ledger format](../../../protocol/ledger-data/ledger-entry-types/index.md). |
-| `node_binary`  | String           | _(Omitted unless `"binary":true` specified)_ The [binary representation](../../../protocol/binary-format.md) of the ledger object, as hexadecimal. |
-
-An example of a successful response:
-
-<!-- MULTICODE_BLOCK_START -->
-
-*WebSocket*
-
-```json
-{
-  "id": "example_get_accountroot",
-  "result": {
-    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-    "ledger_hash": "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
-    "ledger_index": 61966146,
-    "node": {
-      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-      "AccountTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-      "Balance": "424021949",
-      "Domain": "6D64756F31332E636F6D",
-      "EmailHash": "98B4375E1D753E5B91627516F6D70977",
-      "Flags": 9568256,
-      "LedgerEntryType": "AccountRoot",
-      "MessageKey": "0000000000000000000000070000000300",
-      "OwnerCount": 12,
-      "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-      "PreviousTxnLgrSeq": 61965653,
-      "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
-      "Sequence": 385,
-      "TransferRate": 4294967295,
-      "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-    },
-    "validated": true
-  },
-  "status": "success",
-  "type": "response"
-}
-```
-
-*JSON-RPC*
-
-```json
-200 OK
-
-{
-  "result": {
-    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-    "ledger_hash": "395946243EA36C5092AE58AF729D2875F659812409810A63096AC006C73E656E",
-    "ledger_index": 61966165,
-    "node": {
-      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-      "AccountTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-      "Balance": "424021949",
-      "Domain": "6D64756F31332E636F6D",
-      "EmailHash": "98B4375E1D753E5B91627516F6D70977",
-      "Flags": 9568256,
-      "LedgerEntryType": "AccountRoot",
-      "MessageKey": "0000000000000000000000070000000300",
-      "OwnerCount": 12,
-      "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-      "PreviousTxnLgrSeq": 61965653,
-      "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
-      "Sequence": 385,
-      "TransferRate": 4294967295,
-      "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-    },
-    "status": "success",
-    "validated": true
-  }
-}
-```
-
-*Commandline*
-
-```json
-{
-  "result": {
-    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-    "ledger_hash": "395946243EA36C5092AE58AF729D2875F659812409810A63096AC006C73E656E",
-    "ledger_index": 61966165,
-    "node": {
-      "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-      "AccountTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-      "Balance": "424021949",
-      "Domain": "6D64756F31332E636F6D",
-      "EmailHash": "98B4375E1D753E5B91627516F6D70977",
-      "Flags": 9568256,
-      "LedgerEntryType": "AccountRoot",
-      "MessageKey": "0000000000000000000000070000000300",
-      "OwnerCount": 12,
-      "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-      "PreviousTxnLgrSeq": 61965653,
-      "RegularKey": "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ",
-      "Sequence": 385,
-      "TransferRate": 4294967295,
-      "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-    },
-    "status": "success",
-    "validated": true
-  }
-}
-```
-
-<!-- MULTICODE_BLOCK_END -->
 
 
 ## Possible Errors

--- a/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
+++ b/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
@@ -862,7 +862,7 @@ Return an `MPToken` object.
 
 | Field                     | Type             | Description |
 |:--------------------------|:-----------------|:------------|
-| `mptoken`                 | ️Object or String | If a string, interpret as ledger entry ID of the MPToken to retrieve. If an object, requires the sub-fields `account` and `mpt_issuance_id` to unique identify the MPToken. |
+| `mptoken`                 | ️Object or String | If a string, interpret as ledger entry ID of the MPToken to retrieve. If an object, requires the sub-fields `account` and `mpt_issuance_id` to uniquely identify the MPToken. |
 | `mptoken.mpt_issuance_id` | String           | (Required if the `MPToken` is specified as an object) The 192-bit MPTokenIssuanceID that's associated with the MPTokenIssuance. |
 | `mptoken.account` ️        | String           | (Required if the `MPToken` is specified as an object) The account that owns the MPToken. |
 


### PR DESCRIPTION
- The "Response Format" section was duplicated (possibly a merge conflict resolved wrong). Deleted the one that was out of place (with more request format options following it).
- The MPT section had non-functional "try-it" links. Commented these out for now. They need to (a) specify a Devnet server, since MPTs aren't on for Mainnet and Testnet yet, and (b) have the appropriate entries created on-ledger.
- The MPT methods were using the old (pre-Redocly) tab syntax. Updated.
- Fixed a few typos in the request formatting and parameter tables for the MPT methods.