### PR TITLE
Display publication dates for blogs

### DIFF
--- a/@theme/templates/blogpost.tsx
+++ b/@theme/templates/blogpost.tsx
@@ -1,20 +1,30 @@
-import React from 'react';
-import { Markdown as MarkdownWrapper } from '@redocly/theme/components/Markdown/Markdown';
+import { Markdown } from '@redocly/theme/components/Markdown/Markdown';
 import { DocumentationLayout } from '@redocly/theme/layouts/DocumentationLayout';
+import { TableOfContent } from '@redocly/theme/components/TableOfContent/TableOfContent';
+import styled from 'styled-components';
+
+const LayoutWrapper = styled.div`
+display: flex;
+flex: 1;
+width: 100%;
+`;
 
 function PostInfo(data) {
     return (
         <div className="blog-post-info">
-            Publication date: {data.date}
+            Publication date: {data.data.date}
         </div>
     )
 }
 
 export default function BlogPost({ pageProps, children }) {
   return (
-    <DocumentationLayout tableOfContent={null} feedback={null}>
-      <PostInfo data={pageProps.frontmatter} />
-      <MarkdownWrapper>{children}</MarkdownWrapper>
-    </DocumentationLayout>
+    <LayoutWrapper>
+      <DocumentationLayout {...pageProps}>
+        <PostInfo data={pageProps.frontmatter} />
+        <Markdown>{children}</Markdown>
+      </DocumentationLayout>
+      <TableOfContent {...pageProps} />
+    </LayoutWrapper>
   );
 }

--- a/@theme/templates/blogpost.tsx
+++ b/@theme/templates/blogpost.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Markdown as MarkdownWrapper } from '@redocly/theme/components/Markdown/Markdown';
+import { DocumentationLayout } from '@redocly/theme/layouts/DocumentationLayout';
+
+function PostInfo(data) {
+    return (
+        <div className="blog-post-info">
+            Publication date: {data.date}
+        </div>
+    )
+}
+
+export default function BlogPost({ pageProps, children }) {
+  return (
+    <DocumentationLayout tableOfContent={null} feedback={null}>
+      <PostInfo data={pageProps.frontmatter} />
+      <MarkdownWrapper>{children}</MarkdownWrapper>
+    </DocumentationLayout>
+  );
+}

--- a/blog/2014/biweekly-release-notes-14-august-2014.md
+++ b/blog/2014/biweekly-release-notes-14-august-2014.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-08-14
+date: "2014-08-14"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Release Notes

--- a/blog/2014/biweekly-release-notes-17-september-2014.md
+++ b/blog/2014/biweekly-release-notes-17-september-2014.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-07-17
+date: "2014-07-17"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Release Notes

--- a/blog/2014/biweekly-release-notes-3-september-2014.md
+++ b/blog/2014/biweekly-release-notes-3-september-2014.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-07-03
+date: "2014-07-03"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Release Notes

--- a/blog/2014/biweekly-release-notes-31-july-2014.md
+++ b/blog/2014/biweekly-release-notes-31-july-2014.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-07-31
+date: "2014-07-31"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Release Notes

--- a/blog/2014/curves-with-a-twist.md
+++ b/blog/2014/curves-with-a-twist.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-06-26
+date: "2014-06-26"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Features

--- a/blog/2014/dev-portal-adds-rippled-apis.md
+++ b/blog/2014/dev-portal-adds-rippled-apis.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-08-01
+date: "2014-08-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Development
 markdown:

--- a/blog/2014/gateway-advisory-on-partial-payment-flag.md
+++ b/blog/2014/gateway-advisory-on-partial-payment-flag.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-10-22
+date: "2014-10-22"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Advisories

--- a/blog/2014/how-ripple-labs-supports-gateways.md
+++ b/blog/2014/how-ripple-labs-supports-gateways.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-09-22
+date: "2014-09-22"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2014/introducing-offer-autobridging.md
+++ b/blog/2014/introducing-offer-autobridging.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-07-02
+date: "2014-07-02"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Features

--- a/blog/2014/introducing-ripple-names.md
+++ b/blog/2014/introducing-ripple-names.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-04-28
+date: "2014-04-28"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Features

--- a/blog/2014/release-notes-14-october-2014.md
+++ b/blog/2014/release-notes-14-october-2014.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-10-14
+date: "2014-10-14"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Release Notes

--- a/blog/2014/release-notes-19-november-2014.md
+++ b/blog/2014/release-notes-19-november-2014.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-11-19
+date: "2014-11-19"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 markdown:

--- a/blog/2014/release-notes-29-october-2014.md
+++ b/blog/2014/release-notes-29-october-2014.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-10-29
+date: "2014-10-29"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 markdown:

--- a/blog/2014/release-notes-3-december-2014.md
+++ b/blog/2014/release-notes-3-december-2014.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-12-03
+date: "2014-12-03"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Release Notes

--- a/blog/2014/ripple-labs-bounty-program-moves-to-bountysource.md
+++ b/blog/2014/ripple-labs-bounty-program-moves-to-bountysource.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-07-07
+date: "2014-07-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2014/ripplerest-1.3-release.md
+++ b/blog/2014/ripplerest-1.3-release.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-11-04
+date: "2014-11-04"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 markdown:

--- a/blog/2014/turn-your-exchange-into-a-ripple-gateway.md
+++ b/blog/2014/turn-your-exchange-into-a-ripple-gateway.md
@@ -1,6 +1,7 @@
 ---
 category: 2014
-date: 2014-12-18
+date: "2014-12-18"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2014/use-of-cpp14-in-rippled.md
+++ b/blog/2014/use-of-cpp14-in-rippled.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-08-19
+date: "2014-08-19"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Development

--- a/blog/2014/why-the-stellar-forking-issue-does-not-affect-ripple.md
+++ b/blog/2014/why-the-stellar-forking-issue-does-not-affect-ripple.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-12-07
+date: "2014-12-07"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Advisories

--- a/blog/2014/xrp-giveaway-for-developers.md
+++ b/blog/2014/xrp-giveaway-for-developers.md
@@ -1,5 +1,6 @@
 ---
