### PR TITLE
Update dependencies & fix some bugs in JS code

### DIFF
--- a/docs/tutorials/how-tos/use-tokens/issue-a-fungible-token.md
+++ b/docs/tutorials/how-tos/use-tokens/issue-a-fungible-token.md
@@ -1,9 +1,6 @@
 ---
-html: issue-a-fungible-token.html
-parent: use-tokens.html
 seo:
     description: Create your own token and issue it on the XRP Ledger Testnet.
-embed_xrpl_js: true
 filters:
   - interactive_steps
 labels:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/view": "^6.22.2",
         "@docsearch/react": "^3.8.0",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.115.0",
+        "@redocly/realm": "0.119.1",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -26,7 +26,7 @@
         "react18-json-view": "^0.2.6",
         "smol-toml": "^1.3.1",
         "use-query-params": "^2.2.1",
-        "xrpl": "^4.0.0"
+        "xrpl": "^4.2.0"
       },
       "devDependencies": {
         "bootstrap": "^4.6.2",
@@ -272,11 +272,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -345,11 +347,12 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -416,9 +419,10 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -436,17 +440,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -460,37 +466,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
-      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.4"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -500,11 +494,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -514,9 +509,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
-      "integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -525,13 +521,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -555,13 +552,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -640,9 +637,9 @@
       }
     },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.2.tgz",
-      "integrity": "sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz",
+      "integrity": "sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -854,9 +851,10 @@
       "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
-      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -864,7 +862,8 @@
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
@@ -912,7 +911,8 @@
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -989,9 +989,9 @@
       "license": "MIT"
     },
     "node_modules/@hookstate/core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@hookstate/core/-/core-4.0.1.tgz",
-      "integrity": "sha512-Uh2D8Z0z/pqOJ7t+SfC+2sj13JQcB4yFhtL+T1choCaBxTSlgOS/CKRBohgJ4cjTKoxOmTT8uSQysu3gUjX+Gw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hookstate/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-DTyb4fKk8GCwKFCVoF/2v1qnvs9rEB2Rc9ZH5eh1LRNemUVnC41Vuy6d8UGqQSA0PIUk3DRPzlOA0QQKONpSmQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0 || ^18.0.0"
@@ -1062,6 +1062,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -1083,9 +1089,9 @@
       "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
     },
     "node_modules/@lezer/css": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.9.tgz",
-      "integrity": "sha512-TYwgljcDv+YrV0MZFFvYFQHCfGgbPMR6nuqLabBdmZoFH3EP1gvw8t0vae326Ne3PszQkbXfVBjCnf3ZVCr0bA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.11.tgz",
+      "integrity": "sha512-FuAnusbLBl1SEAtfN8NdShxYJiESKw9LAFysfea1T96jD3ydBn12oYjaSG1a04BQRIUd93/0D8e5CV1cUMkmQg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -1154,14 +1160,15 @@
       }
     },
     "node_modules/@markdoc/markdoc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.4.0.tgz",
-      "integrity": "sha512-fSh4P3Y4E7oaKYc2oNzSIJVPDto7SMzAuQN1Iyx53UxzleA6QzRdNWRxmiPqtVDaDi5dELd2yICoG91csrGrAw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.5.1.tgz",
+      "integrity": "sha512-W2apYOglq0hOnvWbhE70yl6V9++FG+YPFKNHmgiSjv0HTmdJaMLt+NA1LMqoH5LasSiTI7R0yVc5ofjaFh39Pg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.7.0"
       },
       "optionalDependencies": {
+        "@types/linkify-it": "^3.0.1",
         "@types/markdown-it": "12.2.3"
       },
       "peerDependencies": {
@@ -1667,6 +1674,24 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
+      "license": "MIT"
+    },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
@@ -1684,23 +1709,23 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.1.tgz",
-      "integrity": "sha512-TYiTDtuItiv95YMsrRxyCs1HKLrDPtTvpaD3+kDKXBnFDeJuYKZ+eHXpCr6YeN4inxfVBs7DLhHsQcs9srddyQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
       "license": "MIT"
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.7.14.tgz",
-      "integrity": "sha512-/23o5U735PyUl4iTs8WfKDzc0JfS+WJf33yMw6SN7//ufUhnW/1X46s6bzAnWUqiFFepsjTmwg1D2qEMz/HmUA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.8.0.tgz",
+      "integrity": "sha512-Id2cTwdgZBfVceM90ByTKl2AQ6ggtuFVJQVq7jPaWFAgfFFnpaF61K9tLML/JoQ14rSPdsgASsGYzG+w/pEDqQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.20.0",
+        "@redocly/config": "0.22.0",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15"
       },
       "peerDependencies": {
-        "@redocly/theme": "^0.48.0",
+        "@redocly/theme": "^0.51.0-next.0",
         "graphql": "^16.9.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
@@ -1708,20 +1733,14 @@
         "styled-components": "^5.3.11"
       }
     },
-    "node_modules/@redocly/graphql-docs/node_modules/@redocly/config": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.0.tgz",
-      "integrity": "sha512-JECdp+JE04YsOQXnFKu1BP1H81yhpHOJhK8hYJje5yVh5gxZyw901rjWU/KSiZYrCsuBISjZSlDXnwHwKj5VcA==",
-      "license": "MIT"
-    },
     "node_modules/@redocly/mock-server": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.2.5.tgz",
