### PR TITLE
Add All That Node as a Commercial RPC Provider for Arbitrum Mainnet and Sepolia Testnet

### DIFF
--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -21,7 +21,7 @@ If you don't [run your own `rippled` server](../infrastructure/installation/inde
 |:----------|:------------|:-------------|:---------------------|
 | XRP Ledger Foundation full history paid API via [Dhali](https://dhali.io/) | **Mainnet** | `https://xrplcluster.dhali.io/` | You must [create a paid API key](https://pay.dhali.io/?uuids=199fd80b-1776-4708-b1a1-4b2bb386435d) and embed it in the request's `Payment-Claim` header. |
 | [QuickNode](https://www.quicknode.com/chains/xrpl) | Testnet/Mainnet | N/A | QuickNode provides hosted XRPL RPC mainnet and testnet under their free and paid plans, granting flexible and reliable access to the network.
-
+| [All That Node](https://www.allthatnode.com) | **Mainnet, Sepolia** | N/A | All That Node offers reliable RPC endpoints for Arbitrum One (Mainnet) and Sepolia Testnet with WebSocket support. 
 
 ## Test Networks
 


### PR DESCRIPTION
Dear XRPL Documentation Team,

I would like to propose an update to the documentation to include All That Node as a commercial RPC provider for the Arbitrum Mainnet and Sepolia Testnet. All That Node offers reliable and secure RPC endpoints with WebSocket support for these networks.

> Here are the details for the proposed addition:
> Location: https://xrpl.org/docs/tutorials/public-servers
> Provider: All That Node
> Supported Networks: Arbitrum Mainnet, Sepolia Testnet

Please feel free to review the changes, and I would be happy to make any further adjustments as needed.
Thank you for your time and consideration.

Best regards,
Mark