-date: 2014-07-28
+date: "2014-07-28"
+template: '../../@theme/templates/blogpost'
 category: 2014
 labels:
     - Development

--- a/blog/2015/calculating-balance-changes-for-a-transaction.md
+++ b/blog/2015/calculating-balance-changes-for-a-transaction.md
@@ -1,5 +1,6 @@
 ---
-date: 2015-02-19
+date: "2015-02-19"
+template: '../../@theme/templates/blogpost'
 category: 2015
 labels:
     - Development

--- a/blog/2015/correction-to-ripple-white-paper.md
+++ b/blog/2015/correction-to-ripple-white-paper.md
@@ -1,5 +1,6 @@
 ---
-date: 2015-09-02
+date: "2015-09-02"
+template: '../../@theme/templates/blogpost'
 category: 2015
 labels:
     - Advisories

--- a/blog/2015/do-you-have-what-it-takes-to-be-a-gateway.md
+++ b/blog/2015/do-you-have-what-it-takes-to-be-a-gateway.md
@@ -1,6 +1,7 @@
 ---
 category: 2015
-date: 2015-03-18
+date: "2015-03-18"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2015/gatewayd-no-longer-available.md
+++ b/blog/2015/gatewayd-no-longer-available.md
@@ -1,5 +1,6 @@
 ---
-date: 2015-07-01
+date: "2015-07-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 category: 2015

--- a/blog/2015/introducing-the-data-api.md
+++ b/blog/2015/introducing-the-data-api.md
@@ -1,5 +1,6 @@
 ---
-date: 2015-08-05
+date: "2015-08-05"
+template: '../../@theme/templates/blogpost'
 category: 2015
 labels:
     - Features

--- a/blog/2015/ripple-charts-update-payment-volume-and-issued-value.md
+++ b/blog/2015/ripple-charts-update-payment-volume-and-issued-value.md
@@ -1,5 +1,6 @@
 ---
-date: 2015-06-10
+date: "2015-06-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 category: 2015

--- a/blog/2015/validator-registry.md
+++ b/blog/2015/validator-registry.md
@@ -1,5 +1,6 @@
 ---
-date: 2015-08-18
+date: "2015-08-18"
+template: '../../@theme/templates/blogpost'
 category: 2015
 labels:
     - Features

--- a/blog/2016/data-api-v2.2.md
+++ b/blog/2016/data-api-v2.2.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-06-15
+date: "2016-06-15"
+template: '../../@theme/templates/blogpost'
 category: 2016
 labels:
     - Release Notes

--- a/blog/2016/flow-available.md
+++ b/blog/2016/flow-available.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-10-24
+date: "2016-10-24"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/flow-reminder.md
+++ b/blog/2016/flow-reminder.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-10-17
+date: "2016-10-17"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/flow-voting.md
+++ b/blog/2016/flow-voting.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-10-07
+date: "2016-10-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/flowv2-vetoed.md
+++ b/blog/2016/flowv2-vetoed.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-08-18
+date: "2016-08-18"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/flowv2-voting.md
+++ b/blog/2016/flowv2-voting.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-08-10
+date: "2016-08-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/introducing-rippleapi.md
+++ b/blog/2016/introducing-rippleapi.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-06-12
+date: "2016-06-12"
+template: '../../@theme/templates/blogpost'
 category: 2016
 labels:
     - Release Notes

--- a/blog/2016/multisign-available.md
+++ b/blog/2016/multisign-available.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-06-27
+date: "2016-06-27"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/multisign-reminder.md
+++ b/blog/2016/multisign-reminder.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-06-21
+date: "2016-06-21"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 category: 2016

--- a/blog/2016/rippled-0.30.1.md
+++ b/blog/2016/rippled-0.30.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-02-10
+date: "2016-02-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/rippled-0.31.2-updates.md
+++ b/blog/2016/rippled-0.31.2-updates.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-06-10
+date: "2016-06-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/rippled-0.32.0.md
+++ b/blog/2016/rippled-0.32.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-06-27
+date: "2016-06-27"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/rippled-0.32.1.md
+++ b/blog/2016/rippled-0.32.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-07-29
+date: "2016-07-29"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/rippled-0.33.0-hf1.md
+++ b/blog/2016/rippled-0.33.0-hf1.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-10-16
+date: "2016-10-16"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/rippled-0.33.0.md
+++ b/blog/2016/rippled-0.33.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-09-29
+date: "2016-09-29"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/rippled-0.40.0.md
+++ b/blog/2016/rippled-0.40.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-12-20
+date: "2016-12-20"
+template: '../../@theme/templates/blogpost'
 labels:
     - Release Notes
 category: 2016

--- a/blog/2016/testnet-ledger-reset.md
+++ b/blog/2016/testnet-ledger-reset.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-09-01
+date: "2016-09-01"
+template: '../../@theme/templates/blogpost'
 category: 2016
 labels:
     - Advisories

--- a/blog/2016/trustsetauth-available.md
+++ b/blog/2016/trustsetauth-available.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-07-19
+date: "2016-07-19"
+template: '../../@theme/templates/blogpost'
 category: 2016
 labels:
     - Amendments

--- a/blog/2016/trustsetauth-reminder.md
+++ b/blog/2016/trustsetauth-reminder.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-07-12
+date: "2016-07-12"
+template: '../../@theme/templates/blogpost'
 category: 2016
 labels:
     - Amendments

--- a/blog/2016/trustsetauth-voting.md
+++ b/blog/2016/trustsetauth-voting.md
@@ -1,5 +1,6 @@
 ---
-date: 2016-07-05
+date: "2016-07-05"
+template: '../../@theme/templates/blogpost'
 category: 2016
 labels:
     - Amendments

--- a/blog/2017/data-api-load-balancing-test.md
+++ b/blog/2017/data-api-load-balancing-test.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-01-18
+date: "2017-01-18"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Advisories

--- a/blog/2017/decent-strategy-update.md
+++ b/blog/2017/decent-strategy-update.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-10-17
+date: "2017-10-17"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Features