-      "integrity": "sha512-v/h2hDCoDdsSMQRF0dkSyJ0YHA+CI4e6K9RzfvPX75oQWjQc7y2+ZgUebXP9s5hKo9B3lj2w0ilEWBNe2gZZiw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.2.8.tgz",
+      "integrity": "sha512-OB3TZu0p1Vnmwm+Upv9AydgA5drtz5tzXTjLNShzqfBg3FfpwM7iqSfZM0ze7fHyaam7nJ2nWUhhyJNbkjseQw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.11.2",
-        "@redocly/openapi-core": "1.26.1",
+        "@redocly/openapi-core": "1.31.1",
         "ajv": "8.17.1",
         "ajv-formats": "^2.1.1",
         "js-yaml": "4.1.0",
@@ -1732,98 +1751,31 @@
         "yargs": "^17.5.1"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/config": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.17.1.tgz",
-      "integrity": "sha512-CEmvaJuG7pm2ylQg53emPmtgm4nW2nxBgwXzbVEHpGas/lGnMyN8Zlkgiz6rPw0unASg6VW3wlz27SOL5XFHYQ==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.26.1.tgz",
-      "integrity": "sha512-xRuVZqMVRFzqjbUCpOTra4tbnmQMWsya996omZMV3WgD084Z6OWB3FXflhAp93E/yAmbWlWZpddw758AyoaLSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.17.0",
-        "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.4",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^5.0.1",
-        "node-fetch": "^2.6.1",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=14.19.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/mock-server/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.27.1.tgz",
-      "integrity": "sha512-zQ47/A+Drk2Y75/af69MD3Oad4H9LxkUDzcm7XBkyLNDKIWQrDKDnS5476oDq77+zciymNxgMVtxxVXlnGS8kw==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.31.1.tgz",
+      "integrity": "sha512-FoTmi+iA6NGXk6rZpX6QvmEqbApbJgYC6soLj3zfx0f/1M4vUff5GuOEC24GWj7rN0vNx5E6eUx59h0M4sjRnQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.17.0",
+        "@redocly/config": "^0.20.1",
         "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "minimatch": "^5.0.1",
-        "node-fetch": "^2.6.1",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
       "engines": {
-        "node": ">=14.19.0",
-        "npm": ">=7.0.0"
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.17.1.tgz",
-      "integrity": "sha512-CEmvaJuG7pm2ylQg53emPmtgm4nW2nxBgwXzbVEHpGas/lGnMyN8Zlkgiz6rPw0unASg6VW3wlz27SOL5XFHYQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.3.tgz",
+      "integrity": "sha512-Nyyv1Bj7GgYwj/l46O0nkH1GTKWbO3Ixe7KFcn021aZipkZd+z8Vlu1BwkhqtVgivcKaClaExtWU/lDHkjBzag==",
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/colorette": {
@@ -1844,36 +1796,16 @@
         "node": ">=10"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.5.18.tgz",
-      "integrity": "sha512-PxamA0+Efqy9K/mCCIkjqTwqj3Uy+YGAHKx6Ou1dFbFidCZfYagG2RSUnsi1pZm4JGuwU3pz5inExhUt1WDKUQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.7.0.tgz",
+      "integrity": "sha512-DpZchce0qTtSL4BHxKLwaXI3hsnyddv2VatOxDyqVr5phWngm+NmurkWWtT2aeOGtPAB8BhZdOO4xjcn1Q6KaQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@markdoc/markdoc": "0.4.0",
-        "@redocly/config": "0.20.1",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/replay": "0.9.0",
+        "@markdoc/markdoc": "0.5.1",
+        "@redocly/config": "0.22.0",
+        "@redocly/openapi-core": "1.31.1",
+        "@redocly/replay": "0.10.0",
         "deepmerge": "^4.2.2",
         "dompurify": "2.5.4",
         "fast-deep-equal": "^3.1.3",
@@ -1891,7 +1823,8 @@
         "tslib": "^2.2.0",
         "url": "~0.11.0",
         "url-template": "^2.0.8",
-        "util": "~0.12.5"
+        "util": "~0.12.5",
+        "web-vitals": "3.3.1"
       },
       "bin": {
         "openapi-docs": "bin.js"
@@ -1901,7 +1834,7 @@
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "@redocly/theme": ">=0.9.4",
+        "@redocly/theme": ">=0.51.0-next.0",
         "core-js": "^3.1.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -1909,9 +1842,10 @@
       }
     },
     "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.1.1.tgz",
-      "integrity": "sha512-Q7AAZf3vNbtzuqG5D2RvKf5P2FWgWdqlClWbjbfCoEeq6yRnZe/cDpD/TYDV4NSyRCc0Zf4J4NwgvcgLEw6BVw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.2.0.tgz",
+      "integrity": "sha512-7bpwgN7odHd/WB6po+bOSRxiVjlVe48W9uQnTvoZcAu7H/8Sw9LiaCONlcPaJ7eBirtbPWY0QVvbeuw2dsQjWw==",
+      "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "highlight-words-core": "^1.2.2",
         "react": "^17.0.0 || ^18.0.0",
