### PR TITLE
Add related transactions and ledger entries (batch 4)

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -194,6 +194,8 @@
 [PermissionDelegation amendment]: /resources/known-amendments.md#permissiondelegation
 [PermissionedDEX amendment]: /resources/known-amendments.md#permissioneddex
 [Permissioned DEXes]: /docs/concepts/tokens/decentralized-exchange/permissioned-dexes.md
+[PermissionedDomain entry]: /docs/references/protocol/ledger-data/ledger-entry-types/permissioneddomain.md
+[PermissionedDomainDelete transaction]: /docs/references/protocol/transactions/types/permissioneddomaindelete.md
 [PermissionedDomainSet transaction]: /docs/references/protocol/transactions/types/permissioneddomainset.md
 [PermissionedDomainSetトランザクション]: /@l10n/ja/docs/references/protocol/transactions/types/permissioneddomainset.md
 [PermissionedDomains amendment]: /resources/known-amendments.md#permissioneddomains
@@ -263,6 +265,7 @@
 [XChainCreateClaimID transaction]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
 [XChainCreateClaimID transactions]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
 [XChainCreateClaimID]: /docs/references/protocol/transactions/types/xchaincreateclaimid.md
+[XChainOwnedCreateAccountClaimID entry]: /docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid.md
 [XChainOwnedClaimID entry]: /docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid
 [XRP, in drops]: /docs/references/protocol/data-types/basic-data-types.md#specifying-currency-amounts
 [XRPFees amendment]: /resources/known-amendments.md#xrpfees

--- a/docs/references/protocol/ledger-data/ledger-entry-types/permissioneddomain.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/permissioneddomain.md
@@ -77,5 +77,10 @@ The ID of a {% code-page-name /%} entry is the [SHA-512Half][] of the following 
 0. The AccountID of the {% code-page-name /%}'s owner.
 0. The Sequence number of the transaction that created the {% code-page-name /%}.
 
+## See Also
+
+- **Transactions:**
+  - [PermissionedDomainDelete transaction][]
+  - [PermissionedDomainSet transaction][]
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate.md
@@ -124,4 +124,9 @@ The ID of a RippleState entry is the [SHA-512Half][] of the following values, co
 * The AccountID of the high account
 * The 160-bit currency code of the trust line(s)
 
