### PR TITLE
Fix tx-serialization JS sample code

### DIFF
--- a/_code-samples/tx-serialization/js/index.js
+++ b/_code-samples/tx-serialization/js/index.js
@@ -37,7 +37,11 @@ const args = parseArgs(process.argv.slice(2), {
 
 function _pretty(message, color) {
     if (!args.raw) {
-        console.log(color, message)
+        if (color) {
+            console.log(color,message)
+        } else {
+            console.log(message)
+        }
     }
 }
 

--- a/_code-samples/tx-serialization/js/package.json
+++ b/_code-samples/tx-serialization/js/package.json
@@ -7,10 +7,9 @@
     "big-integer": "^1.6.52",
     "buffer": "^6.0.3",
     "decimal.js": "^10.4.3",
-    "fs": "^0.0.1-security",
     "minimist": "^1.2.7",
     "ripple-address-codec": "^5.0.0",
-    "xrpl": "^4.0.0"
+    "xrpl": "^4.2.5"
   },
   "main": "index.js",
   "scripts": {

--- a/_code-samples/tx-serialization/js/test-cases/README.md
+++ b/_code-samples/tx-serialization/js/test-cases/README.md
@@ -6,7 +6,7 @@ you can use to verify the behavior of the transaction serialization code.
 For example (starting from the `tx-serialization/js/` dir above this one):
 
 ```bash
-$ node index.js -f test-cases/tx2.json | \
+$ node index.js -rf test-cases/tx2.json | \
   diff - test-cases/tx2-binary.txt
 ```
 
@@ -46,7 +46,7 @@ CDC63E1DEE7FE3744630440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED
 For a friendlier display, you could pipe the output of the serializer to a file and use a visual tool like [Meld](http://meldmerge.org/) that shows intra-line differences:
 
 ```bash
-$ cat test-cases/tx1.json | sed -e 's/"Fee": "10"/"Fee": "100"/' | node index.js --stdin > /tmp/tx1-modified.txt && meld /tmp/tx1-modified.txt test-cases/tx1-binary.txt
+$ cat test-cases/tx1.json | sed -e 's/"Fee": "10"/"Fee": "100"/' | node index.js --raw --stdin > /tmp/tx1-modified.txt && meld /tmp/tx1-modified.txt test-cases/tx1-binary.txt
 ```
 
 ![Meld screenshot showing the `0A` / `64` difference](meld-example.png)

--- a/_code-samples/tx-serialization/js/tx-serializer.js
+++ b/_code-samples/tx-serialization/js/tx-serializer.js
@@ -92,7 +92,7 @@ class TxSerializer {
     _decodeAddress(address) {
         const decoded = codec.decodeChecked(address)
         if (decoded[0] === 0 && decoded.length === 21) {
-            return decoded.slice(1)
+            return Buffer.from(decoded.slice(1))
         }
 
         throw new Error("Not an AccountID!")
@@ -161,7 +161,7 @@ class TxSerializer {
             const byte2 = this.uint8ToBytes(typeCode)
             const byte3 = this.uint8ToBytes(fieldCode)
 
-            return "" + byte1 + byte2 + byte3 //TODO: bytes is python function
+            return "" + byte1 + byte2 + byte3
         }
     }
 
@@ -681,7 +681,6 @@ class TxSerializer {
                 fieldsAsBytes.push(fieldBytes)
             }
         }
-
         return fieldsAsBytes.join('')
     }
 }


### PR DESCRIPTION
1. Remove `fs` dependency from package.json which isn't needed.
2. Fix output showing "undefined" when a color wasn't provided to the `_pretty(...)` function.
3. Fix some sample commands missing `--raw` argument.
4. Fix account fields decoding to a Uint8array instead of a Buffer, resulting in a comma-separated decimal values instead of hex. I am not sure if this applies to all Node and `ripple-address-codec` versions, but it was happening with the latest `ripple-address-codec` and Node 20.19.0 on my machine.