### PR TITLE
Add downgrade rippled guide

### DIFF
--- a/docs/infrastructure/installation/downgrade-rippled.md
+++ b/docs/infrastructure/installation/downgrade-rippled.md
@@ -1,0 +1,61 @@
+---
+html: downgrade-rippled.html
+parent: install-rippled.html
+seo:
+    description: Downgrade rippled on Linux.
+labels:
+  - Core Server
+
+---
+# Downgrade rippled on Ubuntu or Debian
+
+This page describes how to downgrade to a specific release of `rippled` on Ubuntu Linux. 
+
+These instructions assume you have already [installed `rippled` on a supported version of Ubuntu using Ripple's `deb` package](install-rippled-on-ubuntu.md). 
+
+
+To downgrade rippled to a version of your choice, complete the following steps:
+
+1. Check what version of `rippled` you're running at the moment.
+
+    ```
+    sudo rippled --version
+    ```
+
+2. Before downgrading the `rippled` package, stop the service first.
+
+    ```
+    sudo systemctl stop rippled
+    ```
+
+3. Downgrade `rippled` to a version of your choice, e.g 2.5.0-1 for rippled 2.5.0 .
+
+    ```
+    sudo apt install rippled=2.5.0-1
+    ```
+
+4. Check if `rippled` is running:
+
+    ```
+    sudo systemctl status rippled
+    ```
+
+5. Confirm `rippled` is downgraded successfully:
+
+    ```
+    sudo rippled --version
+    ```
+
+## See Also
+
+- **Concepts:**
+    - [The `rippled` Server](../../concepts/networks-and-servers/index.md)
+    - [Consensus](../../concepts/consensus-protocol/index.md)
+- **Tutorials:**
+    - [Troubleshoot rippled](../troubleshooting/index.md)
+- **References:**
+    - [rippled API Reference](../../references/http-websocket-apis/index.md)
+        - [`rippled` Commandline Usage](../commandline-usage.md)
+        - [server_info method][]
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.122.3",
+        "@redocly/realm": "^0.122.3",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.122.3",
+    "@redocly/realm": "^0.122.3",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -648,6 +648,7 @@
             - page: docs/infrastructure/installation/update-rippled-automatically-on-linux.md
             - page: docs/infrastructure/installation/update-rippled-manually-on-rhel.md
             - page: docs/infrastructure/installation/update-rippled-manually-on-ubuntu.md
+            - page: docs/infrastructure/installation/downgrade-rippled.md
             - page: docs/infrastructure/installation/build-on-linux-mac-windows.md
             - page: docs/infrastructure/installation/capacity-planning.md
         - page: docs/infrastructure/configuration/index.md


### PR DESCRIPTION
Adding downgrade guide path for rippled, currently we have only install and update. In cases where operators may need to downgrade this can be used as an reference.