### PR TITLE
Fix for build failure

### DIFF
--- a/@theme/plugins/blog-posts.js
+++ b/@theme/plugins/blog-posts.js
@@ -47,6 +47,7 @@ export function blogPosts() {
         actions.createSharedData('blog-posts', { blogPosts: sortedPosts });
         actions.addRouteSharedData('/blog/', 'blog-posts', 'blog-posts');
         actions.addRouteSharedData('/ja/blog/', 'blog-posts', 'blog-posts');
+        actions.addRouteSharedData('/es-es/blog/', 'blog-posts', 'blog-posts');
       } catch (e) {
         console.log(e);
       }

--- a/@theme/plugins/code-samples.js
+++ b/@theme/plugins/code-samples.js
@@ -44,6 +44,7 @@ export function codeSamples() {
         });
         actions.addRouteSharedData('/resources/code-samples/', 'code-samples', 'code-samples');
         actions.addRouteSharedData('/ja/resources/code-samples/', 'code-samples', 'code-samples');
+        actions.addRouteSharedData('/es-es/resources/code-samples/', 'code-samples', 'code-samples');
       } catch (e) {
         console.log(e);
       }


### PR DESCRIPTION
Fixes the following build error, which was triggered by the Redocly upgrade to `0.126.0`:

```sh
[2025-10-30 20:49:06:875]:
[error] [1] Runtime error: Cannot destructure property 'blogPosts' of 't(...)' as it is undefined.
at ./@l10n/es-ES/blog/index.page.tsx
[2025-10-30 20:49:06:875]:
[error] [2] Runtime error: Cannot destructure property 'codeSamples' of 't(...)' as it is undefined.
at ./@l10n/es-ES/resources/code-samples.page.tsx
[2025-10-30 20:49:06:876]:
[error] Need to fix 2 runtime error(s) in React pages
[2025-10-30 20:49:07:126]:
fatal error: all goroutines are asleep - deadlock!
[2025-10-30 20:49:07:128]:
goroutine 1 [chan receive]:
github.com/evanw/esbuild/internal/helpers.(*ThreadSafeWaitGroup).Wait(...)
	github.com/evanw/esbuild/internal/helpers/waitgroup.go:36
main.runService.func2()
...
```

The upgrade also broke the Spanish version of these pages (which this change should fix):

- https://xrpl.org/es-es/blog
- https://xrpl.org/es-es/resources/code-samples

This is the fix suggested by the Redocly team. Some context from discussion with Redocly:
> After some investigation I found that this is not exactly a bug but it's something we can definitely improve.
For now, these errors are valid (though the paths are misleading because there are no such physical files).
To fix this, you need to update the @theme/plugins/blog-posts.js and @theme/plugins/code-samples.js files and add one more call of actions.addRouteSharedData for the /es-es path the same way it's duplicated for the /ja path (see screenshot).
Both the [Blog page](https://xrpl.org/es-es/blog) and [Code Samples page](https://xrpl.org/es-es/resources/code-samples) for the Spanish locale are broken right now on 0.122.3. We introduced validation of React pages rendering in 0.126.0 and that is where these errors come from.