--- a/blog/2017/escrow-paychan-fix1368-reminder.md
+++ b/blog/2017/escrow-paychan-fix1368-reminder.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-03-27
+date: "2017-03-27"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Amendments

--- a/blog/2017/explanation-of-ripples-xrp-escrow.md
+++ b/blog/2017/explanation-of-ripples-xrp-escrow.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-12-15
+date: "2017-12-15"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Features

--- a/blog/2017/high-scalability-xrp-ledger.md
+++ b/blog/2017/high-scalability-xrp-ledger.md
@@ -2,7 +2,8 @@
 labels:
     - Features
 category: 2017
-date: 2017-10-02
+date: "2017-10-02"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2017/invariant-checking.md
+++ b/blog/2017/invariant-checking.md
@@ -2,7 +2,8 @@
 category: 2017
 labels:
     - Features
-date: 2017-07-19
+date: "2017-07-19"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2017/response-to-china-cert-report.md
+++ b/blog/2017/response-to-china-cert-report.md
@@ -2,7 +2,8 @@
 category: 2017
 labels:
     - Security
-date: 2017-01-12
+date: "2017-01-12"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2017/ripple-consensus-ledger-can-sustain-1000-transactions-per-second.md
+++ b/blog/2017/ripple-consensus-ledger-can-sustain-1000-transactions-per-second.md
@@ -2,7 +2,8 @@
 category: 2017
 labels:
     - Features
-date: 2017-02-28
+date: "2017-02-28"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2017/rippled-0.40.1.md
+++ b/blog/2017/rippled-0.40.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-01-11
+date: "2017-01-11"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.50.0.md
+++ b/blog/2017/rippled-0.50.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-01-27
+date: "2017-01-27"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.50.2.md
+++ b/blog/2017/rippled-0.50.2.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-01-30
+date: "2017-01-30"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.50.3.md
+++ b/blog/2017/rippled-0.50.3.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-03-14
+date: "2017-03-14"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.60.0.md
+++ b/blog/2017/rippled-0.60.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-03-17
+date: "2017-03-17"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.60.1.md
+++ b/blog/2017/rippled-0.60.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-03-29
+date: "2017-03-29"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.60.2-2-rpm.md
+++ b/blog/2017/rippled-0.60.2-2-rpm.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-05-03
+date: "2017-05-03"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Advisories

--- a/blog/2017/rippled-0.60.2.md
+++ b/blog/2017/rippled-0.60.2.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-03-30
+date: "2017-03-30"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.60.3.md
+++ b/blog/2017/rippled-0.60.3.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-05-11
+date: "2017-05-11"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.70.0.md
+++ b/blog/2017/rippled-0.70.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-06-15
+date: "2017-06-15"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.70.1.md
+++ b/blog/2017/rippled-0.70.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-07-10
+date: "2017-07-10"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.70.2.md
+++ b/blog/2017/rippled-0.70.2.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-09-21
+date: "2017-09-21"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.80.0.md
+++ b/blog/2017/rippled-0.80.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-10-23
+date: "2017-10-23"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/rippled-0.80.2.md
+++ b/blog/2017/rippled-0.80.2.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-12-15
+date: "2017-12-15"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Release Notes

--- a/blog/2017/ticksize-3days.md
+++ b/blog/2017/ticksize-3days.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-02-18
+date: "2017-02-18"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Amendments

--- a/blog/2017/ticksize-7days.md
+++ b/blog/2017/ticksize-7days.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-02-14
+date: "2017-02-14"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Amendments

--- a/blog/2017/ticksize-available.md
+++ b/blog/2017/ticksize-available.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-02-22
+date: "2017-02-22"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Amendments

--- a/blog/2017/ticksize-voting.md
+++ b/blog/2017/ticksize-voting.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-02-10
+date: "2017-02-10"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Amendments

--- a/blog/2017/trust-line-quality-sendmax.md
+++ b/blog/2017/trust-line-quality-sendmax.md
@@ -1,5 +1,6 @@
 ---
-date: 2017-03-16
+date: "2017-03-16"
+template: '../../@theme/templates/blogpost'
 category: 2017
 labels:
     - Security

--- a/blog/2018/data-api-validations-changes.md
+++ b/blog/2018/data-api-validations-changes.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-10-23
+date: "2018-10-23"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Advisories

--- a/blog/2018/depositauth-fix1513-available.md
+++ b/blog/2018/depositauth-fix1513-available.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-04-09
+date: "2018-04-09"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Amendments

--- a/blog/2018/depositpreauth-fix1515-enabled.md
+++ b/blog/2018/depositpreauth-fix1515-enabled.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-10-09
+date: "2018-10-09"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Amendments

--- a/blog/2018/fix1543-fix1571-fix1623-voting.md
+++ b/blog/2018/fix1543-fix1571-fix1623-voting.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-06-08
+date: "2018-06-08"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Amendments

--- a/blog/2018/fix1571-enabled.md
+++ b/blog/2018/fix1571-enabled.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-06-20
+date: "2018-06-20"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Amendments

--- a/blog/2018/introducing-history-sharding.md
+++ b/blog/2018/introducing-history-sharding.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-11-07
+date: "2018-11-07"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Features

--- a/blog/2018/ripple-lib-1.0.0.md
+++ b/blog/2018/ripple-lib-1.0.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-09-10
+date: "2018-09-10"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-0.81.0.md
+++ b/blog/2018/rippled-0.81.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-01-08
+date: "2018-01-08"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-0.90.0.md
+++ b/blog/2018/rippled-0.90.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-02-21
+date: "2018-02-21"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-0.90.1.md
+++ b/blog/2018/rippled-0.90.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-03-22
+date: "2018-03-22"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-1.0.0.md
+++ b/blog/2018/rippled-1.0.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-05-31
+date: "2018-05-31"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-1.0.1.md
+++ b/blog/2018/rippled-1.0.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-06-14
+date: "2018-06-14"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-1.1.0.md
+++ b/blog/2018/rippled-1.1.0.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-09-17
+date: "2018-09-17"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-1.1.1.md
+++ b/blog/2018/rippled-1.1.1.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-10-23
+date: "2018-10-23"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-1.1.2.md
+++ b/blog/2018/rippled-1.1.2.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-11-07
+date: "2018-11-07"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Release Notes

