### PR TITLE
Update mpt_holders, Get MPTokenIssuance, and Get MPToken  with Mainnet "Try It" example

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/clio-methods/mpt_holders.md
+++ b/docs/references/http-websocket-apis/public-api-methods/clio-methods/mpt_holders.md
@@ -46,7 +46,7 @@ For a given `MPTokenIssuanceID` and ledger sequence, `mpt_holders` returns all h
 
 {% /tabs %}
 
-{% try-it method="mpt_holders" server="s1" /%}
+{% try-it method="mpt_holders" /%}
 
 The request contains the following parameters:
 

--- a/docs/references/http-websocket-apis/public-api-methods/clio-methods/mpt_holders.md
+++ b/docs/references/http-websocket-apis/public-api-methods/clio-methods/mpt_holders.md
@@ -24,7 +24,7 @@ For a given `MPTokenIssuanceID` and ledger sequence, `mpt_holders` returns all h
 ```json
 {
   "command": "mpt_holders",
-  "mpt_issuance_id": "0024D204E07DDDFBCD83B1649C07FE27FD536A3A32E6FDD8",
+  "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
   "ledger_index": "validated"
 }
 ```
@@ -36,7 +36,7 @@ For a given `MPTokenIssuanceID` and ledger sequence, `mpt_holders` returns all h
   "method": "mpt_holders",
   "params": [
     {
-      "mpt_issuance_id": "0024D204E07DDDFBCD83B1649C07FE27FD536A3A32E6FDD8",
+      "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
       "ledger_index": "validated"
     }
   ]
@@ -46,7 +46,7 @@ For a given `MPTokenIssuanceID` and ledger sequence, `mpt_holders` returns all h
 
 {% /tabs %}
 
-{% try-it method="mpt_holders" server="devnet-clio" /%}
+{% try-it method="mpt_holders" server="s1" /%}
 
 The request contains the following parameters:
 
@@ -65,19 +65,20 @@ The request contains the following parameters:
 ```json
 {
   "result": {
-    "mpt_issuance_id": "0024D204E07DDDFBCD83B1649C07FE27FD536A3A32E6FDD8",
+    "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
     "limit": 50,
-    "ledger_index": 2414929,
+    "ledger_index": 99563041,
     "mptokens": [
       {
-        "account": "rfyWeQpYM3vCXRHA9cMLs2ZEdZv1F1jzm9",
+        "account": "rsNw23ygZatXv7h8QVSgAE4jktY2uW1iZP",
         "flags": 0,
-        "mpt_amount": "200",
-        "mptoken_index": "22F99DCD55BCCF3D68DC3E4D6CF12602006A7563A6BE93FC57FD63298BCCEB13"
+        "mpt_amount": "100",
+        "mptoken_index": "081078D38E9C36647B4AD95ECB476F434B817753AD4F6B4B5EE0ED4C3185C80F"
       }
     ],
     "validated": true
   },
+  "id": "example_mpt_holders",
   "status": "success",
   "type": "response",
   "warnings": [
@@ -96,15 +97,15 @@ The request contains the following parameters:
 
 {
   "result": {
-    "mpt_issuance_id": "0024D204E07DDDFBCD83B1649C07FE27FD536A3A32E6FDD8",
+    "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
     "limit": 50,
-    "ledger_index": 2415033,
+    "ledger_index": 99563067,
     "mptokens": [
       {
-        "account": "rfyWeQpYM3vCXRHA9cMLs2ZEdZv1F1jzm9",
+        "account": "rsNw23ygZatXv7h8QVSgAE4jktY2uW1iZP",
         "flags": 0,
-        "mpt_amount": "200",
-        "mptoken_index": "22F99DCD55BCCF3D68DC3E4D6CF12602006A7563A6BE93FC57FD63298BCCEB13"
+        "mpt_amount": "100",
+        "mptoken_index": "081078D38E9C36647B4AD95ECB476F434B817753AD4F6B4B5EE0ED4C3185C80F"
       }
     ],
     "validated": true,

--- a/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
+++ b/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
@@ -49,8 +49,8 @@ In addition to the general fields above, you must specify *exactly 1* of the fol
     - [Get DepositPreauth Entry](#get-depositpreauth-entry)
     - [Get Ticket Entry](#get-ticket-entry)
     - [Get NFT Page](#get-nft-page)
-    - [Get MPT Issuance Object](#get-mpt-issuance-object)
-    - [Get MPToken Object](#get-mptoken-object)
+    - [Get MPT Issuance Entry](#get-mpt-issuance-entry)
+    - [Get MPToken Entry](#get-mptoken-entry)
   - [Response Format](#response-format)
   - [Possible Errors](#possible-errors)
 
@@ -885,7 +885,7 @@ rippled json ledger_entry '{ "nft_page": "255DD86DDF59D778081A06D02701E9B2C9F4F0
 
 {% try-it method="ledger_entry-nft-page" /%}
 
-### Get MPT Issuance Object
+### Get MPT Issuance Entry
 
 Return an `MPTokenIssuance` object.
 
@@ -902,7 +902,7 @@ Return an `MPTokenIssuance` object.
 {
     "id": "example_get_mpt_issuance",
     "command": "ledger_entry",
-    "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E",
+    "mpt_issuance": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
     "ledger_index": "validated"
 }
 ```
