### PR TITLE
Add related transactions and ledger entries (batch 3)

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -202,6 +202,7 @@
 [PriceOracle amendment]: /resources/known-amendments.md#priceoracle
 [MPToken entry]: /docs/references/protocol/ledger-data/ledger-entry-types/mptoken.md
 [MPTokenAuthorize transaction]: /docs/references/protocol/transactions/types/mptokenauthorize.md
+[MPTokenIssuance entry]: /docs/references/protocol/ledger-data/ledger-entry-types/mptokenissuance.md
 [MPTokenIssuanceCreate transaction]: /docs/references/protocol/transactions/types/mptokenissuancecreate.md
 [MPTokenIssuanceDestroy transaction]: /docs/references/protocol/transactions/types/mptokenissuancedestroy.md
 [MPTokenIssuanceSet transaction]: /docs/references/protocol/transactions/types/mptokenissuanceset.md

--- a/docs/references/protocol/ledger-data/ledger-entry-types/mptokenissuance.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/mptokenissuance.md
@@ -74,4 +74,11 @@ The `MPTokenIssuanceID` is a 192-bit integer, concatenated in order:
 - The transaction sequence number.
 - The AccountID of the issuer.
 
+## See Also
+
+- **Transactions:**
+   - [MPTokenIssuanceCreate transaction][]
+   - [MPTokenIssuanceDestroy transaction][]
+   - [MPTokenIssuanceSet transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/nftokenoffer.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/nftokenoffer.md
@@ -82,4 +82,11 @@ The unique ID (`NFTokenOfferID`) of a `NFTokenOffer` object is the result of the
 * The `AccountID` of the account placing the offer; and
 * The `Sequence` (or `Ticket`) of the `NFTokenCreateOffer` transaction that created the `NFTokenOffer`.
 
+## See Also
+
+- **Transactions:**
+  - [NFTokenAcceptOffer transaction][]
+  - [NFTokenCancelOffer transaction][]
+  - [NFTokenCreateOffer transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/offer.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/offer.md
@@ -80,4 +80,10 @@ The ID of an `Offer` entry is the [SHA-512Half][] of the following values, conca
 
     If the OfferCreate transaction used a [ticket](../../../../concepts/accounts/tickets.md), use the `TicketSequence` value instead.
 
+## See Also
+
+- **Transactions:**
+  - [OfferCancel transaction][]
+  - [OfferCreate transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/oracle.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/oracle.md
@@ -90,4 +90,10 @@ The `Currency` field type contains 160 bits of arbitrary data representing a cur
 }
 ```
 
+## See Also
+
+- **Transactions:**
+  - [OracleSet transaction][]
+  - [OracleDelete transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/paychannel.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/paychannel.md
@@ -106,4 +106,11 @@ The ID of a `PayChannel` entry is the [SHA-512Half][] of the following values, c
 * The Sequence number of the [PaymentChannelCreate transaction][] that created the channel
     If the PaymentChannelCreate transaction used a [Ticket](../../../../concepts/accounts/tickets.md), use the `TicketSequence` value instead.
 
+## See Also
+
+- **Transactions:**
+  - [PaymentChannelClaim transaction][]
+  - [PaymentChannelCreate transaction][]
+  - [PaymentChannelFund transaction][]
+  
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/mptokenissuancecreate.md
+++ b/docs/references/protocol/transactions/types/mptokenissuancecreate.md
@@ -54,4 +54,8 @@ Transactions of the MPTokenIssuanceCreate type support additional values in the 
 | `tfMPTCanTransfer` | `0x00000020` | `32`          | If set, indicates that tokens can be transferred to other accounts that are not the issuer. |
 | `tfMPTCanClawback` | `0x00000040` | `64`          | If set, indicates that the issuer can use the `Clawback` transaction to claw back value from individual holders. |
 
+## See Also
+
+- [MPTokenIssuance entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/mptokenissuancedestroy.md
+++ b/docs/references/protocol/transactions/types/mptokenissuancedestroy.md
@@ -30,4 +30,8 @@ _(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
 |:--------------------|:--------------------|:------------------|:-------------------|
 | `MPTokenIssuanceID` | String              | UInt192           | Identifies the `MPTokenIssuance` object to be removed by the transaction. |
 
+## See Also
+
+- [MPTokenIssuance entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/mptokenissuanceset.md
+++ b/docs/references/protocol/transactions/types/mptokenissuanceset.md
@@ -39,4 +39,8 @@ Transactions of the `MPTokenIssuanceSet` type support additional values in the `
 | `tfMPTLock`        | `0x00000001` | 1             | Enable to lock balances of this MPT issuance. |
 | `tfMPTUnlock`      | `0x00000002` | 2             | Enable to unlock balances of this MPT issuance. |
 
+## See Also
+
+- [MPTokenIssuance entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/nftokenacceptoffer.md
+++ b/docs/references/protocol/transactions/types/nftokenacceptoffer.md
@@ -103,4 +103,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecNFTOKEN_OFFER_TYPE_MISMATCH`   | The object identified by the `NFTokenBuyOffer` is not actually a buy offer, or the object identified by the `NFTokenSellOffer` is not actually a sell offer. |
 | `tecNO_PERMISSION`                 | The seller does not own the `NFToken` being sold; or the matching offer specifies a different `Destination` account than the account accepting the offer. |
 
+## See Also
+
+- [NFTokenOffer entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/nftokencanceloffer.md
+++ b/docs/references/protocol/transactions/types/nftokencanceloffer.md
@@ -59,4 +59,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `temMALFORMED`     | The transaction was not validly formatted. For example, the `NFTokenOffers` array was empty or contained more than the maximum number of offers that can be canceled at one time. |
 | `tecNO_PERMISSION` | At least one of the IDs in the `NFTokenOffers` field refers to an object that cannot be canceled. For example, the sender of this transaction is not the owner or `Destination` of the offer, or the object was not an `NFTokenOffer` type object. |
 
+## See Also
+
+- [NFTokenOffer entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/nftokencreateoffer.md
+++ b/docs/references/protocol/transactions/types/nftokencreateoffer.md
@@ -70,4 +70,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecUNFUNDED_OFFER`              | For a buy offer, the sender does have the funds specified in the `Amount` field available. If the `Amount` is XRP, this could be due to the reserve requirement; if the `Amount` is denominated in fungible tokens, this could be because they are [frozen](../../../../concepts/tokens/fungible-tokens/freezes.md). |
 | `tefNFTOKEN_IS_NOT_TRANSFERABLE` | The `NFToken` has the [`lsfTransferable` flag](../../data-types/nftoken.md#nftoken-flags) disabled and this transaction would not transfer the `NFToken` to or from the issuer. |
 
+## See Also
+
+- [NFTokenOffer entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/offercancel.md
+++ b/docs/references/protocol/transactions/types/offercancel.md
@@ -38,4 +38,8 @@ An OfferCancel transaction removes an Offer object from the XRP Ledger.
 
 The OfferCancel method returns [`tesSUCCESS`](../transaction-results/tes-success.md) even if it did not find an offer with the matching sequence number.
 
+## See Also
+
+- [Offer entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/offercreate.md
+++ b/docs/references/protocol/transactions/types/offercreate.md
@@ -77,4 +77,8 @@ Transactions of the OfferCreate type support additional values in the [`Flags` f
 | `temINVALID_FLAG`        | The transaction specifies an invalid flag combination, such as both `tfImmediateOrCancel` and `tfFillOrKill`, or the transaction uses `tfHybrid` but omits the `DomainID` field. |
 | `temREDUNDANT`           | The transaction would trade a token for the same token (same issuer and currency code). |
 
+## See Also
+
+- [Offer entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/oracledelete.md
+++ b/docs/references/protocol/transactions/types/oracledelete.md
@@ -42,4 +42,8 @@ Besides errors that can occur for all transactions, `OracleDelete` transactions 
 |---------------|-------------|
 | `tecNO_ENTRY` | The `Oracle` object doesn't exist. |
 
+## See Also
+
+- [Oracle entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/oracleset.md
+++ b/docs/references/protocol/transactions/types/oracleset.md
@@ -91,4 +91,8 @@ Besides errors that can occur for all transactions, `OracleSet` transactions can
 | `tecARRAY_EMPTY`          | The `PriceDataSeries` has no `PriceData` objects. |
 | `temARRAY_TOO_LARGE`      | The `PriceDataSeries` exceeds the ten `PriceData` objects limit. |
 
+## See Also
+
+- [Oracle entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/paymentchannelclaim.md
+++ b/docs/references/protocol/transactions/types/paymentchannelclaim.md
@@ -72,4 +72,8 @@ Transactions of the `PaymentChannelClaim` type support additional values in the 
 | `tfRenew` | `0x00010000` | 65536         | Clear the channel's `Expiration` time. (`Expiration` is different from the channel's immutable `CancelAfter` time.) Only the source address of the payment channel can use this flag. |
 | `tfClose` | `0x00020000` | 131072        | Request to close the channel. Only the channel source and destination addresses can use this flag. This flag closes the channel immediately if it has no more XRP allocated to it after processing the current claim, or if the destination address uses it. If the source address uses this flag when the channel still holds XRP, this schedules the channel to close after `SettleDelay` seconds have passed. (Specifically, this sets the `Expiration` of the channel to the close time of the previous ledger plus the channel's `SettleDelay` time, unless the channel already has an earlier `Expiration` time.) If the destination address uses this flag when the channel still holds XRP, any XRP that remains after processing the claim is returned to the source address. |
 
+## See Also
+
+- [PayChannel entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/paymentchannelcreate.md
+++ b/docs/references/protocol/transactions/types/paymentchannelcreate.md
@@ -43,4 +43,8 @@ _(Added by the [PayChan amendment][].)_
 
 If the `Destination` account is blocking incoming payment channels, the transaction fails with result code `tecNO_PERMISSION`. _(Requires the [DisallowIncoming amendment][] )_
 
+## See Also
+
+- [PayChannel entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/paymentchannelfund.md
+++ b/docs/references/protocol/transactions/types/paymentchannelfund.md
@@ -49,4 +49,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `temBAD_AMOUNT`           | The `Amount` field of the transaction is invalid. The amount must either be XRP or fungible tokens and cannot be zero or negative. |
 | `temBAD_EXPIRATION`       | The `Expiration` field is invalid.              |
 
+## See Also
+
+- [PayChannel entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
Fixes https://github.com/XRPLF/xrpl-dev-portal/issues/3220

- Adds related topics to the ledger entry and transaction type pages.

Preview [here](https://xrpl-dev-portal--related-topics-batch-3.preview.redocly.app/docs/references/protocol/ledger-data/ledger-entry-types/mptokenissuance)

Related PRs:
- Batch 1: https://github.com/XRPLF/xrpl-dev-portal/pull/3235
- Batch 2: https://github.com/XRPLF/xrpl-dev-portal/pull/3246

Batch 3 covers:

- [x] MPTokenIssuance + transactions
- [x] NFTokenOffer + transactions
- [x] Offer + transactions
- [x] Oracle + transactions
- [x] PayChannel + transactions