@@ -1921,26 +1855,26 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.3.70",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.3.70.tgz",
-      "integrity": "sha512-5mUeq+id0AGiigUCix7W8Z2yWfwZlhKa45jfGdwu0eBL0BFX0I/H7cWqJyQ02zm+5fWmIT0HQBSA9041G7dQVg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.4.0.tgz",
+      "integrity": "sha512-9qlHWvWTpp9PKAG7+OYoi1I1da5smdINrNuw4HwwWIW4IrkGX4IvxNzS4mENAVWrXeVAdvn2jmNgH8IlGHTGIA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.20.1",
-        "@redocly/mock-server": "0.2.5",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/openapi-docs": "3.5.18"
+        "@redocly/config": "0.22.0",
+        "@redocly/mock-server": "0.2.8",
+        "@redocly/openapi-core": "1.31.1",
+        "@redocly/openapi-docs": "3.7.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.115.0.tgz",
-      "integrity": "sha512-fB38SdOHMYZ9SKc6wsszfTG0bOz78+i+on7+VNgcghUqyAAMIZG1rT5fJSAw7jT5BHefYTitjBny+zG7px6thw==",
+      "version": "0.119.1",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.119.1.tgz",
+      "integrity": "sha512-troNNqmH3N57pCONpjw1cxrZx5TfemStVcYKVv7g/WuRu2ndiXn3nkfMsW/vA7VuQL0G2fNSb3zc+b9siMiylw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
         "@cocalc/ansi-to-react": "7.0.0",
-        "@markdoc/markdoc": "0.4.0",
+        "@markdoc/markdoc": "0.5.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-zone": "1.26.0",
         "@opentelemetry/core": "1.26.0",
@@ -1955,14 +1889,13 @@
         "@opentelemetry/sdk-trace-web": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.20.1",
-        "@redocly/graphql-docs": "0.7.14",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/openapi-docs": "3.5.18",
-        "@redocly/portal-legacy-ui": "0.1.1",
-        "@redocly/portal-plugin-mock-server": "0.3.70",
-        "@redocly/theme": "0.48.0",
-        "@redocly/xml-crypto": "3.0.1",
+        "@redocly/config": "0.22.0",
+        "@redocly/graphql-docs": "0.8.0",
+        "@redocly/openapi-core": "1.31.1",
+        "@redocly/openapi-docs": "3.7.0",
+        "@redocly/portal-legacy-ui": "0.2.0",
+        "@redocly/portal-plugin-mock-server": "0.4.0",
+        "@redocly/theme": "0.51.0",
         "@shikijs/transformers": "^1.22.2",
         "@tanstack/react-query": "5.62.3",
         "@wojtekmaj/react-datetimerange-picker": "5.0.2",
@@ -2012,7 +1945,10 @@
         "typesense": "1.8.2",
         "ulid": "^2.3.0",
         "web-vitals": "3.3.1",
+        "workerpool": "9.2.0",
         "ws": "^8.17.1",
+        "xml-crypto": "6.0.1",
+        "xpath": "0.0.34",
         "yaml-ast-parser": "0.0.43"
       },
       "bin": {
@@ -2081,9 +2017,9 @@
       }
     },
     "node_modules/@redocly/replay": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.9.0.tgz",
-      "integrity": "sha512-EVA0QZ+wjX/PVARlfIhIK+IQ571PN1so2xg0KFUEZ/MzXNNiz7vebIJhBGf+20I19Q6KyqWt/dfusadFcZ7Yzg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.10.0.tgz",
+      "integrity": "sha512-KH0gu+v359lvpaqzMRB5rAlIclkDxvKHfhemqFOI0sD8xBwJvX68VAf4pya/xM8UoubY4L3XgQfCn8BB5k2ExQ==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.15.0",
         "@codemirror/lang-html": "^6.4.7",
@@ -2104,14 +2040,17 @@
         "crypto-js": "^4.2.0",
         "dayjs": "^1.11.7",
         "js-yaml": "4.1.0",
+        "jszip": "3.10.1",
         "marked": "^4.0.15",
         "rc-tooltip": "^6.1.3",
+        "react-arborist": "3.4.0",
         "react-resizable-panels": "^1.0.9",
         "react-select": "5.8.1",
-        "styled-components": "^5.3.11"
+        "styled-components": "^5.3.11",
+        "use-resize-observer": "^9.1.0"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.48.0",
+        "@redocly/theme": "0.51.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.21.1",
@@ -2119,25 +2058,27 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.48.0.tgz",
-      "integrity": "sha512-zY5W1GQN3tMHJD5Ms/8idNGDXgyzVmhQVieZl91jV4yaXG0gIMtwy3B0L+zHgxvSly9wGOGFlh6T8cIhQ7SSeA==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.51.0.tgz",
+      "integrity": "sha512-/EFQWrO8qMxvw7B9uoUVk84hWzasfaSsv3JQnCcSB7TE31j7K7xOJlMzDZPQC80s/zdRYskKW6wGRCMpZpZbOw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.20.0",
+        "@redocly/config": "0.22.0",
         "copy-to-clipboard": "3.3.3",
         "file-saver": "2.0.5",
         "highlight-words-core": "1.2.2",
         "hotkeys-js": "3.10.1",
         "i18next": "22.4.15",
         "jszip": "3.10.1",
