### PR TITLE
Add related transactions and ledger entries (batch 2)

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -82,14 +82,15 @@
 [DelegateSet transactions]: /docs/references/protocol/transactions/types/delegateset.md
 [DepositAuth amendment]: /resources/known-amendments.md#depositauth
 [DepositPreauth amendment]: /resources/known-amendments.md#depositpreauth
-[DepositPreauth entry]: /docs/references/protocol/transactions/types/depositpreauth.md
-[DepositPreauth object]: /docs/references/protocol/transactions/types/depositpreauth.md
+[DepositPreauth entry]: /docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth.md
+[DepositPreauth object]: /docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth.md
 [DepositPreauth transaction]: /docs/references/protocol/transactions/types/depositpreauth.md
 [DepositPreauth transactions]: /docs/references/protocol/transactions/types/depositpreauth.md
 [DepositPreauth]: /docs/references/protocol/transactions/types/depositpreauth.md
 [DIDSet transaction]: /docs/references/protocol/transactions/types/didset.md
 [DIDSet transactions]: /docs/references/protocol/transactions/types/didset.md
 [DIDSet]: /docs/references/protocol/transactions/types/didset.md
+[DIDDelete transaction]: /docs/references/protocol/transactions/types/diddelete.md
 [DirectoryNode entry]: /docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
 [DirectoryNode object]: /docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md
 [DisallowIncoming amendment]: /resources/known-amendments.md#disallowincoming
@@ -99,8 +100,8 @@
 [EnableAmendment]: /docs/references/protocol/transactions/pseudo-transaction-types/enableamendment.md
 [EnforceInvariants amendment]: /resources/known-amendments.md#enforceinvariants
 [Escrow amendment]: /resources/known-amendments.md#escrow
-[Escrow entry]: /docs/concepts/payment-types/escrow.md
-[Escrow object]: /docs/concepts/payment-types/escrow.md
+[Escrow entry]: /docs/references/protocol/ledger-data/ledger-entry-types/escrow.md
+[Escrow object]: /docs/references/protocol/ledger-data/ledger-entry-types/escrow.md
 [EscrowCancel transaction]: /docs/references/protocol/transactions/types/escrowcancel.md
 [EscrowCancel transactions]: /docs/references/protocol/transactions/types/escrowcancel.md
 [EscrowCancel]: /docs/references/protocol/transactions/types/escrowcancel.md

--- a/docs/references/protocol/ledger-data/ledger-entry-types/delegate.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/delegate.md
@@ -65,4 +65,9 @@ There are no flags defined for {% code-page-name /%} entries.
 
 {% code-page-name /%} entries are not deletion blockers. If the owner (delegating) account is deleted, all such ledger entries are deleted along with them. However, the `Authorize`
 
