### PR TITLE
remove links to portable build from release notes

### DIFF
--- a/blog/2024/rippled-2.2.0.md
+++ b/blog/2024/rippled-2.2.0.md
@@ -32,7 +32,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.2.0-1.el7.x86_64.rpm) | `aeee54f2cafb651c42d12791ea62ebd20786b94165723ae5f405a089f7eec80a` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.2.0-1_amd64.deb) | `1bd26cea8e289e40368542eb370cec95b42905855f9ada8ece361a43134834c9` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 

--- a/blog/2024/rippled-2.2.1.md
+++ b/blog/2024/rippled-2.2.1.md
@@ -33,7 +33,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.2.1-1.el7.x86_64.rpm) | `32312c90ac4c685f11b168c5b9ec75aee8f4b2d7bef5dc11b42232679d0cd1f4` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.2.1-1_amd64.deb) | `f696e6898ad64e73d75bb9a1f50fb325b9675b168ffaeeacfce53fbd9e35bbee` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 

--- a/blog/2024/rippled-2.2.2.md
+++ b/blog/2024/rippled-2.2.2.md
@@ -33,7 +33,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.2.2-1.el7.x86_64.rpm) | `d17d2dfc52a776015ba71a93bdd70cca5d57e51ba2c27ab0bb01afe6b645d3f0` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.2.2-1_amd64.deb) | `9e0734966089d9cfde40d1a3551ae1e219faaadfe9fdc69eb900c6cb5024d658` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 

--- a/blog/2024/rippled-2.2.3.md
+++ b/blog/2024/rippled-2.2.3.md
@@ -74,7 +74,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.2.3-1.el7.x86_64.rpm) | `fb90f8f78799c24dd1f6286e96aa31afd0586bf21d32bc711ccc3dc868977da5` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.2.3-1_amd64.deb) | `e6a77cbe32228f9d68a8545c3b4e9a25d098ab30ea01852658ee5efe3371b9f1` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 

--- a/blog/2024/rippled-2.3.0.md
+++ b/blog/2024/rippled-2.3.0.md
@@ -30,7 +30,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.3.0-1.el7.x86_64.rpm) | `fb74f401e5ba121bbc37e6188aa064488ad78ffef549a1e19bc8b71316d08031` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.3.0-1_amd64.deb) | `5d616d53218b47a2f0803c1d37d410f72d19b57cdb9cabdf77b1cf0134cce3ca` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 {% admonition type="info" name="Note" %}
 The packages in the stable repository were accidentally overwritten with a different build from the same source code as a result of version 2.3.0 being merged to both the `release` and `master` source code branches. This post has been updated with the new package hashes based on the packages currently available in the stable branch of each repository. The previous package hashes, below, are also acceptable, and represent the same release:

--- a/blog/2025/rippled-2.3.1.md
+++ b/blog/2025/rippled-2.3.1.md
@@ -29,7 +29,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.3.1-1.el7.x86_64.rpm) | `db3ad27d3b61675caad0e0f74e66b2e2004c7d7ee97b5decd297168d27e48a25` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.3.1-1_amd64.deb) | `21931aa5fbf8cd2cf3fb4dc71a3b593bff754e4a804ba712891dea5ed48357e9` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 

--- a/blog/2025/rippled-2.4.0.md
+++ b/blog/2025/rippled-2.4.0.md
@@ -52,7 +52,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.4.0-1.el7.x86_64.rpm) | `f87f44005b84b35606413313f7414bfdf2bf09f01ce88bfe9fafc3ff75fd5199` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.4.0-1_amd64.deb) | `a3df84ba3d21f7182a57c8ca11fb2fbd1707e5cf53112822e60aa89886d943ad` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 

--- a/blog/2025/rippled-2.5.0.md
+++ b/blog/2025/rippled-2.5.0.md
@@ -39,7 +39,6 @@ On supported platforms, see the [instructions on installing or updating `rippled
 |:--------|:--------|
 | [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-2.5.0-1.el7.x86_64.rpm) | `7719be1889619a37a83795a9740d803bbc1c08b0bd8c755cbf266aeb68b875b6` |
 | [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_2.5.0-1_amd64.deb) | `d935f678624349e422dff1944a40acaf3e287b11244b4f5b5056cb343fc31e9d` |
-| [Portable Builds (Linux x86-64)](https://github.com/XRPLF/rippled-portable-builds) | (Use signature verification) |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
 


### PR DESCRIPTION
Portable build hasn't been updated since 2.1.1.