### PR TITLE
WS Tool fixes: cURL modal, Clio Only

### DIFF
--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -829,6 +829,9 @@ resources.dev-tools.websocket-api.curl.modal.desc.part2: を使用してこれ�
 API Methods: APIメソッド
 Methods: メソッド
 Examples: の例
+# resources/dev-tools/websocket-api/ClioOnly.tsx
+resources.dev-tools.websocket-api.clio-only-badge: Clioのみ
+resources.dev-tools.websocket-api.clio-only-tooltip: このメソッドはClioサーバーからのみ利用可能です。
 
 # resources/dev-tools/xrp-ledger-toml-checker.page.tsx
 resources.dev-tools.toml-checker.p.part1: もしあなたがXRP Ledgerバリデータを運営していたり、XRP Ledgerをビジネスで利用しているのであれば、XRP Ledgerの利用状況に関する情報を、機械読み取り可能な

--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -11,6 +11,13 @@ ul.nav.navbar-nav {
   flex-grow: 1;
 }
 
+.clio-only-notice {
+	background-color: var(--admonition-info-bg-color);
+	margin-left: var(--spacing-sm);
+	padding: var(--spacing-xs);
+	border-radius: var(--border-radius);
+}
+
 :root, :root.dark {
   --navbar-height: 80px;
 

--- a/resources/dev-tools/components/AlertTemplate.tsx
+++ b/resources/dev-tools/components/AlertTemplate.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
-import * as React from 'react';
-import { useThemeHooks } from '@redocly/theme/core/hooks';
+import * as React from 'react'
+import { useThemeHooks } from '@redocly/theme/core/hooks'
   
 const alertStyle = {
   position: "relative",
@@ -30,7 +30,7 @@ interface AlertTemplateProps {
 }
   
 export default function AlertTemplate ({ message, options, style, close }: AlertTemplateProps): React.JSX.Element {
-  const { useTranslate } = useThemeHooks();
+  const { useTranslate } = useThemeHooks()
   const { translate } = useTranslate()
   return(
     <div className={clsx("bootstrap-growl alert alert-dismissible", typeToClass(options.type))} style={{ ...alertStyle, ...style }}>

--- a/resources/dev-tools/components/websocket-api/ClioOnly.tsx
+++ b/resources/dev-tools/components/websocket-api/ClioOnly.tsx
@@ -1,0 +1,26 @@
+import { useThemeHooks } from '@redocly/theme/core/hooks';
+
+export function ClioOnlyIcon () {
+  const { useTranslate } = useThemeHooks()
+  const { translate } = useTranslate()
+  return (
+      <span
+        className="status clio_only"
+        title={translate("This method is only available from the Clio server.")}
+      >
+        <i className="fa fa-exclamation-circle"></i>
+      </span>
+  )
+}
+
+export function ClioOnlyNotice() {
+  const { useTranslate } = useThemeHooks()
+  const { translate } = useTranslate()
+  return (
+    <span className="clio-only-notice"
+    >
+      <ClioOnlyIcon />
+      {translate(" Clio only")}
+    </span>
+  )
+}

--- a/resources/dev-tools/components/websocket-api/ClioOnly.tsx
+++ b/resources/dev-tools/components/websocket-api/ClioOnly.tsx
@@ -6,7 +6,7 @@ export function ClioOnlyIcon () {
   return (
       <span
         className="status clio_only"
-        title={translate("This method is only available from the Clio server.")}
+        title={translate("resources.dev-tools.websocket-api.clio-only-tooltip", "This method is only available from the Clio server.")}
       >
         <i className="fa fa-exclamation-circle"></i>
       </span>
@@ -20,7 +20,7 @@ export function ClioOnlyNotice() {
     <span className="clio-only-notice"
     >
       <ClioOnlyIcon />
-      {translate(" Clio only")}
+      {translate("resources.dev-tools.websocket-api.clio-only-badge", " Clio only")}
     </span>
   )
 }

--- a/resources/dev-tools/components/websocket-api/curl-modal.tsx
+++ b/resources/dev-tools/components/websocket-api/curl-modal.tsx
@@ -1,6 +1,6 @@
+import React, { useRef, useState } from 'react';
 import { useThemeHooks } from '@redocly/theme/core/hooks';
 import { Connection } from './types';
-import { useRef, useState } from 'react';
 import { Modal, ModalClipboardBtn, ModalCloseBtn } from '../Modal';
 
 interface CurlButtonProps {
@@ -12,36 +12,18 @@ interface CurlProps extends CurlButtonProps{
   closeCurlModal: () => void;
 }
 
-const getCurl = function (currentBody, selectedConnection: Connection) {
-  let body;
-  try {
-    // change WS to JSON-RPC syntax
-    const params = JSON.parse(currentBody);
-    delete params.id;
-    const method = params.command;
-    delete params.command;
-    const body_json = { method: method, params: [params] };
-    body = JSON.stringify(body_json, null, null);
-  } catch (e) {
-    alert("Can't provide curl format of invalid JSON syntax");
-    return;
-  }
-
-  const server = selectedConnection.jsonrpc_url;
-
-  return `curl -H 'Content-Type: application/json' -d '${body}' ${server}`;
-};
-
 export const CurlModal: React.FC<CurlProps> = ({
-                                                 currentBody,
-                                                 selectedConnection,
+                                                  closeCurlModal,
+                                                  currentBody,
+                                                  selectedConnection,
                                                }) => {
-  const curlRef = useRef(null);
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
+  const curlRef = useRef(null);
+
   const footer = <>
     <ModalClipboardBtn textareaRef={curlRef} />
-    <ModalCloseBtn onClick={() => {}} />
+    <ModalCloseBtn onClick={closeCurlModal} />
   </>
 
   return (
@@ -63,16 +45,16 @@ export const CurlModal: React.FC<CurlProps> = ({
             className="form-control"
             rows={8}
             ref={curlRef}
-          >
-            {getCurl(currentBody, selectedConnection)}
-          </textarea>
+            value={getCurl(selectedConnection, currentBody)}
+            onChange={() => {}}
+          />
         </div>
       </form>
     </Modal>
   );
 };
 
-export const CurlButton = ({selectedConnection, currentBody}: CurlButtonProps) => {
+export function CurlButton ({selectedConnection, currentBody}: CurlButtonProps) {
   const [showCurlModal, setShowCurlModal] = useState(false);
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
@@ -87,10 +69,32 @@ export const CurlButton = ({selectedConnection, currentBody}: CurlButtonProps) =
       >
         <i className="fa fa-terminal"></i>
       </button>
-      {showCurlModal && <CurlModal
-        closeCurlModal={() => setShowCurlModal(false)}
-        currentBody={currentBody}
-        selectedConnection={selectedConnection}
-      />}
+      {showCurlModal && (
+        <CurlModal
+          closeCurlModal={() => setShowCurlModal(false)}
+          currentBody={currentBody}
+          selectedConnection={selectedConnection}
+        />
+      )}
   </>
+}
+
+function getCurl(selectedConnection: Connection, currentBody) {
+  let body : string;
+  try {
+    // change WS to JSON-RPC syntax
+    const params = JSON.parse(currentBody);
+    delete params.id;
+    const method = params.command;
+    delete params.command;
+    const body_json = { method: method, params: [params] };
+    body = JSON.stringify(body_json, null, null);
+  } catch (e) {
+    alert("Can't provide curl format of invalid JSON syntax");
+    return;
+  }
+
+  const server = selectedConnection.jsonrpc_url;
+
+  return `curl -H 'Content-Type: application/json' -d '${body}' ${server}`;
 }

--- a/resources/dev-tools/components/websocket-api/data/command-list.json
+++ b/resources/dev-tools/components/websocket-api/data/command-list.json
@@ -469,18 +469,6 @@
     "group": "Payment Channel Methods",
     "methods": [
       {
-        "name": "channel_authorize",
-        "description": "Creates a signature that can be used to redeem a specific amount of XRP from a payment channel.",
-        "link": "/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_authorize",
-        "body": {
-          "id": "channel_authorize_example_id1",
-          "command": "channel_authorize",
-          "channel_id": "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
-          "secret": "s████████████████████████████",
-          "amount": "1000000"
-        }
-      },
-      {
         "name": "channel_verify",
         "description": "Checks the validity of a signature that can be used to redeem a specific amount of XRP from a payment channel.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify",

--- a/resources/dev-tools/components/websocket-api/data/command-list.json
+++ b/resources/dev-tools/components/websocket-api/data/command-list.json
@@ -4,7 +4,7 @@
     "methods": [
       {
         "name": "account_channels",
-        "description": "Returns information about an account's <a href='/docs/concepts/payment-types/payment-channels/'>payment channels</a>.",
+        "description": "Returns information about an account's payment channels.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/account-methods/account_channels",
         "body": {
           "command": "account_channels",
@@ -414,7 +414,7 @@
     "methods": [
       {
         "name": "mpt_holders",
-        "description": "Return all holders of an MPT and their balance (Clio only).",
+        "description": "Return all holders of an MPT and their balance.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/clio-methods/mpt_holders",
         "clio_only": true,
         "body": {
@@ -431,7 +431,7 @@
     "methods": [
       {
         "name": "nft_history",
-        "description": "Get past transaction metadata for an NFT (Clio only).",
+        "description": "Get past transaction metadata for an NFT.",
         "link": "/docs/references/http-websocket-apis/public-api-methods/clio-methods/nft_history",
         "clio_only": true,
         "body": {
@@ -442,7 +442,7 @@
       },
       {
         "name": "nft_info",
-        "description": "Get info about an NFT (Clio only).",
+        "description": "Get info about an NFT.",
         "clio_only": true,
         "link": "/docs/references/http-websocket-apis/public-api-methods/clio-methods/nft_info",
         "body": {
@@ -453,7 +453,7 @@
       },
       {
         "name": "nfts_by_issuer",
-        "description": "Get a list of NFTs issued by a specific account, optionally filtered by taxon (Clio only).",
+        "description": "Get a list of NFTs issued by a specific account, optionally filtered by taxon.",
         "clio_only": true,
         "link": "/docs/references/http-websocket-apis/public-api-methods/clio-methods/nfts_by_issuer",
         "body": {

--- a/resources/dev-tools/components/websocket-api/data/connections.json
+++ b/resources/dev-tools/components/websocket-api/data/connections.json
@@ -45,14 +45,14 @@
   {
     "id": "connection-testnet-clio",
     "ws_url": "wss://clio.altnet.rippletest.net:51233/",
-    "jsonrpc-url": "https://clio.altnet.rippletest.net:51234/",
+    "jsonrpc_url": "https://clio.altnet.rippletest.net:51234/",
     "shortname": "Testnet-clio",
     "longname": "clio.altnet.rippletest.net (Testnet Public Cluster with Clio)"
   },
   {
     "id": "connection-devnet-clio",
     "ws_url": "wss://clio.devnet.rippletest.net:51233/",
-    "jsonrpc-url": "https://clio.devnet.rippletest.net:51234/",
+    "jsonrpc_url": "https://clio.devnet.rippletest.net:51234/",
     "shortname": "Devnet-clio",
     "longname": "clio.devnet.rippletest.net (Devnet Public Cluster with Clio)"
   }

--- a/resources/dev-tools/components/websocket-api/permalink-modal.tsx
+++ b/resources/dev-tools/components/websocket-api/permalink-modal.tsx
@@ -9,7 +9,7 @@ interface PermaLinkButtonProps {
 }
 
 interface PermaLinkProps extends PermaLinkButtonProps {
-  closePermalinkModal: any;
+  closePermalinkModal: () => void;
 }
 
 const PermalinkModal: React.FC<PermaLinkProps> = ({
@@ -43,6 +43,7 @@ const PermalinkModal: React.FC<PermaLinkProps> = ({
           <textarea
             id="permalink-box-1"
             className="form-control"
+            rows={8}
             ref={permalinkRef}
             value={getPermalink(selectedConnection, currentBody)}
             onChange={() => {}}
@@ -53,15 +54,8 @@ const PermalinkModal: React.FC<PermaLinkProps> = ({
   );
 };
 
-export const PermalinkButton = ({currentBody, selectedConnection}: PermaLinkButtonProps) => {
-  const [isPermalinkModalVisible, setIsPermalinkModalVisible] = useState(false);
-
-  const openPermalinkModal = () => {
-    setIsPermalinkModalVisible(true);
-  };
-  const closePermalinkModal = () => {
-    setIsPermalinkModalVisible(false);
-  };
+export function PermalinkButton ({currentBody, selectedConnection}: PermaLinkButtonProps) {
+  const [showPermalinkModal, setShowPermalinkModal] = useState(false);
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
 
@@ -71,13 +65,13 @@ export const PermalinkButton = ({currentBody, selectedConnection}: PermaLinkButt
       data-toggle="modal"
       data-target="#wstool-1-permalink"
       title={translate("Permalink")}
-      onClick={openPermalinkModal}
+      onClick={() => setShowPermalinkModal(true)}
     >
       <i className="fa fa-link"></i>
     </button>
-    {isPermalinkModalVisible && (
+    {showPermalinkModal && (
       <PermalinkModal
-        closePermalinkModal={closePermalinkModal}
+        closePermalinkModal={() => setShowPermalinkModal(false)}
         currentBody={currentBody}
         selectedConnection={selectedConnection}
       />
@@ -85,12 +79,12 @@ export const PermalinkButton = ({currentBody, selectedConnection}: PermaLinkButt
   </>
 }
 
-const getPermalink = (selectedConnection, currentBody) => {
+function getPermalink (selectedConnection: Connection, currentBody) {
   const startHref = window.location.origin + window.location.pathname;
   const encodedBody = encodeURIComponent(get_compressed_body(currentBody));
   const encodedServer = encodeURIComponent(selectedConnection.ws_url);
   return `${startHref}?server=${encodedServer}&req=${encodedBody}`;
-};
+}
 
 function get_compressed_body(currentBody) {
   return currentBody.replace("\n", "").trim();

--- a/resources/dev-tools/components/websocket-api/right-sidebar.tsx
+++ b/resources/dev-tools/components/websocket-api/right-sidebar.tsx
@@ -3,6 +3,7 @@ import { useThemeHooks } from '@redocly/theme/core/hooks';
 import { Link } from "@redocly/theme/components/Link/Link";
 import { slugify } from "./slugify";
 import { CommandGroup, CommandMethod } from './types';
+import { ClioOnlyIcon } from './ClioOnly';
 
 interface RightSideBarProps {
   commandList: CommandGroup[];
@@ -53,12 +54,7 @@ export const RightSideBar: React.FC<RightSideBarProps> = ({
                     </span>
                   )}
                   {method.clio_only && (
-                    <span
-                      className="status clio_only"
-                      title="This method is only available from the Clio server."
-                    >
-                      <i className="fa fa-exclamation-circle"></i>
-                    </span>
+                    <ClioOnlyIcon />
                   )}
                 </Link>
               </li>

--- a/resources/dev-tools/websocket-api-tool.page.tsx
+++ b/resources/dev-tools/websocket-api-tool.page.tsx
@@ -23,6 +23,7 @@ import { CommandGroup, CommandMethod } from './components/websocket-api/types';
 import commandList from "./components/websocket-api/data/command-list.json";
 import connections from "./components/websocket-api/data/connections.json";
 import XRPLoader from '../../@theme/components/XRPLoader';
+import { ClioOnlyNotice } from './components/websocket-api/ClioOnly';
 
 export const frontmatter = {
   seo: {
@@ -208,10 +209,12 @@ export function WebsocketApiTool() {
               {currentMethod.description && (
                 <p
                   className="blurb"
-                  dangerouslySetInnerHTML={{
-                    __html: currentMethod.description,
-                  }}
-                />
+                >
+                  {currentMethod.description}
+                  {currentMethod.clio_only ? 
+                    <ClioOnlyNotice /> : ""
+                  }
+                </p>
               )}
               {currentMethod.link && (
                 <Link


### PR DESCRIPTION
- Fix #3276. cURL modal once again reflects the current status instead of always using the default body/server (account_channels/s1)
- Improve display of Clio-only methods:
    | Before | After |
    |----|---|
    | <img width="317" height="108" alt="2025-09-09_135846_250388831" src="https://github.com/user-attachments/assets/f65dfb19-bb15-4955-adb8-075f4440aa89" /> | <img width="305" height="110" alt="2025-09-09_135903_251805652" src="https://github.com/user-attachments/assets/b2cd6347-d01a-4e48-83aa-235dfd4f0b07" /> |
    | <img width="259" height="117" alt="2025-09-09_140220_585485358" src="https://github.com/user-attachments/assets/e81ac3d7-16b7-43c5-be58-aaba922015d2" /> | <img width="273" height="117" alt="2025-09-09_140155_394370861" src="https://github.com/user-attachments/assets/96aa947d-10bf-4616-b938-1520abe8edc2" /> |
    - Automatically add a (more visible) "Clio only" badge to the description line.
    - Removed the text "(Clio only)" that was hard-coded in descriptions—it's now redundant with the boolean that marks a method as Clio only. It was missing from the `ledger_index` method already.

    - Translate the Clio-only tooltip and the badge
- Remove one-off case of inlined HTML in API method description for WebSocket tool. This lets us avoid "dangerouslySetInnerHTML". 
    - The one case was to link to the Payment Channels concept from the description of the `account_channels` method. There's already a link to the API method page, which should link back to the relevant concept anyway, so this seemed unnecessary.
- Remove `channel_authorize` method from WS tool. This method was made admin-only (unless public signing is enabled) in `rippled` 2.5.0 because it takes a secret key. The WS tool doesn't display other signing methods (to try and discourage people from sending secret keys to public servers).

## Known issues

The following issues are unchanged from what's in production now, and not fixed by this PR:

- #3278
- #3197
