### PR TITLE
Invalid hot wallet error

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/account-methods/gateway_balances.md
+++ b/docs/references/http-websocket-apis/public-api-methods/account-methods/gateway_balances.md
@@ -304,4 +304,8 @@ The response follows the [standard format][], with a successful result containin
 * `actNotFound` - The [Address][] specified in the `account` field of the request does not correspond to an account in the ledger.
 * `lgrNotFound` - The ledger specified by the `ledger_hash` or `ledger_index` does not exist, or it does exist but the server does not have it.
 
+{% admonition type="info" name="Note" %}
+Due to a discrepancy in behavior between the Clio server and `rippled`, which was fixed in [Clio version 2.3.1](../../../../../blog/2025/clio-2.3.1.md#bug-fixes), the Clio server returns the `invalidParams` error in API v2 instead of `invalidHotWallet` when the `hotwallet` field is invalid. API v1 returns the `invalidHotWallet` error.
+{% /admonition %}
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
Fixes issue https://github.com/orgs/XRPLF/projects/4/views/1?pane=issue&itemId=95298179&issue=XRPLF%7Cxrpl-dev-portal%7C2949

I've added an admonition to note that Clio server returns different errors for API v1 and v2 when the `hotwallet` field is invalid.