--- a/blog/2018/rippled-boost166-warning.md
+++ b/blog/2018/rippled-boost166-warning.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-01-12
+date: "2018-01-12"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Advisories

--- a/blog/2018/rippled-validator-key-replacement.md
+++ b/blog/2018/rippled-validator-key-replacement.md
@@ -1,5 +1,6 @@
 ---
-date: 2018-01-17
+date: "2018-01-17"
+template: '../../@theme/templates/blogpost'
 category: 2018
 labels:
     - Advisories

--- a/blog/2019/corrections-to-data-api-xrp-charts-metrics.md
+++ b/blog/2019/corrections-to-data-api-xrp-charts-metrics.md
@@ -3,7 +3,8 @@ labels:
     - Advisories
     - Data API
 category: 2019
-date: 2019-04-04
+date: "2019-04-04"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/discover-xrp-ledger-explorer.md
+++ b/blog/2019/discover-xrp-ledger-explorer.md
@@ -2,7 +2,8 @@
 labels:
     - Features
 category: 2019
-date: 2019-07-03
+date: "2019-07-03"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/fix1578-enabled.md
+++ b/blog/2019/fix1578-enabled.md
@@ -2,7 +2,8 @@
 labels:
     - Amendments
 category: 2019
-date: 2019-03-23
+date: "2019-03-23"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/fix1578-expected.md
+++ b/blog/2019/fix1578-expected.md
@@ -2,7 +2,8 @@
 labels:
     - Amendments
 category: 2019
-date: 2019-03-19
+date: "2019-03-19"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/fixmasterkeyasregularkey-1day.md
+++ b/blog/2019/fixmasterkeyasregularkey-1day.md
@@ -1,7 +1,8 @@
 ---
 labels:
     - Amendments
-date: 2019-09-30
+date: "2019-09-30"
+template: '../../@theme/templates/blogpost'
 category: 2019
 markdown:
     editPage:

--- a/blog/2019/fixmasterkeyasregularkey-enabled.md
+++ b/blog/2019/fixmasterkeyasregularkey-enabled.md
@@ -1,7 +1,8 @@
 ---
 labels:
     - Amendments
-date: 2019-10-02
+date: "2019-10-02"
+template: '../../@theme/templates/blogpost'
 category: 2019
 markdown:
     editPage:

--- a/blog/2019/fixmasterkeyasregularkey-expected.md
+++ b/blog/2019/fixmasterkeyasregularkey-expected.md
@@ -1,7 +1,8 @@
 ---
 labels:
     - Amendments
-date: 2019-09-18
+date: "2019-09-18"
+template: '../../@theme/templates/blogpost'
 category: 2019
 markdown:
     editPage:

--- a/blog/2019/fixtakerdryofferremoval-enabled.md
+++ b/blog/2019/fixtakerdryofferremoval-enabled.md
@@ -2,7 +2,8 @@
 labels:
     - Amendments
 category: 2019
-date: 2019-04-02
+date: "2019-04-02"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/interledger-checkin.md
+++ b/blog/2019/interledger-checkin.md
@@ -2,7 +2,8 @@
 labels:
     - Features
 category: 2019
-date: 2019-04-03
+date: "2019-04-03"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/labeling-the-internet-of-value.md
+++ b/blog/2019/labeling-the-internet-of-value.md
@@ -2,7 +2,8 @@
 labels:
     - Features
 category: 2019
-date: 2019-07-12
+date: "2019-07-12"
+template: '../../@theme/templates/blogpost'
 author: Rome Reginelli
 ---
 # Labeling the Internet of Value

--- a/blog/2019/multisignreserve-enabled.md
+++ b/blog/2019/multisignreserve-enabled.md
@@ -2,7 +2,8 @@
 labels:
     - Amendments
 category: 2019
-date: 2019-04-17
+date: "2019-04-17"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/multisignreserve-expected.md
+++ b/blog/2019/multisignreserve-expected.md
@@ -2,7 +2,8 @@
 labels:
     - Amendments
 category: 2019
-date: 2019-04-04
+date: "2019-04-04"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.2.0.md
+++ b/blog/2019/rippled-1.2.0.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-02-13
+date: "2019-02-13"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.2.1.md
+++ b/blog/2019/rippled-1.2.1.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-02-26
+date: "2019-02-26"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.2.2.md
+++ b/blog/2019/rippled-1.2.2.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-03-06
+date: "2019-03-06"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.2.3.md
+++ b/blog/2019/rippled-1.2.3.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-04-02
+date: "2019-04-02"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.2.4.md
+++ b/blog/2019/rippled-1.2.4.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-04-17
+date: "2019-04-17"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.3.1.md
+++ b/blog/2019/rippled-1.3.1.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-07-25
+date: "2019-07-25"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/rippled-1.4.0.md
+++ b/blog/2019/rippled-1.4.0.md
@@ -2,7 +2,8 @@
 labels:
     - Release Notes
 category: 2019
-date: 2019-12-02
+date: "2019-12-02"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/secure-development-practices.md
+++ b/blog/2019/secure-development-practices.md
@@ -3,7 +3,8 @@ labels:
     - Features
     - Security
 category: 2019
-date: 2019-04-05
+date: "2019-04-05"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/statement-on-the-biased-nonce-sense-paper.md
+++ b/blog/2019/statement-on-the-biased-nonce-sense-paper.md
@@ -2,7 +2,8 @@
 labels:
     - Security
 category: 2019
-date: 2019-01-14
+date: "2019-01-14"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/testnet-reset.md
+++ b/blog/2019/testnet-reset.md
@@ -1,7 +1,8 @@
 ---
 labels:
     - Advisories
-date: 2019-08-30
+date: "2019-08-30"
+template: '../../@theme/templates/blogpost'
 category: 2019
 markdown:
     editPage:

