### PR TITLE
update mpt docs for permissioneddomains

### DIFF
--- a/docs/references/protocol/transactions/types/mptokenissuancecreate.md
+++ b/docs/references/protocol/transactions/types/mptokenissuancecreate.md
@@ -13,6 +13,7 @@ If the transaction is successful, it creates an [MPTokenIssuance entry][] where 
 
 {% amendment-disclaimer name="MPTokensV1" /%}
 
+
 ## Example MPTokenIssuanceCreate JSON
 
 This example assumes that the issuer of the token is the signer of the transaction.
@@ -24,6 +25,7 @@ This example assumes that the issuer of the token is the signer of the transacti
   "AssetScale": 4,
   "TransferFee": 0,
   "MaximumAmount": "50000000",
+  "Flags": 83659,
   "MPTokenMetadata": "7B2274223A225442494C4C222C226E223A22542D42696C6C205969656C6420546F6B656E222C2264223A2241207969656C642D62656172696E6720737461626C65636F696E206261636B65642062792073686F72742D7465726D20552E532E205472656173757269657320616E64206D6F6E6579206D61726B657420696E737472756D656E74732E222C2269223A226578616D706C652E6F72672F7462696C6C2D69636F6E2E706E67222C226163223A22727761222C226173223A227472656173757279222C22696E223A224578616D706C65205969656C6420436F2E222C227573223A5B7B2275223A226578616D706C657969656C642E636F2F7462696C6C222C2263223A2277656273697465222C2274223A2250726F647563742050616765227D2C7B2275223A226578616D706C657969656C642E636F2F646F6373222C2263223A22646F6373222C2274223A225969656C6420546F6B656E20446F6373227D5D2C226169223A7B22696E7465726573745F72617465223A22352E303025222C22696E7465726573745F74797065223A227661726961626C65222C227969656C645F736F75726365223A22552E532E2054726561737572792042696C6C73222C226D617475726974795F64617465223A22323034352D30362D3330222C226375736970223A22393132373936525830227D7D",
   "Fee": "12",
   "Flags": 122,
@@ -38,6 +40,7 @@ This example assumes that the issuer of the token is the signer of the transacti
 | Field             | JSON Type            | [Internal Type][] | Required? | Description |
 |:------------------|:---------------------|:------------------|:----------|:------------|
 | `AssetScale`      | Number               | UInt8             | No        | Where to put the decimal place when displaying amounts of this MPT. More formally, the asset scale is a non-negative integer (0, 1, 2, …) such that one standard unit equals 10^(-scale) of a corresponding fractional unit. For example, if a US Dollar Stablecoin has an asset scale of _2_, then 1 unit of that MPT would equal 0.01 US Dollars. This indicates to how many decimal places the MPT can be subdivided. If omitted, the default is 0, meaning that the MPT cannot be divided into smaller than 1 unit. |
+| `DomainID`        | String - [Hash][]    | UInt256           | No        | The ledger entry ID of a permissioned domain that grants access to the MPT. You must enable the `tfMPTRequireAuth` flag to use permissioned domains. {% amendment-disclaimer name="PermissionedDomains" /%} {% amendment-disclaimer name="SingleAssetVault" /%} |
 | `TransferFee`     | Number               | UInt16            | No        | The value specifies the fee to charged by the issuer for secondary sales of the Token, if such sales are allowed. Valid values for this field are between 0 and 50,000 inclusive, allowing transfer rates of between 0.000% and 50.000% in increments of 0.001. The field _must not_ be present if the tfMPTCanTransfer flag is not set. If it is, the transaction should fail and a fee should be claimed. |
 | `MaximumAmount`   | String - Number      | UInt64            | No        | The maximum asset amount of this token that can ever be issued, as a base-10 number encoded as a string. The current default maximum limit is 9,223,372,036,854,775,807 (2^63-1). _This limit may increase in the future. If an upper limit is required, you must specify this field._ |
 | `MPTokenMetadata` | String - Hexadecimal | Blob              | No        | Arbitrary metadata about this issuance. The limit for this field is 1024 bytes. By convention, the metadata should decode to JSON data describing what the MPT represents. The [XLS-89 specification](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0089-multi-purpose-token-metadata-schema) defines a recommended format for metadata. |
@@ -45,6 +48,7 @@ This example assumes that the issuer of the token is the signer of the transacti
 {% admonition type="success" name="Tip" %}
 For an example of how to encode metadata for the `MPTokenMetadata` field, see {% repo-link path="_code-samples/issue-mpt-with-metadata/" %}Code Sample: Issue MPT with Metadata{% /repo-link %}.
 {% /admonition %}
+
 
 ## MPTokenIssuanceCreate Flags
 
@@ -58,6 +62,20 @@ Transactions of the MPTokenIssuanceCreate type support additional values in the 
 | `tfMPTCanTrade`    | `0x00000010` | `16`          | If set, indicates that individual holders can trade their balances using the XRP Ledger DEX. |
 | `tfMPTCanTransfer` | `0x00000020` | `32`          | If set, indicates that tokens can be transferred to other accounts that are not the issuer. |
 | `tfMPTCanClawback` | `0x00000040` | `64`          | If set, indicates that the issuer can use the `Clawback` transaction to claw back value from individual holders. |
