### PR TITLE
clarify infra doc

### DIFF
--- a/docs/infrastructure/installation/capacity-planning.md
+++ b/docs/infrastructure/installation/capacity-planning.md
@@ -176,7 +176,7 @@ Memory requirements are mainly a function of the `node_size` configuration setti
 
 #### Network
 
-Any enterprise or carrier-class data center should have enough network bandwidth to support running XRP Ledger servers. The actual bandwidth necessary varies significantly based on the current transaction volume in the network. Server behavior (such as backfilling [ledger history](../../concepts/networks-and-servers/ledger-history.md)) also affects network use. Consumer-grade home internet is generally not enough to run a reliable server.
+Any enterprise or carrier-class data center should have enough network bandwidth to support running XRP Ledger servers. The actual bandwidth necessary varies significantly based on the current transaction volume in the network. Server behavior (such as backfilling [ledger history](../../concepts/networks-and-servers/ledger-history.md)) also affects network use.
 
 During exceptionally high periods of transaction volume, some operators have reported that their servers have completely saturated a 100 megabit/s network link, so a gigabit network interface is required for reliable performance.
 

--- a/docs/infrastructure/installation/system-requirements.md
+++ b/docs/infrastructure/installation/system-requirements.md
@@ -13,7 +13,7 @@ labels:
 For reliable performance in production environments, it is recommended to run an XRP Ledger (`rippled`) server on bare metal with the following characteristics or better:
 
 - Operating System: Ubuntu (LTS), Red Hat Enterprise Linux (latest release), or a compatible Linux distribution.
-- CPU: 64-bit x86_64, 8+ cores.
+- CPU: 3+ GHz 64-bit x86_64 processor with 8+ cores.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
 - RAM: 64 GB.
 - Network: Enterprise data center network with a gigabit network interface on the host.

--- a/docs/infrastructure/installation/system-requirements.md
+++ b/docs/infrastructure/installation/system-requirements.md
@@ -13,7 +13,7 @@ labels:
 For reliable performance in production environments, it is recommended to run an XRP Ledger (`rippled`) server on bare metal with the following characteristics or better:
 
 - Operating System: Ubuntu (LTS), Red Hat Enterprise Linux (latest release), or a compatible Linux distribution.
-- CPU: Intel Xeon 3+ GHz processor with 8+ cores and hyperthreading enabled.
+- CPU: 64-bit x86_64, 8+ cores.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
 - RAM: 64 GB.
 - Network: Enterprise data center network with a gigabit network interface on the host.


### PR DESCRIPTION
New members of the XRPL Infra community pointed out not clear documentation wording. 

1. removed explicit CPU brand naming (Intel XEON )
2. removed wording suggesting uncertainty of home networks suitable for rippled.