### PR TITLE
1838 - Add limit response field in account_lines

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines.md
@@ -419,6 +419,7 @@ The response follows the [standard format][], with a successful result containin
 | `ledger_index`         | Integer - [Ledger Index][] | _(Omitted if `ledger_current_index` provided instead)_ The ledger index of the ledger version that was used when retrieving this data. |
 | `ledger_hash`          | String - [Hash][]          | _(May be omitted)_ The identifying hash the ledger version that was used when retrieving this data. |
 | `marker`               | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. Omitted when there are no additional pages after this one. |
+|`limit`                 | Unsigned Integer           | The maximum number of trust lines retrieved. The server may return fewer than the specified limit, even if more results are available. If no limit was specified in the request, this defaults to 200. |
 
 Each trust line object has some combination of the following fields:
 
@@ -427,8 +428,8 @@ Each trust line object has some combination of the following fields:
 | `account`        | String           | The unique [Address][] of the counterparty to this trust line. |
 | `balance`        | String           | Representation of the numeric balance currently held against this line. A positive balance means that the perspective account holds value; a negative balance means that the perspective account owes value. |
 | `currency`       | String           | A [Currency Code][] identifying what currency this trust line can hold. |
-| `limit`          | String           | The maximum amount of the given currency that this account is willing to owe the peer account |
-| `limit_peer`     | String           | The maximum amount of currency that the counterparty account is willing to owe the perspective account |
+| `limit`          | String           | The maximum amount of the given currency that this account is willing to owe the peer account. |
+| `limit_peer`     | String           | The maximum amount of currency that the counterparty account is willing to owe the perspective account. |
 | `quality_in`     | Unsigned Integer | Rate at which the account values incoming balances on this trust line, as a ratio of this value per 1 billion units. (For example, a value of 500 million represents a 0.5:1 ratio.) As a special case, 0 is treated as a 1:1 ratio. |
 | `quality_out`    | Unsigned Integer | Rate at which the account values outgoing balances on this trust line, as a ratio of this value per 1 billion units. (For example, a value of 500 million represents a 0.5:1 ratio.) As a special case, 0 is treated as a 1:1 ratio. |
 | `no_ripple`      | Boolean          | _(May be omitted)_ If `true`, this account has enabled the [No Ripple flag](../../../../concepts/tokens/fungible-tokens/rippling.md) for this trust line. If present and `false`, this account has disabled the No Ripple flag, but, because the account also has the Default Ripple flag disabled, that is not considered [the default state](../../../protocol/ledger-data/ledger-entry-types/ripplestate.md#contributing-to-the-owner-reserve). If omitted, the account has the No Ripple flag disabled for this trust line and Default Ripple enabled. {% badge href="https://github.com/XRPLF/rippled/releases/tag/1.7.0" %}Updated in: rippled 1.7.0{% /badge %} |


### PR DESCRIPTION
Adds the missing `limit` field in top level response object.