+        "lodash.debounce": "4.0.8",
+        "lodash.throttle": "4.1.1",
         "nprogress": "0.2.0",
         "react-calendar": "4.2.1",
         "react-date-picker": "10.0.3",
         "timeago.js": "4.0.2"
       },
       "peerDependencies": {
-        "@markdoc/markdoc": "0.4.0",
+        "@markdoc/markdoc": "0.5.1",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "react": "^17.0.0 || ^18.0.0",
@@ -2147,10 +2088,10 @@
         "styled-system": "^5.1.5"
       }
     },
-    "node_modules/@redocly/theme/node_modules/@redocly/config": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.0.tgz",
-      "integrity": "sha512-JECdp+JE04YsOQXnFKu1BP1H81yhpHOJhK8hYJje5yVh5gxZyw901rjWU/KSiZYrCsuBISjZSlDXnwHwKj5VcA==",
+    "node_modules/@redocly/theme/node_modules/highlight-words-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
       "license": "MIT"
     },
     "node_modules/@redocly/vscode-json-languageservice": {
@@ -2163,18 +2104,6 @@
         "vscode-languageserver-textdocument": "^1.0.0-next.4",
         "vscode-languageserver-types": "^3.15.0-next.6",
         "vscode-uri": "^2.1.1"
-      }
-    },
-    "node_modules/@redocly/xml-crypto": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@redocly/xml-crypto/-/xml-crypto-3.0.1.tgz",
-      "integrity": "sha512-qtZUNLi5QUjbY8oIWbw/73MYJb00+iB1LfYIbAJsb3ZP7cHrAppRgHjYmjdrOrJ6Kz24z03ywN4oFQflEO4tHQ==",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.3",
-        "xpath": "0.0.32"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2411,6 +2340,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
       "integrity": "sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2420,6 +2350,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.1.5.tgz",
       "integrity": "sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2429,6 +2360,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.1.2.tgz",
       "integrity": "sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2438,6 +2370,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.1.2.tgz",
       "integrity": "sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1"
@@ -2447,12 +2380,14 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
       "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@styled-system/flexbox": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.1.2.tgz",
       "integrity": "sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2462,6 +2397,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.1.2.tgz",
       "integrity": "sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2471,6 +2407,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.1.2.tgz",
       "integrity": "sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2480,6 +2417,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.1.2.tgz",
       "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2489,6 +2427,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.1.2.tgz",
       "integrity": "sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2498,6 +2437,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
       "integrity": "sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2507,6 +2447,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.1.2.tgz",
       "integrity": "sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
@@ -2516,6 +2457,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.5.tgz",
       "integrity": "sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2",
@@ -2582,9 +2524,9 @@
       }
     },
     "node_modules/@tauri-apps/plugin-fs/node_modules/@tauri-apps/api": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.2.0.tgz",
-      "integrity": "sha512-R8epOeZl1eJEl603aUMIGb4RXlhPjpgxbGVEaqY+0G5JG9vzV/clNlzTeqc+NLYXVqXcn8mb4c5b9pJIUDEyAg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.4.0.tgz",
+      "integrity": "sha512-F1zXTsmwcCp+ocg6fbzD/YL0OHeSG1eynCag1UNlX2tD5+dlXy7eRbTu9cAcscPjcR7Nix7by2wiv/+VfWUieg==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -2631,9 +2573,9 @@
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
       "license": "MIT",
       "optional": true
     },
@@ -2752,21 +2694,21 @@
       }
     },
     "node_modules/@uiw/codemirror-theme-material": {
-      "version": "4.23.7",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.23.7.tgz",
-      "integrity": "sha512-PSuPTPMA4/a6tiBmeAPLlxl98Ehk9D7WYab419PW664eHdzziTU6v9uqZ+nEtJvAwb7E5m2la+DhTndvttdiQA==",
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.23.10.tgz",
+      "integrity": "sha512-RN+K7Vc/qea+ky5w0KVCtfwfVqtedicOMKxeBu/fs82tyU5Q5oQ2UlS5Y94Sv05BRkHYluOvMwypUwWkSq2q6g==",
       "license": "MIT",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.23.7"
+        "@uiw/codemirror-themes": "4.23.10"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/@uiw/codemirror-theme-material/node_modules/@uiw/codemirror-themes": {
-      "version": "4.23.7",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.23.7.tgz",
-      "integrity": "sha512-UNf1XOx1hG9OmJnrtT86PxKcdcwhaNhbrcD+nsk8WxRJ3n5c8nH6euDvgVPdVLPwbizsaQcZTILACgA/FjRpVg==",
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.23.10.tgz",
+      "integrity": "sha512-dU0UgEEgEXCAYpxuVDQ6fovE82XsqgHZckTJOH6Bs8xCi3Z7dwBKO4pXuiA8qGDwTOXOMjSzfi+pRViDm7OfWw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -2871,10 +2813,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/@xmldom/is-dom-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3023,17 +2975,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3141,6 +3082,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
       "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.5",
@@ -3171,6 +3113,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3290,9 +3233,9 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3303,13 +3246,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3337,6 +3280,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3374,19 +3318,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/character-entities-html4": {
@@ -3489,19 +3420,6 @@
         "@codemirror/view": "^6.0.0"
       }
     },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -3543,9 +3461,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