+## See Also
+
+- **Transactions:**
+  - [DelegateSet transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth.md
@@ -109,4 +109,9 @@ In this case, the ID is the [SHA-512Half][] of the following values, concatenate
 * The AccountID of the owner of this object (the sender of the [DepositPreauth transaction][] that created this object; in other words, the one that granted the preauthorization)
 * The contents of the `AuthorizeCredentials` field.
 
+## See Also
+
+- **Transactions**
+  - [DepositPreauth transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/did.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/did.md
@@ -61,4 +61,10 @@ The ID of a `DID` entry is the [SHA-512Half][] of the following values, concaten
 1. The `DID` space key (`0x0049`).
 2. The AccountID that controls the DID.
 
+## See Also
+
+- **Transactions:**
+  - [DIDDelete transaction][]
+  - [DIDSet transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/escrow.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/escrow.md
@@ -74,4 +74,11 @@ The ID of an `Escrow` entry is the [SHA-512Half][] of the following values, conc
 * The Sequence number of the [EscrowCreate transaction][] that created the `Escrow` entry
     If the EscrowCreate transaction used a [Ticket](../../../../concepts/accounts/tickets.md), use the `TicketSequence` value instead.
 
+## See Also
+
+- **Transactions:**
+  - [EscrowCancel transaction][]
+  - [EscrowCreate transaction][]
+  - [EscrowFinish transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/mptoken.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/mptoken.md
@@ -54,4 +54,8 @@ The ID of an `MPToken` entry is the [SHA-512Half][] of the following values, con
 - The `MPTokenIssuanceID` for the issuance being held.
 - The `AccountID` of the token holder.
 
+## See Also
+
+- [MPTokenAuthorize transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/delegateset.md
+++ b/docs/references/protocol/transactions/types/delegateset.md
@@ -73,5 +73,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `temDISABLED`             | The [Permission Delegation amendment][] is not enabled. |
 | `temMALFORMED`            | The transaction was invalid. For example, the `Authorize` account is the same as the sender of the transaction, the `Permissions` list contains duplicate entries, or one of the permissions in the list is not a valid permission. |
 
+## See Also
+
+- [Delegate ledger entry][]
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/depositpreauth.md
+++ b/docs/references/protocol/transactions/types/depositpreauth.md
@@ -89,5 +89,8 @@ In addition to error types that can occur for all transactions, DepositPreauth t
 | `temCANNOT_PREAUTH_SELF`  | The address in the `Authorize` field is the sender of the transaction. You cannot preauthorize yourself. |
 | `temDISABLED`             | A required amendment is not enabled. |
 
+## See Also
+
+- [DepositPreauth object][]
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/diddelete.md
+++ b/docs/references/protocol/transactions/types/diddelete.md
@@ -39,4 +39,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 |:--------------------|:---------------------------------------------|
 | `tecNO_ENTRY`       | The account doesn't have a DID.              |
 
+## See Also
+
+- [DID entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/didset.md
+++ b/docs/references/protocol/transactions/types/didset.md
@@ -48,4 +48,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecEMPTY_DID`      | The transaction will create an empty DID ledger entry. Check that your updates don't remove the `Data`, `DIDDocument`, and `URI` fields. |
 | `temEMPTY_DID`      | The transaction is malformed and missing any DID information. Include either the `Data`, `DIDDocument`, or `URI` fields. |
 
+## See Also
+
+- [DID entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/escrowcancel.md
+++ b/docs/references/protocol/transactions/types/escrowcancel.md
@@ -38,4 +38,8 @@ Any account may submit an EscrowCancel transaction.
 * If the corresponding [EscrowCreate transaction][] did not specify a `CancelAfter` time, the EscrowCancel transaction fails.
 * Otherwise the EscrowCancel transaction fails if the `CancelAfter` time is after the close time of the most recently-closed ledger.
 
+## See Also
+
+- [Escrow entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/escrowcreate.md
+++ b/docs/references/protocol/transactions/types/escrowcreate.md
@@ -58,4 +58,8 @@ It is not possible to create a conditional escrow with no expiration, but you ca
 Before the [fix1571 amendment][] became enabled on 2018-06-19, it was possible to create an escrow with `CancelAfter` only. These escrows could be finished by anyone at any time before the specified expiration.
 {% /admonition %}
 
+## See Also
+
+- [Escrow entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/escrowfinish.md
+++ b/docs/references/protocol/transactions/types/escrowfinish.md
@@ -49,4 +49,8 @@ Any account may submit an EscrowFinish transaction.
 
 In [non-production networks](../../../../concepts/networks-and-servers/parallel-networks.md), it may be possible [to delete](../../../../concepts/accounts/deleting-accounts.md) the destination account of a pending escrow. In this case, an attempt to finish the escrow fails with the result `tecNO_TARGET`, but the escrow object remains unless it has expired normally. If another payment re-creates the destination account, the escrow can be finished successfully. The destination account of an escrow can only be deleted if the escrow was created before the [fix1523 amendment](/resources/known-amendments.md#fix1523) became enabled. No such escrows exist in the production XRP Ledger, so this edge case is not possible on the production XRP Ledger. This edge case is also not possible in test networks that enable both fix1523 and Escrow amendments at the same time, which is the default when you [start a new genesis ledger](../../../../infrastructure/testing-and-auditing/start-a-new-genesis-ledger-in-stand-alone-mode.md).
 
+## See Also
+
+- [Escrow entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/mptokenauthorize.md
+++ b/docs/references/protocol/transactions/types/mptokenauthorize.md
@@ -30,4 +30,8 @@ Transactions of the MPTokenAuthorize type support additional values in the `Flag
 |:-------------------|:-------------|:--------------|:------------------------------|
 | `tfMPTUnauthorize` | `0x00000001` | 1             | When the holder enables this flag, if their balance of the given MPT is zero, it revokes their willingness to hold this MPT and deletes their `MPToken` entry. If their balance is non-zero, the transaction fails. When an issuer enables this flag, it revokes permission for the specified holder to hold this MPT; the transaction fails if the MPT does not use allow-listing. |
 
+## See Also
+
+- [MPToken entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
Fixes https://github.com/XRPLF/xrpl-dev-portal/issues/3220

- Adds related topics to the ledger entry and transaction type pages.

Preview [here](https://xrpl-dev-portal--related-topics-batch-2.preview.redocly.app/docs/references/protocol/ledger-data/ledger-entry-types/delegate)

Batch 1 was added in https://github.com/XRPLF/xrpl-dev-portal/pull/3235

Batch 2 covers:

- [x] Delegate + transactions.
- [x] DepositPreAuth + transactions.
- [x] DID + transactions.
- [x] Escrow + transactions.
- [x] MPToken + transactions.