+## See Also
+
+- **Transactions:**
+  - [TrustSet transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/signerlist.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/signerlist.md
@@ -102,4 +102,9 @@ The ID of a `SignerList` entry is the SHA-512Half of the following values, conca
 * The AccountID of the owner of the signer list
 * The `SignerListID` (currently always `0`)
 
+## See Also
+
+- **Transactions:**
+  - [SignerListSet transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/ticket.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/ticket.md
@@ -60,4 +60,9 @@ The ID of a Ticket object is the SHA-512Half of the following values, concatenat
 * The AccountID of the owner of the Ticket
 * The `TicketSequence` number of the Ticket
 
+## See Also
+
+- **Transactions:**
+  - [TicketCreate transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid.md
@@ -102,4 +102,9 @@ _(Requires the [XChainBridge amendment][] {% not-enabled /%})_
 | `LockingChainDoor`  | String    | AccountID         | Yes       | The door account on the locking chain. |
 | `LockingChainIssue` | Issue     | Issue             | Yes       | The asset that is locked and unlocked on the locking chain. |
 
+## See Also
+
+- **Transactions:**
+  - [XChainCreateClaimID transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid.md
@@ -85,4 +85,9 @@ _(Requires the [XChainBridge amendment][] {% not-enabled /%})_
 | `LockingChainDoor`  | String    | AccountID         | Yes       | The door account on the locking chain. |
 | `LockingChainIssue` | Issue     | Issue             | Yes       | The asset that is locked and unlocked on the locking chain. |
 
+## See Also
+
+- **Transactions:**
+  - [XChainAddAccountCreateAttestation transaction][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/permissioneddomaindelete.md
+++ b/docs/references/protocol/transactions/types/permissioneddomaindelete.md
@@ -45,4 +45,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecNO_ENTRY` | The permissioned domain specified in the `DomainID` field doesn't exist in the ledger. |
 | `temDISABLED` | The `PermissionedDomains` amendment is not enabled. |
 
+## See Also
+
+- [PermissionedDomain entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/permissioneddomainset.md
+++ b/docs/references/protocol/transactions/types/permissioneddomainset.md
@@ -61,5 +61,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecNO_PERMISSION`        | The transaction attempted to modify an existing Domain, but the sender of the transaction is not the owner of the specified Domain. |
 | `temDISABLED`             | Either the `PermissionedDomains` amendment is not enabled, or the `Credentials` amendment is not enabled. |
 
+## See Also
+
+- [PermissionedDomain entry][]
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/signerlistset.md
+++ b/docs/references/protocol/transactions/types/signerlistset.md
@@ -64,4 +64,8 @@ You cannot remove the last method of signing transactions from an account. If an
 
 Creating or replacing a signer list enables the `lsfOneOwnerCount` flag on the [SignerList object](../../ledger-data/ledger-entry-types/signerlist.md). Lists that were created before the [MultiSignReserve amendment][] became enabled do not have this flag and have a higher [owner reserve](../../../../concepts/accounts/reserves.md#owner-reserves). You can decrease the owner reserve for these lists by replacing the list with the same list. For more information, see [SignerList Flags](../../ledger-data/ledger-entry-types/signerlist.md#signerlist-flags).
 
+## See Also
+
+- [SignerList entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/ticketcreate.md
+++ b/docs/references/protocol/transactions/types/ticketcreate.md
@@ -49,4 +49,8 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecDIR_FULL`             | This transaction would cause the account to own more than the limit of 250 Tickets at a time, or more than the maximum number of ledger objects in general. |
 | `tecINSUFFICIENT_RESERVE` | The sending account does not have enough XRP to meet the [owner reserve](../../../../concepts/accounts/reserves.md) of all the requested Tickets. |
 
+## See Also
+
+- [Ticket entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/trustset.md
+++ b/docs/references/protocol/transactions/types/trustset.md
@@ -65,4 +65,8 @@ If a transaction tries to enable No Ripple but cannot, it fails with the result 
 
 The Auth flag of a trust line does not determine whether the trust line counts towards its owner's XRP reserve requirement. An issuer can pre-authorize a trust line with the `tfSetfAuth` flag only, even if the limit and balance of the trust line are 0.
 
+## See Also
+
+- [RippleState entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
+++ b/docs/references/protocol/transactions/types/xchainaddaccountcreateattestation.md
@@ -78,4 +78,8 @@ Any account can submit signatures.
 | `LockingChainDoor`  | String    | AccountID         | Yes       | The door account on the locking chain. |
 | `LockingChainIssue` | Issue     | Issue             | Yes       | The asset that is locked and unlocked on the locking chain. |
 
+## See Also
+
+- [XChainOwnedCreateAccountClaimID entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/protocol/transactions/types/xchaincreateclaimid.md
+++ b/docs/references/protocol/transactions/types/xchaincreateclaimid.md
@@ -59,4 +59,8 @@ It also includes the account on the source chain that locks or burns the funds o
 | `LockingChainDoor`  | String    | Account           | Yes       | The door account on the locking chain. |
 | `LockingChainIssue` | Issue     | Issue             | Yes       | The asset that is locked and unlocked on the locking chain. |
 
+## See Also
+
+- [XChainOwnedClaimID entry][]
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
Fixes https://github.com/XRPLF/xrpl-dev-portal/issues/3220

- Adds related topics to the ledger entry and transaction type pages.

Preview [here](https://xrpl-dev-portal--related-topics-batch-4.preview.redocly.app/docs/references/protocol/ledger-data/ledger-entry-types/permissioneddomain)

Related PRs:
- Batch 1: https://github.com/XRPLF/xrpl-dev-portal/pull/3235
- Batch 2: https://github.com/XRPLF/xrpl-dev-portal/pull/3246
- Batch 3: https://github.com/XRPLF/xrpl-dev-portal/pull/3247

Batch 4 (final one) covers:

- [x] PermissionedDomain + transactions
- [x] RippleState + transactions
- [x] SignerList + transactions
- [x] Ticket + transactions
- [x] XChainOwnedClaimID + transactions
- [x] XChainOwnedCreateAccountClaimID + transactions