+      "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -3596,6 +3514,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
@@ -3604,6 +3523,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -3754,6 +3674,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dnd-core": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
+      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.1.1"
       }
     },
     "node_modules/dom-helpers": {
@@ -3991,14 +3922,6 @@
       "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
       "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw=="
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4060,9 +3983,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
-      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
       "funding": [
         {
           "type": "github",
@@ -4076,22 +3999,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4174,12 +4093,18 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreach": {
@@ -4248,17 +4173,17 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -4531,14 +4456,17 @@
       }
     },
     "node_modules/highlight-words-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
-      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -4546,7 +4474,8 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hono": {
       "version": "4.6.5",
@@ -4801,9 +4730,9 @@
       "license": "MIT"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5038,9 +4967,9 @@
       "dev": true
     },
     "node_modules/jotai": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.11.0.tgz",
-      "integrity": "sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.12.2.tgz",
+      "integrity": "sha512-oN8715y7MkjXlSrpyjlR887TOuc/NLZMs9gvgtfWH/JP47ChwO0lR2ijSwBvPMYyXRAPT+liIAhuBavluKGgtA==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -5392,7 +5321,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
@@ -5404,15 +5334,13 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
@@ -5946,9 +5874,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6181,9 +6109,9 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6192,7 +6120,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.29.0",
@@ -6334,9 +6263,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.44.3",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.3.tgz",
-      "integrity": "sha512-q6KCcOFk3rv/zD3MckhJteZxb0VjAIFuf622B7ElK4vfrZdAzs16XR5p3VTdy3+U5jfJU5ACz4QnhLSuAGe5dA==",
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -6346,6 +6275,12 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -6370,6 +6305,29 @@
         "react": "^16.8.1 || ^17",
         "react-dom": "^16.8.1 || ^17"
       }
+    },
+    "node_modules/react-arborist": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.4.0.tgz",
+      "integrity": "sha512-QI46oRGXJr0oaQfqqVobIiIoqPp5Y5gM69D2A2P7uHVif+X75XWnScR5drC7YDKgJ4CXVaDeFwnYKOWRRfncMg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dnd": "^14.0.3",
+        "react-dnd-html5-backend": "^14.0.3",
+        "react-window": "^1.8.10",
+        "redux": "^5.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
+      }
+    },
+    "node_modules/react-arborist/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/react-calendar": {
       "version": "4.2.1",
@@ -6543,6 +6501,45 @@
         }
       }
     },
+    "node_modules/react-dnd": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
+      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^2.0.0",
+        "@react-dnd/shallowequal": "^2.0.0",
+        "dnd-core": "14.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
+      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "14.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -6603,9 +6600,11 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-resizable-panels": {
       "version": "1.0.10",
@@ -6733,6 +6732,29 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window/node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/react18-json-view": {
       "version": "0.2.8",
@@ -7030,16 +7052,17 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.1.0.tgz",
-      "integrity": "sha512-q0GAx+hj3UVcDbhXVjk7qeNfgUMehlElYJwiCuIBwqs/51GVTOwLr39Ht3eNsX5ow2xPRaC5mqHwcFDvLRm6cA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.3.0.tgz",
+      "integrity": "sha512-CPMzkknXlgO9Ow5Qa5iqQm0vOIlJyN8M1bc8etyhLw2Xfrer6bPzLA8/apuKlGQ+XdznYSKPBz5LAhwYjaDAcA==",
+      "license": "ISC",
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",
         "bignumber.js": "^9.0.0",
         "ripple-address-codec": "^5.0.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       }
     },
     "node_modules/ripple-keypairs": {
@@ -7209,7 +7232,8 @@
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "1.24.4",
@@ -7580,9 +7604,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/style-mod": {
@@ -7594,6 +7624,7 @@
       "version": "5.3.11",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -7622,12 +7653,14 @@
     "node_modules/styled-components/node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
       "integrity": "sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@styled-system/background": "^5.1.2",
@@ -7737,14 +7770,6 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7871,9 +7896,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -8112,6 +8137,28 @@
         }
       }
     },
+    "node_modules/use-resize-observer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "16.8.0 - 18",
+        "react-dom": "16.8.0 - 18"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -8262,15 +8309,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
@@ -8292,6 +8340,12 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.2.0.tgz",
+      "integrity": "sha512-PKZqBOCo6CYkVOwAxWxQaSF2Fvb5Iv2fCeTP7buyWI2GiynWr46NcXSgK/idoV6e60dgCBfgYc+Un3HMvmqP8w==",
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -8363,6 +8417,29 @@
         }
       }
     },
+    "node_modules/xml-crypto": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.1.tgz",
+      "integrity": "sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "xpath": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/xml-crypto/node_modules/xpath": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz",
@@ -8379,17 +8456,18 @@
       }
     },
     "node_modules/xpath": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
       }
     },
     "node_modules/xrpl": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.0.0.tgz",
-      "integrity": "sha512-VZm1lQWHQ6PheAAFGdH+ISXKvqB2hZDQ0w4ZcdAEtmqZQXtSIVQHOKPz95rEgGANbos7+XClxJ73++joPhA8Cw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.2.0.tgz",
+      "integrity": "sha512-RR6lJhRyQHPoI/rZGuKBzUc45KSC3thpYVzn3ATu78GXDZ6vsyn8SXmNveMhAJ2AVRvpRiyyztbU2TmGRUp2Xg==",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.3.1",
@@ -8399,7 +8477,7 @@
         "bignumber.js": "^9.0.0",
         "eventemitter3": "^5.0.1",
         "ripple-address-codec": "^5.0.0",
