### PR TITLE
Fix `account_tx` fields

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
@@ -80,7 +80,6 @@ The request includes the following parameters:
 | `limit`            | Integer                                    | _(Optional)_ Default varies. Limit the number of transactions to retrieve. The server is not required to honor this value. |
 | `marker`           | [Marker][] | Value from a previous paginated response. Resume retrieving data where that response left off. This value is stable even if there is a change in the server's range of available ledgers. |
 
-- You must use at least one of the following fields in your request: `ledger_index`, `ledger_hash`, `ledger_index_min`, or `ledger_index_max`.
 - [API v2]: If you specify either `ledger_index` or `ledger_hash`, including `ledger_index_min` and `ledger_index_max` returns an `invalidParams` error.
 
 

--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
@@ -440,6 +440,7 @@ The response follows the [standard format][], with a successful result containin
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
+| `validated` | Boolean | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 {% admonition type="info" name="Note" %}The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.{% /admonition %}
 
@@ -469,6 +470,7 @@ Each transaction object includes the following fields, depending on whether it w
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
+| `validated` | Boolean | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 {% admonition type="info" name="Note" %}The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.{% /admonition %}
 

--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
@@ -439,8 +439,6 @@ The response follows the [standard format][], with a successful result containin
 | `ledger_index_max` | Integer - [Ledger Index][] | The ledger index of the most recent ledger actually searched for transactions. |
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
-| `meta`             | Object (JSON)              | (JSON mode) The transaction results metadata in JSON. |
-| `meta_blob`        | String (Binary)            | (Binary mode) The transaction results metadata as a hex string. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
 | `validated`        | Boolean                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
@@ -456,6 +454,8 @@ Each transaction object includes the following fields, depending on whether it w
 | `ledger_index`   | Integer         | The [ledger index][] of the ledger version that included this transaction. |
 | `tx_json`        | Object (JSON)   | (JSON mode) JSON object defining the transaction. |
 | `tx_blob`        | String (Binary) | (Binary mode) A unique hex string defining the transaction. |
+| `meta`           | Object (JSON)   | (JSON mode) The transaction results metadata in JSON. |
+| `meta_blob`      | String (Binary) | (Binary mode) The transaction results metadata as a hex string. |
 | `validated`      | Boolean         | Whether or not the transaction is included in a validated ledger. Any transaction not yet in a validated ledger is subject to change. |
 
 {% /tab %}

--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
@@ -440,7 +440,6 @@ The response follows the [standard format][], with a successful result containin
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
-| `validated`        | Boolean                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 {% admonition type="info" name="Note" %}The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.{% /admonition %}
 
@@ -469,9 +468,7 @@ Each transaction object includes the following fields, depending on whether it w
 | `ledger_index_max` | Integer - [Ledger Index][] | The ledger index of the most recent ledger actually searched for transactions. |
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
-| `meta`       | Object (JSON) or String (Binary) | If `binary` is `true`, then this is a hex string of the transaction results metadata. Otherwise, the transaction results metadata is included in JSON format. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
-| `validated`        | Boolean                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 {% admonition type="info" name="Note" %}The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.{% /admonition %}
 
@@ -482,6 +479,7 @@ Each transaction object includes the following fields, depending on whether it w
 | `ledger_index` | Integer                          | The [ledger index][] of the ledger version that included this transaction. |
 | `tx`           | Object                           | (JSON mode) JSON object defining the transaction. |
 | `tx_blob`      | String                           | (Binary mode) Hex string representing the transaction. |
+| `meta`         | Object (JSON) or String (Binary) | If `binary` is `true`, then this is a hex string of the transaction results metadata. Otherwise, the transaction results metadata is included in JSON format. |
 | `validated`    | Boolean                          | Whether or not the transaction is included in a validated ledger. Any transaction not yet in a validated ledger is subject to change. |
 
 {% /tab %}

--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx.md
@@ -440,7 +440,7 @@ The response follows the [standard format][], with a successful result containin
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
-| `validated` | Boolean | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
+| `validated`        | Boolean                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 {% admonition type="info" name="Note" %}The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.{% /admonition %}
 
@@ -470,7 +470,7 @@ Each transaction object includes the following fields, depending on whether it w
 | `limit`            | Integer                    | The `limit` value used in the request. (This may differ from the actual limit value enforced by the server.) |
 | `marker`           | [Marker][]                 | Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
 | `transactions`     | Array                      | Array of transactions matching the request's criteria, as explained below. |
-| `validated` | Boolean | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
+| `validated`        | Boolean                    | If included and set to `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
 
 {% admonition type="info" name="Note" %}The server may respond with different values of `ledger_index_min` and `ledger_index_max` than you provided in the request, for example if it did not have the versions you specified on hand.{% /admonition %}
 


### PR DESCRIPTION
This PR removes one statement in the `account_tx` description:
```
You must use at least one of the following fields in your request: `ledger_index`, `ledger_hash`, `ledger_index_min`, or `ledger_index_max`.
```

This statement is false, as evidenced by this query: https://xrpl.org/resources/dev-tools/websocket-api-tool?server=wss%3A%2F%2Fs1.ripple.com%2F&req=%7B%20%20%22command%22%3A%20%22account_tx%22%2C%0A%20%20%22account%22%3A%20%22rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn%22%0A%7D

It also moves the `meta` and `meta_blob` fields to the correct places.