### PR TITLE
Fix dead link in rate-limiting.md

### DIFF
--- a/docs/references/http-websocket-apis/api-conventions/rate-limiting.md
+++ b/docs/references/http-websocket-apis/api-conventions/rate-limiting.md
@@ -46,7 +46,7 @@ Server is overloaded
 ```
 
 ## Rate Per Request
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/resource/Fees.h "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/libxrpl/resource/Fees.cpp "Source")
 
 The server calculates a client's usage rate based on the number of requests made over time, and weighs different types of requests based on approximately how much work the server must do to serve them. Follow-up messages from the server for the [subscribe method][] and [path_find method][] also count towards a client's usage rate.
 


### PR DESCRIPTION
The source link for the 'Rate Per Request' section links to a non-extant file. Update to nearest contemporaneous equivalent.