### PR TITLE
Update MPTokenAuthorize tx docs

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -254,6 +254,7 @@
 [PermissionedDomains amendment]: /resources/known-amendments.md#permissioneddomains
 [permissioned domain]: /docs/concepts/tokens/decentralized-exchange/permissioned-domains.md
 [PriceOracle amendment]: /resources/known-amendments.md#priceoracle
+[MPToken entry]: /docs/references/protocol/ledger-data/ledger-entry-types/mptoken.md
 [MPTokensV1_1 amendment]: /resources/known-amendments.md#priceoracle
 [RFC-1751]: https://tools.ietf.org/html/rfc1751
 [Reporting Mode]: /docs/concepts/networks-and-servers/rippled-server-modes.md#reporting-mode

--- a/docs/references/protocol/transactions/types/mptokenauthorize.md
+++ b/docs/references/protocol/transactions/types/mptokenauthorize.md
@@ -1,6 +1,4 @@
 ---
-html: mptokenauthorize.html
-parent: transaction-types.html
 blurb: Allow an account to hold an amount of a particular MPT.
 labels:
  - Multi-purpose Tokens, MPTs
@@ -11,27 +9,25 @@ labels:
 
 _(Requires the [MPTokensV1 amendment][] {% not-enabled /%})_
 
-This transaction enables an account to hold an amount of a particular MPT issuance. When applied successfully, it creates a new `MPToken` object with an initial zero balance, owned by the holder account.
+An MPTokenAuthorize transaction controls whether an account can hold a given [Multi-purpose Token (MPT)](../../../../concepts/tokens/fungible-tokens/multi-purpose-tokens.md). It has several uses:
 
-If the issuer has set `lsfMPTRequireAuth` (allow-listing) on the `MPTokenIssuance`, the issuer must submit an `MPTokenAuthorize` transaction as well in order to give permission to the holder. If `lsfMPTRequireAuth` is not set and the issuer attempts to submit this transaction, it will fail.
-
-<!-- ## MPTokenAuthorize Fields -->
+- An account indicates their willingness to hold an MPT. This creates a new [MPToken entry][] with an initial zero balance owned by that account. This is a prerequisite to receive that type of MPT in a payment.
+- An account revokes their willingness to hold an MPT, deleting the [MPToken entry][]. This can only be done if their balance of the given MPT is zero.
+- For an MPT that uses allow-listing, an issuer grants or revokes permission for another account to hold the given MPT.
 
 {% raw-partial file="/docs/_snippets/tx-fields-intro.md" /%}
 
-| Field               | JSON Type           | [Internal Type][] | Description        |
-|:--------------------|:--------------------|:------------------|:-------------------|
-| `Account`           | string              | `AccountID`       | This address can indicate either an issuer or a potential holder of a MPT. |
-| `TransactionType`   | object              | `UInt16`          | Indicates the new transaction type MPTokenAuthorize. The integer value is 29. |
-| `MPTokenIssuanceID` | string              | `UIn192`         | Indicates the ID of the MPT involved. |
-| `Holder`     | string              | `AccountID`       | (Optional) Specifies the holder's address that the issuer wants to authorize. Only used for authorization/allow-listing; must be empty if submitted by the holder. |
-| `Flags`             | number              | `UInt32`          | See [MPTokenAuthorize Flags](#mptokenauthorize-flags). |
+| Field               | JSON Type            | [Internal Type][] | Required? | Description |
+|:--------------------|:---------------------|:------------------|:----------|:------------|
+| `MPTokenIssuanceID` | String               | `UInt192`         | Yes       | The ID of the MPT to authorize. |
+| `Holder`            | String - [Address][] | `AccountID`       | No        | The holder to authorize. Only used for authorization/allow-listing; must be omitted if submitted by the holder. |
 
 ### MPTokenAuthorize Flags
-Transactions of the MPTokenAuthorize type support additional values in the Flags field, as follows:
+
+Transactions of the MPTokenAuthorize type support additional values in the `Flags` field, as follows:
 
 | Flag Name          | Hex Value    | Decimal Value | Description                   |
 |:-------------------|:-------------|:--------------|:------------------------------|
-| `tfMPTUnauthorize` | `0x00000001` | 1             | If set, and transaction is submitted by a holder, it indicates that the holder no longer wants to hold the `MPToken`, which will be deleted as a result. If the holder's `MPToken` has a non-zero balance while trying to set this flag, the transaction fails. On the other hand, if set, and transaction is submitted by an issuer, it would mean that the issuer wants to unauthorize the holder (only applicable for allow-listing), which would unset the `lsfMPTAuthorized` flag on the `MPToken`. |
+| `tfMPTUnauthorize` | `0x00000001` | 1             | When the holder enables this flag, if their balance of the given MPT is zero, it revokes their willingness to hold this MPT and deletes their `MPToken` entry. If their balance is non-zero, the transaction fails. When an issuer enables this flag, it revokes permission for the specified holder to hold this MPT; the transaction fails if the MPT does not use allow-listing. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
- Remove unused frontmatter
- Remove fields that are duplicates from common fields
- Fix typos like `UIn192` (missing 't')
- Explicitly state the separate use cases for the transaction as different modes
- Reword some descriptions for brevity & style (no future tense, etc.)