### PR TITLE
Link MPTs from Payment page

### DIFF
--- a/docs/references/protocol/transactions/types/payment.md
+++ b/docs/references/protocol/transactions/types/payment.md
@@ -145,7 +145,7 @@ In the above example with a ¥95/$15 offer and a ¥5/$2 offer, the situation is 
 
 _(Requires the [MPTokensV1 amendment][] {% not-enabled /%})_
 
-When you send a payment using MPTs, the _Amount_ field requires only the `mpt_issuance_id` and the `value`. The `MPTokenIssuanceID` is used to uniquely identify the MPT for the transaction.
+When you send a payment using [MPTs](/docs/concepts/tokens/fungible-tokens/multi-purpose-tokens), the _Amount_ field requires only the `mpt_issuance_id` and the `value`. The `MPTokenIssuanceID` is used to uniquely identify the MPT for the transaction.
 
 Version 1 MPTokens only support direct MPT payment between accounts. They cannot be traded in the decentralized exchange.
 


### PR DESCRIPTION
The "MPT Payments" section of this page is one of the first search results for MPTs. This seems like a place where it's useful to link back to the concept article for MPTs.