### PR TITLE
Add code snippets from xrpl.js and xrpl-py

### DIFF
--- a/_code-samples/claim-payment-channel/js/claimPayChannel.ts
+++ b/_code-samples/claim-payment-channel/js/claimPayChannel.ts
@@ -12,13 +12,11 @@ import {
 
 const client = new Client('wss://s.altnet.rippletest.net:51233')
 
-void claimPayChannel()
-
 // The snippet walks us through creating and claiming a Payment Channel.
 async function claimPayChannel(): Promise<void> {
   await client.connect()
 
-  // creating wallets as prerequisite
+  // Creating wallets as prerequisite
   const { wallet: wallet1 } = await client.fundWallet()
   const { wallet: wallet2 } = await client.fundWallet()
 
@@ -26,13 +24,13 @@ async function claimPayChannel(): Promise<void> {
   console.log(`Balance of ${wallet1.address} is ${await client.getXrpBalance(wallet1.address)} XRP`)
   console.log(`Balance of ${wallet2.address} is ${await client.getXrpBalance(wallet2.address)} XRP`)
 
-  // create a Payment Channel and submit and wait for tx to be validated
+  // Create a Payment Channel and submit and wait for tx to be validated
   const paymentChannelCreate: PaymentChannelCreate = {
     TransactionType: 'PaymentChannelCreate',
     Account: wallet1.classicAddress,
-    Amount: '100',
+    Amount: '100', // 10 XRP
     Destination: wallet2.classicAddress,
-    SettleDelay: 86400,
+    SettleDelay: 86400,  // 1 day in seconds
     PublicKey: wallet1.publicKey,
   }
   
@@ -44,7 +42,7 @@ async function claimPayChannel(): Promise<void> {
   console.log("PaymentChannelCreate transaction response:")
   console.log(paymentChannelResponse)
 
-  // check that the object was actually created
+  // Check that the object was actually created
   const accountObjectsRequest: AccountObjectsRequest = {
     command: 'account_objects',
     account: wallet1.classicAddress,
@@ -52,23 +50,21 @@ async function claimPayChannel(): Promise<void> {
 
   const accountObjects = (await client.request(accountObjectsRequest)).result
     .account_objects
-
   console.log("Account Objects:", accountObjects)
 
-  // destination claims the Payment Channel and we see the balances to verify.
+  // Destination claims the Payment Channel and we see the balances to verify.
   const paymentChannelClaim: PaymentChannelClaim = {
     Account: wallet2.classicAddress,
     TransactionType: 'PaymentChannelClaim',
     Channel: hashes.hashPaymentChannel(
       wallet1.classicAddress,
       wallet2.classicAddress,
-      paymentChannelResponse.result.Sequence ?? 0,
+      paymentChannelResponse.result.tx_json.Sequence ?? 0, 
     ),
     Amount: '100',
   }
 
   console.log("Submitting a PaymentChannelClaim transaction...")
-
   const channelClaimResponse = await client.submit(paymentChannelClaim, {
     wallet: wallet1,
   })
@@ -81,3 +77,5 @@ async function claimPayChannel(): Promise<void> {
 
   await client.disconnect()
 }
+
+void claimPayChannel()

--- a/_code-samples/claim-payment-channel/js/claimPayChannel.ts
+++ b/_code-samples/claim-payment-channel/js/claimPayChannel.ts
@@ -1,6 +1,6 @@
 /*
  * Create, claim and verify a Payment Channel.
- * Reference: https://xrpl.org/paychannel.html 
+ * Reference: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/paychannel
  */
 import {
   AccountObjectsRequest,

--- a/_code-samples/claim-payment-channel/js/claimPayChannel.ts
+++ b/_code-samples/claim-payment-channel/js/claimPayChannel.ts
@@ -66,7 +66,7 @@ async function claimPayChannel(): Promise<void> {
 
   console.log("Submitting a PaymentChannelClaim transaction...")
   const channelClaimResponse = await client.submit(paymentChannelClaim, {
-    wallet: wallet1,
+    wallet: wallet2,
   })
   console.log("PaymentChannelClaim transaction response:")
   console.log(channelClaimResponse)

--- a/_code-samples/claim-payment-channel/py/claim_pay_channel.py
+++ b/_code-samples/claim-payment-channel/py/claim_pay_channel.py
@@ -1,6 +1,6 @@
 """
 Create, claim and verify a Payment Channel.
-Reference: https://xrpl.org/paychannel.html
+Reference: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/paychannel
 """
 from xrpl.clients import JsonRpcClient
 from xrpl.models import (
@@ -18,6 +18,7 @@ from xrpl.account import get_balance
 client = JsonRpcClient("https://s.altnet.rippletest.net:51234")
 
 # Creating wallets as prerequisite
+print("Setting up wallets...")
 wallet1 = generate_faucet_wallet(client)
 wallet2 = generate_faucet_wallet(client)
 

--- a/_code-samples/claim-payment-channel/py/claim_pay_channel.py
+++ b/_code-samples/claim-payment-channel/py/claim_pay_channel.py
@@ -35,7 +35,7 @@ payment_channel_create = PaymentChannelCreate(
     public_key=wallet1.public_key,
 )
 
-print("Submitting a PaymentChannelCreate transaction...")
+print("\nSubmitting a PaymentChannelCreate transaction...")
 payment_channel_response = submit_and_wait(
     payment_channel_create,
     client,
@@ -53,15 +53,16 @@ account_objects = account_objects_response.result["account_objects"]
 
 # Find the PayChannel object to get the correct channel ID
 channel_id = None
-for obj in account_objects:
-    if obj["LedgerEntryType"] == "PayChannel":
-        channel_id = obj["index"]
-        break
+if 'meta' in payment_channel_response.result and 'AffectedNodes' in payment_channel_response.result['meta']:
+    for node in payment_channel_response.result["meta"]["AffectedNodes"]:
+        if 'CreatedNode' in node and node["CreatedNode"]["LedgerEntryType"] == 'PayChannel':
+            channel_id = node['CreatedNode']['LedgerIndex']
+            break
 
 if not channel_id:
-    raise Exception("PayChannel not found in account objects")
+    raise Exception("Payment Channel ID not found in the response.")
 
-print(f"PayChannel ID: {channel_id}")
+print(f"Payment Channel ID: {channel_id}")
 
 # Destination claims the Payment Channel and we see the balances to verify.
 payment_channel_claim = PaymentChannelClaim(
@@ -70,7 +71,7 @@ payment_channel_claim = PaymentChannelClaim(
     amount="100",
 )
 
-print("Submitting a PaymentChannelClaim transaction...")
+print("\nSubmitting a PaymentChannelClaim transaction...")
 channel_claim_response = submit_and_wait(
     payment_channel_claim,
     client,

--- a/_code-samples/claim-payment-channel/py/claim_pay_channel.py
+++ b/_code-samples/claim-payment-channel/py/claim_pay_channel.py
@@ -1,0 +1,87 @@
+"""
+Create, claim and verify a Payment Channel.
+Reference: https://xrpl.org/paychannel.html
+"""
+from xrpl.clients import JsonRpcClient
+from xrpl.models import (
+    AccountObjects,
+    PaymentChannelCreate,
+    PaymentChannelClaim,
+)
+from xrpl.wallet import generate_faucet_wallet
+from xrpl.transaction import submit, submit_and_wait
+from xrpl.account import get_balance
+
+
+def claim_pay_channel():
+    """The snippet walks us through creating and claiming a Payment Channel."""
+
+    client = JsonRpcClient("https://s.altnet.rippletest.net:51234")
+    
+    # Creating wallets as prerequisite
+    wallet1 = generate_faucet_wallet(client)
+    wallet2 = generate_faucet_wallet(client)
+
+    print("Balances of wallets before Payment Channel is claimed:")
+    print(f"Balance of {wallet1.address} is {get_balance(wallet1.address, client)} XRP")
+    print(f"Balance of {wallet2.address} is {get_balance(wallet2.address, client)} XRP")
+
+    # Create a Payment Channel and submit and wait for tx to be validated
+    payment_channel_create = PaymentChannelCreate(
+        account=wallet1.address,
+        amount="100",  # 10 XRP
+        destination=wallet2.address,
+        settle_delay=86400,  # 1 day in seconds
+        public_key=wallet1.public_key,
+    )
+
+    print("Submitting a PaymentChannelCreate transaction...")
+    payment_channel_response = submit_and_wait(
+        payment_channel_create,
+        client,
+        wallet1
+    )
+    print("PaymentChannelCreate transaction response:")
+    print(payment_channel_response.result)
+
+    # Check that the object was actually created
+    account_objects_request = AccountObjects(
+        account=wallet1.address,
+    )
+    account_objects_response = client.request(account_objects_request)
+    account_objects = account_objects_response.result["account_objects"]
+
+    # Find the PayChannel object to get the correct channel ID
+    channel_id = None
+    for obj in account_objects:
+        if obj["LedgerEntryType"] == "PayChannel":
+            channel_id = obj["index"]
+            break
+
+    if not channel_id:
+        raise Exception("PayChannel not found in account objects")
+
+    print(f"PayChannel ID: {channel_id}")
+
+    # Destination claims the Payment Channel and we see the balances to verify.
+    payment_channel_claim = PaymentChannelClaim(
+        account=wallet2.address,
+        channel=channel_id,
+        amount="100",
+    )
+
+    print("Submitting a PaymentChannelClaim transaction...")
+    channel_claim_response = submit_and_wait(
+        payment_channel_claim,
+        client,
+        wallet1,
+    )
+    print("PaymentChannelClaim transaction response:")
+    print(channel_claim_response.result)
+    
+    print("Balances of wallets after Payment Channel is claimed:")
+    print(f"Balance of {wallet1.address} is {get_balance(wallet1.address, client)} XRP")
+    print(f"Balance of {wallet2.address} is {get_balance(wallet2.address, client)} XRP")
+    
+if __name__ == "__main__":
+    claim_pay_channel()

--- a/_code-samples/escrow/js/create-escrow.js
+++ b/_code-samples/escrow/js/create-escrow.js
@@ -44,7 +44,7 @@ async function main() {
       "Destination": wallet.address,
       "Amount": "6000000", //drops XRP
       "DestinationTag": 2023,
-      "Condition": conditionHex,
+      "Condition": conditionHex, // Omit this for time-held escrows
       "Fee": "12",
       "FinishAfter": xrpl.isoTimeToRippleTime(finishAfter.toISOString()),
     };

--- a/_code-samples/escrow/js/create-escrow.js
+++ b/_code-samples/escrow/js/create-escrow.js
@@ -14,15 +14,6 @@ const seed = "sEd7jfWyNG6J71dEojB3W9YdHp2KCjy";
 async function main() {
   try {
 
-    // Construct condition and fulfillment ------------------------------------
-    const preimageData = crypto.randomBytes(32);
-    const myFulfillment = new cc.PreimageSha256();
-    myFulfillment.setPreimage(preimageData);
-    const conditionHex = myFulfillment.getConditionBinary().toString('hex').toUpperCase();
-
-    console.log('Condition:', conditionHex);
-    console.log('Fulfillment:', myFulfillment.serializeBinary().toString('hex').toUpperCase());
-
     // Connect ----------------------------------------------------------------
     const client = new xrpl.Client('wss://s.altnet.rippletest.net:51233');
     await client.connect();
@@ -37,6 +28,16 @@ async function main() {
     finishAfter = new Date(finishAfter * 1000);
     console.log("This escrow will finish after: ", finishAfter);
 
+    // Construct condition and fulfillment ------------------------------------
+    const preimageData = crypto.randomBytes(32);
+    const myFulfillment = new cc.PreimageSha256();
+    myFulfillment.setPreimage(preimageData);
+    const conditionHex = myFulfillment.getConditionBinary().toString('hex').toUpperCase();
+
+    console.log('Condition:', conditionHex);
+    console.log('Fulfillment:', myFulfillment.serializeBinary().toString('hex').toUpperCase());
+
+    // Prepare EscrowCreate transaction ------------------------------------
     const escrowCreateTransaction = {
       "TransactionType": "EscrowCreate",
       "Account": wallet.address,
@@ -46,7 +47,7 @@ async function main() {
       "Condition": conditionHex,
       "Fee": "12",
       "FinishAfter": xrpl.isoTimeToRippleTime(finishAfter.toISOString()),
-  };
+    };
 
     xrpl.validate(escrowCreateTransaction);
 
@@ -54,7 +55,7 @@ async function main() {
     console.log('Signing and submitting the transaction:',
                 JSON.stringify(escrowCreateTransaction, null,  "\t"), "\n"
     );
-    const response  = await client.submitAndWait(escrowCreateTransaction, { wallet });
+    const response = await client.submitAndWait(escrowCreateTransaction, { wallet });
     console.log(`Sequence number: ${response.result.tx_json.Sequence}`);
     console.log(`Finished submitting! ${JSON.stringify(response.result, null, "\t")}`);
 

--- a/_code-samples/escrow/js/finish-escrow.js
+++ b/_code-samples/escrow/js/finish-escrow.js
@@ -35,9 +35,11 @@ const main = async () => {
         "Owner": wallet.address,
         // This should equal the sequence number of the escrow transaction
         "OfferSequence": offerSequence,
-        // Crypto condition that must be met before escrow can be completed, passed on escrow creation
+        // Crypto condition that must be met before escrow can be completed, passed on escrow creation.
+        // Omit this for time-held escrows.
         "Condition": condition,
-        // Fulfillment of the condition, passed on escrow creation
+        // Fulfillment of the condition, passed on escrow creation.
+        // Omit this for time-held escrows.
         "Fulfillment": fulfillment,
     };
 

--- a/_code-samples/escrow/js/finish-escrow.js
+++ b/_code-samples/escrow/js/finish-escrow.js
@@ -28,6 +28,7 @@ const main = async () => {
         throw new Error("Please specify the sequence number, condition and fulfillment of the escrow you created");
     };
 
+    // Prepare EscrowFinish transaction ---------------------------------
     const escrowFinishTransaction = {
         "Account": wallet.address,
         "TransactionType": "EscrowFinish",

--- a/_code-samples/escrow/py/cancel_escrow.py
+++ b/_code-samples/escrow/py/cancel_escrow.py
@@ -14,7 +14,11 @@ escrow_sequence = 30215126
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build escrow cancel transaction
-cancel_txn = EscrowCancel(account=sender_wallet.address, owner=sender_wallet.address, offer_sequence=escrow_sequence)
+cancel_txn = EscrowCancel(
+    account=sender_wallet.address, 
+    owner=sender_wallet.address,
+    offer_sequence=escrow_sequence
+)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(cancel_txn, client, sender_wallet)

--- a/_code-samples/escrow/py/create_escrow.py
+++ b/_code-samples/escrow/py/create_escrow.py
@@ -34,7 +34,8 @@ create_txn = EscrowCreate(
     destination=receiver_addr,
     finish_after=claim_date, 
     cancel_after=expiry_date,
-    condition=condition)
+    condition=condition
+)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(create_txn, client, sender_wallet)

--- a/_code-samples/escrow/py/create_escrow.py
+++ b/_code-samples/escrow/py/create_escrow.py
@@ -34,7 +34,7 @@ create_txn = EscrowCreate(
     destination=receiver_addr,
     finish_after=claim_date, 
     cancel_after=expiry_date,
-    condition=condition
+    condition=condition # Omit this for time-held escrows
 )
 
 # Autofill, sign, then submit transaction and wait for result

--- a/_code-samples/escrow/py/finish_escrow.py
+++ b/_code-samples/escrow/py/finish_escrow.py
@@ -25,7 +25,13 @@ fulfillment = "A0228020AED2C5FE4D147D310D3CFEBD9BFA81AD0F63CE1ADD92E00379DDDAF8E
 sender_wallet = generate_faucet_wallet(client=client)
 
 # Build escrow finish transaction
-finish_txn = EscrowFinish(account=sender_wallet.address, owner=escrow_creator, offer_sequence=escrow_sequence, condition=condition, fulfillment=fulfillment)
+finish_txn = EscrowFinish(
+    account=sender_wallet.address,
+    owner=escrow_creator,
+    offer_sequence=escrow_sequence, # The sequence number of the escrow transaction
+    condition=condition, 
+    fulfillment=fulfillment
+)
 
 # Autofill, sign, then submit transaction and wait for result
 stxn_response = submit_and_wait(finish_txn, client, sender_wallet)

--- a/_code-samples/escrow/py/finish_escrow.py
+++ b/_code-samples/escrow/py/finish_escrow.py
@@ -29,8 +29,8 @@ finish_txn = EscrowFinish(
     account=sender_wallet.address,
     owner=escrow_creator,
     offer_sequence=escrow_sequence, # The sequence number of the escrow transaction
-    condition=condition, 
-    fulfillment=fulfillment
+    condition=condition, # Omit this for time-held escrows
+    fulfillment=fulfillment # Omit this for time-held escrows
 )
 
 # Autofill, sign, then submit transaction and wait for result

--- a/_code-samples/multisigning/js/multisigning.ts
+++ b/_code-samples/multisigning/js/multisigning.ts
@@ -22,6 +22,7 @@ async function multisigning(): Promise<void> {
   const { wallet: wallet1 } = await client.fundWallet()
   const { wallet: wallet2 } = await client.fundWallet()
   const { wallet: walletMaster } = await client.fundWallet()
+
   const signerListSet: SignerListSet = {
     TransactionType: 'SignerListSet',
     Account: walletMaster.classicAddress,
@@ -56,9 +57,14 @@ async function multisigning(): Promise<void> {
   const accountSetTx = await client.autofill(accountSet, 2)
   console.log('AccountSet transaction is ready to be multisigned:')
   console.log(accountSetTx)
+
   const { tx_blob: tx_blob1 } = wallet1.sign(accountSetTx, true)
   const { tx_blob: tx_blob2 } = wallet2.sign(accountSetTx, true)
   const multisignedTx = multisign([tx_blob1, tx_blob2])
+
+  console.log("Successfully multisigned the transaction")
+  console.log(multisignedTx)
+
   const submitResponse = await client.submit(multisignedTx)
 
   if (submitResponse.result.engine_result === 'tesSUCCESS') {

--- a/_code-samples/paths/js/paths.ts
+++ b/_code-samples/paths/js/paths.ts
@@ -2,7 +2,7 @@
  * Extract best paths from RipplePathFind to trade with and send a payment using paths.
  * Reference: https://xrpl.org/paths.html
  */
-import { Client, Payment, RipplePathFindResponse } from 'xrpl'
+import { Client, Payment, RipplePathFindResponse, RipplePathFindRequest } from 'xrpl'
 
 const client = new Client('wss://s.altnet.rippletest.net:51233')
 
@@ -17,7 +17,7 @@ async function createTxWithPaths(): Promise<void> {
     issuer: 'rVnYNK9yuxBz4uP8zC8LEFokM2nqH3poc',
   }
 
-  const request = {
+  const request: RipplePathFindRequest = {
     command: 'ripple_path_find',
     source_account: wallet.classicAddress,
     source_currencies: [

--- a/docs/_snippets/wait-for-validation.md
+++ b/docs/_snippets/wait-for-validation.md
@@ -1,5 +1,3 @@
 On a live network (including Mainnet, Testnet, or Devnet), you can wait 4-7 seconds for the ledger to close automatically.
 
 If you're running `rippled` in stand-alone mode, use the [ledger_accept method][] to manually close the ledger.
-
-{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/_snippets/wait-for-validation.md
+++ b/docs/_snippets/wait-for-validation.md
@@ -1,3 +1,5 @@
 On a live network (including Mainnet, Testnet, or Devnet), you can wait 4-7 seconds for the ledger to close automatically.
 
 If you're running `rippled` in stand-alone mode, use the [ledger_accept method][] to manually close the ledger.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/tutorials/how-tos/manage-account-settings/disable-master-key-pair.md
+++ b/docs/tutorials/how-tos/manage-account-settings/disable-master-key-pair.md
@@ -308,7 +308,7 @@ If the transaction fails with the result `tecNO_ALTERNATIVE_KEY`, your account d
 
 ### 4. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%}
 
 ### 5. Confirm Account Flags
 

--- a/docs/tutorials/how-tos/manage-account-settings/send-a-multi-signed-transaction.md
+++ b/docs/tutorials/how-tos/manage-account-settings/send-a-multi-signed-transaction.md
@@ -25,6 +25,9 @@ Keep in mind that the `Fee` for multi-signed transactions is significantly highe
 
 Here's an example transaction ready to be multi-signed:
 
+{% tabs %}
+
+{% tab label="JSON" %}
 ```json
 {
     "TransactionType": "TrustSet",
@@ -42,7 +45,17 @@ Here's an example transaction ready to be multi-signed:
 ```
 
 (This transaction creates an accounting relationship from `rEuLyBCvcw4CFmzv8RepSiAoNgF8tTGJQC` to `rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh` with a maximum balance of 100 USD.)
+{% /tab %}
 
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/multisigning/js/multisigning.ts" language="js" from="const accountSet: AccountSet = {" before="const { tx_blob" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/multisigning/py/multisigning.py" language="py" from="account_set_tx = AccountSet" before="# Since" /%}
+{% /tab %}
+
+{% /tabs %}
 
 ## 2. Get one signature
 
@@ -185,6 +198,9 @@ If you collected the signatures in serial, the `tx_json` from the last `sign_for
 
 If you collected the signatures in parallel, you must manually construct a `tx_json` object with all the signatures included. Take the `Signers` arrays from all the `sign_for` responses, and combine their contents into a single `Signers` array that has each signature. Add the combined `Signers` array to the original transaction JSON value, and use that as the argument to the [submit_multisigned method][].
 
+{% tabs %}
+
+{% tab label="Commandline" %}
 ```
 $ rippled submit_multisigned '{
 >              "Account" : "rEuLyBCvcw4CFmzv8RepSiAoNgF8tTGJQC",
@@ -256,9 +272,18 @@ Connecting to 127.0.0.1:5005
 }
 ```
 
-
 Take note of the `hash` value from the response so you can check the results of the transaction later.  (In this case, the hash is `BD636194C48FD7A100DE4C972336534C8E710FD008C0F3CF7BC5BF34DAF3C3E6`.)
+{% /tab %}
 
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/multisigning/js/multisigning.ts" language="js" from="const { tx_blob" before="if (submitResponse" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/multisigning/py/multisigning.py" language="py" from="tx_1 =" before="if multisigned_tx_response" /%}
+{% /tab %}
+
+{% /tabs %}
 
 ## 5. Close the ledger
 
@@ -278,7 +303,6 @@ Connecting to 127.0.0.1:5005
 }
 ```
 
-
 ## 6. Confirm transaction results
 
 Use the hash value from the response to the `submit_multisigned` command to look up the transaction using the [tx method][]. In particular, check that the `TransactionResult` is the string `tesSUCCESS`.
@@ -287,6 +311,9 @@ On the live network, you must also confirm that the `validated` field is set to 
 
 In stand-alone mode, the server automatically considers a ledger to be `validated` if it has been manually closed.
 
+{% tabs %}
+
+{% tab label="Commandline" %}
 ```
 $ rippled tx BD636194C48FD7A100DE4C972336534C8E710FD008C0F3CF7BC5BF34DAF3C3E6
 Loading: "/etc/opt/ripple/rippled.cfg"
@@ -399,5 +426,17 @@ Connecting to 127.0.0.1:5005
     }
 }
 ```
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/multisigning/js/multisigning.ts" language="js" from="if (submitResponse" before="await client.disconnect" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/multisigning/py/multisigning.py" language="py" from="if multisigned_tx_response" /%}
+{% /tab %}
+
+{% /tabs %}
+
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/tutorials/how-tos/manage-account-settings/set-up-multi-signing.md
+++ b/docs/tutorials/how-tos/manage-account-settings/set-up-multi-signing.md
@@ -160,7 +160,7 @@ Make sure that the [Transaction Result](../../../references/protocol/transaction
 
 ## 4. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%}
 
 
 ## 5. Confirm the new signer list

--- a/docs/tutorials/how-tos/manage-account-settings/set-up-multi-signing.md
+++ b/docs/tutorials/how-tos/manage-account-settings/set-up-multi-signing.md
@@ -67,7 +67,9 @@ In this example, the signer list has 3 members, with the weights and quorum set 
 
 {% partial file="/docs/_snippets/secret-key-warning.md" /%}
 
+{% tabs %}
 
+{% tab label="Commandline" %}
 ```
 $ rippled submit shqZZy2Rzs9ZqWTCQAdqc3bKgxnYq '{
 >     "Flags": 0,
@@ -139,6 +141,17 @@ Connecting to 127.0.0.1:5005
    }
 }
 ```
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/multisigning/js/multisigning.ts" language="js" from="  const { wallet: wallet1" before="const accountSet:" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/multisigning/py/multisigning.py" language="py" from="master_wallet ="  before="# Now that" /%}
+{% /tab %}
+
+{% /tabs %}
 
 Make sure that the [Transaction Result](../../../references/protocol/transactions/transaction-results/index.md) is [**`tesSUCCESS`**](../../../references/protocol/transactions/transaction-results/tes-success.md). Otherwise, the transaction failed. If you have a problem in stand-alone mode or a non-production network, check that [multi-sign is enabled](../../../infrastructure/testing-and-auditing/start-a-new-genesis-ledger-in-stand-alone-mode.md#settings-in-new-genesis-ledgers).
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/cancel-an-expired-escrow.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/cancel-an-expired-escrow.md
@@ -67,22 +67,22 @@ Response:
 
 {% partial file="/docs/_snippets/secret-key-warning.md" /%} 
 
-Request:
-
 {% tabs %}
 
 {% tab label="Websocket" %}
+Request:
 {% code-snippet file="/_api-examples/escrow/websocket/submit-request-escrowcancel.json" language="json" /%}
-{% /tab %}
-
-{% /tabs %}
 
 Response:
-
-{% tabs %}
-
-{% tab label="Websocket" %}
 {% code-snippet file="/_api-examples/escrow/websocket/submit-response-escrowcancel.json" language="json" /%}
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/escrow/js/cancel-escrow.js" language="js" from="const escrowCancelTransaction" before="await client.disconnect" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/escrow/py/cancel_escrow.py" language="py"  from="# Build escrow cancel" /%}
 {% /tab %}
 
 {% /tabs %}

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/cancel-an-expired-escrow.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/cancel-an-expired-escrow.md
@@ -91,7 +91,7 @@ Take note of the transaction's identifying `hash` value so you can check its fin
 
 ## 4. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%}
 
 ## 5. Confirm final result
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/look-up-escrows.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/look-up-escrows.md
@@ -15,29 +15,27 @@ All pending escrows are stored in the ledger as [Escrow objects](../../../../con
 
 Use the [account_objects method][], where the sender or destination address is the `account` value.
 
-Request:
-
 {% tabs %}
 
 {% tab label="Websocket" %}
+Request:
 {% code-snippet file="/_api-examples/escrow/websocket/account_objects-request.json" language="json" /%}
-{% /tab %}
-
-{% /tabs %}
-
-The response includes all pending escrow objects with `rfztBskAVszuS3s5Kq7zDS74QtHrw893fm`, where the sender address is the `Account` value, or the destination address is the `Destination` value.
 
 Response:
-
-{% tabs %}
-
-{% tab label="Websocket" %}
 {% code-snippet file="/_api-examples/escrow/websocket/account_objects-response.json" language="json" /%}
+
+The response includes all pending escrow objects with `rfztBskAVszuS3s5Kq7zDS74QtHrw893fm`, where the sender address is the `Account` value, or the destination address is the `Destination` value.
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/escrow/js/list-escrows.js" language="js" from="const response" before="client.disconnect" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/escrow/py/account_escrows.py" language="py"  from="req =" /%}
 {% /tab %}
 
 {% /tabs %}
-
-
 
 ## See Also
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditionally-held-escrow.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditionally-held-escrow.md
@@ -118,7 +118,7 @@ Response:
 
 ## 4. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%} 
 
 ## 5. Confirm that the escrow was created
 
@@ -178,7 +178,7 @@ Take note of the transaction's identifying `hash` value so you can check its fin
 
 ## 7. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%} 
 
 ## 8. Confirm final result
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditionally-held-escrow.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditionally-held-escrow.md
@@ -96,22 +96,22 @@ print(cancel_after)
 
 {% partial file="/docs/_snippets/secret-key-warning.md" /%} 
 
-Request:
-
 {% tabs %}
 
 {% tab label="Websocket" %}
+Request:
 {% code-snippet file="/_api-examples/escrow/websocket/submit-request-escrowcreate-condition.json" language="json" /%}
-{% /tab %}
-
-{% /tabs %}
 
 Response:
-
-{% tabs %}
-
-{% tab label="Websocket" %}
 {% code-snippet file="/_api-examples/escrow/websocket/submit-response-escrowcreate-condition.json" language="json" /%}
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/escrow/js/create-escrow.js" language="js" from="// Prepare EscrowCreate" before="await client.disconnect" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/escrow/py/create_escrow.py" language="py"  from="# Build escrow create" /%}
 {% /tab %}
 
 {% /tabs %}
@@ -157,17 +157,19 @@ If the escrow has expired, you can only [cancel the escrow](cancel-an-expired-es
 {% tabs %}
 
 {% tab label="Websocket" %}
+Request:
 {% code-snippet file="/_api-examples/escrow/websocket/submit-request-escrowfinish-condition.json" language="json" /%}
-{% /tab %}
-
-{% /tabs %}
 
 Response:
-
-{% tabs %}
-
-{% tab label="Websocket" %}
 {% code-snippet file="/_api-examples/escrow/websocket/submit-response-escrowfinish-condition.json" language="json" /%}
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/escrow/js/finish-escrow.js" language="js" from="// Prepare EscrowFinish" before="await client.disconnect" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/escrow/py/finish_escrow.py" language="py"  from="# Build escrow finish" /%}
 {% /tab %}
 
 {% /tabs %}

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-time-held-escrow.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-time-held-escrow.md
@@ -58,54 +58,11 @@ Response:
 {% /tab %}
 
 {% tab label="Javascript" %}
-```js
-// Prepare EscrowCreate transaction ------------------------------------
-const escrowCreateTransaction = {
-    "TransactionType": "EscrowCreate",
-    "Account": wallet.address,
-    "Destination": wallet.address,
-    "Amount": "6000000", //drops XRP
-    "DestinationTag": 2023,
-    "Fee": "12",
-    "FinishAfter": xrpl.isoTimeToRippleTime(finishAfter.toISOString()),
-};
-
-xrpl.validate(escrowCreateTransaction);
-
-// Sign and submit the transaction ----------------------------------------
-console.log('Signing and submitting the transaction:',
-            JSON.stringify(escrowCreateTransaction, null,  "\t"), "\n"
-);
-const response = await client.submitAndWait(escrowCreateTransaction, { wallet });
-console.log(`Sequence number: ${response.result.tx_json.Sequence}`);
-console.log(`Finished submitting! ${JSON.stringify(response.result, null, "\t")}`);
-```
+{% code-snippet file="/_code-samples/escrow/js/create-escrow.js" language="js" from="// Prepare EscrowCreate" before="await client.disconnect" /%}
 {% /tab %}
 
 {% tab label="Python" %}
-```python
-# Build escrow create transaction
-create_txn = EscrowCreate(
-    account=sender_wallet.address,
-    amount=xrp_to_drops(10.000), 
-    destination=receiver_addr,
-    finish_after=claim_date
-)
-
-# Autofill, sign, then submit transaction and wait for result
-stxn_response = submit_and_wait(create_txn, client, sender_wallet)
-
-# Return result of transaction
-stxn_result = stxn_response.result
-
-
-# Parse result and print out the neccesary info
-print(stxn_result["tx_json"]["Account"])
-print(stxn_result["tx_json"]["Sequence"])
-
-print(stxn_result["meta"]["TransactionResult"])
-print(stxn_result["hash"])
-```
+{% code-snippet file="/_code-samples/escrow/py/create_escrow.py" language="py"  from="# Build escrow create" /%}
 {% /tab %}
 
 {% /tabs %}
@@ -114,7 +71,7 @@ Take note of the transaction's identifying `hash` value so you can check its fin
 
 ## 3. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%}
 
 ## 4. Confirm that the escrow was created
 
@@ -191,44 +148,11 @@ Response:
 {% /tab %}
 
 {% tab label="Javascript" %}
-```js
-// Prepare EscrowFinish transaction ---------------------------------
-const escrowFinishTransaction = {
-    "Account": wallet.address,
-    "TransactionType": "EscrowFinish",
-    "Owner": wallet.address,
-    // This should equal the sequence number of the escrow transaction
-    "OfferSequence": offerSequence,
-};
-
-xrpl.validate(escrowFinishTransaction);
-
-// Sign and submit the transaction ----------------------------------------
-console.log('Signing and submitting the transaction:', JSON.stringify(escrowFinishTransaction, null,  "\t"));
-const response  = await client.submitAndWait(escrowFinishTransaction, { wallet });
-console.log(`Finished submitting! ${JSON.stringify(response.result, null,  "\t")}`);
-```
+{% code-snippet file="/_code-samples/escrow/js/finish-escrow.js" language="js" from="// Prepare EscrowFinish" before="await client.disconnect" /%}
 {% /tab %}
 
 {% tab label="Python" %}
-```python
-# Build escrow finish transaction
-finish_txn = EscrowFinish(
-    account=sender_wallet.address,
-    owner=escrow_creator,
-    offer_sequence=escrow_sequence, # The sequence number of the escrow transaction
-)
-
-# Autofill, sign, then submit transaction and wait for result
-stxn_response = submit_and_wait(finish_txn, client, sender_wallet)
-
-# Parse response and return result
-stxn_result = stxn_response.result
-
-# Parse result and print out the transaction result and transaction hash
-print(stxn_result["meta"]["TransactionResult"])
-print(stxn_result["hash"])
-```
+{% code-snippet file="/_code-samples/escrow/py/finish_escrow.py" language="py"  from="# Build escrow finish" /%}
 {% /tab %}
 
 {% /tabs %}
@@ -237,7 +161,7 @@ Take note of the transaction's identifying `hash` value so you can check its fin
 
 ## 7. Wait for validation
 
-{% partial file="/docs/_snippets/wait-for-validation.md" /%} 
+{% raw-partial file="/docs/_snippets/wait-for-validation.md" /%} 
 
 ## 8. Confirm final result
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels/index.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels/index.md
@@ -62,6 +62,9 @@ The following example shows creation of a payment channel by [submitting](../../
 
 {% admonition type="info" name="Note" %}A payment channel counts as one object toward the payer's [owner reserve](../../../../concepts/accounts/reserves.md#owner-reserves). The owner must keep at least enough XRP to satisfy the reserve after subtracting the XRP allocated to the payment channel.{% /admonition %}
 
+{% tabs %}
+
+{% tab label="JSON-RPC" %}
 Request:
 
 ```json
@@ -105,6 +108,17 @@ Response:
     }
 }
 ```
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/claim-payment-channel/js/claimPayChannel.ts" language="js" from="// Create a Payment"  before="// Check" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/claim-payment-channel/py/claim_pay_channel.py" language="py" from="# Create a Payment" before="# Check" /%}
+{% /tab %}
+
+{% /tabs %}
 
 The immediate response to the `submit` request contains a _provisional_ result with the transaction's identifying `hash` value. The payer should check the transaction's _final_ result in a validated ledger and get the Channel ID from the metadata. This can be done with the `tx` command:
 
@@ -399,6 +413,9 @@ The payee can do this multiple times, to settle partially while still doing busi
 
 Example of claiming XRP from a channel:
 
+{% tabs %}
+
+{% tab label="JSON-RPC" %}
 Request:
 
 ```json
@@ -453,6 +470,17 @@ Response:
     }
 }
 ```
+{% /tab %}
+
+{% tab label="Javascript" %}
+{% code-snippet file="/_code-samples/claim-payment-channel/js/claimPayChannel.ts" language="js" from="// Destination claims"  before="console.log('Balances of" /%}
+{% /tab %}
+
+{% tab label="Python" %}
+{% code-snippet file="/_code-samples/claim-payment-channel/py/claim_pay_channel.py" language="py" from="# Destination claims" before="print(\"Balances of" /%}
+{% /tab %}
+
+{% /tabs %}
 
 The payee should confirm that this transaction is successful in a validated ledger. For the full details, see [Reliable Transaction Submission](../../../../concepts/transactions/reliable-transaction-submission.md).
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels/index.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels/index.md
@@ -84,7 +84,7 @@ Content-Type: application/json
         "fee_mult_max": 1000
     }]
 }
-```json
+```
 
 Response:
 
@@ -105,7 +105,6 @@ Response:
     }
 }
 ```
-
 
 The immediate response to the `submit` request contains a _provisional_ result with the transaction's identifying `hash` value. The payer should check the transaction's _final_ result in a validated ledger and get the Channel ID from the metadata. This can be done with the `tx` command:
 


### PR DESCRIPTION
Addresses https://github.com/XRPLF/xrpl-dev-portal/issues/3141 

We already have most/all of these examples in our repository, but I noticed we didn't use them in our docs, so I'm adding snippets where possible in the How To guides.

I also noticed we didn't have a pay channel code snippet for Python, so I added one myself for parity with Javascript. ~~However, it looks like there is an issue when I run the original `claimPayChannel.ts` sample code - it fails with 'tefBAD_AUTH' for the `PaymentChannelClaim` transaction. I'm chasing this up with DGE to understand what the original intention was for the code sample and why it's failing.~~ (**UPDATE**: got a response, we've solved the error in the example code, the wrong wallet was being used to sign the transaction).