--- a/blog/2019/websocket-tool-update.md
+++ b/blog/2019/websocket-tool-update.md
@@ -2,7 +2,8 @@
 labels:
     - Features
 category: 2019
-date: 2019-06-24
+date: "2019-06-24"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/welcome-to-xrpl-org.md
+++ b/blog/2019/welcome-to-xrpl-org.md
@@ -2,7 +2,8 @@
 labels:
     - Features
 category: 2019
-date: 2019-06-14
+date: "2019-06-14"
+template: '../../@theme/templates/blogpost'
 markdown:
     editPage:
         hide: true

--- a/blog/2019/xrpl-devnet-launch.md
+++ b/blog/2019/xrpl-devnet-launch.md
@@ -1,7 +1,8 @@
 ---
 labels:
     - Features
-date: 2019-10-02
+date: "2019-10-02"
+template: '../../@theme/templates/blogpost'
 category: 2019
 markdown:
     editPage:

--- a/blog/2020/checks-enabled.md
+++ b/blog/2020/checks-enabled.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-06-17
+date: "2020-06-17"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/checks-expected.md
+++ b/blog/2020/checks-expected.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-06-11
+date: "2020-06-11"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/deletableaccounts-enabled.md
+++ b/blog/2020/deletableaccounts-enabled.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-05-08
+date: "2020-05-08"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/deletableaccounts-expected.md
+++ b/blog/2020/deletableaccounts-expected.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-04-28
+date: "2020-04-28"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/developer-reflections-xrp-toolkit.md
+++ b/blog/2020/developer-reflections-xrp-toolkit.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-07-17
+date: "2020-07-17"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2020/developer-reflections-xrplorer.md
+++ b/blog/2020/developer-reflections-xrplorer.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-05-30
+date: "2020-05-30"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2020/developer-reflections-xrpscan.md
+++ b/blog/2020/developer-reflections-xrpscan.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-05-02
+date: "2020-05-02"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected.md
+++ b/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-01-08
+date: "2020-01-08"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority.md
+++ b/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-01-13
+date: "2020-01-13"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/get-ready-for-deletable-accounts.md
+++ b/blog/2020/get-ready-for-deletable-accounts.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-05-06
+date: "2020-05-06"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/moving-devnet-to-vl.md
+++ b/blog/2020/moving-devnet-to-vl.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-08-10
+date: "2020-08-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2020/requirefullycanonicalsig-expected.md
+++ b/blog/2020/requirefullycanonicalsig-expected.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-06-24
+date: "2020-06-24"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled.md
+++ b/blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-08-04
+date: "2020-08-04"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2020/rippled-1.4.0-upgrade-advisory.md
+++ b/blog/2020/rippled-1.4.0-upgrade-advisory.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-01-13
+date: "2020-01-13"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2020/rippled-1.5.0.md
+++ b/blog/2020/rippled-1.5.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-04-10
+date: "2020-04-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2020/rippled-1.6.0.md
+++ b/blog/2020/rippled-1.6.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-08-19
+date: "2020-08-19"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2020/running-an-xrp-ledger-validator.md
+++ b/blog/2020/running-an-xrp-ledger-validator.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2021-02-07
+date: "2021-02-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - Features
 markdown:

--- a/blog/2020/testnet-amendments-rippled-1.5.0.md
+++ b/blog/2020/testnet-amendments-rippled-1.5.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-04-10
+date: "2020-04-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2020/two-fixes-enabled.md
+++ b/blog/2020/two-fixes-enabled.md
@@ -1,6 +1,7 @@
 ---
 category: 2020
-date: 2020-05-01
+date: "2020-05-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2021/community-spotlight-developing-wallet-protect.md
+++ b/blog/2021/community-spotlight-developing-wallet-protect.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2020-03-10
+date: "2020-03-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 ---

--- a/blog/2021/five-upcoming-amendments.md
+++ b/blog/2021/five-upcoming-amendments.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-11-10
+date: "2021-11-10"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 ---

--- a/blog/2021/introducing-xrpl-js.md
+++ b/blog/2021/introducing-xrpl-js.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-10-20
+date: "2021-10-20"
+template: '../../@theme/templates/blogpost'
 labels:
     - xrpl.js Release Notes
 author: Team RippleX

--- a/blog/2021/introducing-xrpl-py-for-pythonistas.md
+++ b/blog/2021/introducing-xrpl-py-for-pythonistas.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-04-06
+date: "2021-04-06"
+template: '../../@theme/templates/blogpost'
 labels:
     - xrpl-py Release Notes
 author: Team RippleX

--- a/blog/2021/introducing-xrpl4j.md
+++ b/blog/2021/introducing-xrpl4j.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-05-20
+date: "2021-05-20"
+template: '../../@theme/templates/blogpost'
 labels:
     - xrpl4j Release Notes
 ---

--- a/blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying.md
+++ b/blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-03-16
+date: "2021-03-16"
+template: '../../@theme/templates/blogpost'
 labels:
     - Development
 author: Gregory Tsipenyuk and Nikolaos D. Bougalis

--- a/blog/2021/reserves-lowered.md
+++ b/blog/2021/reserves-lowered.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-09-21
+date: "2021-09-21"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 ---

--- a/blog/2021/ripple-lib-drops-lodash-browsers.md
+++ b/blog/2021/ripple-lib-drops-lodash-browsers.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-08-26
+date: "2021-08-26"
+template: '../../@theme/templates/blogpost'
 labels:
     - xrpl.js Release Notes
 ---

--- a/blog/2021/rippled-1.7.0.md
+++ b/blog/2021/rippled-1.7.0.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-02-24
+date: "2021-02-24"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 ---

--- a/blog/2021/rippled-1.7.2.md
+++ b/blog/2021/rippled-1.7.2.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-05-24
+date: "2021-05-24"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 ---

--- a/blog/2021/rippled-1.7.3.md
+++ b/blog/2021/rippled-1.7.3.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-08-27
+date: "2021-08-27"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 ---

