### PR TITLE
Add missing and latest Clio release notes to blog site

### DIFF
--- a/blog/2024/clio-2.3.0.md
+++ b/blog/2024/clio-2.3.0.md
@@ -1,0 +1,178 @@
+---
+category: 2024
+date: 2024-12-12
+seo:
+    title: Introducing Clio version 2.3.0
+    description: Version 2.3.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds new features and bug fixes.
+labels:
+    - Clio Release Notes
+markdown:
+    editPage:
+        hide: true
+---
+
+## Introducing Clio version 2.3.0
+
+Version 2.3.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds new features and bug fixes.
+
+## Notable New Features
+
+- [AmendmentCenter: central place to query amendment-related data](https://github.com/XRPLF/clio/pull/1418)
+- [`ledger_index` API: returns latest closed ledger index before the given date](https://github.com/XRPLF/clio/pull/1503)
+- [More verbose forwarding errors](https://github.com/XRPLF/clio/pull/1523)
+- [Native `feature` API](https://github.com/XRPLF/clio/pull/1526)
+- [Add `force_forward` field in requests](https://github.com/XRPLF/clio/pull/1647)
+- [Cache on `server_info` API](https://github.com/XRPLF/clio/pull/1671)
+
+## Amendment Support
+
+The following amendments have been introduced since Clio 2.2.5 and have transaction model changes. Clio 2.3.0 is built with `libxrpl` 2.3.0, which supports these amendments.
+
+- [AMMClawback](https://xrpl.org/resources/known-amendments#ammclawback)
+- [Credentials](https://xrpl.org/resources/known-amendments#credentials)
+- [MPTokensV1](https://xrpl.org/resources/known-amendments#mptokensv1)
+- [NFTokenMintOffer](https://xrpl.org/resources/known-amendments#nftokenmintoffer)
+
+If these amendments are enabled and you have not upgraded Clio to 2.3.0 or newer, the ETL will be amendment blocked and new ledgers will not be processed.
+
+To check the current voting status of these amendments on Mainnet, see the [XRPL Amendments Dashboard](https://livenet.xrpl.org/amendments).
+
+## Install / Upgrade
+
+| Package |
+|:--------|
+| [Clio server Linux package](https://github.com/XRPLF/clio/releases/download/2.3.0/clio_server_Linux.zip) |
+
+For other platforms, please [build from source](https://github.com/XRPLF/clio/releases/tag/2.3.0). The most recent commit in the git log should be:
+
+```text
+Author: Alex Kremer <akremer@ripple.com>
+Date:   Tue Sep 10 22:33:11 2024 +0100
+
+    fix: Add upper bound to limit
+```
+
+## What's Changed
+
+See the [Full Changelog on GitHub](https://github.com/XRPLF/clio/compare/2.2.5...2.3.0).
+
+### Features
+
+- AmendmentCenter [(#1418)](https://github.com/XRPLF/clio/pull/1418)
+- Ledger index [(#1503)](https://github.com/XRPLF/clio/pull/1503)
+- More verbose forwarding errors [(#1523)](https://github.com/XRPLF/clio/pull/1523)
+- Native Feature RPC [(#1526)](https://github.com/XRPLF/clio/pull/1526)
+- Add stop to WorkQueue [(#1600)](https://github.com/XRPLF/clio/pull/1600)
+- Move/copy support in async framework [(#1609)](https://github.com/XRPLF/clio/pull/1609)
+- Delete-before support in data removal tool [(#1649)](https://github.com/XRPLF/clio/pull/1649)
+- Add `force_forward` field to request [(#1647)](https://github.com/XRPLF/clio/pull/1647)
+- Server info cache [(#1671)](https://github.com/XRPLF/clio/pull/1671)
+- ETLng Registry [(#1713)](https://github.com/XRPLF/clio/pull/1713)
+- Upgrade to `libxrpl 2.3.0-rc1` [(#1718)](https://github.com/XRPLF/clio/pull/1718)
+- Implement MPT changes [(#1147)](https://github.com/XRPLF/clio/pull/1147)
+- Add Support Credentials for Clio [(#1712)](https://github.com/XRPLF/clio/pull/1712)
+- Upgrade to `libxrpl 2.3.0-rc2` [(#1736)](https://github.com/XRPLF/clio/pull/1736)
+
+### Bug Fixes
+
+- Duplicate messages when subscribe both accounts and proposed_accounts ([#1415](https://github.com/XRPLF/clio/pull/1415))
+- Remove unused file ([#1496](https://github.com/XRPLF/clio/pull/1496))
+- Fix extra brackets in warnings ([#1519](https://github.com/XRPLF/clio/pull/1519))
+- Fix the ledger_index timezone issue ([#1522](https://github.com/XRPLF/clio/pull/1522))
+- Change the field name from "close_time_iso" to "closed ([#1531](https://github.com/XRPLF/clio/pull/1531))
+- Compatible `feature` response ([#1539](https://github.com/XRPLF/clio/pull/1539))
+- Relax error when `full` or `accounts` set to `false` ([#1540](https://github.com/XRPLF/clio/pull/1540))
+- Add more account check ([#1543](https://github.com/XRPLF/clio/pull/1543))
+- Support deleted object in ledger_entry ([#1483](https://github.com/XRPLF/clio/pull/1483))
+- Fail to deduplicate the same nfts in `ttNFTOKEN_CANCEL_OFFER` ([#1542](https://github.com/XRPLF/clio/pull/1542))
+- Static linkage ([#1551](https://github.com/XRPLF/clio/pull/1551))
+- NftData unique bug ([#1550](https://github.com/XRPLF/clio/pull/1550))
+- LedgerEntryNotExist unittest failure ([#1564](https://github.com/XRPLF/clio/pull/1564))
+- Remove cassandra from log ([#1557](https://github.com/XRPLF/clio/pull/1557))
+- Account_objects returns error when filter does not make sense ([#1579](https://github.com/XRPLF/clio/pull/1579))
+- Use doxygen 1.12 ([#1587](https://github.com/XRPLF/clio/pull/1587))
+- Support conan channels in `check_libxrpl` flow ([#1583](https://github.com/XRPLF/clio/pull/1583))
+- AccountNFT with invalid marker ([#1589](https://github.com/XRPLF/clio/pull/1589))
+- Not forward admin API ([#1628](https://github.com/XRPLF/clio/pull/1628))
+- Fix logging in SubscriptionSource ([#1617](https://github.com/XRPLF/clio/pull/1617)) ([#1632](https://github.com/XRPLF/clio/pull/1632))
+- Subscription source bugs fix ([#1626](https://github.com/XRPLF/clio/pull/1626)) ([#1633](https://github.com/XRPLF/clio/pull/1633))
+- Don't forward ledger API if 'full' is a string ([#1640](https://github.com/XRPLF/clio/pull/1640))
+- Add more restrictions to admin fields ([#1643](https://github.com/XRPLF/clio/pull/1643))
+- No restriction on type field ([#1644](https://github.com/XRPLF/clio/pull/1644))
+- Pre-push tag ([#1614](https://github.com/XRPLF/clio/pull/1614))
+- Upgrade Cassandra driver ([#1646](https://github.com/XRPLF/clio/pull/1646))
+- Add no lint to ignore clang-tidy ([#1660](https://github.com/XRPLF/clio/pull/1660))
+- Workaround for gcc12 bug with defaulted destructors ([#1666](https://github.com/XRPLF/clio/pull/1666))
+- Deletion script will not OOM ([#1679](https://github.com/XRPLF/clio/pull/1679))
+- Remove log ([#1694](https://github.com/XRPLF/clio/pull/1694))
+- Example config syntax ([#1696](https://github.com/XRPLF/clio/pull/1696))
+- Fix timer spurious calls ([#1700](https://github.com/XRPLF/clio/pull/1700))
+- Fix issues clang-tidy found ([#1708](https://github.com/XRPLF/clio/pull/1708))
+- Add queue size limit for websocket ([#1701](https://github.com/XRPLF/clio/pull/1701))
+- Support Delete NFT ([#1695](https://github.com/XRPLF/clio/pull/1695))
+- Credential error message ([#1738](https://github.com/XRPLF/clio/pull/1738))
+- Authorized_credential elements in array not objects bug ([#1744](https://github.com/XRPLF/clio/pull/1744)) ([#1747](https://github.com/XRPLF/clio/pull/1747))
+- Add upper bound to limit
+
+### Refactor
+
+- Structure global validators better ([#1484](https://github.com/XRPLF/clio/pull/1484))
+- Separate fixtures ([#1495](https://github.com/XRPLF/clio/pull/1495))
+- Refactor main ([#1555](https://github.com/XRPLF/clio/pull/1555))
+- Clio Config ([#1544](https://github.com/XRPLF/clio/pull/1544))
+- Move interval timer into a separate class ([#1588](https://github.com/XRPLF/clio/pull/1588))
+- Create interface for DOSGuard ([#1602](https://github.com/XRPLF/clio/pull/1602))
+- Subscription Manager uses async framework ([#1605](https://github.com/XRPLF/clio/pull/1605))
+- Remove SubscriptionManagerRunner ([#1623](https://github.com/XRPLF/clio/pull/1623))
+- Clio Config ([#1593](https://github.com/XRPLF/clio/pull/1593))
+- Coroutine based webserver ([#1699](https://github.com/XRPLF/clio/pull/1699))
+
+### Documentation
+
+- Mention conventional commits ([#1490](https://github.com/XRPLF/clio/pull/1490))
+- Use non-admin WS port ([#1592](https://github.com/XRPLF/clio/pull/1592))
+- Document how to build with custom libxrpl ([#1572](https://github.com/XRPLF/clio/pull/1572))
+
+### Testing
+
+- Add more tests for warnings ([#1532](https://github.com/XRPLF/clio/pull/1532))
+- Make ForwardingSource tests more stable ([#1607](https://github.com/XRPLF/clio/pull/1607))
+- Add test for WsConnection for ping response ([#1619](https://github.com/XRPLF/clio/pull/1619))
+
+### Miscellaneous Tasks
+
+- Added conventional commits check ([#1487](https://github.com/XRPLF/clio/pull/1487))
+- Upgrade to libxrpl 2.3.0-b1 ([#1489](https://github.com/XRPLF/clio/pull/1489))
+- Add permissions to pr title check workflow ([#1491](https://github.com/XRPLF/clio/pull/1491))
+- Turn off PR labelling ([#1492](https://github.com/XRPLF/clio/pull/1492))
+- Clio docker image ([#1509](https://github.com/XRPLF/clio/pull/1509))
+- Fix nightly ([#1514](https://github.com/XRPLF/clio/pull/1514))
+- Fix bugs in nightly docker publishing ([#1520](https://github.com/XRPLF/clio/pull/1520))
+- Setup dependabot for github-actions ([#1556](https://github.com/XRPLF/clio/pull/1556))
+- Update clang-format and ccache ([#1559](https://github.com/XRPLF/clio/pull/1559))
+- Bump peter-evans/create-pull-request from 5 to 6 ([#1560](https://github.com/XRPLF/clio/pull/1560))
+- Bump crazy-max/ghaction-import-gpg from 5 to 6 ([#1561](https://github.com/XRPLF/clio/pull/1561))
+- Bump actions/configure-pages from 4 to 5 ([#1562](https://github.com/XRPLF/clio/pull/1562))
+- Bump wandalen/wretry.action from 1.4.10 to 3.5.0 ([#1563](https://github.com/XRPLF/clio/pull/1563))
+- Fix errors in docker image uploading ([#1570](https://github.com/XRPLF/clio/pull/1570))
+- Fix nightly release workflow ([#1577](https://github.com/XRPLF/clio/pull/1577))
+- Bump peter-evans/create-pull-request from 6 to 7 ([#1636](https://github.com/XRPLF/clio/pull/1636))
+- Revert Cassandra driver upgrade ([#1656](https://github.com/XRPLF/clio/pull/1656))
+- Update libxrpl to 2.3.0-b4 ([#1667](https://github.com/XRPLF/clio/pull/1667))
+- Apply commits for `2.3.0-b4` ([#1725](https://github.com/XRPLF/clio/pull/1725))
+- Bump ytanikin/PRConventionalCommits from 1.2.0 to 1.3.0 ([#1670](https://github.com/XRPLF/clio/pull/1670))
+- Upgrade to llvm 19 tooling ([#1681](https://github.com/XRPLF/clio/pull/1681))
+- Remove unused static variables ([#1683](https://github.com/XRPLF/clio/pull/1683))
+- Add counter for total messages waiting to be sent ([#1691](https://github.com/XRPLF/clio/pull/1691))
+- Fix nightly build ([#1709](https://github.com/XRPLF/clio/pull/1709))
+- Bump wandalen/wretry.action from 3.5.0 to 3.7.0 ([#1714](https://github.com/XRPLF/clio/pull/1714))
+- Bump wandalen/wretry.action from 3.7.0 to 3.7.2 ([#1723](https://github.com/XRPLF/clio/pull/1723))
+- Add relevant changes from develop ([#1762](https://github.com/XRPLF/clio/pull/1762))
+
+
+## Feedback
+
+The Clio open-source project is seeking feedback and engagement from the XRPL community.
+
+- To provide feedback, please [fill out this survey](https://forms.gle/fnGPTUCAdmEzkFy57).
+- To report an issue or propose a new idea, please [open an issue](https://github.com/XRPLF/clio/issues).

--- a/blog/2025/clio-2.3.1.md
+++ b/blog/2025/clio-2.3.1.md
@@ -1,0 +1,58 @@
+---
+category: 2025
+date: 2025-02-12
+seo:
+    title: Introducing Clio version 2.3.1
+    description: Version 2.3.1 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds bug fixes.
+labels:
+    - Clio Release Notes
+markdown:
+    editPage:
+        hide: true
+---
+
+## Introducing Clio version 2.3.1
+
+Version 2.3.1 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds bug fixes.
+
+## Bug fixes
+
+- Update `libxrpl` to 2.3.1 by @kuznetsss in [#1866](https://github.com/XRPLF/clio/pull/1866).
+- Remove `InvalidHotWallet` error from `gateway_balances` RPC handler by @nkramer44 in [#1830](https://github.com/XRPLF/clio/pull/1830).
+- Fix `gateway_balance` discrepancy by @cindyyan317 in [#1839](https://github.com/XRPLF/clio/pull/1839)
+
+## Install / Upgrade
+
+| Package  |
+| :------- |
+| [Clio Server Linux Release (GCC)](https://github.com/XRPLF/clio/releases/download/2.3.1/clio_server_Linux_Release_gcc.zip) |
+| [Clio Server macOS Release (Apple Clang 15)](https://github.com/XRPLF/clio/releases/download/2.3.1/clio_server_macOS_Release_apple_clang_15.zip) |
+
+For other platforms, please [build from source](https://github.com/XRPLF/clio/releases/tag/2.3.1). The most recent commit in the git log should be:
+
+```text
+Merge: 47c0a6a2 8a418bfe
+Author: Sergey Kuznetsov <skuznetsov@ripple.com>
+Date:   Tue Feb 4 17:10:12 2025 +0000
+
+    fix: gateway_balance discrepancy  (#1839) (#1874)
+
+    Port of #1839 into 2.3.1.
+    Fixes #1832.
+
+    rippled code:
+
+
+    https://github.com/XRPLF/rippled/blob/develop/src/xrpld/rpc/handlers/GatewayBalances.cpp#L129
+```
+
+## What's Changed
+
+See the [Full Changelog on GitHub](https://github.com/XRPLF/clio/compare/2.3.0...2.3.1).
+
+## Feedback
+
+The Clio open-source project is seeking feedback and engagement from the XRPL community.
+
+- To provide feedback, please [fill out this survey](https://forms.gle/fnGPTUCAdmEzkFy57).
+- To report an issue or propose a new idea, please [open an issue](https://github.com/XRPLF/clio/issues).

--- a/blog/2025/clio-2.4.0.md
+++ b/blog/2025/clio-2.4.0.md
@@ -102,7 +102,7 @@ See the [Full Changelog on GitHub](https://github.com/XRPLF/clio/compare/2.3.1..
 | Package  |
 | :------- |
 | [Clio Server Linux Release (GCC)](https://github.com/XRPLF/clio/releases/download/2.4.0/clio_server_Linux_Release_gcc_2.4.0.zip) |
-| [Clio Server macOS Release (Apple Clang 16)](https://github.com/XRPLF/clio/releases/download/2.4.0/clio_server_Linux_Release_gcc_2.4.0.zip) |
+| [Clio Server macOS Release (Apple Clang 16)](https://github.com/XRPLF/clio/releases/download/2.4.0/clio_server_macOS_Release_apple_clang_16_2.4.0.zip) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/clio/releases/tag/2.4.0). The most recent commit in the git log should be:
 
@@ -116,7 +116,4 @@ Date:   Thu Mar 13 17:02:52 2025 +0000
 
 ## Feedback
 
-The Clio open-source project is seeking feedback and engagement from the XRPL community.
-
-- To provide feedback, please [fill out this survey](https://forms.gle/fnGPTUCAdmEzkFy57).
-- To report an issue or propose a new idea, please [open an issue](https://github.com/XRPLF/clio/issues).
+To report an issue or propose a new idea, please [open an issue](https://github.com/XRPLF/clio/issues).

--- a/blog/2025/clio-2.4.0.md
+++ b/blog/2025/clio-2.4.0.md
@@ -1,0 +1,122 @@
+---
+category: 2025
+date: 2025-03-18
+seo:
+    title: Introducing Clio version 2.4.0
+    description: Version 2.4.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds bug fixes.
+labels:
+    - Clio Release Notes
+markdown:
+    editPage:
+        hide: true
+---
+
+## Introducing Clio version 2.4.0
+
+Version 2.4.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds bug fixes.
+
+## Notable New Features
+
+- [Refactor of Clio config and generation of config descriptions](https://github.com/XRPLF/clio/blob/develop/docs/configure-clio.md)
+- [Snapshot exporting tool](https://github.com/XRPLF/clio/pull/1877)
+- [Expose ledger cache full and disabled to prometheus](https://github.com/XRPLF/clio/pull/1957)
+
+## Amendment Support
+
+The following amendments have been introduced since Clio 2.3.1 and have transaction model changes. Clio 2.4.0 is built with `libxrpl` 2.4.0, which supports these amendments.
+
+- [DynamicNFT](https://xrpl.org/resources/known-amendments#dynamicnft)
+- [PermissionedDomains](https://xrpl.org/resources/known-amendments#permissioneddomains)
+- [DeepFreeze](https://xrpl.org/resources/known-amendments#deepfreeze)
+- [fixFrozenLPTokenTransfer](https://xrpl.org/resources/known-amendments#fixfrozenlptokentransfer)
+
+If these amendments are enabled and you have not upgraded Clio to 2.4.0 or newer, the ETL will be amendment blocked and new ledgers will not be processed.
+
+To check the current voting status of these amendments on Mainnet, see the [XRPL Amendments Dashboard](https://livenet.xrpl.org/amendments).
+
+## What's Changed
+
+See the [Full Changelog on GitHub](https://github.com/XRPLF/clio/compare/2.3.1...2.4.0).
+
+### Features
+
+- Add Conan profiles for common Sanitizers to docker ci image ([#1856](https://github.com/XRPLF/clio/pull/1856)) by [@godexsoft](https://github.com/godexsoft)
+- ETLng task manager ([#1843](https://github.com/XRPLF/clio/pull/1843)) by [@godexsoft](https://github.com/godexsoft)
+- Support Dynamic NFT ([#1525](https://github.com/XRPLF/clio/pull/1525)) by [@cindyyan317](https://github.com/cindyyan317)
+- Permissioned domains ([#1841](https://github.com/XRPLF/clio/pull/1841)) by [@kuznetsss](https://github.com/kuznetsss)
+- Run tests with sanitizers in CI ([#1879](https://github.com/XRPLF/clio/pull/1879)) by [@godexsoft](https://github.com/godexsoft)
+- Generate config descriptions ([#1842](https://github.com/XRPLF/clio/pull/1842)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Support Simulate ([#1891](https://github.com/XRPLF/clio/pull/1891)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Snapshot exporting tool ([#1877](https://github.com/XRPLF/clio/pull/1877)) by [@cindyyan317](https://github.com/cindyyan317)
+- ETLng monitor ([#1898](https://github.com/XRPLF/clio/pull/1898)) by [@godexsoft](https://github.com/godexsoft)
+- LPT freeze ([#1840](https://github.com/XRPLF/clio/pull/1840)) by [@shawnxie999](https://github.com/shawnxie999)
+- Add workflow to check config description ([#1894](https://github.com/XRPLF/clio/pull/1894)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Add support for deep freeze ([#1875](https://github.com/XRPLF/clio/pull/1875)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Implement and use LedgerCacheInterface ([#1955](https://github.com/XRPLF/clio/pull/1955)) by [@godexsoft](https://github.com/godexsoft)
+- Expose ledger cache full and disabled to prometheus ([#1957](https://github.com/XRPLF/clio/pull/1957)) by [@kuznetsss](https://github.com/kuznetsss)
+
+### Bug Fixes
+
+- CacheLoader causes crash when no cache is used ([#1853](https://github.com/XRPLF/clio/pull/1853)) by [@kuznetsss](https://github.com/kuznetsss)
+- Re-add account_tx max limit ([#1855](https://github.com/XRPLF/clio/pull/1855)) by [@godexsoft](https://github.com/godexsoft)
+- Array parsing in new config ([#1884](https://github.com/XRPLF/clio/pull/1884)) by [@kuznetsss](https://github.com/kuznetsss)
+- Array parsing in new config ([#1896](https://github.com/XRPLF/clio/pull/1896)) by [@kuznetsss](https://github.com/kuznetsss)
+- Better errors on logger init failure ([#1857](https://github.com/XRPLF/clio/pull/1857)) by [@kuznetsss](https://github.com/kuznetsss)
+- Fix backtrace usage ([#1932](https://github.com/XRPLF/clio/pull/1932)) by [@kuznetsss](https://github.com/kuznetsss)
+- Data race in new webserver ([#1926](https://github.com/XRPLF/clio/pull/1926)) by [@kuznetsss](https://github.com/kuznetsss)
+- Fix dangling reference in new web server ([#1938](https://github.com/XRPLF/clio/pull/1938)) by [@kuznetsss](https://github.com/kuznetsss)
+- Change math/rand to crypto/rand ([#1941](https://github.com/XRPLF/clio/pull/1941)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Improve error message when starting read only mode with empty DB ([#1946](https://github.com/XRPLF/clio/pull/1946)) by [@kuznetsss](https://github.com/kuznetsss)
+- Fix url check in config ([#1953](https://github.com/XRPLF/clio/pull/1953)) by [@kuznetsss](https://github.com/kuznetsss)
+
+### Refactor
+
+- Use mutex from utils ([#1851](https://github.com/XRPLF/clio/pull/1851)) by [@kuznetsss](https://github.com/kuznetsss)
+- Remove boost filesystem ([#1859](https://github.com/XRPLF/clio/pull/1859)) by [@PeterChen13579](https://github.com/PeterChen13579)
+
+### Documentation
+
+- Move metrics and static analysis docs ([#1864](https://github.com/XRPLF/clio/pull/1864)) by [@maria-robobug](https://github.com/maria-robobug)
+
+### Styling
+
+- Use error code instead of exception when parsing json ([#1942](https://github.com/XRPLF/clio/pull/1942)) by [@kuznetsss](https://github.com/kuznetsss)
+
+### Testing
+
+- Add non-admin test for simulate ([#1893](https://github.com/XRPLF/clio/pull/1893)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Add assert mock to avoid death tests ([#1947](https://github.com/XRPLF/clio/pull/1947)) by [@kuznetsss](https://github.com/kuznetsss)
+
+### Miscellaneous Tasks
+
+- Fix issue found by clang-tidy ([#1849](https://github.com/XRPLF/clio/pull/1849)) by [@kuznetsss](https://github.com/kuznetsss)
+- Fix error in grafana dashboard example ([#1878](https://github.com/XRPLF/clio/pull/1878)) by [@kuznetsss](https://github.com/kuznetsss)
+- Revert workflow names ([#1890](https://github.com/XRPLF/clio/pull/1890)) by [@godexsoft](https://github.com/godexsoft)
+- Upload cache only for develop branch ([#1897](https://github.com/XRPLF/clio/pull/1897)) by [@kuznetsss](https://github.com/kuznetsss)
+- Use ubuntu latest for some ci jobs ([#1939](https://github.com/XRPLF/clio/pull/1939)) by [@kuznetsss](https://github.com/kuznetsss)
+- Update libxrpl ([#1943](https://github.com/XRPLF/clio/pull/1943)) by [@PeterChen13579](https://github.com/PeterChen13579)
+- Upgrade libxrpl to 2.4.0 ([#1961](https://github.com/XRPLF/clio/pull/1961)) by [@kuznetsss](https://github.com/kuznetsss)
+
+## Install / Upgrade
+
+| Package  |
+| :------- |
+| [Clio Server Linux Release (GCC)](https://github.com/XRPLF/clio/releases/download/2.4.0/clio_server_Linux_Release_gcc_2.4.0.zip) |
+| [Clio Server macOS Release (Apple Clang 16)](https://github.com/XRPLF/clio/releases/download/2.4.0/clio_server_Linux_Release_gcc_2.4.0.zip) |
+
+For other platforms, please [build from source](https://github.com/XRPLF/clio/releases/tag/2.4.0). The most recent commit in the git log should be:
+
+```text
+Merge: 5e7ff66b 67e451ec
+Author: Sergey Kuznetsov <skuznetsov@ripple.com>
+Date:   Thu Mar 13 17:02:52 2025 +0000
+
+    chore: Commits for 2.4.0-rc2 (#1964)
+```
+
+## Feedback
+
+The Clio open-source project is seeking feedback and engagement from the XRPL community.
+
+- To provide feedback, please [fill out this survey](https://forms.gle/fnGPTUCAdmEzkFy57).
+- To report an issue or propose a new idea, please [open an issue](https://github.com/XRPLF/clio/issues).

--- a/blog/sidebars.yaml
+++ b/blog/sidebars.yaml
@@ -6,14 +6,17 @@
     - group: '2025'
       expanded: false
       items:
+        - page: 2025/clio-2.4.0.md
         - page: 2025/rippled-2.4.0.md
         - page: 2025/move-to-the-new-xrpl-foundation-commences.md
+        - page: 2025/clio-2.3.1.md
         - page: 2025/rippled-2.3.1.md
         - page: 2025/devnet-reset.md
         - page: 2025/vulnerabilitydisclosurereport-bug-nov2024.md
     - group: '2024'
       expanded: false
       items:
+        - page: 2024/clio-2.3.0.md
         - page: 2024/lower-reserves-are-in-effect.md
         - page: 2024/a-new-era-for-the-xrp-ledger.md
         - page: 2024/rippled-2.3.0.md


### PR DESCRIPTION
- Adds the following missing Clio release notes:
  - `2.3.0`
  - `2.3.1`

- Adds the latest Clio release `2.4.0`