-        "ripple-binary-codec": "^2.1.0",
+        "ripple-binary-codec": "^2.3.0",
         "ripple-keypairs": "^2.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/view": "^6.22.2",
         "@docsearch/react": "^3.8.0",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.119.1",
+        "@redocly/realm": "0.120.2",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -818,18 +818,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
@@ -1709,23 +1697,23 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
-      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.23.0.tgz",
+      "integrity": "sha512-owusXnKNSo68mrsyfrOKCLojpV7y1AU7fQpIhc3nGn0PJv7SMlOauVvfur+SUKIqBHRzatKFwvXA2E3djawAjA==",
       "license": "MIT"
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.8.0.tgz",
-      "integrity": "sha512-Id2cTwdgZBfVceM90ByTKl2AQ6ggtuFVJQVq7jPaWFAgfFFnpaF61K9tLML/JoQ14rSPdsgASsGYzG+w/pEDqQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.9.0.tgz",
+      "integrity": "sha512-cBNF44WiEWpboerCuTo7O+Amfh93SN+VE1upfUDZux8e9B7RVF1hSR6+gtvSP/gVaVB4/i0LL8e3/2GBapu2ng==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.22.0",
+        "@redocly/config": "0.23.0",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15"
       },
       "peerDependencies": {
-        "@redocly/theme": "^0.51.0-next.0",
+        "@redocly/theme": "^0.52.0-next.0",
         "graphql": "^16.9.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
@@ -1734,13 +1722,13 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.2.8.tgz",
-      "integrity": "sha512-OB3TZu0p1Vnmwm+Upv9AydgA5drtz5tzXTjLNShzqfBg3FfpwM7iqSfZM0ze7fHyaam7nJ2nWUhhyJNbkjseQw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.2.11.tgz",
+      "integrity": "sha512-7oNf1LpqWcCpqnc68wiFYK40xpAeVPxeNHNT/XMeChTBVlevqUxUN/Zzj6TNM1Dhw32UZ/mfTpY+fPhHDVSQAA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.11.2",
-        "@redocly/openapi-core": "1.31.1",
+        "@redocly/openapi-core": "1.34.1",
         "ajv": "8.17.1",
         "ajv-formats": "^2.1.1",
         "js-yaml": "4.1.0",
@@ -1752,13 +1740,13 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.31.1.tgz",
-      "integrity": "sha512-FoTmi+iA6NGXk6rZpX6QvmEqbApbJgYC6soLj3zfx0f/1M4vUff5GuOEC24GWj7rN0vNx5E6eUx59h0M4sjRnQ==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.1.tgz",
+      "integrity": "sha512-KI1QOGvDk6oREbTu0JORxZX1NBxraXUbXczv0LYDs9EPp06coq874hQORqSHGEUV/DX2A6gjv4Ax33g/LFJBww==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.20.1",
+        "@redocly/config": "^0.22.0",
         "colorette": "^1.2.0",
         "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
@@ -1773,9 +1761,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.3.tgz",
-      "integrity": "sha512-Nyyv1Bj7GgYwj/l46O0nkH1GTKWbO3Ixe7KFcn021aZipkZd+z8Vlu1BwkhqtVgivcKaClaExtWU/lDHkjBzag==",
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz",
+      "integrity": "sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==",
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/colorette": {
@@ -1797,24 +1785,23 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.7.0.tgz",
-      "integrity": "sha512-DpZchce0qTtSL4BHxKLwaXI3hsnyddv2VatOxDyqVr5phWngm+NmurkWWtT2aeOGtPAB8BhZdOO4xjcn1Q6KaQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.8.0.tgz",
+      "integrity": "sha512-W8lD0SUSs45KnLEfGa8cQt+Hqr10fD3R5d7QPfwvgc7R6lARvXX2lx4cggm1bljiBvAShu5MI2KxHIY0Va2kaw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.1",
-        "@redocly/config": "0.22.0",
-        "@redocly/openapi-core": "1.31.1",
-        "@redocly/replay": "0.10.0",
+        "@redocly/config": "0.23.0",
+        "@redocly/openapi-core": "1.34.1",
+        "@redocly/replay": "0.11.0",
         "deepmerge": "^4.2.2",
-        "dompurify": "2.5.4",
+        "dompurify": "3.2.4",
         "fast-deep-equal": "^3.1.3",
         "jotai": "^2.4.2",
         "json-pointer": "^0.6.2",
         "jstoxml": "^5.0.2",
         "openapi-sampler": "^1.6.1",
         "path-browserify": "^1.0.1",
-        "prismjs": "1.29.0",
         "react-router-dom": "^6.21.1",
         "slugify": "^1.4.4",
         "stringify-object": "^3.3.0",
@@ -1834,7 +1821,7 @@
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "@redocly/theme": ">=0.51.0-next.0",
+        "@redocly/theme": ">=0.52.0-next.0",
         "core-js": "^3.1.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -1842,9 +1829,9 @@
       }
     },
     "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.2.0.tgz",