--- a/blog/2021/rippled-1.8.1.md
+++ b/blog/2021/rippled-1.8.1.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-12-02
+date: "2021-12-02"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 ---

--- a/blog/2021/rippled-1.8.2.md
+++ b/blog/2021/rippled-1.8.2.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-12-20
+date: "2021-12-20"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 ---

--- a/blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security.md
+++ b/blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-02-24
+date: "2021-02-24"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 ---

--- a/blog/2021/sidechain-engineering-preview.md
+++ b/blog/2021/sidechain-engineering-preview.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-09-30
+date: "2021-09-30"
+template: '../../@theme/templates/blogpost'
 labels:
     - Development
 ---

--- a/blog/2021/three-amendments-expected.md
+++ b/blog/2021/three-amendments-expected.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-03-30
+date: "2021-03-30"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 ---

--- a/blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation.md
+++ b/blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-06-05
+date: "2021-06-05"
+template: '../../@theme/templates/blogpost'
 labels:
     - Features
 ---

--- a/blog/2021/xrpl-node-configurator.md
+++ b/blog/2021/xrpl-node-configurator.md
@@ -3,7 +3,8 @@ category: 2021
 markdown:
     editPage:
         hide: true
-date: 2021-04-14
+date: "2021-04-14"
+template: '../../@theme/templates/blogpost'
 labels:
     - Development
 author: Javier Romero

--- a/blog/2022/clio-1.0.0.md
+++ b/blog/2022/clio-1.0.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-06-29
+date: "2022-06-29"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2022/cryptoiso20022interop.md
+++ b/blog/2022/cryptoiso20022interop.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-11-15
+date: "2022-11-15"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2022/dev-reflections-relaunch.md
+++ b/blog/2022/dev-reflections-relaunch.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-10-26
+date: "2022-10-26"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2022/expandedsignerlist-enabled-and-nfts-approaching.md
+++ b/blog/2022/expandedsignerlist-enabled-and-nfts-approaching.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-10-13
+date: "2022-10-13"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2022/gemwallet.md
+++ b/blog/2022/gemwallet.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-11-23
+date: "2022-11-23"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2022/get-ready-for-nfts.md
+++ b/blog/2022/get-ready-for-nfts.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-09-01
+date: "2022-09-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2022/introducing-clio.md
+++ b/blog/2022/introducing-clio.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-03-22
+date: "2022-03-22"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2022/introducing-learning-portal.md
+++ b/blog/2022/introducing-learning-portal.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-10-03
+date: "2022-10-03"
+template: '../../@theme/templates/blogpost'
 labels:
     - Features
 markdown:

--- a/blog/2022/introducing-xrpl-py-2.0.0beta.md
+++ b/blog/2022/introducing-xrpl-py-2.0.0beta.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-12-13
+date: "2022-12-13"
+template: '../../@theme/templates/blogpost'
 labels:
     - xrpl-py Release Notes
 markdown:

--- a/blog/2022/nft-devnet-reset.md
+++ b/blog/2022/nft-devnet-reset.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-03-01
+date: "2022-03-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2022/nftmaster.md
+++ b/blog/2022/nftmaster.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-12-14
+date: "2022-12-14"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2022/non-fungible-tokens-are-now-available.md
+++ b/blog/2022/non-fungible-tokens-are-now-available.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-11-01
+date: "2022-11-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2022/rippled-1.8.4.md
+++ b/blog/2022/rippled-1.8.4.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-01-13
+date: "2022-01-13"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2022/rippled-1.8.5.md
+++ b/blog/2022/rippled-1.8.5.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-02-08
+date: "2022-02-08"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2022/rippled-1.9.0.md
+++ b/blog/2022/rippled-1.9.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-04-07
+date: "2022-04-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2022/rippled-1.9.1.md
+++ b/blog/2022/rippled-1.9.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-05-23
+date: "2022-05-23"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2022/rippled-1.9.2.md
+++ b/blog/2022/rippled-1.9.2.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-07-26
+date: "2022-07-26"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2022/rippled-1.9.3.md
+++ b/blog/2022/rippled-1.9.3.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-08-26
+date: "2022-08-26"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2022/rippled-1.9.4.md
+++ b/blog/2022/rippled-1.9.4.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-09-20
+date: "2022-09-20"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
     - Amendments

--- a/blog/2022/xpmarket.md
+++ b/blog/2022/xpmarket.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-12-07
+date: "2022-12-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2022/ziggurat.md
+++ b/blog/2022/ziggurat.md
@@ -1,6 +1,7 @@
 ---
 category: 2022
-date: 2022-11-30
+date: "2022-11-30"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/aesthetes.md
+++ b/blog/2023/aesthetes.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-01-18
+date: "2023-01-18"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/bei-api.md
+++ b/blog/2023/bei-api.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-03-01
+date: "2023-03-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/blockdaemon.md
+++ b/blog/2023/blockdaemon.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-08-29
+date: "2023-08-29"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/chispend.md
+++ b/blog/2023/chispend.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-04-05
+date: "2023-04-05"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/ciso.md
+++ b/blog/2023/ciso.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-06-07
+date: "2023-06-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/clio-2.0.0.md
+++ b/blog/2023/clio-2.0.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-10-31
+date: "2023-10-31"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2023/data-api-v2-deprecated.md
+++ b/blog/2023/data-api-v2-deprecated.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-10-05
+date: "2023-10-05"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
     - Data API

--- a/blog/2023/decommissioning-amm-devnet.md
+++ b/blog/2023/decommissioning-amm-devnet.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-12-05
+date: "2023-12-05"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2023/devnet-reset-scheduled-sep-19-2023.md
+++ b/blog/2023/devnet-reset-scheduled-sep-19-2023.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-09-11
+date: "2023-09-11"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2023/disallowincoming-and-others-expected.md
+++ b/blog/2023/disallowincoming-and-others-expected.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-08-07
+date: "2023-08-07"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2023/edge.md
+++ b/blog/2023/edge.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-05-17
+date: "2023-05-17"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/fieldboss.md
+++ b/blog/2023/fieldboss.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-06-28
+date: "2023-06-28"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/gemwallet-update.md
+++ b/blog/2023/gemwallet-update.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-10-08
+date: "2023-10-08"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/mandla-money.md
+++ b/blog/2023/mandla-money.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-02-01
+date: "2023-02-01"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/nft-devnet-decommission.md
+++ b/blog/2023/nft-devnet-decommission.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2022-01-27
+date: "2022-01-27"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2023/rippled-1.10.0.md
+++ b/blog/2023/rippled-1.10.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-03-14
+date: "2023-03-14"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
     - Amendments

