### PR TITLE
Update API Versions doc

### DIFF
--- a/docs/references/http-websocket-apis/index.md
+++ b/docs/references/http-websocket-apis/index.md
@@ -12,6 +12,8 @@ Currently, there are two API versions: `1` and `2` {% badge href="https://github
 
 Separate API requests can use different API versions even on the same persistent connection. For example, if you connect through WebSocket to a server that supports API versions 1 and 2, you can make an `account_tx` request using API version 2 and then make another `account_tx` request using API version 1 from the same connection.
 
+For a full list of the differences between API versions, see [API-CHANGELOG on GitHub](https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md).
+
 
 ## Default API Versions
 
@@ -26,7 +28,7 @@ The table below shows which version of the `rippled` API is used if you don't sp
 | [xrpl-py](https://github.com/XRPLF/xrpl-py) | 2 | Defaults to [API v2][] starting in v3.0.0. |
 
 {% admonition type="info" name="Note" %}
-Clio responses use [API v1][] by default, but support [API v2][] requests.
+Clio behaves the same as `rippled`.
 {% /admonition %}
 
 Future versions of `rippled` that introduce breaking changes will introduce a new API version 3.


### PR DESCRIPTION
- Add link to API-CHANGELOG
- Clio now behaves the same as `rippled`