### PR TITLE
Remove old/inadvertent TODO notes

### DIFF
--- a/@l10n/ja/docs/infrastructure/configuration/server-modes/run-rippled-as-a-validator.md
+++ b/@l10n/ja/docs/infrastructure/configuration/server-modes/run-rippled-as-a-validator.md
@@ -313,9 +313,6 @@ _**公開ハブを使用してバリデータをネットワークに接続す�
 
 4. 記入したGoogleフォームを送信すると、ドメイン検証の成否を通知するメールがXRP Chartsから送信されます。ドメイン検証が成功した場合は、XRP Chartsの[バリデータレジストリー](https://xrpcharts.ripple.com/#/validators)にバリデータとドメインが表示されます。
 
-<!--{ ***TODO: For the future - add a new section or separate document: "Operating a Trusted Validator" -- things that you need to be aware of once your validator has been added to a UNL and is participating in consensus. We should tell the user what to expect once they are listed in a UNL. How to tell if your validator is participating in the consensus process? How to tell if something isn't right with your validator - warning signs that they should look out for? How to tell if your validator has fallen out of agreement - what is the acceptable vs unacceptable threshold? Maybe provide a script that will alert them when something is going wrong.*** }-->
-
-
 
 ## バリデータキーの破棄
 

--- a/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-time-held-escrow.md
+++ b/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-time-held-escrow.md
@@ -128,7 +128,6 @@ Response:
 
 [Sign and submit](../../../../concepts/transactions/index.md#signing-and-submitting-transactions) an [EscrowFinish transaction][] to execute the release of the funds after the `FinishAfter` time has passed. Set the `Owner` field of the transaction to the `Account` address from the EscrowCreate transaction, and the `OfferSequence` to the `Sequence` number from the EscrowCreate transaction. For an escrow held only by time, omit the `Condition` and `Fulfillment` fields.
 
-***TODO: First half of this statement is covered by concept info already. It's also reiterated in escrow.md. The second portion about potential recipients should remain.***
 {% admonition type="success" name="Tip" %}
 The EscrowFinish transaction is necessary because the XRP Ledger's state can only be modified by transactions. The sender of this transaction may be the recipient of the escrow, the original sender of the escrow, or any other XRP Ledger address.
 {% /admonition %}


### PR DESCRIPTION
Neither of these TODOs is relevant at the moment and they should not be
visible to readers (even in the HTML comments).

(I think the Japanese page might not be in sync with the English version, also, but that's a separate concern.)