### PR TITLE
update known amendment page

### DIFF
--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -667,6 +667,19 @@ Fixes a bug that could cause an amendment to achieve a majority and later activa
 Without this amendment, the minimum threshold for amendment activation is any value that rounds to 204/256 of trusted validators, which depends on the number of trusted validators at the time. For example, an amendment could activate with exactly 28 out of 36 validators (approximately 77.8%). With this amendment, the actual minimum number of validators needed is never less than 80% of trusted validators.
 
 
+### fixAMMClawbackRounding
+[fixAMMClawbackRounding]: #fixammclawbackrounding
+
+| Amendment    | fixAMMClawbackRounding |
+|:-------------|:-------------------------|
+| Amendment ID | 5E9586DB3D765B4C5794658FB6BB385071E9838DF4016027E6E26820C8526724 |
+| Status       | Open for Voting |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Fixes a rounding error that can occur in the `LPTokenBalance` of an AMM when performing an `AMMClawback` transaction.
+
+
 ### fixAMMOverflowOffer
 [fixAMMOverflowOffer]: #fixammoverflowoffer
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -677,7 +677,7 @@ Without this amendment, the minimum threshold for amendment activation is any va
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-Fixes a rounding error that can occur in the `LPTokenBalance` of an AMM when performing an `AMMClawback` transaction.
+Fixes an accounting error that can occur when performing an `AMMClawback` transaction on the last LP token holder. Due to rounding errors, the AMMs `LPTokenBalance` may not match the holder's trust line balance. This amendment adjusts the `LPTokenBalance` to match the trust line balance before the clawback, so invariant checks pass without errors.
 
 
 ### fixAMMOverflowOffer
@@ -878,10 +878,14 @@ With this amendment enabled, if an LP token is associated with a liquidity pool 
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-This amendment adds missing keylet fields to these ledger entries:
-  - `Sequence` to `Escrow` and `PayChannel`.
-  - `Owner` to `SignerList`.
-  - `OracleDocumentID` to `Oracle`.
+This amendment adds fields to ledger entries in cases where those fields are part of the identifying information that forms their ledger entry ID:
+  - Add a `Sequence` field to `Escrow` and `PayChannel` entries.
+  - Add an `Owner` field to `SignerList` entries.
+  - Add an `OracleDocumentID` field to `Oracle` entries.
+
+Without this amendment, some ledger entries do not store all the data that was used to create their ledger entry ID. After this amendment is enabled, ledger entries of those types have those fields added when the ledger entry is created or modified. Ledger entries that were created before the amendment are not changed until a transaction modifies them.
+
+The presence of a `Sequence` field on Escrow ledger entries is especially useful since you need that value to finish or cancel the escrow, and you otherwise might have to look up the sequence number of the transaction that created the escrow.
 
 
 ### fixInnerObjTemplate
@@ -964,7 +968,7 @@ With this amendment enabled, a SetRegularKey transaction cannot set the regular 
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-This amendment adds missing `DeliveredAmount` and `delivered_amount` metadata fields from direct MPT `Payment` transactions.
+This amendment adds missing `DeliveredAmount` and `delivered_amount` metadata fields from direct MPT `Payment` transactions. Without this amendment, direct MPT payments deliver the full amount but do not have the metadata fields to summarize how much was delivered.
 
 
 ### fixNFTokenDirV1
@@ -1148,7 +1152,7 @@ Without this amendment, some types of ledger entries don't have those fields, wh
 
 Fixes an issue where the order of asset pair data is different from when a price oracle is created versus when it is updated.
 
-This amendment ensures asset pairs follow a canonical order at all times.
+This amendment ensures asset pairs follow a canonical order at all times, so you can predictably look up asset prices.
 
 
 ### fixQualityUpperBound
@@ -1353,7 +1357,7 @@ The Flow Engine also makes it easier to improve and expand the payment engine wi
 | Amendment ID | 3012E8230864E95A58C60FD61430D7E1B4D3353195F2981DC12B0C7C0950FFAC |
 | Status       | Enabled |
 | Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Streamlines the offer crossing logic in the XRP Ledger's decentralized exchange. Uses the updated code from the [Flow](#flow) amendment to power offer crossing, so [OfferCreate transactions][] and [Payment transactions][] share more code. This has subtle differences in how offers are processed:
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -855,6 +855,22 @@ With this amendment enabled, if an LP token is associated with a liquidity pool 
 2. The holder can receive frozen LP tokens, but can't send them out (similar to frozen trust lines).
 
 