--- a/blog/2023/rippled-1.11.0.md
+++ b/blog/2023/rippled-1.11.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-06-21
+date: "2023-06-21"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
     - Amendments

--- a/blog/2023/rippled-1.12.0.md
+++ b/blog/2023/rippled-1.12.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-09-06
+date: "2023-09-06"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
     - Amendments

--- a/blog/2023/santiment.md
+++ b/blog/2023/santiment.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-10-06
+date: "2023-10-06"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/stably.md
+++ b/blog/2023/stably.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-01-04
+date: "2023-01-04"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/summarizing-xrpl-docs-iav3.md
+++ b/blog/2023/summarizing-xrpl-docs-iav3.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-07-25
+date: "2023-07-25"
+template: '../../@theme/templates/blogpost'
 labels:
     - Features
 markdown:

--- a/blog/2023/upcoming-devnet-reset.md
+++ b/blog/2023/upcoming-devnet-reset.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-09-06
+date: "2023-09-06"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2023/xrp-toolkit.md
+++ b/blog/2023/xrp-toolkit.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-07-28
+date: "2023-07-28"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/xrpcafe.md
+++ b/blog/2023/xrpcafe.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-05-03
+date: "2023-05-03"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2023/xrpl-py-2.0-release.md
+++ b/blog/2023/xrpl-py-2.0-release.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-07-05
+date: "2023-07-05"
+template: '../../@theme/templates/blogpost'
 labels:
     - xrpl-py Release Notes
 markdown:

--- a/blog/2023/zoetic.md
+++ b/blog/2023/zoetic.md
@@ -1,6 +1,7 @@
 ---
 category: 2023
-date: 2023-02-15
+date: "2023-02-15"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2024/a-new-era-for-the-xrp-ledger.md
+++ b/blog/2024/a-new-era-for-the-xrp-ledger.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-11-26
+date: "2024-11-26"
+template: '../../@theme/templates/blogpost'
 seo:
     title: The Evolution of the XRPL Foundation - A New Era for XRPL
     description: Discover the latest updates on the new XRPL Foundation’s incorporation, objectives, governance, and structure.

--- a/blog/2024/amm-status-update.md
+++ b/blog/2024/amm-status-update.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-03-26
+date: "2024-03-26"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
     - Amendments

--- a/blog/2024/clio-2.1.0.md
+++ b/blog/2024/clio-2.1.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-02-14
+date: "2024-02-14"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2024/clio-2.1.2.md
+++ b/blog/2024/clio-2.1.2.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-06-05
+date: "2024-06-05"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2024/clio-2.2.0.md
+++ b/blog/2024/clio-2.2.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-06-26
+date: "2024-06-26"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2024/clio-2.2.1.md
+++ b/blog/2024/clio-2.2.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-07-08
+date: "2024-07-08"
+template: '../../@theme/templates/blogpost'
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/2024/clio-2.2.2.md
+++ b/blog/2024/clio-2.2.2.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-07-22
+date: "2024-07-22"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing Clio version 2.2.2
     description: Version 2.2.2 of Clio, the XRP Ledger API server optimized for HTTP and WebSocket calls, is now available. Learn more about this update and bug fixes.

--- a/blog/2024/clio-2.3.0.md
+++ b/blog/2024/clio-2.3.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-12-12
+date: "2024-12-12"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing Clio version 2.3.0
     description: Version 2.3.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds new features and bug fixes.

--- a/blog/2024/deep-dive-into-amm-integration.md
+++ b/blog/2024/deep-dive-into-amm-integration.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-08-05
+date: "2024-08-05"
+template: '../../@theme/templates/blogpost'
 seo:
     title: XLS-30 - XRP Ledger Automated Market Maker
     description: The XLS-30 AMM amendment unlocks new liquidity and trading options on the XRP Ledger network. Explore how developers can integrate with AMM.

--- a/blog/2024/evolving-the-xrp-ledger.md
+++ b/blog/2024/evolving-the-xrp-ledger.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-08-10
+date: "2024-08-10"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Evolving the XRP Ledger Foundation
     description: Discover the latest in the XRPL community, including key organizations' plans to establish a more effective, inclusive, and visible XRPL Foundation with democratic governance.

--- a/blog/2024/filedgr.md
+++ b/blog/2024/filedgr.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-07-24
+date: "2024-07-24"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2024/get-ready-for-amm.md
+++ b/blog/2024/get-ready-for-amm.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-03-21
+date: "2024-03-21"
+template: '../../@theme/templates/blogpost'
 labels:
     - Amendments
 markdown:

--- a/blog/2024/how-to-master-xrp-transfers.md
+++ b/blog/2024/how-to-master-xrp-transfers.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-04-15
+date: "2024-04-15"
+template: '../../@theme/templates/blogpost'
 seo:
     title: How to Master XRP Transfers using Python
     description:  Discover how to create and manage accounts on the XRPL Testnet and master the art of transferring XRP using Python.

--- a/blog/2024/how-to-mint-nfts.md
+++ b/blog/2024/how-to-mint-nfts.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-03-08
+date: "2024-03-08"
+template: '../../@theme/templates/blogpost'
 seo:
     title: How to Mint an NFT
     description: Learn the basics of minting an NFT on XRP Ledger and how you can get started quickly and easily with this step-by-step guide. Get started today!

--- a/blog/2024/lower-reserves-are-in-effect.md
+++ b/blog/2024/lower-reserves-are-in-effect.md
@@ -3,7 +3,8 @@ category: 2024
 markdown:
     editPage:
         hide: true
