### PR TITLE
Fix tiny typo and update package reference

### DIFF
--- a/@l10n/ja/docs/infrastructure/troubleshooting/server-wont-start.md
+++ b/@l10n/ja/docs/infrastructure/troubleshooting/server-wont-start.md
@@ -68,7 +68,7 @@ Aborted (core dumped)
 
 - `rippled`ユーザが読み取ることができる構成ファイルを`$HOME/.config/ripple/rippled.cfg`に作成します（`$HOME`は`rippled`ユーザのホームディレクトリを指しています）。
 
-    {% admonition type="success" name="ヒント" %}`rippled`リポジトリには、RPMのインストール時にデフォルトの構成として提供される[`rippled.cfg`サンプルファイル](https://github.com/XRPLF/rippled/blob/master/cfg/rippled-example.cfg)が含まれています。このファイルがない場合は、上記のリンク先からコピーできます。{% /admonition %}
+    {% admonition type="success" name="ヒント" %}`rippled`リポジトリには、パケージのインストール時にデフォルトの構成として提供される[`rippled.cfg`サンプルファイル](https://github.com/XRPLF/rippled/blob/master/cfg/rippled-example.cfg)が含まれています。このファイルがない場合は、上記のリンク先からコピーできます。{% /admonition %}
 
 - `--conf`[コマンドラインオプション](../commandline-usage.md)を使用して、使用する構成ファイルのパスを指定します。
 
@@ -86,7 +86,7 @@ Aborted (core dumped)
 
 - `validators.txt`ファイルが存在し、`rippled`ユーザにこのファイルの読み取り権限があることを確認します。
 
-    {% admonition type="success" name="ヒント" %}`rippled`リポジトリには、RPMのインストール時にデフォルトの構成として提供される[`validators.txt`サンプルファイル](https://github.com/XRPLF/rippled/blob/master/cfg/validators-example.txt)が含まれています。このファイルがない場合は、上記のリンク先からコピーできます。{% /admonition %}
+    {% admonition type="success" name="ヒント" %}`rippled`リポジトリには、パケージのインストール時にデフォルトの構成として提供される[`validators.txt`サンプルファイル](https://github.com/XRPLF/rippled/blob/master/cfg/validators-example.txt)が含まれています。このファイルがない場合は、上記のリンク先からコピーできます。{% /admonition %}
 
 - `rippled.cfg`ファイルを編集し、`[validators_file]`設定を変更して、`validators.txt`ファイル（またはこれに相当するファイル）の正しいパスを指定します。ファイル名の前後に余分な空白があるかどうかを確認します。
 

--- a/@l10n/ja/docs/infrastructure/troubleshooting/server-wont-start.md
+++ b/@l10n/ja/docs/infrastructure/troubleshooting/server-wont-start.md
@@ -84,7 +84,7 @@ Aborted (core dumped)
 
 考えられる解決策:
 
-- `[validators.txt]`ファイルが存在し、`rippled`ユーザにこのファイルの読み取り権限があることを確認します。
+- `validators.txt`ファイルが存在し、`rippled`ユーザにこのファイルの読み取り権限があることを確認します。
 
     {% admonition type="success" name="ヒント" %}`rippled`リポジトリには、RPMのインストール時にデフォルトの構成として提供される[`validators.txt`サンプルファイル](https://github.com/XRPLF/rippled/blob/master/cfg/validators-example.txt)が含まれています。このファイルがない場合は、上記のリンク先からコピーできます。{% /admonition %}
 

--- a/docs/infrastructure/troubleshooting/server-wont-start.md
+++ b/docs/infrastructure/troubleshooting/server-wont-start.md
@@ -69,7 +69,7 @@ Possible solutions:
 
 - Create a config file that can be read by the `rippled` user at `$HOME/.config/ripple/rippled.cfg` (where `$HOME` points to the `rippled` user's home directory).
 
-    {% admonition type="success" name="Tip" %}The `rippled` repository contains [an example `rippled.cfg` file](https://github.com/XRPLF/rippled/blob/master/cfg/rippled-example.cfg) which is provided as the default config when you do an RPM installation. If you do not have the file, you can copy it from there.{% /admonition %}
+    {% admonition type="success" name="Tip" %}The `rippled` repository contains [an example `rippled.cfg` file](https://github.com/XRPLF/rippled/blob/master/cfg/rippled-example.cfg) which is provided as the default config when you do an installation from a binary package. If you do not have the file, you can copy it from there.{% /admonition %}
 
 - Specify the path to your preferred config file using the `--conf` [commandline option](../commandline-usage.md).
 
@@ -85,9 +85,9 @@ Aborted (core dumped)
 
 Possible solutions:
 
-- Check that the `[validators.txt]` file exists and the `rippled` user has permissions to read it.
+- Check that the `validators.txt` file exists and the `rippled` user has permissions to read it.
 
-    {% admonition type="success" name="Tip" %}The `rippled` repository contains [an example `validators.txt` file](https://github.com/XRPLF/rippled/blob/master/cfg/validators-example.txt) which is provided as the default config when you do an RPM installation. If you do not have the file, you can copy it from there.{% /admonition %}
+    {% admonition type="success" name="Tip" %}The `rippled` repository contains [an example `validators.txt` file](https://github.com/XRPLF/rippled/blob/master/cfg/validators-example.txt) which is provided as the default config when you do an installation from a binary package. If you do not have the file, you can copy it from there.{% /admonition %}
 
 - Edit your `rippled.cfg` file and modify the `[validators_file]` setting to have the correct path to your `validators.txt` (or equivalent) file. Check for extra whitespace before or after the filename.
 


### PR DESCRIPTION
1. Just a reference to the `validators.txt` file that makes it look like a non-existent `rippled.cfg` key.
2. Updating the fact that we provide more than just rpm packages.