### PR TITLE
Use amendment disclaimer component for MPTs

### DIFF
--- a/docs/concepts/tokens/fungible-tokens/index.md
+++ b/docs/concepts/tokens/fungible-tokens/index.md
@@ -46,7 +46,7 @@ Some notable features and their status:
 | Escrow | {% amendment-disclaimer name="TokenEscrow" compact=true /%} (implements escrow for both trust line tokens and MPTs) |
 | Mutable token properties | In development: [XLS-94](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0094-dynamic-MPT) |
 | Confidentiality | [Proposed XLS](https://github.com/XRPLF/XRPL-Standards/discussions/372) |
-| Decentralized exchange (DEX), trading, cross-currency payments, and AMM compatibility | Expected future work |
+| Decentralized exchange (DEX), trading, cross-currency payments, and AMM compatibility | [Proposed XLS](https://github.com/XRPLF/XRPL-Standards/discussions/231) |
 
 ## Which Fungible Token Type to Use
 

--- a/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
+++ b/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
@@ -887,7 +887,7 @@ rippled json ledger_entry '{ "nft_page": "255DD86DDF59D778081A06D02701E9B2C9F4F0
 
 ### Get MPT Issuance Object
 
-_(Requires the [MPToken amendment][] {% not-enabled /%})_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 Return an `MPTokenIssuance` object.
 
@@ -933,7 +933,7 @@ rippled json ledger_entry '{ "mpt_issuance": "000004C463C52827307480341125DA0577
 
 ### Get MPToken Object
 
-_(Requires the [MPToken amendment][] {% not-enabled /%})_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 Return an `MPToken` object.
 

--- a/docs/references/protocol/data-types/currency-formats.md
+++ b/docs/references/protocol/data-types/currency-formats.md
@@ -12,11 +12,11 @@ label:
 
 The XRP Ledger has three kinds of digital asset: XRP, [tokens](../../../concepts/tokens/index.md), and [Multi-purpose Tokens (MPTs)](../../../concepts/tokens/fungible-tokens/multi-purpose-tokens.md). All three types have high precision, although their formats are different.
 
-_(Requires the [MPToken amendment][] {% not-enabled /%})_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 ## Comparison
 
-The following table summarizes some of the differences XRP, tokens, and MPTs in the XRP Ledger:
+The following table summarizes some of the differences between XRP, tokens, and MPTs in the XRP Ledger:
 
 | XRP                                                      | Tokens            | MPTs                 |
 |:---------------------------------------------------------|:------------------|:---------------------|

--- a/docs/references/protocol/data-types/permission-values.md
+++ b/docs/references/protocol/data-types/permission-values.md
@@ -73,8 +73,8 @@ Granular Permissions have numeric types of 65537 and up, corresponding to specif
 | `65544`       | `AccountTickSizeSet`     | [AccountSet][]         | Can set the [tick size of fungible tokens issued by the account](/docs/concepts/tokens/decentralized-exchange/ticksize). |
 | `65545`       | `PaymentMint`            | [Payment][]            | Can send payments that mint new fungible tokens or MPTs. |
 | `65546`       | `PaymentBurn`            | [Payment][]            | Can send payments that burn fungible tokens or MPTs. |
-| `65547`       | `MPTokenIssuanceLock`    | [MPTokenIssuanceSet][] | Can lock the balances of a particular MPT issued by the account. _(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_ |
-| `65548`       | `MPTokenIssuanceUnlock`  | [MPTokenIssuanceSet][] | Can unlock the balances of a particular MPT issued by the account. _(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_ |
+| `65547`       | `MPTokenIssuanceLock`    | [MPTokenIssuanceSet][] | Can lock the balances of a particular MPT issued by the account. {% amendment-disclaimer name="MPTokensV1" /%} |
+| `65548`       | `MPTokenIssuanceUnlock`  | [MPTokenIssuanceSet][] | Can unlock the balances of a particular MPT issued by the account. {% amendment-disclaimer name="MPTokensV1" /%} |
 
 ### Limitations to Granular Permissions
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/mptoken.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/mptoken.md
@@ -9,7 +9,7 @@ status: not_enabled
 
 An `MPToken` entry tracks [MPTs](../../../../concepts/tokens/fungible-tokens/multi-purpose-tokens.md) held by an account that is not the token issuer. You can create or delete an empty `MPToken` entry by sending an [MPTokenAuthorize transaction][]. You can send and receive MPTs using several other transaction types including [Payment][] and [OfferCreate][] transactions.
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 ## Example MPToken JSON
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/mptokenissuance.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/mptokenissuance.md
@@ -9,7 +9,7 @@ status: not_enabled
 
 An `MPTokenIssuance` entry represents a single [MPT](../../../../concepts/tokens/fungible-tokens/multi-purpose-tokens.md) issuance and holds data associated with the issuance itself. You can create an `MPTokenIssuance` using an [MPTokenIssuanceCreate transaction][], and can delete it with an [MPTokenIssuanceDestroy transaction][].
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 ## Example MPTokenIssuance JSON
 

--- a/docs/references/protocol/transactions/types/mptokenauthorize.md
+++ b/docs/references/protocol/transactions/types/mptokenauthorize.md
@@ -15,7 +15,7 @@ An MPTokenAuthorize transaction controls whether an account can hold a given [Mu
 - An account revokes their willingness to hold an MPT, deleting the [MPToken entry][]. This can only be done if their balance of the given MPT is zero.
 - For an MPT that uses allow-listing, an issuer grants or revokes permission for another account to hold the given MPT.
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 {% raw-partial file="/docs/_snippets/tx-fields-intro.md" /%}
 

--- a/docs/references/protocol/transactions/types/mptokenissuancecreate.md
+++ b/docs/references/protocol/transactions/types/mptokenissuancecreate.md
@@ -15,7 +15,7 @@ If the transaction is successful, the newly created token is owned by the accoun
 
 Whenever your query returns an `MPTokenIssuance` transaction response, there will always be an `mpt_issuance_id` field on the Transaction Metadata page.
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 ## Example MPTokenIssuanceCreate JSON
 

--- a/docs/references/protocol/transactions/types/mptokenissuancedestroy.md
+++ b/docs/references/protocol/transactions/types/mptokenissuancedestroy.md
@@ -12,7 +12,7 @@ The `MPTokenIssuanceDestroy` transaction is used to remove an `MPTokenIssuance` 
 
 If this operation succeeds, the corresponding `MPTokenIssuance` is removed and the owner’s reserve requirement is reduced by one. This operation must fail if there are any holders of the MPT in question.
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 ## Example MPTokenIssuanceDestroy JSON
 

--- a/docs/references/protocol/transactions/types/mptokenissuanceset.md
+++ b/docs/references/protocol/transactions/types/mptokenissuanceset.md
@@ -10,7 +10,7 @@ status: not_enabled
 
 Use this transaction to update a mutable property for a Multi-purpose Token. The transaction flags determine which change(s) to apply.
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%}.)_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 ## Example
 

--- a/docs/tutorials/javascript/send-payments/sending-mpts.md
+++ b/docs/tutorials/javascript/send-payments/sending-mpts.md
@@ -7,7 +7,7 @@ labels:
 ---
 # Sending MPTs
 
-_(Requires the [MPToken amendment][] {% not-enabled /%})_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 To send an MPT to another account, the receiving account must first authorize the receipt of the MPT, based on its MPToken Issuance ID. This is to prevent malicious users from spamming accounts with unwanted tokens that could negatively impact storage and XRP reserves.
 

--- a/docs/use-cases/tokenization/creating-an-asset-backed-multi-purpose-token.md
+++ b/docs/use-cases/tokenization/creating-an-asset-backed-multi-purpose-token.md
@@ -7,7 +7,7 @@ labels:
 ---
 # Creating an Asset-backed Multi-purpose Token
 
-_(Requires the [MPTokensV1 amendment][] {% not-enabled /%})_
+{% amendment-disclaimer name="MPTokensV1" /%}
 
 _As a financial professional, I want to use multi-purpose tokens to create an asset-backed token in order to profit from resale transactions._
 


### PR DESCRIPTION
Updated a few places that were not using the component for MPTs.

Also, I added a minor unrelated change (since it's rather small) to provide a link to the MPTs on DEX discussion in the MPT section of the Fungible Tokens landing page.