### PR TITLE
Add a faucet link

### DIFF
--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -832,6 +832,7 @@ resources.dev-tool.faucet.content.part4: これらの資金は
 resources.dev-tool.faucet.content.part5: テストのみ
 resources.dev-tool.faucet.content.part6: を目的としています。テストネットワークの履歴と残高は必要に応じてリセットされます。Devnetは警告なしにリセットされることがあります。
 resources.dev-tool.faucet.content.part7: これらのネットワーク上のすべての残高とXRPは、メインネットとは別のものです。安全のため、テストネットやDevnetの認証情報をメインネットで使用しないでください。
+resources.dev-tool.faucet.content.part8: "以下のツールは、認証情報を生成して即座にチャージします。既存のアドレスにチャージしたい場合は、こちらで行えます:"
 "Choose Network:": "ネットワークを選択:"
 Mainnet-like network for testing applications.: アプリケーションのテスト用のメインネットに似たネットワーク。
 Preview of upcoming amendments.: 今後のAmendmentのプレビューネットワーク。

--- a/resources/dev-tools/xrp-faucets.page.tsx
+++ b/resources/dev-tools/xrp-faucets.page.tsx
@@ -88,7 +88,16 @@ export default function XRPFaucets(): React.JSX.Element {
                 <p>{translate("resources.dev-tool.faucet.content.part1", "These ")}<Link to="../../docs/concepts/networks-and-servers/parallel-networks">{translate("resources.dev-tool.faucet.content.part2", "parallel XRP Ledger test networks")}</Link> {translate("resources.dev-tool.faucet.content.part3", "provide platforms for testing changes to the XRP Ledger and software built on it, without using real funds.")}</p>
                 <p>{translate("resources.dev-tool.faucet.content.part4", "These funds are intended for")} <strong>{translate("resources.dev-tool.faucet.content.part5", "testing")}</strong> {translate("resources.dev-tool.faucet.content.part6", "only. Test networks' ledger history and balances are reset as necessary. Devnets may be reset without warning.")}</p>
                 <p>{translate("resources.dev-tool.faucet.content.part7", "All balances and XRP on these networks are separate from Mainnet. As a precaution, do not use the Testnet or Devnet credentials on the Mainnet.")}</p>
-
+                <p>
+                  {translate("resources.dev-tool.faucet.content.part8", "The tool below will generate credentials for you and recharge it immediately; if you want to top up an already existing address, you can do it here:")}
+                  {' '}
+                  <a
+                    className="external-link"
+                    href="https://test.xrplexplorer.com/faucet"
+                    target="_blank"
+                   >test.xrplexplorer.com/faucet</a>
+                </p>
+                
                 <h3>{translate("Choose Network:")}</h3>
                 { faucets.map((net) => (
                 <div className="form-check" key={"network-" + net.shortName}>


### PR DESCRIPTION
Adds the last paragraph with the link to a faucet, where devs can recharge the existing addresses. 

<img width="791" alt="Screenshot 2025-03-22 at 20 56 29" src="https://github.com/user-attachments/assets/6c365109-8aea-4937-8822-556f724dc1b4" />