-      "integrity": "sha512-7bpwgN7odHd/WB6po+bOSRxiVjlVe48W9uQnTvoZcAu7H/8Sw9LiaCONlcPaJ7eBirtbPWY0QVvbeuw2dsQjWw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.3.0.tgz",
+      "integrity": "sha512-5GZAr1bSjA2+8KztMdK4ShNdsSmyhgu0G+RUW7Mpk4DqpRj/EnNpjq6RcrHdHo1wtjj79INYFUyszaZIneLCJw==",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "highlight-words-core": "^1.2.2",
@@ -1855,21 +1842,21 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.4.0.tgz",
-      "integrity": "sha512-9qlHWvWTpp9PKAG7+OYoi1I1da5smdINrNuw4HwwWIW4IrkGX4IvxNzS4mENAVWrXeVAdvn2jmNgH8IlGHTGIA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.5.0.tgz",
+      "integrity": "sha512-DhwjlGmftF6tN/52IROjTbMvD0GpTUP+Nvsq10hu8sS9B3bUFQEI5uHkeM9gs5AJlX8fRW/1xPD5jhtHLegj5w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.22.0",
-        "@redocly/mock-server": "0.2.8",
-        "@redocly/openapi-core": "1.31.1",
-        "@redocly/openapi-docs": "3.7.0"
+        "@redocly/config": "0.23.0",
+        "@redocly/mock-server": "0.2.11",
+        "@redocly/openapi-core": "1.34.1",
+        "@redocly/openapi-docs": "3.8.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.119.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.119.1.tgz",
-      "integrity": "sha512-troNNqmH3N57pCONpjw1cxrZx5TfemStVcYKVv7g/WuRu2ndiXn3nkfMsW/vA7VuQL0G2fNSb3zc+b9siMiylw==",
+      "version": "0.120.2",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.120.2.tgz",
+      "integrity": "sha512-fvRqy1MCqf+WywuN5qRVxaOm58PUYnreZUSPHDE68gJ2ryKhFYo+iB6S86k0Q95oxPjigcuSVWAqUdSUvKANzQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -1889,15 +1876,16 @@
         "@opentelemetry/sdk-trace-web": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.22.0",
-        "@redocly/graphql-docs": "0.8.0",
-        "@redocly/openapi-core": "1.31.1",
-        "@redocly/openapi-docs": "3.7.0",
-        "@redocly/portal-legacy-ui": "0.2.0",
-        "@redocly/portal-plugin-mock-server": "0.4.0",
-        "@redocly/theme": "0.51.0",
+        "@redocly/config": "0.23.0",
+        "@redocly/graphql-docs": "0.9.0",
+        "@redocly/openapi-core": "1.34.1",
+        "@redocly/openapi-docs": "3.8.0",
+        "@redocly/portal-legacy-ui": "0.3.0",
+        "@redocly/portal-plugin-mock-server": "0.5.0",
+        "@redocly/theme": "0.52.0",
         "@shikijs/transformers": "^1.22.2",
         "@tanstack/react-query": "5.62.3",
+        "@tanstack/react-virtual": "3.13.0",
         "@wojtekmaj/react-datetimerange-picker": "5.0.2",
         "@xmldom/xmldom": "0.8.10",
         "babel-plugin-styled-components": "2.1.4",
@@ -1926,10 +1914,10 @@
         "os-browserify": "0.3.0",
         "path-browserify": "1.0.1",
         "picomatch": "2.3.1",
-        "react": "^18.2.0",
+        "react": "^18.3.1",
         "react-calendar": "4.2.1",
         "react-date-picker": "10.0.3",
-        "react-dom": "^18.2.0",
+        "react-dom": "^18.3.1",
         "react-helmet": "^6.1.0",
         "react-router-dom": "^6.21.1",
         "react-select": "5.8.1",
@@ -2017,9 +2005,9 @@
       }
     },
     "node_modules/@redocly/replay": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.10.0.tgz",
-      "integrity": "sha512-KH0gu+v359lvpaqzMRB5rAlIclkDxvKHfhemqFOI0sD8xBwJvX68VAf4pya/xM8UoubY4L3XgQfCn8BB5k2ExQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.11.0.tgz",
+      "integrity": "sha512-YNMKtmW0VpIHGYJ6GviXcKErMMX0IC9uxsVOZH5OVxBi3nzj1sOUhBn6esZApNSglYKdVE6itpX7ETWFBfFPCg==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.15.0",
         "@codemirror/lang-html": "^6.4.7",
@@ -2050,7 +2038,7 @@
         "use-resize-observer": "^9.1.0"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.51.0",
+        "@redocly/theme": "0.52.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.21.1",
@@ -2058,12 +2046,13 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.51.0.tgz",
-      "integrity": "sha512-/EFQWrO8qMxvw7B9uoUVk84hWzasfaSsv3JQnCcSB7TE31j7K7xOJlMzDZPQC80s/zdRYskKW6wGRCMpZpZbOw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.52.0.tgz",
+      "integrity": "sha512-n6w4qup+tHna3SXifWkV2Axq6jTxpB/rRRdvkYvVoCUeHkK5OozlNV81fKuVhWmUBxcQ0i9hFFJIJ1FzeodLew==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.22.0",
+        "@redocly/config": "0.23.0",
+        "@tanstack/react-virtual": "3.13.0",
         "copy-to-clipboard": "3.3.3",
         "file-saver": "2.0.5",
         "highlight-words-core": "1.2.2",
