### PR TITLE
Fix binary-format.md link

### DIFF
--- a/docs/references/protocol/binary-format.md
+++ b/docs/references/protocol/binary-format.md
@@ -390,6 +390,7 @@ The following example shows the serialization format for a PathSet:
 [UInt96]: #uint-fields
 [UInt128]: #uint-fields
 [UInt160]: #uint-fields
+[UInt192]: #uint-fields
 [UInt256]: #uint-fields
 [UInt384]: #uint-fields
 [UInt512]: #uint-fields


### PR DESCRIPTION
The `UInt192` link wasn't working properly.

<img width="180" height="313" alt="image" src="https://github.com/user-attachments/assets/f0c5128e-456f-4a97-b6f7-42a19f47ca4a" />