+### fixIncludeKeyletFields
+[fixIncludeKeyletFields]: #fixincludekeyletfields
+
+| Amendment    | fixIncludeKeyletFields |
+|:-------------|:--------------------|
+| Amendment ID | 6143A27B71F7DAF9330ECA7C5EC3D54C8083A4FDEF7016737EEC06AB61E82EE0 |
+| Status       | Open for Voting |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+This amendment adds missing keylet fields to these ledger entries:
+  - `Sequence` to `Escrow` and `PayChannel`.
+  - `Owner` to `SignerList`.
+  - `OracleDocumentID` to `Oracle`.
+
+
 ### fixInnerObjTemplate
 [fixInnerObjTemplate]: #fixinnerobjtemplate
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -169,7 +169,7 @@ See [Clawback](../docs/concepts/tokens/fungible-tokens/clawing-back-tokens.md) f
 | Amendment    | Credentials |
 |:-------------|:------------|
 | Amendment ID | 1CB67D082CF7D9102412D34258CEDB400E659352D3B207348889297A6D90F5EF |
-| Status       | Open for Voting |
+| Status       | Enabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1093,6 +1093,21 @@ Ledger entries that were created before this amendment was enabled will get the 
 Without this amendment, some types of ledger entries don't have those fields, which makes it harder to trace the history of modifications to those ledger entries.
 
 
+### fixPriceOracleOrder
+[fixPriceOracleOrder]: #fixpriceoracleorder
+
+| Amendment    | fixPriceOracleOrder |
+|:-------------|:--------------------|
+| Amendment ID | TBD |
+| Status       | Open for Voting |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Fixes an issue where the order of asset pair data is different from when a price oracle is created versus when it is updated.
+
+This amendment ensures asset pairs follow a canonical order at all times.
+
+
 ### fixQualityUpperBound
 [fixQualityUpperBound]: #fixqualityupperbound
 
