### PR TITLE
Fix unparsed common links

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -66,6 +66,9 @@
 [Checks amendment]: /resources/known-amendments.md#checks
 [Clawback amendment]: /resources/known-amendments.md#clawback
 [Clawbackの修正]: /resources/known-amendments.md#clawback
+[Clawback transaction]: /docs/references/protocol/transactions/types/clawback.md
+[Clawback transactions]: /docs/references/protocol/transactions/types/clawback.md
+[Clawbackトランザクション]: /docs/references/protocol/transactions/types/clawback.md
 [Credentials amendment]: /resources/known-amendments.md#credentials
 [CredentialCreate transaction]: /docs/references/protocol/transactions/types/credentialcreate.md
 [CredentialCreate transactions]: /docs/references/protocol/transactions/types/credentialcreate.md
@@ -79,6 +82,8 @@
 [CredentialDelete transactions]: /docs/references/protocol/transactions/types/credentialdelete.md
 [CredentialDelete]: /docs/references/protocol/transactions/types/credentialdelete.md
 [CredentialDeleteトランザクション]: /docs/references/protocol/transactions/types/credentialdelete.md
+[Credential entry]: /docs/references/protocol/ledger-data/ledger-entry-types/credential
+[Credentialエントリ]: /docs/references/protocol/ledger-data/ledger-entry-types/credential
 [Crypto-Conditions Specification]: https://tools.ietf.org/html/draft-thomas-crypto-conditions-04
 [CryptoConditions amendment]: /resources/known-amendments.md#cryptoconditions
 [CryptoConditionsSuite amendment]: /resources/known-amendments.md#cryptoconditionssuite
@@ -292,6 +297,9 @@
 [XChainAddAccountCreateAttestation transactions]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
 [XChainAddAccountCreateAttestation]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
 [XChainAddAccountCreateAttestationトランザクション]: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
+[XChainAddClaimAttestation transaction]: /docs/references/protocol/transactions/types/xchainaddclaimattestation.md
+[XChainAddClaimAttestation transactions]: /docs/references/protocol/transactions/types/xchainaddclaimattestation.md
+[XChainAddClaimAttestationトランザクション]: /docs/references/protocol/transactions/types/xchainaddclaimattestation.md
 [XChainBridge amendment]: /resources/known-amendments.md#xchainbridge
 [XChainCreateBridge transaction]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
 [XChainCreateBridge transactions]: /docs/references/protocol/transactions/types/xchaincreatebridge.md
@@ -301,6 +309,7 @@
 [XChainCreateClaimID transactions]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
 [XChainCreateClaimID]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
 [XChainCreateClaimIDトランザクション]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
+[XChainOwnedClaimID entry]: /docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid
 [XRP, in drops]: /docs/references/protocol/data-types/basic-data-types.md#specifying-currency-amounts
 [XRPFees amendment]: /resources/known-amendments.md#xrpfees
 [XRP、drop単位]: /docs/references/protocol/data-types/basic-data-types.md#通貨額の指定

--- a/docs/concepts/decentralized-storage/credentials.md
+++ b/docs/concepts/decentralized-storage/credentials.md
@@ -53,3 +53,5 @@ All three parties need XRP Ledger accounts. The flow works as follows:
 Importantly, the documents that Alice sends to Isabel can include personally identifiable or private information that's needed to verify Alice's identity, but this information is never published or stored on the blockchain and Verity does not need to see it. Also, other businesses that trust Isabel can accept the same credentials so Alice does not need to repeatedly re-verify for every party she wants to interact with.
 
 To revoke a credential, Isabel can delete it from the ledger. Alice can also delete her own credentials.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -860,13 +860,13 @@ Currently, the inner object template isn't set upon object creation. If the obje
 
 This amendment standardizes the way inner objects ([Object-type fields in the canonical binary format](../docs/references/protocol/binary-format.md#object-fields)) have their formats and default values enforced. This is the same type of check that the `fixInnerObjTemplate` applies to AMM-related fields, but this amendment applies to all other types of inner objects, namely:
 
-- `DisabledValidator` field of the [NegativeUNL ledger entry][].
-- Members of the `Majorities` array in the [Amendments ledger entry][].
+- `DisabledValidator` field of the [NegativeUNL entry][].
+- Members of the `Majorities` array in the [Amendments entry][].
 - Members of the [`Signers` array](../docs/references/protocol/transactions/common-fields.md#signers-field) of multi-signed transactions.
-- Members of the `SignerEntries` array of [SignerList ledger entries][].
+- Members of the `SignerEntries` array of [SignerList ledger entries][SignerList entry].
 - Several parts of the [XChainBridge][] amendment {% not-enabled /%}:
-    - Members of the `XChainClaimAttestations` array in [XChainOwnedClaimID ledger entries][]
-    - Members of the `XChainCreateAccountAttestations` array in [XChainOwnedCreateAccountClaimID ledger entries][]
+    - Members of the `XChainClaimAttestations` array in [XChainOwnedClaimID ledger entries][XChainOwnedClaimID entry]
+    - Members of the `XChainCreateAccountAttestations` array in [XChainOwnedCreateAccountClaimID ledger entries][XChainOwnedCreateAccountClaimID entry]
     - Members of the `XChainClaimAttestationBatch` array in [XChainAddClaimAttestation transactions][]
     - Members of the `XChainCreateAccountAttestationBatch` array in [XChainAddClaimAttestation transactions][]
 
@@ -932,7 +932,7 @@ This amendment has no effect unless the [NonFungibleTokensV1][] amendment is ena
 
 This amendment fixes a bug that can cause NFT directories to have missing links in the middle of the directory chain. It also introduces invariant checks that can prevent similar types of corruption from occurring in the future, and introduces a new transaction type:
 
-- [LedgerStateFix transactions][] can be used to repair corruptions in ledger data. With this amendment enabled, you can use a LedgerStateFix transaction to repair a broken link in NFT directories. In the case that future bugs cause new types of ledger corruption, this transaction type can be extended to repair the other types of corruption as well.
+- **LedgerStateFix transactions** <!-- TODO: link when docs have been added --> can be used to repair corruptions in ledger data. With this amendment enabled, you can use a LedgerStateFix transaction to repair a broken link in NFT directories. In the case that future bugs cause new types of ledger corruption, this transaction type can be extended to repair the other types of corruption as well.
 
 Without this amendment, it is possible in specific circumstances to delete the last page of an NFT directory, then later create a new last page that is missing a link to the previous page. For a detailed description of the scenario that can cause this problem, see [PR #4945](https://github.com/XRPLF/rippled/pull/4945). With this amendment, the bug that caused that corruption is fixed; additionally, a new invariant check ensures that other bugs cannot remove the last page inappropriately.
 


### PR DESCRIPTION
Fix several cases where reference-style links were not being parsed properly and were showing up with square brackets visible in the text instead, including:

- Known Amendments page:
    - several in fixInnerObjTemplate2 amendment description
    - [[LedgerStateFix transactions][] link in the fixNFTokenPageLinks amendment description
- [Credential entry][] link in the `ledger_entry` API method page
- [Credentials amendment][] link in the Credentials concept page