@@ -2490,6 +2479,33 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.0.tgz",
+      "integrity": "sha512-CchF0NlLIowiM2GxtsoKBkXA4uqSnY2KvnXo+kyUFD4a4ll6+J0qzoRsUPMwXV/H26lRsxgJIr/YmjYum2oEjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.0.tgz",
+      "integrity": "sha512-NBKJP3OIdmZY3COJdWkSonr50FMVIi+aj5ZJ7hI/DTpEKg2RMfo/KvP8A3B/zOSpMgIe52B5E2yn7rryULzA6g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.0.0-beta.15",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.0.0-beta.15.tgz",
@@ -2524,9 +2540,9 @@
       }
     },
     "node_modules/@tauri-apps/plugin-fs/node_modules/@tauri-apps/api": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.4.0.tgz",
-      "integrity": "sha512-F1zXTsmwcCp+ocg6fbzD/YL0OHeSG1eynCag1UNlX2tD5+dlXy7eRbTu9cAcscPjcR7Nix7by2wiv/+VfWUieg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.4.1.tgz",
+      "integrity": "sha512-5sYwZCSJb6PBGbBL4kt7CnE5HHbBqwH+ovmOW6ZVju3nX4E3JX6tt2kRklFEH7xMOIwR0btRkZktuLhKvyEQYg==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -2660,6 +2676,13 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2973,6 +2996,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -3420,6 +3458,24 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -3735,10 +3791,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.4.tgz",
-      "integrity": "sha512-l5NNozANzaLPPe0XaAwvg3uZcHtDBnziX/HjsY1UcDj1MxTK8Dd0Kv096jyPK5HRzs/XM5IMj20dW8Fk+HnbUA==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "3.1.0",
@@ -3921,6 +3980,18 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
       "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -4365,6 +4436,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -6123,15 +6195,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
-    "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6600,9 +6663,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
-      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT",
       "peer": true
     },
@@ -7688,6 +7751,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -7896,9 +7960,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -8151,9 +8215,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8363,39 +8427,6 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@codemirror/view": "^6.22.2",
     "@docsearch/react": "^3.8.0",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.119.1",
+    "@redocly/realm": "0.120.2",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@codemirror/view": "^6.22.2",
     "@docsearch/react": "^3.8.0",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.115.0",
+    "@redocly/realm": "0.119.1",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -29,7 +29,7 @@
     "react18-json-view": "^0.2.6",
     "smol-toml": "^1.3.1",
     "use-query-params": "^2.2.1",
-    "xrpl": "^4.0.0"
+    "xrpl": "^4.2.0"
   },
   "overrides": {
     "react": "^18.2.0",

--- a/resources/dev-tools/tx-sender.page.tsx
+++ b/resources/dev-tools/tx-sender.page.tsx
@@ -77,7 +77,7 @@ async function onClickCreateEscrow(
         }
         setEscrowWidthPercent(0)
 
-        if(escrowCreateResponse.result.Sequence === undefined) {
+        if(escrowCreateResponse.result.tx_json.Sequence === undefined) {
             
             errorNotif(submitConstData.alert, 
                 "Error: Unable to get the sequence number from EscrowCreate, so cannot submit an EscrowFinish transaction.")
@@ -95,7 +95,7 @@ async function onClickCreateEscrow(
                 Account: sendingWallet.address,
                 TransactionType: "EscrowFinish",
                 Owner: sendingWallet.address,
-                OfferSequence: escrowCreateResponse.result.Sequence
+                OfferSequence: escrowCreateResponse.result.tx_json.Sequence
             })
         }
     }

--- a/static/js/tutorials/issue-a-token.js
+++ b/static/js/tutorials/issue-a-token.js
@@ -24,17 +24,13 @@ function setup_2x_generate_step() {
           <div><strong>${tl("Cold Address:")}</strong>
           <span id="cold-use-address">${data.account.address}</span></div>
           <div><strong>${tl("Cold Secret:")}</strong>
-          <span id="cold-use-secret">${data.account.secret}</span></div>
-          <strong>${tl("XRP Balance:")}</strong>
-          ${data.balance} XRP
+          <span id="cold-use-secret">${data.seed}</span></div>
         </div>
         <div class="col-xl-6 p-3">
           <div><strong>${tl("Hot Address:")}</strong>
           <span id="hot-use-address">${data2.account.address}</span></div>
           <div><strong>${tl("Hot Secret:")}</strong>
-          <span id="hot-use-secret">${data2.account.secret}</span></div>
-          <strong>${tl("XRP Balance:")}</strong>
-          ${data2.balance} XRP
+          <span id="hot-use-secret">${data2.seed}</span></div>
         </div>
       </div>`)
 


### PR DESCRIPTION
- [x] Updates Realm to v0.120.2 which contains a number of fixes including some security issues among dependencies. It was supposed to contain a fix for interactive tutorials, but it turns out that fix was incomplete. Redocly has confirmed they've reproduced the bug and are working on a fix. But for now we can update to satisfy dependabot.
- [x] Updated the "Issue a Fungible Token" tutorial to match the updated format for the Testnet faucet's response format. (The faucet no longer tells you your current balance, just the amount that it sent you.) The "Issue a Fungible Token" interactive tutorial works in local dev mode now if you navigate to it from another page, but (due to the aforementioned Redocly bug) not if you load it directly.
- [x] Updates the Transaction Sender dev tool for the current version of xrpl.js which uses the rippled API v2 by default. Prior to this fix, the tool would fail to send an EscrowFinish transaction because it was looking in the old place for the `Sequence` field.