@@ -1208,6 +1223,21 @@ Fixes a bug in [auto-bridging](../docs/concepts/tokens/decentralized-exchange/au
 Without this fix, the dry offer remains on the ledger and counts toward its owner's [reserve requirement](../docs/concepts/accounts/reserves.md#owner-reserves) without providing any benefit to the owner. Another offer crossing of the right type and quality can remove the dry offer. However, if the required offer crossing type and quality are rare, it may take a while for the dry offer to be removed.
 
 With this amendment enabled, the XRP Ledger removes these dry offers when they're matched in auto-bridging.
+
+
+### fixTokenEscrowV1
+[fixTokenEscrowV1]: #fixtokenescrowv1
+
+| Amendment    | fixTokenEscrowV1 |
+|:-------------|:-----------------|
+| Amendment ID | TBD |
+| Status       | Open for Voting |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+Fixes an accounting error in MPT escrows. Specifically, when an escrow unlocks MPTs that have a transfer fee, the system incorrectly reduces the MPT issuer's locked token balance by the gross amount (without fees) rather than the net amount (with fees). This leads to discrepancies in the token's total supply accounting.
+
+This amendment ensures that when escrowed MPTs are unlocked, the issuer's locked amount is reduced by the net amount, and the total supply is reduced by the transfer fees.
 
 
 ### fixTrustLinesToSelf

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -677,7 +677,7 @@ Without this amendment, the minimum threshold for amendment activation is any va
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-Fixes an accounting error that can occur when performing an `AMMClawback` transaction on the last LP token holder. Due to rounding errors, the AMMs `LPTokenBalance` may not match the holder's trust line balance. This amendment adjusts the `LPTokenBalance` to match the trust line balance before the clawback, so invariant checks pass without errors.
+Fixes an accounting error that can occur when performing an `AMMClawback` transaction on the last LP token holder. Due to rounding errors, the `LPTokenBalance` of the AMM may not match the holder's trust line balance. This amendment adjusts the `LPTokenBalance` to match the trust line balance before the clawback, so invariant checks pass without errors.
 
 
 ### fixAMMOverflowOffer

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -924,6 +924,19 @@ Without this fix, a user can unintentionally "black hole" their account by setti
 With this amendment enabled, a SetRegularKey transaction cannot set the regular key to match the master key; such a transaction results in the transaction code `temBAD_REGKEY`. Additionally, this amendment changes the signature verification code so that accounts which _already_ have their regular key set to match their master key can send transactions successfully using the key pair.
 
 
+### fixMPTDeliveredAmount
+[fixMPTDeliveredAmount]: #fixmptdeliveredamount
+
+| Amendment    | fixMPTDeliveredAmount |
+|:-------------|:----------------|
+| Amendment ID | AB8D932A5F338903FE5BCBD80B611FFED70839ABA3170E9CE01D947C0EDEDCF2 |
+| Status       | Open for Voting |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+This amendment adds missing `DeliveredAmount` or `delivered_amount` metadata fields from direct MPT `Payment` transactions.
+
+
 ### fixNFTokenDirV1
 [fixNFTokenDirV1]: #fixnftokendirv1
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -23,6 +23,7 @@ The following is a list of [amendments](../docs/concepts/networks-and-servers/am
 |:----------------------------------|:------------------------------------------|:-------------------------------|
 | [Hooks][]                         | {% badge %}In Development: TBD{% /badge %} | [XRPL Hooks](https://hooks.xrpl.org/) |
 | [InvariantsV1_1][]                | {% badge %}In Development: TBD{% /badge %} |  |
+| [LendingProtocol][]               | {% badge %}In Development: TBD{% /badge %} | [Lending Protocol (Ripple Opensource)](https://opensource.ripple.com/docs/xls-66d-lending-protocol) |
 | [SingleAssetVault][]              | {% badge %}In Development: TBD{% /badge %} | [Single Asset Vault (Ripple Opensource)](https://opensource.ripple.com/docs/xls-65d-single-asset-vault) |
 
 {% admonition type="success" name="Tip" %}
@@ -934,7 +935,7 @@ With this amendment enabled, a SetRegularKey transaction cannot set the regular 
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-This amendment adds missing `DeliveredAmount` or `delivered_amount` metadata fields from direct MPT `Payment` transactions.
+This amendment adds missing `DeliveredAmount` and `delivered_amount` metadata fields from direct MPT `Payment` transactions.
 
 
 ### fixNFTokenDirV1
@@ -1414,6 +1415,21 @@ Without this amendment, "Immediate or Cancel" Offers that failed to move any fun
 This amendment adds several new invariants to protect the ledger against bugs in transaction processing. The developers intend to set it as open for voting after a set of several invariants are implemented. The invariants included are as follows:
 
 - When deleting an account, ensure that certain types of ledger entries are also deleted, including that account's `DirectoryNode`, `SignerList`, `NFTokenPage`, and `AMM` directories, if any, are deleted with it.
+
+
+### LendingProtocol
+[LendingProtocol]: #lendingprotocol
+
+| Amendment    | LendingProtocol |
+|:-------------|:-----------------|
+| Amendment ID | 565B90CA1AB2B9D42208ED10884188C64F9E19083DECB9634AAF06EB03299509 |
+| Status       | In Development |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | No |
+
+The Lending Protocol enables on-chain, fixed-term, uncollateralized loans using pooled funds from a Single Asset Vault. This implementation relies on off-chain underwriting and risk management to assess the creditworthiness of borrowers, but offers configurable, peer-to-peer loans.
+
+Specification: [XLS-66](https://github.com/Tapanito/XRPL-Standards/tree/xls-66-lending-protocol/XLS-0066d-lending-protocol).
 
 
 ### MPTokensV1

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -1230,7 +1230,7 @@ With this amendment enabled, the XRP Ledger removes these dry offers when they'r
 
 | Amendment    | fixTokenEscrowV1 |
 |:-------------|:-----------------|
-| Amendment ID | TBD |
+| Amendment ID | 32B8614321F7E070419115ABEAB1742EA20F3E3AF34432B5E2F474F8083260DC |
 | Status       | Open for Voting |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -1098,7 +1098,7 @@ Without this amendment, some types of ledger entries don't have those fields, wh
 
 | Amendment    | fixPriceOracleOrder |
 |:-------------|:--------------------|
-| Amendment ID | TBD |
+| Amendment ID | FF2D1E13CF6D22427111B967BD504917F63A900CECD320D6FD3AC9FA90344631 |
 | Status       | Open for Voting |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |


### PR DESCRIPTION
- Adds `fixPriceOracleOrder` and `fixTokenEscrowV1` info
- Updates **Credentials** section to enabled.

To Do:
- [x] Update Amendment IDs