@@ -913,7 +913,7 @@ Return an `MPTokenIssuance` object.
 {
   "method": "ledger_entry",
   "params": [{
-    "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E",
+    "mpt_issuance": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
     "ledger_index": "validated"
   }]
 }
@@ -922,16 +922,14 @@ Return an `MPTokenIssuance` object.
 
 {% tab label="Commandline" %}
 ```sh
-rippled json ledger_entry '{ "mpt_issuance": "000004C463C52827307480341125DA0577DEFC38405B0E3E", "ledger_index": "validated" }'
+rippled json ledger_entry '{ "mpt_issuance": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA", "ledger_index": "validated" }'
 ```
 {% /tab %}
 {% /tabs %}
 
-<!-- TODO: add try-it for MPT issuance
-{% try-it method="ledger_entry-mpt_issuance" /%}
--->
+{% try-it method="ledger_entry-mptokenissuance" /%}
 
-### Get MPToken Object
+### Get MPToken Entry
 
 Return an `MPToken` object.
 
@@ -948,11 +946,11 @@ Return an `MPToken` object.
 {% tab label="WebSocket" %}
 ```json
 {
-    "id": "example_get_mpt_issuance",
+    "id": "example_get_mpt",
     "command": "ledger_entry",
     "mptoken": {
-      "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D",
-      "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"
+      "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
+      "account":"rsNw23ygZatXv7h8QVSgAE4jktY2uW1iZP"
     }
 }
 ```
@@ -965,8 +963,8 @@ Return an `MPToken` object.
     "params": [
         {
             "mptoken":{
-                "mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D",
-                "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"
+                "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
+                "account":"rsNw23ygZatXv7h8QVSgAE4jktY2uW1iZP"
             } 
         }
     ]
@@ -976,15 +974,12 @@ Return an `MPToken` object.
 
 {% tab label="Commandline" %}
 ```sh
-rippled json ledger_entry '{ "mptoken": {"mpt_issuance_id": "000002DFA4D893CFBC4DC6AE877EB585F90A3B47528B958D", "account":"r33kves44ksufkHSGg3M6GPPAsoVHEN8C1"} }'
+rippled json ledger_entry '{ "mptoken": {"mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA", "account":"rsNw23ygZatXv7h8QVSgAE4jktY2uW1iZP"} }'
 ```
 {% /tab %}
 {% /tabs %}
 
-<!-- TODO: make a try-it link for MPT object
 {% try-it method="ledger_entry-mptoken" /%}
- -->
-
 
 ## Response Format
 

--- a/resources/dev-tools/components/websocket-api/data/command-list.json
+++ b/resources/dev-tools/components/websocket-api/data/command-list.json
@@ -420,7 +420,7 @@
         "body": {
           "id": "example_mpt_holders",
           "command": "mpt_holders",
-          "mpt_issuance_id": "0024D204E07DDDFBCD83B1649C07FE27FD536A3A32E6FDD8",
+          "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
           "ledger_index": "validated"
         }
       }

--- a/resources/dev-tools/components/websocket-api/data/command-list.json
+++ b/resources/dev-tools/components/websocket-api/data/command-list.json
@@ -802,6 +802,30 @@
           },
           "ledger_index": "validated"
         }
+      },
+      {
+        "name": "ledger_entry - MPTokenIssuance",
+        "description": "Returns an MPTokenIssuance object in its raw ledger format.",
+        "link": "/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry#get-mpt-issuance-entry",
+        "body": {
+          "id": "example_get_mpt_issuance",
+          "command": "ledger_entry",
+          "mpt_issuance": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
+          "ledger_index": "validated"
+        }
+      },
+      {
+        "name": "ledger_entry - MPToken",
+        "description": "Returns an MPToken object in its raw ledger format.",
+        "link": "/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry#get-mptoken-entry",
+        "body": {
+          "id": "example_get_mpt",
+          "command": "ledger_entry",
+          "mptoken": {
+            "mpt_issuance_id": "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA",
+            "account":"rsNw23ygZatXv7h8QVSgAE4jktY2uW1iZP"
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
Fix [#3107](https://github.com/XRPLF/xrpl-dev-portal/issues/3107)

- Updates `mpt_holders`, `Get MPTokenIssuance`, and `Get MPToken` with a Mainnet "Try It" example.
- Also changed "Get MPT Issuance Object" to "Get MPT Issuance Entry" for consistency. Same with "Get MPToken Object".