### PR TITLE
Remove unused rbac configuration.

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -42,9 +42,6 @@ metadataGlobs:
     redocly_category: Community
 seo:
   siteUrl: https://xrpl.org/
-rbac:
-  reunite:
-    xrpl-org-editors: maintain
 analytics:
   gtm:
     includeInDevelopment: true


### PR DESCRIPTION
The rbac configuration needs to be removed to enable anonymous connections to the doc's MCP server.