### PR TITLE
Fix broken imports in custom plugins for `@redocly/realm@0.126.0`

### DIFF
--- a/@theme/plugins/blog-posts.js
+++ b/@theme/plugins/blog-posts.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { getInnerText } from '@redocly/realm/dist/shared/markdoc.js';
+import { getInnerText } from '@redocly/realm/dist/server/plugins/markdown/markdoc/helpers/get-inner-text.js';
 
 import { dirname, relative, join as joinPath } from 'path';
 import markdoc from '@markdoc/markdoc';

--- a/@theme/plugins/code-samples.js
+++ b/@theme/plugins/code-samples.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { getInnerText } from '@redocly/realm/dist/shared/markdoc.js';
+import { getInnerText } from '@redocly/realm/dist/server/plugins/markdown/markdoc/helpers/get-inner-text.js';
 
 import { dirname, relative, join as joinPath } from 'path';
 


### PR DESCRIPTION
This PR fixes broken imports in custom plugins caused by changes introduced in `@redocly/realm@0.126.0`.