### PR TITLE
[JA] Add translations for time.past keys

### DIFF
--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -21,6 +21,21 @@ footer.docs: ドキュメント
 footer.resources: リソース
 footer.community: コミュニティ
 
+time.past.second: 1秒前
+time.past.seconds: "{{value}}秒前"
+time.past.minute: 1分前
+time.past.minutes: "{{value}}分前"
+time.past.hour: 1時間前
+time.past.hours: "{{value}}時間前"
+time.past.day: 1日前
+time.past.days: "{{value}}日前"
+time.past.week: 1週間前
+time.past.weeks: "{{value}}週間前"
+time.past.month: 1ヶ月前
+time.past.months: "{{value}}ヶ月前"
+time.past.year: 1年前
+time.past.years: "{{value}}年前"
+
 sidebar.docs: ドキュメント
 sidebar.docs.introduction.what-is-xrp: XRPとは？
 sidebar.docs.use-cases.tokenization: Tokenization


### PR DESCRIPTION
## Before
<img width="359" height="96" alt="スクリーンショット 2025-07-18 21 59 12" src="https://github.com/user-attachments/assets/d6ae443d-d35c-4247-b351-5e3da2550b34" />

## After
<img width="354" height="81" alt="スクリーンショット 2025-07-18 21 59 24" src="https://github.com/user-attachments/assets/53849abb-6825-4820-ad6d-8bbffa1424c3" />
