### PR TITLE
Fix unparsed ref link to Object in Binary reference

### DIFF
--- a/docs/references/protocol/binary-format.md
+++ b/docs/references/protocol/binary-format.md
@@ -338,7 +338,7 @@ Some fields specify a _type_ of asset, which could be XRP or a fungible [token](
 
 
 ### Object Fields
-[STObject]: #object-fields
+[Object]: #object-fields
 
 Some fields, such as `SignerEntry` (in [SignerListSet transactions][]), and `Memo` (in `Memos` arrays) are objects (called the "STObject" type). The serialization of objects is very similar to that of arrays, with one difference: **object members must be placed in canonical order** within the object field, where array fields have an explicit order already.
 


### PR DESCRIPTION
Fix this error in the Type List:

<img width="662" height="110" alt="2025-07-23_132321_157782530" src="https://github.com/user-attachments/assets/1b420c79-31f5-4aa7-be26-ef23bcf32e29" />
