### PR TITLE
Fix source link formatting

### DIFF
--- a/docs/concepts/tokens/fungible-tokens/index.md
+++ b/docs/concepts/tokens/fungible-tokens/index.md
@@ -1,6 +1,4 @@
 ---
-html: trust-lines-and-issuing.html
-parent: tokens.html
 seo:
     description: Learn about the properties and rationale of trust lines.
 labels:
@@ -72,7 +70,7 @@ If your balance is negative (you are the issuer) or the other side's settings ar
 Since the **Authorized** setting cannot be turned off after it has been turned on, it does not count toward the trust line's default state.
 
 ### Free Trust Lines
-[[Source]](https://github.com/XRPLF/rippled/blob/72377e7bf25c4eaee5174186d2db3c6b4210946f/src/ripple/app/tx/impl/SetTrust.cpp#L148-L168)
+[[Source]](https://github.com/XRPLF/rippled/blob/2df7dcfdebcb0cdbd030c1f4b09ac748af95659c/src/xrpld/app/tx/detail/SetTrust.cpp#L387-L407 "Source")
 
 Since trust lines are a powerful feature of the XRP Ledger, there is a special feature to make an account's first two trust lines "free".
 


### PR DESCRIPTION
- Replace the old link with a link to the updated source version
- Add the missing "Source" title attribute so the source link will float right as intended
- Remove deprecated frontmatter