+
+
+## Error Cases
+
+Besides errors that can occur for all transactions, {% $frontmatter.seo.title %} transactions can result in the following [transaction result codes](../transaction-results/index.md):
+
+| Error Code                | Description |
+|:--------------------------|:------------|
+| `tecDIR_FULL`             | The owner directory of the account creating the `MPTokenIssuance` ledger entry is full. |
+| `temBAD_TRANSFER_FEE`     | The transfer fee specified is greater than the maximum allowed value of 50,000. |
+| `temDISABLED`             | The `MPTokensV1` amendment is disabled. You will also receive this error if you include a `DomainID` field in the transaction, but the `PermissionedDomains` and `SingleAssetVault` amendments are both disabled. |
+| `tecINSUFFICIENT_RESERVE` | The account creating the `MPTokenIssuance` ledger entry doesn't have enough XRP to meet the owner reserve. |
+| `temMALFORMED`            | Besides generally malformed transactions, you can receive this error if:<br>- A non-zero transfer fee is set, but the `tfMPTCanTransfer` flag is _not_ set.<br>- The `DomainID` points to an invalid permissioned domain; you can also receive this error if you include a `DomainID` without setting the `tfMPTRequireAuth` flag.<br>- The `MPTokenMetadata` field is an invalid length (0 or exceeds 1024 bytes).<br>- The `MaximumAmount` field is 0 or exceeds 9,223,372,036,854,775,807 (2^63-1). |
+
 
 ## See Also
 

--- a/docs/references/protocol/transactions/types/mptokenissuanceset.md
+++ b/docs/references/protocol/transactions/types/mptokenissuanceset.md
@@ -11,6 +11,7 @@ Update a mutable property of a [Multi-purpose Token (MPT)](../../../../concepts/
 
 {% amendment-disclaimer name="MPTokensV1" /%}
 
+
 ## Example MPTokenIssuanceSet JSON
 
 This example locks the balances of all holders of the specified MPT issuance.
@@ -32,8 +33,10 @@ This example locks the balances of all holders of the specified MPT issuance.
 
 | Field               | JSON Type            | [Internal Type][] | Required? | Description |
 |:--------------------|:---------------------|:------------------|:----------|-------------|
+| `DomainID`          | String - [Hash][]    | UInt256           | No        | The ledger entry ID of a permissioned domain that grants access to the MPT. An empty value or `0` removes the permissioned domain from the MPT issuance so that only users who are explicitly approved by the issuer can send and receive the MPT. You can only set a `DomainID` if the MPT issuance has [**Require Auth**](/docs/concepts/tokens/fungible-tokens/multi-purpose-tokens#transferability-controls) enabled. {% amendment-disclaimer name="PermissionedDomains" /%} {% amendment-disclaimer name="SingleAssetVault" /%} |
 | `MPTokenIssuanceID` | String - Hexadecimal | UInt192           | Yes       | The identifier of the `MPTokenIssuance` to update. |
 | `Holder`            | String - [Address][] | AccountID         | No        | An individual token holder. If provided, apply changes to the given holder's balance of the given MPT issuance. If omitted, apply to all accounts holding the given MPT issuance. |
+
 
 ### MPTokenIssuanceSet Flags
 
@@ -43,6 +46,20 @@ Transactions of the `MPTokenIssuanceSet` type support additional values in the `
 |:-------------------|:-------------|:--------------|:------------------------------|
 | `tfMPTLock`        | `0x00000001` | 1             | Enable to lock balances of this MPT issuance. |
 | `tfMPTUnlock`      | `0x00000002` | 2             | Enable to unlock balances of this MPT issuance. |
+
+
+## Error Cases
+
+Besides errors that can occur for all transactions, {% $frontmatter.seo.title %} transactions can result in the following [transaction result codes](../transaction-results/index.md):
+
+| Error Code                | Description |
+|:--------------------------|:------------|
+| `temDISABLED`             | The `MPTokensV1` amendment is disabled. You will also receive this error if you include a `DomainID` field in the transaction, but the `PermissionedDomains` and `SingleAssetVault` amendments are both disabled. |
+| `tecNO_DST`               | The account specified in the `Holder` field doesn't exist. |
+| `tecNO_PERMISSION`        | - The `lsfMPTCanLock` flag isn't enabled, but you are attempting to lock or unlock an MPT.<br>- The `SingleAssetVault` amendment is disabled and you're trying to modify a `DomainID` field. | 
+| `temMALFORMED`            | Besides generally malformed transactions, you can receive this error if:<br>- You specified a `DomainID` and `Holder` value; only one can be set in a single transaction.<br>- You specified the same account for both `Account` and `Holder`.<br>- The transaction isn't changing anything; it must either update a flag or modify the `DomainID`. |
+| `tecOBJECT_NOT_FOUND`    | The specified `MPToken`, `MPTokenIssuance`, or `PermissionedDomain` ledger entry doesn't exist. |
+
 
 ## See Also
 


### PR DESCRIPTION
Updated `MPTTokenIssuanceCreate` and `MPTokenIssuanceSet` transaction docs to include `DomainID` field. Also added additional error codes.

Documents changes to MPT that are gated by Single Asset Vaults: https://github.com/XRPLF/rippled/pull/5509