### PR TITLE
Fix source link in server_definitions.md

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions.md
+++ b/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions.md
@@ -8,7 +8,7 @@ labels:
 ---
 # server_definitions
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/ripple/rpc/handlers/ServerInfo.cpp#L43 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/rpc/handlers/ServerInfo.cpp#L42 "Source")
 
 The `server_definitions` command returns an SDK-compatible `definitions.json`, generated from the `rippled` instance currently running. You can use this to query a node in a network, quickly receiving the definitions necessary to serialize/deserialize its binary data.
 


### PR DESCRIPTION
The `ripple` portion of the source path is now `xrpld`