### PR TITLE
Fix minor issues with Code Samples

### DIFF
--- a/@theme/plugins/code-samples.js
+++ b/@theme/plugins/code-samples.js
@@ -28,7 +28,7 @@ export function codeSamples() {
           samples.push({
             path: dirPath,
             title: title || toTitleCase(dirname(dirPath)),
-            description: getInnerText([data.ast.children[1]]).replace(title, '').trim(),
+            description: getInnerText([data.ast.children[1]]).trim(),
             href: joinPath('content', dirPath),
             langs,
           });

--- a/_code-samples/build-a-browser-wallet/README.md
+++ b/_code-samples/build-a-browser-wallet/README.md
@@ -1,3 +1,3 @@
 # Build a Browser Wallet
 
-Implement a non-custodial wallet application that runs on in a web browser and can check an account's balances, send XRP, and notify when the account receives incoming transactions.
+Implement a non-custodial wallet application that runs in a web browser and can check an account's balances, send XRP, and notify when the account receives incoming transactions.

--- a/_code-samples/did/README.md
+++ b/_code-samples/did/README.md
@@ -1,3 +1,3 @@
 # Create, Update, and Delete Decentralized Identifiers (DIDs)
 
-Create, Update, and Delete Decentralized Identifiers (DIDs). A Decentralized Identifier (DID) is a new type of identifier defined by the World Wide Web Consortium (W3C) that enables verifiable, digital identities.
+Create, update, and delete decentralized identifiers (DIDs). A Decentralized Identifier (DID) is a new type of identifier defined by the World Wide Web Consortium (W3C) that enables verifiable, digital identities.

--- a/_code-samples/price_oracles/README.md
+++ b/_code-samples/price_oracles/README.md
@@ -1,3 +1,3 @@
 # Create, Update, and Delete Price Oracles
 
-Create, Update, and Delete Price Oracles. A price oracle is a mechanism that feeds external data, such as asset prices, and exchange rates, onto the XRPLedger.
+Create, update, and delete Price Oracles. A price oracle is a mechanism that feeds external data, such as asset prices, and exchange rates, onto the XRPLedger.

--- a/resources/code-samples.page.tsx
+++ b/resources/code-samples.page.tsx
@@ -29,7 +29,7 @@ export default function CodeSamples() {
   const { codeSamples, langs } = usePageSharedData<any>('code-samples');
 
   return (
-    <div className="landing page-community">
+    <main className="landing page-code-samples">
       <div className="">
         <section className="py-26">
           <div className="col-lg-8 mx-auto text-lg-center">
@@ -126,6 +126,6 @@ export default function CodeSamples() {
           </div>
         </section>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
- Remov a "feature" where the description gets deleted if it matches the title exactly (due to how our plugin finds the text of the README).
    | Before | After |
    |---|---|
    | ![price oracles description starts with '. '](https://github.com/user-attachments/assets/1c43a2b6-9068-42d0-8609-ab8ac4f573a7) | ![price oracles code sample has the correct description](https://github.com/user-attachments/assets/4e8a1bd6-4812-42ca-81aa-68f45e560df3) |
- Changed the top level of the Code Sampels layout to be a `<main>` element, which allows some styles to apply correctly and also helps the search crawler find the contents of the page.
    - The text now (correctly) does not turn purple when a card is hovered.
- Changed a couple code sample descriptions that had weird casing or typos.