-date: 2024-12-12
+date: "2024-12-12"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 ---

--- a/blog/2024/rippled-2.0.0.md
+++ b/blog/2024/rippled-2.0.0.md
@@ -7,6 +7,7 @@ labels:
 markdown:
     editPage:
         hide: true
+template: '../../@theme/templates/blogpost'
 ---
 # Introducing XRP Ledger version 2.0.0
 

--- a/blog/2024/rippled-2.0.0.md
+++ b/blog/2024/rippled-2.0.0.md
@@ -1,6 +1,6 @@
 ---
 category: 2024
-date: 2024-01-09
+date: "2024-01-09"
 labels:
     - rippled Release Notes
     - Amendments

--- a/blog/2024/rippled-2.0.1.md
+++ b/blog/2024/rippled-2.0.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-01-29
+date: "2024-01-29"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2024/rippled-2.1.0.md
+++ b/blog/2024/rippled-2.1.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-02-20
+date: "2024-02-20"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2024/rippled-2.1.1.md
+++ b/blog/2024/rippled-2.1.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-03-27
+date: "2024-03-27"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2024/rippled-2.2.0.md
+++ b/blog/2024/rippled-2.2.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-06-04
+date: "2024-06-04"
+template: '../../@theme/templates/blogpost'
 labels:
     - rippled Release Notes
 markdown:

--- a/blog/2024/rippled-2.2.1.md
+++ b/blog/2024/rippled-2.2.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-07-30
+date: "2024-07-30"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version 2.2.1
     description: rippled version 2.2.1 is now available, addressing a critical bug when handling some types of RPC requests. Learn more about this release.

--- a/blog/2024/rippled-2.2.2.md
+++ b/blog/2024/rippled-2.2.2.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-09-03
+date: "2024-09-03"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version 2.2.2
     description: rippled version 2.2.2 is now available, addressing a Mainnet issue that caused validators to stall during consensus. Learn more about this release.

--- a/blog/2024/rippled-2.2.3.md
+++ b/blog/2024/rippled-2.2.3.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-09-14
+date: "2024-09-14"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version 2.2.3
     description: rippled version 2.2.3 is now available, addressing an issue that could cause full-history servers to run out of space in their SQLite databases. Learn more about this release.

--- a/blog/2024/rippled-2.3.0.md
+++ b/blog/2024/rippled-2.3.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-11-25
+date: "2024-11-25"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version 2.3.0
     description: rippled version 2.3.0 is now available. This version introduces new features and stability fixes.

--- a/blog/2024/testnet-reset-notification.md
+++ b/blog/2024/testnet-reset-notification.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-08-14
+date: "2024-08-14"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Upcoming Testnet Reset Notification
     description: The Testnet reset was completed successfully on Monday, August 19, 2024 to improve stability and reduce the cost of running a Testnet node. Learn more.

--- a/blog/2024/testnet-reset.md
+++ b/blog/2024/testnet-reset.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-04-17
+date: "2024-04-17"
+template: '../../@theme/templates/blogpost'
 labels:
     - Advisories
 markdown:

--- a/blog/2024/verifyed.md
+++ b/blog/2024/verifyed.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-03-14
+date: "2024-03-14"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2024/web3auth.md
+++ b/blog/2024/web3auth.md
@@ -1,6 +1,7 @@
 ---
 category: 2024
-date: 2024-01-23
+date: "2024-01-23"
+template: '../../@theme/templates/blogpost'
 labels:
     - Developer Reflections
 markdown:

--- a/blog/2025/clio-2.3.1.md
+++ b/blog/2025/clio-2.3.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-02-12
+date: "2025-02-12"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing Clio version 2.3.1
     description: Version 2.3.1 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds bug fixes.

--- a/blog/2025/clio-2.4.0.md
+++ b/blog/2025/clio-2.4.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-03-18
+date: "2025-03-18"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing Clio version 2.4.0
     description: Version 2.4.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds bug fixes.

--- a/blog/2025/devnet-reset.md
+++ b/blog/2025/devnet-reset.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-01-24
+date: "2025-01-24"
+template: '../../@theme/templates/blogpost'
 seo:
     description: Devnet is scheduled to reset on Monday, February 3, 2025 due to Clio databases nearing capacity. Learn more.
 labels:

--- a/blog/2025/move-to-the-new-xrpl-foundation-commences.md
+++ b/blog/2025/move-to-the-new-xrpl-foundation-commences.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-02-19
+date: "2025-02-19"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Move to the New Foundation Commences
     description: With the new XRPL Foundation now incorporated in France, the Founding Members are migrating assets from the previous entity. Learn about the Unique Node List (UNL) transition and necessary actions for community members.

--- a/blog/2025/rippled-2.3.1.md
+++ b/blog/2025/rippled-2.3.1.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-01-30
+date: "2025-01-30"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version 2.3.1
     description: rippled version 2.3.1 is now available. This version includes stability fixes.

--- a/blog/2025/rippled-2.4.0.md
+++ b/blog/2025/rippled-2.4.0.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-03-06
+date: "2025-03-06"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version 2.4.0
     description: rippled version 2.4.0 is now available. This version introduces new features and stability fixes.

--- a/blog/2025/vulnerabilitydisclosurereport-bug-nov2024.md
+++ b/blog/2025/vulnerabilitydisclosurereport-bug-nov2024.md
@@ -1,6 +1,7 @@
 ---
 category: 2025
-date: 2025-01-10
+date: "2025-01-10"
+template: '../../@theme/templates/blogpost'
 seo:
     title: Malicious transaction crashed network node(s) and paused new transactions momentarily
     description: This vulnerability disclosure report contains technical details of the XRP Ledger bug reported on November 25, 2024.


### PR DESCRIPTION
- [x] Add a custom template for blog pages which is like the regular one except it has "Publication date: YYYY-MM-DD" at the top.
- [x] Apply the custom template to blog pages
- [x] Change the date field of blogs to be a string to work around a Redocly bug.

Hopefully this will fix #3083.