### PR TITLE
Update Known Amendments status (2025-06-03)

### DIFF
--- a/blog/2025/fixes-enabled-dnfts-expected.md
+++ b/blog/2025/fixes-enabled-dnfts-expected.md
@@ -1,0 +1,64 @@
+---
+category: 2025
+date: "2025-06-03"
+template: '../../@theme/templates/blogpost'
+seo:
+    description: 
+labels:
+    - Amendments
+markdown:
+    editPage:
+        hide: true
+---
+# Two Fix Amendments Enabled, dNFTs Expected
+
+Two fixes to the XRP Ledger protocol, [fixFrozenLPTokenTransfer](/resources/known-amendments#fixfrozenlptokentransfer) and [fixInvalidTxFlags](/resources/known-amendments#fixinvalidtxflags), became enabled on 2025-015-15. Additionally, the [DynamicNFT amendment](/resources/known-amendments#dynamicnft) has gained support from a supermajority of validators and will become enabled on 2025-06-11 if it maintains continuous support. The minimum core server version to support these amendments is **v2.4.0**; any servers on older versions are now amendment blocked.
+
+<!-- BREAK -->
+
+## Action Required
+
+- If you operate a core XRP Ledger (`rippled`) server, you must upgrade to version [**2.4.0**](./rippled-2.4.0.md) or higher, for service continuity.
+- If you operate a Clio server, you must upgrade to version **2.4.0** or higher, for service continuity. [Version **2.4.1**](./clio-2.4.1.md) is recommended.
+
+### Impact of Not Upgrading
+
+If you operate a `rippled` server that is older than version 2.4.0, then your server is now amendment blocked, meaning that your server:
+
+* Cannot determine the validity of a ledger
+* Cannot submit or process transactions
+* Does not participate in the consensus process
+* Does not vote on future amendments
+* Could rely on potentially invalid data
+
+If you operate a Clio server that is older than version 2.4.0, then your server cannot process new ledgers from the network.
+
+For instructions on upgrading core servers on supported platforms, see [Installation](/docs/infrastructure/installation/).
+
+## DynamicNFT Amendment Details
+
+The DynamicNFT amendment adds functionality to make mutable Non-Fungible Tokens (NFTs). NFTs that are minted with the new `tfMutable` flag enabled are mutable, which means their `URI` field can be updated after minting. NFTs that are not marked as mutable when they are minted cannot be changed.
+
+The new [NFTokenModify transaction](/docs/references/protocol/transactions/types/nftokenmodify.md) can modify the `URI` field of a mutable NFT.
+
+## Upcoming Amendments
+
+The [Known Amendments](/resources/known-amendments) page has been updated to list several amendments which are on track to be included in the upcoming 2.5.0 release of the core XRP Ledger server. These amendments are:
+
+- **Batch**: Submit several transactions as one batch to be processed together.
+- **fixAMMv1_3**: Fix some bugs in Automated Market Makers, including rounding on deposits and stricter validation in the auction slot mechanism.
+- **fixEnforceNFTokenTrustlineV2**: Fix bugs that could allow NFT issuers to receive fungible tokens as transfer fees, circumventing authorized trust lines or deep freeze.
+- **fixPayChanCancelAfter**: Fix a bug that could allow you to create a payment channel that has already expired.
+- **PermissionDelegation**: Allow accounts to delegate some permissions to other accounts.
+- **PermissionedDEX**: Create controlled environments for trading in the Decentralized Exchange, restricted by permissioned domains.
+- **SingleAssetVault**: Create a mechanism for pooling assets from multiple depositors into a single structure in the ledger.
+- **TokenEscrow**: Extend escrow functionality to support issued tokens and MPTs.
+
+All of these amendments have already been merged to the `develop` branch and are undergoing final testing now. They will be officially _open for voting_ when they are included in a stable release. Any amendments that are open for voting can become enabled following two weeks of support from a supermajority of greater than 80% of trusted validators, per the [amendment process](/docs/concepts/networks-and-servers/amendments).
+
+## Learn and Discuss
+
+If you have more feedback on these and other upcoming protocol features, your feedback is welcome! See the following resources for more:
+
+- [XRPL Standards Repository](https://github.com/XRPLF/XRPL-Standards)
+- [XRPL Dev Discord](https://discord.gg/sfX3ERAMjH)

--- a/blog/2025/fixes-enabled-dnfts-expected.md
+++ b/blog/2025/fixes-enabled-dnfts-expected.md
@@ -12,7 +12,7 @@ markdown:
 ---
 # Two Fix Amendments Enabled, dNFTs Expected
 
-Two fixes to the XRP Ledger protocol, [fixFrozenLPTokenTransfer](/resources/known-amendments#fixfrozenlptokentransfer) and [fixInvalidTxFlags](/resources/known-amendments#fixinvalidtxflags), became enabled on 2025-015-15. Additionally, the [DynamicNFT amendment](/resources/known-amendments#dynamicnft) has gained support from a supermajority of validators and will become enabled on 2025-06-11 if it maintains continuous support. The minimum core server version to support these amendments is **v2.4.0**; any servers on older versions are now amendment blocked.
+Two fixes to the XRP Ledger protocol, [fixFrozenLPTokenTransfer](/resources/known-amendments#fixfrozenlptokentransfer) and [fixInvalidTxFlags](/resources/known-amendments#fixinvalidtxflags), became enabled on 2025-05-15. Additionally, the [DynamicNFT amendment](/resources/known-amendments#dynamicnft) has gained support from a supermajority of validators and will become enabled on 2025-06-11 if it maintains continuous support. The minimum core server version to support these amendments is **v2.4.0**; any servers on older versions are now amendment blocked.
 
 <!-- BREAK -->
 

--- a/blog/sidebars.yaml
+++ b/blog/sidebars.yaml
@@ -6,6 +6,7 @@
     - group: '2025'
       expanded: false
       items:
+        - page: 2025/fixes-enabled-dnfts-expected.md
         - page: 2025/clio-2.4.1.md
         - page: 2025/integrating-dia-oracles-on-xrpl.md
         - page: 2025/vulnerabilitydisclosurereport-bug-apr2025.md

--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -48,6 +48,7 @@
 [Amendments object]: /docs/concepts/networks-and-servers/amendments.md
 [Amendmentsエントリ]: /docs/concepts/networks-and-servers/amendments.md
 [Amendmentsオブジェクト]: /docs/concepts/networks-and-servers/amendments.md
+[Batch amendment]: /resources/known-amendments.md#batch
 [Check entry]: /docs/references/protocol/ledger-data/ledger-entry-types/check.md
 [Check object]: /docs/references/protocol/ledger-data/ledger-entry-types/check.md
 [Checkエントリ]: /docs/references/protocol/ledger-data/ledger-entry-types/check.md
@@ -247,6 +248,8 @@
 [PaymentChannelFundトランザクション]: /docs/references/protocol/transactions/types/paymentchannelfund.md
 [Payment]: /docs/references/protocol/transactions/types/payment.md
 [Paymentトランザクション]: /docs/references/protocol/transactions/types/payment.md
+[PermissionDelegation amendment]: /resources/known-amendments.md#permissiondelegation
+[PermissionedDEX amendment]: /resources/known-amendments.md#permissioneddex
 [PermissionedDomainSet transaction]: /docs/references/protocol/transactions/types/permissioneddomainset.md
 [PermissionedDomains amendment]: /resources/known-amendments.md#permissioneddomains
 [permissioned domain]: /docs/concepts/tokens/decentralized-exchange/permissioned-domains.md
@@ -280,6 +283,7 @@
 [SignerListSet transactions]: /docs/references/protocol/transactions/types/signerlistset.md
 [SignerListSet]: /docs/references/protocol/transactions/types/signerlistset.md
 [SignerListSetトランザクション]: /docs/references/protocol/transactions/types/signerlistset.md
+[SingleAssetVault amendment]: /resources/known-amendments.md#singleassetvault
 [SortedDirectories amendment]: /resources/known-amendments.md#sorteddirectories
 [Specifying Currency Amounts]: /docs/references/protocol/data-types/basic-data-types.md#specifying-currency-amounts
 [Specifying Ledgers]: /docs/references/protocol/data-types/basic-data-types.md#specifying-ledgers
@@ -297,6 +301,7 @@
 [TicketCreate]: /docs/references/protocol/transactions/types/ticketcreate.md
 [TicketCreateトランザクション]: /docs/references/protocol/transactions/types/ticketcreate.md
 [Tickets amendment]: /resources/known-amendments.md#tickets
+[TokenEscrow amendment]: /resources/known-amendments.md#tokenescrow
 [Transaction Cost]: /docs/concepts/transactions/transaction-cost.md
 [TrustSet transaction]: /docs/references/protocol/transactions/types/trustset.md
 [TrustSet transactions]: /docs/references/protocol/transactions/types/trustset.md
@@ -410,8 +415,10 @@
 [fix1571 amendment]: /resources/known-amendments.md#fix1571
 [fix1578 amendment]: /resources/known-amendments.md#fix1578
 [fix1623 amendment]: /resources/known-amendments.md#fix1623
+[fixAMMv1_3 amendment]: /resources/known-amendments.md#fixammv1_3
 [fixCheckThreading amendment]: /resources/known-amendments.md#fixcheckthreading
 [fixDisallowIncomingV1 amendment]: /resources/known-amendments.md#fixdisallowincomingv1
+[fixEnforceNFTokenTrustlineV2 amendment]: /resources/known-amendments.md#fixenforcenftokentrustlinev2
 [fixFillOrKill amendment]: /resources/known-amendments.md#fixfillorkill
 [fixFrozenLPTokenTransfer]: /resources/known-amendments.md#fixfrozenlptokentransfer
 [fixInvalidTxFlags amendment]: /resources/known-amendments.md#fixinvalidtxflags
@@ -419,6 +426,7 @@
 [fixNFTokenDirV1 amendment]: /resources/known-amendments.md#fixnftokendirv1
 [fixNFTokenPageLinks amendment]: /resources/known-amendments.md#fixnftokenpagelinks
 [fixNFTokenRemint amendment]: /resources/known-amendments.md#fixnftokenremint
+[fixPayChanCancelAfter amendment]: /resources/known-amendments.md#fixpaychancancelafter
 [fixPayChanRecipientOwnerDir amendment]: /resources/known-amendments.md#fixpaychanrecipientownerdir
 [fixPreviousTxnID amendment]: /resources/known-amendments.md#fixprevioustxnid
 [fixQualityUpperBound amendment]: /resources/known-amendments.md#fixqualityupperbound

--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -157,6 +157,10 @@
 [LedgerHashes object]: /docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes.md
 [LedgerHashesエントリ]: /docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes.md
 [LedgerHashesオブジェクト]: /docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes.md
+[LedgerStateFix transaction]: /docs/references/protocol/transactions/types/ledgerstatefix.md
+[LedgerStateFix transactions]: /docs/references/protocol/transactions/types/ledgerstatefix.md
+[LedgerStateFix]: /docs/references/protocol/transactions/types/ledgerstatefix.md
+[LedgerStateFixトランザクション]: /docs/references/protocol/transactions/types/ledgerstatefix.md
 [Marker]: /docs/references/http-websocket-apis/api-conventions/markers-and-pagination.md
 [MPTokensV1 amendment]: /resources/known-amendments.md#mptokensv1
 [MultiSign amendment]: /resources/known-amendments.md#multisign

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -819,7 +819,7 @@ Adds several fixes to Automated Market Maker code, specifically:
 - Add several invariant checks to ensure that AMMs function as designed.
 - Add rounding to AMM deposit and withdraw to ensure that the AMM's balance meets the invariant:
     - On deposit, tokens out are rounded downward and deposit amount is rounded upward.
-    - On withdrawal, tokens in are rounded upward and withdrawal amount is rounded downard.
+    - On withdrawal, tokens in are rounded upward and withdrawal amount is rounded downward.
 - Fix validation of [AMMBid transactions][] to ensure that `AuthAccounts` cannot contain duplicates or the transaction sender.
 
 
@@ -909,8 +909,8 @@ Fixes two bugs relating to the handling of NFT transfer fees and trust lines:
 
 Fix a bug where NFT transfer fees could bypass certain limitations on receiving tokens, specifically:
 
-- Prevent an NFT issuer from receiving fungible tokens as transfer fees if the fungible tokens' issuer uses Authorized Trust Lines and the NFT issuer's trust line is not authorized.
-- Prevent an NFT issuer from receiving fungible tokens as transfer fees on a deep-frozen trust line.
+- Prevent an NFT issuer from receiving fungible tokens as transfer fees if the fungible tokens' issuer uses [authorized trust lines](/docs/concepts/tokens/fungible-tokens/authorized-trust-lines) and the NFT issuer's trust line is not authorized.
+- Prevent an NFT issuer from receiving fungible tokens as transfer fees on a [deep-frozen](/docs/concepts/tokens/fungible-tokens/deep-freeze) trust line.
 
 Without this amendment, NFT transfer fees could be paid to an NFT issuer circumventing these restrictions.
 
@@ -1151,7 +1151,7 @@ See [Issue 4373](https://github.com/XRPLF/rippled/issues/4373).
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-Prevents new payment channels from being created with a `CancelAfter` time that is before the current ledger. Instead, the PaymentChannelCreate transaction fails with the result code `tecEXPIRED`.
+Prevents new payment channels from being created with a `CancelAfter` time that is before the current ledger. Instead, the [PaymentChannelCreate transaction][] fails with the result code `tecEXPIRED`.
 
 Without this amendment, transactions can create a payment channel whose `CancelAfter` time is in the past. This payment channel is automatically removed as expired by the next transaction to affect it.
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -17,14 +17,14 @@ This list is updated manually. For a live view of amendment voting, see the Amen
 
 | Name                              | Introduced | Status                        |
 |:----------------------------------|:-----------|:------------------------------|
-| [DynamicNFT][]                    | v2.4.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.4.0" %}Open for Voting: 2025-03-06{% /badge %} |
-| [fixFrozenLPTokenTransfer][]      | v2.4.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.4.0" %}Expected: 2025-05-15{% /badge %} |
-| [fixInvalidTxFlags][]             | v2.4.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.4.0" %}Expected: 2025-05-15{% /badge %} |
+| [DynamicNFT][]                    | v2.4.0     | {% badge href="https://xrpl.org/blog/2025/fixes-enabled-dnfts-expected" %}Expected: 2025-06-11{% /badge %} |
 | [PermissionedDomains][]           | v2.4.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.4.0" %}Open for Voting: 2025-03-06{% /badge %} |
 | [Credentials][]                   | v2.3.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.3.0" %}Open for Voting: 2024-11-26{% /badge %} |
 | [MPTokensV1][]                    | v2.3.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.3.0" %}Open for Voting: 2024-11-26{% /badge %} |
 | [fixXChainRewardRounding][]       | v2.2.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.2.0" %}Open for Voting: 2024-06-04{% /badge %} |
 | [XChainBridge][]                  | v2.0.0     | {% badge href="https://xrpl.org/blog/2024/rippled-2.0.0.html" %}Open for Voting: 2024-01-09{% /badge %} |
+| [fixFrozenLPTokenTransfer][]      | v2.4.0     | {% badge href="https://livenet.xrpl.org/transactions/34F11D09E15EC3FE78FFB238EB33030A9E2F2B6233716712A4B7A9D13C55C89A" %}Enabled: 2025-05-15{% /badge %} |
+| [fixInvalidTxFlags][]             | v2.4.0     | {% badge href="https://livenet.xrpl.org/transactions/D53E906A53C46A9AACFEB0093DF26EFD8634C3DAF50A18930D7910C51FFE3E9D" %}Enabled: 2025-05-15{% /badge %} |
 | [DeepFreeze][]                    | v2.4.0     | {% badge href="https://livenet.xrpl.org/transactions/976281D793337FF5377A36409F2A1432DADAB64DB5064E12E71B1AC491EA3021" %}Enabled: 2025-05-04{% /badge %} |
 | [NFTokenMintOffer][]              | v2.3.0     | {% badge href="https://livenet.xrpl.org/transactions/E74C0196A9D4F193DD2A1DB5CCC5E37D3D43A21E2CB6185F6797E9BF2EDBE36C" %}Enabled: 2025-02-15{% /badge %} |
 | [AMMClawback][]                   | v2.3.0     | {% badge href="https://livenet.xrpl.org/transactions/8672DFD11FCF79F8E8F92E300187E8E533899ED8C8CF5AFB1A9C518195C16261" %}Enabled: 2025-01-30{% /badge %} |
@@ -113,6 +113,14 @@ The following is a list of [amendments](../docs/concepts/networks-and-servers/am
 | [Hooks][]                         | {% badge %}In Development: TBD{% /badge %} | [XRPL Hooks](https://hooks.xrpl.org/) |
 | [InvariantsV1_1][]                | {% badge %}In Development: TBD{% /badge %} |  |
 | [OwnerPaysFee][]                  | {% badge %}In Development: TBD{% /badge %} |  |
+| [Batch][]                         | {% badge %}In Development: TBD{% /badge %} |  |
+| [fixAMMv1_3][]                    | {% badge %}In Development: TBD{% /badge %} |  |
+| [fixEnforceNFTokenTrustlineV2][]  | {% badge %}In Development: TBD{% /badge %} |  |
+| [fixPayChanCancelAfter][]         | {% badge %}In Development: TBD{% /badge %} |  |
+| [PermissionDelegation][]          | {% badge %}In Development: TBD{% /badge %} |  |
+| [PermissionedDEX][]               | {% badge %}In Development: TBD{% /badge %} |  |
+| [SingleAssetVault][]              | {% badge %}In Development: TBD{% /badge %} |  |
+| [TokenEscrow][]                   | {% badge %}In Development: TBD{% /badge %} |  |
 
 {% admonition type="success" name="Tip" %}
 This list is updated manually. If you're working on an amendment and have a private network to test the changes, you can edit this page to add your in-development amendment to this list. For more information on contributing to the XRP Ledger, see [Contribute Code to the XRP Ledger](contribute-code/index.md).
@@ -185,6 +193,19 @@ Allows tokens with clawback enabled to be used in Automated Market Makers (AMMs)
 Also modifies the AMMDeposit transaction type to prevent depositing frozen tokens into the AMM.
 
 For details, see the [XLS-73: AMMClawback specification](https://github.com/XRPLF/XRPL-Standards/discussions/212).
+
+
+### Batch
+[Batch]: #batch
+
+| Amendment    | Batch |
+|:-------------|:------|
+| Amendment ID | 894646DD5284E97DECFE6674A6D6152686791C4A95F8C132CCA9BAF9E5812FB6 |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Allows multiple transactions to be bundled into a batch that's processed all together. Standard: [XLS-56d](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0056d-batch)
 
 
 ### CheckCashMakesTrustLine
@@ -360,7 +381,7 @@ Also fixes a bug in the EscrowCreate and PaymentChannelCreate transactions where
 
 
 ### DepositPreauth
-[DepositPreauth]: #depositpreauth
+[DepositPreauthAmendment]: #depositpreauth
 
 | Amendment    | DepositPreauth |
 |:-------------|:---------------|
@@ -430,7 +451,7 @@ Without this amendment, any account can create these objects with any object as 
 | Amendment    | DynamicNFT |
 |:-------------|:-----------|
 | Amendment ID | C1CE18F2A268E6A849C27B3DE485006771B4C01B2FCEC4F18356FE92ECD6BB74 |
-| Status       | Open for Voting |
+| Status       | Expected |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -783,6 +804,25 @@ Fixes two bugs in Automated Market Maker (AMM) transaction processing:
 - Fixes a bug in payment processing that causes cross-currency payments not to use the full amount of liquidity available from the combination of AMM and order books in some cases.
 
 
+### fixAMMv1_3
+[fixAMMv1_3]: #fixammv1_3
+
+| Amendment    | fixAMMv1_3 |
+|:-------------|:-----------|
+| Amendment ID | 7CA70A7674A26FA517412858659EBC7EDEEF7D2D608824464E6FDEFD06854E14 |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Adds several fixes to Automated Market Maker code, specifically:
+
+- Add several invariant checks to ensure that AMMs function as designed.
+- Add rounding to AMM deposit and withdraw to ensure that the AMM's balance meets the invariant:
+    - On deposit, tokens out are rounded downward and deposit amount is rounded upward.
+    - On withdrawal, tokens in are rounded upward and withdrawal amount is rounded downard.
+- Fix validation of [AMMBid transactions][] to ensure that `AuthAccounts` cannot contain duplicates or the transaction sender.
+
+
 ### fixCheckThreading
 [fixCheckThreading]: #fixcheckthreading
 
@@ -857,6 +897,23 @@ Fixes two bugs relating to the handling of NFT transfer fees and trust lines:
 - Adjusts a check for the presence of a trust line when the minter of the NFT is also the issuer of the fungible token that would be paid as a transfer fee. Without this amendment, the [NFTokenCreateOffer transaction][] fails with the result code `tecNO_LINE` if the NFT in question has a transfer fee, the offer amount is denominated in fungible tokens issued by the minter, and the account placing the offer does not have a trust line for those tokens. With the amendment, the offer can be created successfully. (For more detail, see [issue #4941](https://github.com/XRPLF/rippled/issues/4941).)
 
 
+### fixEnforceNFTokenTrustlineV2
+[fixEnforceNFTokenTrustlineV2]: #fixenforcenftokentrustlinev2
+
+| Amendment    | fixEnforceNFTokenTrustlineV2 |
+|:-------------|:-----------------------------|
+| Amendment ID | B32752F7DCC41FB86534118FC4EEC8F56E7BD0A7DB60FD73F93F257233C08E3A |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Fix a bug where NFT transfer fees could bypass certain limitations on receiving tokens, specifically:
+
+- Prevent an NFT issuer from receiving fungible tokens as transfer fees if the fungible tokens' issuer uses Authorized Trust Lines and the NFT issuer's trust line is not authorized.
+- Prevent an NFT issuer from receiving fungible tokens as transfer fees on a deep-frozen trust line.
+
+Without this amendment, NFT transfer fees could be paid to an NFT issuer circumventing these restrictions.
+
 ### fixFillOrKill
 [fixFillOrKill]: #fixfillorkill
 
@@ -880,7 +937,7 @@ This amendment has no effect unless the [FlowCross][] amendment is enabled.
 | Amendment    | fixFrozenLPTokenTransfer |
 |:-------------|:-------------------------|
 | Amendment ID | 83FD6594FF83C1D105BD2B41D7E242D86ECB4A8220BD9AF4DA35CB0F69E39B2A |
-| Status       | Expected |
+| Status       | Enabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -938,7 +995,7 @@ It is believed that this change does not affect transaction processing, but it i
 | Amendment    | fixInvalidTxFlags |
 |:-------------|:------------------|
 | Amendment ID | 8EC4304A06AF03BE953EA6EDA494864F6F3F30AA002BABA35869FBB8C6AE5D52 |
-| Status       | Expected |
+| Status       | Enabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1004,7 +1061,7 @@ This amendment has no effect unless the [NonFungibleTokensV1][] amendment is ena
 
 This amendment fixes a bug that can cause NFT directories to have missing links in the middle of the directory chain. It also introduces invariant checks that can prevent similar types of corruption from occurring in the future, and introduces a new transaction type:
 
-- **LedgerStateFix transactions** <!-- TODO: link when docs have been added --> can be used to repair corruptions in ledger data. With this amendment enabled, you can use a LedgerStateFix transaction to repair a broken link in NFT directories. In the case that future bugs cause new types of ledger corruption, this transaction type can be extended to repair the other types of corruption as well.
+- **[LedgerStateFix transactions][]** can be used to repair corruptions in ledger data. With this amendment enabled, you can use a LedgerStateFix transaction to repair a broken link in NFT directories. In the case that future bugs cause new types of ledger corruption, this transaction type can be extended to repair the other types of corruption as well.
 
 Without this amendment, it is possible in specific circumstances to delete the last page of an NFT directory, then later create a new last page that is missing a link to the previous page. For a detailed description of the scenario that can cause this problem, see [PR #4945](https://github.com/XRPLF/rippled/pull/4945). With this amendment, the bug that caused that corruption is fixed; additionally, a new invariant check ensures that other bugs cannot remove the last page inappropriately.
 
@@ -1082,6 +1139,21 @@ See [Issue 4374](https://github.com/XRPLF/rippled/issues/4374).
 If you set a destination on an NFT offer, only that destination can settle through brokerage (fix #4373).
 
 See [Issue 4373](https://github.com/XRPLF/rippled/issues/4373).
+
+
+### fixPayChanCancelAfter
+[fixPayChanCancelAfter]: #fixpaychancancelafter
+
+| Amendment    | fixPayChanCancelAfter |
+|:-------------|:----------------------|
+| Amendment ID | D3456A862DC07E382827981CA02E21946E641877F19B8889031CC57FDCAC83E2 |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Prevents new payment channels from being created with a `CancelAfter` time that is before the current ledger. Instead, the PaymentChannelCreate transaction fails with the result code `tecEXPIRED`.
+
+Without this amendment, transactions can create a payment channel whose `CancelAfter` time is in the past. This payment channel is automatically removed as expired by the next transaction to affect it.
 
 
 ### fixPayChanRecipientOwnerDir
@@ -1595,6 +1667,36 @@ Creates three new transaction types: [PaymentChannelCreate][], [PaymentChannelCl
 For more information, see the [Payment Channels Tutorial](../docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels/index.md).
 
 
+### PermissionDelegation
+[PermissionDelegation]: #permissiondelegation
+
+| Amendment    | PermissionDelegation |
+|:-------------|:---------------------|
+| Amendment ID | AE6AB9028EEB7299EBB03C7CBCC3F2A4F5FBE00EA28B8223AA3118A0B436C1C5 |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Allows accounts to delegate some permissions to other accounts.
+
+Specification: [XLS-75](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0075d-permission-delegation).
+
+
+### PermissionedDEX
+[PermissionedDEX]: #permissioneddex
+
+| Amendment    | PermissionedDEX |
+|:-------------|:----------------|
+| Amendment ID | 677E401A423E3708363A36BA8B3A7D019D21AC5ABD00387BDBEA6BDE4C91247E |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Creates Permissioned DEXes, controlled environments for trading within the XRP Ledger's [decentralized exchange (DEX)](/docs/concepts/tokens/decentralized-exchange). Trading in a permissioned DEX works like trading in the open DEX, except that a permissioned domain controls who can place and accept offers.
+
+Specification: [XLS-81](https://github.com/XRPLF/XRPL-Standards/pull/281)
+
+
 ### PermissionedDomains
 [PermissionedDomains]: #permissioneddomains
 
@@ -1657,6 +1759,21 @@ For more information, see [`rippled` issue #3042](https://github.com/XRPLF/rippl
 Changes the hash tree structure that `rippled` uses to represent a ledger. The new structure is more compact and efficient than the previous version. This affects how ledger hashes are calculated, but has no other user-facing consequences.
 
 When this amendment is activated, the XRP Ledger will undergo a brief scheduled unavailability while the network calculates the changes to the hash tree structure. <!-- STYLE_OVERRIDE: will -->
+
+
+### SingleAssetVault
+[SingleAssetVault]: #singleassetvault
+
+| Amendment    | SingleAssetVault |
+|:-------------|:-----------------|
+| Amendment ID | 81BD2619B6B3C8625AC5D0BC01DE17F06C3F0AB95C7C87C93715B87A4FD240D8 |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Creates a structure for aggregating assets from multiple depositors. This is intended to be used with the proposed on-chain Lending Protocol.
+
+Specification: [XLS-65](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0065d-single-asset-vault).
 
 
 ### SortedDirectories
@@ -1728,6 +1845,21 @@ This amendment was replaced by the [TicketBatch][] amendment.
 Changes the way [Offers](../docs/concepts/tokens/decentralized-exchange/offers.md#lifecycle-of-an-offer) are ranked in order books, so that currency issuers can configure how many significant digits are taken into account when ranking Offers by exchange rate. With this amendment, the exchange rates of Offers are rounded to the configured number of significant digits, so that more Offers have the same exact exchange rate. The intent of this change is to require a meaningful improvement in price to outrank a previous Offer. If used by major issuers, this should reduce the incentive to spam the ledger with Offers that are only a tiny fraction of a percentage point better than existing offers. It may also increase the efficiency of order book storage in the ledger, because Offers can be grouped into fewer exchange rates.
 
 Introduces a `TickSize` field to accounts, which can be set with the [AccountSet transaction type](../docs/references/protocol/transactions/types/accountset.md). If a currency issuer sets the `TickSize` field, the XRP Ledger truncates the exchange rate (ratio of funds in to funds out) of Offers to trade the issuer's currency, and adjusts the amounts of the Offer to match the truncated exchange rate. If only one currency in the trade has a `TickSize` set, that number of significant digits applies. When trading two currencies that have different `TickSize` values, whichever `TickSize` indicates the fewest significant digits applies. XRP does not have a `TickSize`.
+
+
+### TokenEscrow
+[TokenEscrow]: #tokenescrow
+
+| Amendment    | TokenEscrow |
+|:-------------|:------------|
+| Amendment ID | 138B968F25822EFBF54C00F97031221C47B1EAB8321D93C7C2AEAF85F04EC5DF |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Extends the existing Escrow functionality to support escrowing issued tokens or MPTs.
+
+Specification: [XLS-85](https://github.com/XRPLF/XRPL-Standards/pull/272/)
 
 
 ### TrustSetAuth


### PR DESCRIPTION
- Add blog post noting that fixFrozenLPTokenTransfer and fixInvalidTxFlags are enabled, v2.4.0 is the minimum required version now, and the DynamicNFT amendment currently holds a supermajority and is expected on 2025-06-11.
- Update Known Amendments with the amendments that are already merged to `develop` and likely to be included in v2.5.0.
- Fix a couple other minor link issues on the Known Amendments page.
- Create common link definitions for all the v2.5.0 amendments.

(Note: the blog is not expected to be translated to Japanese, but the Known Amendments updates should be.)