### PR TITLE
Amendment disclaimer

### DIFF
--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -139,6 +139,10 @@ footer.community.report-a-scam: 詐欺の報告
 
 component.tryit: 試してみる
 component.queryexampletx: トランザクションの例を確認
+component.amendment-status.requires.1: " "
+component.amendment-status.requires.2: が必要です。
+component.amendment-status.added.1: " "
+component.amendment-status.added.2: により追加されました。
 
 # Amendment tracker translations
 amendment.loading: ロード中Amendments...

--- a/@theme/markdoc/components.tsx
+++ b/@theme/markdoc/components.tsx
@@ -380,3 +380,29 @@ function AmendmentBadge(props: { amendment: Amendment }) {
 
   return <img src={badgeUrl} alt={status} className="shield" />;
 }
+
+export function AmendmentDisclaimer(props: {
+  name: string,
+  isVoting: boolean
+}) {
+  const { useTranslate } = useThemeHooks();
+  const { translate } = useTranslate();
+
+  const link = () => <Link to={`/resources/known-amendments#${props.name.toLowerCase()}`}>{props.name} amendment</Link>
+  
+  return (
+    <div><i>(
+      {
+        props.isVoting ? (
+          <>
+          {translate("component.amendment-status.requires.1", "Requires the ")}{link()}{translate("component.amendment-status.requires.2", ".")}
+          </>
+        ) : (
+            <>
+          {translate("component.amendment-status.added.1", "Added by the ")}{link()}{translate("component.amendment-status.added.2", ".")}
+            </>
+        )
+      }
+    )</i></div>
+  )
+}

--- a/@theme/markdoc/components.tsx
+++ b/@theme/markdoc/components.tsx
@@ -383,26 +383,89 @@ function AmendmentBadge(props: { amendment: Amendment }) {
 
 export function AmendmentDisclaimer(props: {
   name: string,
-  isVoting: boolean
 }) {
+  const [amendmentStatus, setStatus] = React.useState<Amendment | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
 
   const link = () => <Link to={`/resources/known-amendments#${props.name.toLowerCase()}`}>{props.name} amendment</Link>
+
+  React.useEffect(() => {
+    const fetchAmendments = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(`https://vhs.prod.ripplex.io/v1/network/amendments/vote/main/`);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data: AmendmentsResponse = await response.json()
+        console.log("data.amendments is:", data.amendments)
+
+        let found_amendment = false
+        for (const amendment of data.amendments) {
+          if (amendment.name == props.name) {
+            setStatus(amendment)
+            found_amendment = true
+            break
+          }
+        }
+        if (!found_amendment) {
+          throw new Error(`Couldn't find ${props.name} amendment in status table.`)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch amendments');
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchAmendments()
+  }, [])
+
+  if (loading) {
+    return (
+      <p><em>
+      {translate("component.amendment-status.requires.1", "Requires the ")}{link()}{translate("component.amendment-status.requires.2", ".")}
+      {" "}
+      <span className="spinner-border text-primary" role="status">
+        <span className="sr-only">{translate("amendment.loading_status", "Loading...")}</span>
+      </span>
+      </em></p>
+    )
+  }
+  
+  if (error) {
+    return (
+      <p><em>
+      {translate("component.amendment-status.requires.1", "Requires the ")}{link()}{translate("component.amendment-status.requires.2", ".")}
+      {" "}
+      <span className="alert alert-danger" style={{display: "block"}}>
+        <strong>{translate("amendment.error_status", "Error loading amendment status")}:</strong> {error}
+      </span>
+      </em></p>
+    )
+  }
   
   return (
-    <div><i>(
+    <p><em>(
       {
-        props.isVoting ? (
+        amendmentStatus.date ? (
           <>
-          {translate("component.amendment-status.requires.1", "Requires the ")}{link()}{translate("component.amendment-status.requires.2", ".")}
+          {translate("component.amendment-status.added.1", "Added by the ")}{link()}
+          {translate("component.amendment-status.added.2", ".")}
+          {" "}
+          <AmendmentBadge amendment={amendmentStatus} />
           </>
         ) : (
-            <>
-          {translate("component.amendment-status.added.1", "Added by the ")}{link()}{translate("component.amendment-status.added.2", ".")}
-            </>
+          <>
+          {translate("component.amendment-status.requires.1", "Requires the ")}{link()}
+          {translate("component.amendment-status.requires.2", ".")}
+          {" "}
+          <AmendmentBadge amendment={amendmentStatus} />
+          </>
         )
       }
-    )</i></div>
+    )</em></p>
   )
 }

--- a/@theme/markdoc/schema.ts
+++ b/@theme/markdoc/schema.ts
@@ -229,11 +229,6 @@ export const amendmentDisclaimer: Schema &  { tagName: string } = {
       type: 'String',
       required: true
     },
-    isVoting: {
-      type: 'Boolean',
-      required: false,
-      default: false
-    }
   },
   render: 'AmendmentDisclaimer',
   selfClosing: true

--- a/@theme/markdoc/schema.ts
+++ b/@theme/markdoc/schema.ts
@@ -221,3 +221,20 @@ export const amendmentsTable: Schema & { tagName: string } = {
   render: 'AmendmentsTable',
   selfClosing: true
 }
+
+export const amendmentDisclaimer: Schema &  { tagName: string } = {
+  tagName: 'amendment-disclaimer',
+  attributes: {
+    name: {
+      type: 'String',
+      required: true
+    },
+    isVoting: {
+      type: 'Boolean',
+      required: false,
+      default: false
+    }
+  },
+  render: 'AmendmentDisclaimer',
+  selfClosing: true
+}


### PR DESCRIPTION
Extends amendment disclaimer tag (#3223) using the live data from the amendment tracker (#3219).

The result is amendment disclaimers that automatically update with the status of the amendment on Mainnet and are also automatically translated. Before the amendment is enabled, the disclaimer says, "Requires the ... amendment." and the badge shows the voting status. After the amendment is enabled, the disclaimer says, "Added by the ... amendment." and the badge shows the date when the amendment became enabled.

Example usage:

```
{% amendment-disclaimer name="MPTokensV1" /%}
```

Examples of the disclaimer in action:
<img width="495" height="43" alt="2025-08-05_145900_544064338" src="https://github.com/user-attachments/assets/b2743959-1039-440d-b15f-de8cfed82eb4" />
<img width="458" height="41" alt="2025-08-05_145842_944112843" src="https://github.com/user-attachments/assets/f014adc0-a78e-4a12-a069-26f093698ea7" />
<img width="490" height="43" alt="2025-08-05_150618_910116499" src="https://github.com/user-attachments/assets/402ff819-3719-441a-8f05-b4f4d386f48a" />

Note, this PR does not actually replace any the instances of the old hand-written disclaimers with the new markdoc tag. After it gets merged, we can make a follow-up PR to mass-replace instances of it.
