### PR TITLE
Update XRPLF UNL migration comms

### DIFF
--- a/blog/2025/move-to-the-new-xrpl-foundation-commences.md
+++ b/blog/2025/move-to-the-new-xrpl-foundation-commences.md
@@ -19,23 +19,12 @@ Late last year the initial groundwork for the launch of the new XRPL Foundation 
 
 The migration includes the transition of the Unique Node List (UNL) published by the old XRPL Foundation to the new XRPL Foundation. Importantly, any validators and node operators that rely on the old UNL will need to update their configurations to reflect the new Foundation’s infrastructure.
 
-To ensure continued network participation and avoid potential downtime, validators and node operators must take this action **by Monday, March 10, 2025**.
+In order to maintain continuous network participation and prevent downtime, validators and node operators will receive additional instructions via various channels to increase awareness.
 
 ### Why this Transition Matters
 
 Throughout its history, the XRPL Foundation has played a critical role in maintaining the security and decentralized status of the XRPL by publishing a trusted UNL. Validators and node operators are able to contribute to maintaining an up-to-date, secure, and well-managed network by updating their configurations to the new UNL, ensuring a smoother and more reliable blockchain infrastructure.
 
-### Required Actions for Validators and Node Operators
+The transition to the new XRPL Foundation marks an important step in ensuring the continued stability and security of the XRPL network. Validators and node operators play a pivotal role in this process, their participation is crucial for maintaining a robust and decentralized infrastructure. 
 
-Ahead of the migration date, validators and node operators need to take the following actions:
-
-1. Update their configuration to reflect the new cryptographic public key provided by the new Foundation.
-2. Restart their node to apply the updated configuration.
-
-Failure to complete these actions may result in network disruptions, impacting connectivity and participation in consensus processes. 
-
-Detailed instructions of the actions validators and node operators are required to take will be communicated soon.
-
-The transition to the new XRPL Foundation marks an important step in ensuring the continued stability and security of the XRPL network. Validators and node operators play a pivotal role in this process, and their timely action is crucial for maintaining a robust and decentralized infrastructure. 
-
-As the migration from the old to the new Foundation progresses, additional support and updates will be provided on XRPL.org to ensure a seamless transition for all participants.
+As the migration from the old to the new Foundation progresses, additional support and updates will be provided on XRPL.org to ensure a seamless transition for all participants throughput the process.


### PR DESCRIPTION
March 10th is upcoming which was set as the migration date. A new migration plan with detailed description and comms campaign seems to be in the works. 

To ensure operators are served with date and urgency neutral comms i updated the blog post. Subject to changes once the plans above are ready to announce.

