### PR TITLE
Fix WebSocket API Tool errors

### DIFF
--- a/resources/dev-tools/websocket-api-tool.page.tsx
+++ b/resources/dev-tools/websocket-api-tool.page.tsx
@@ -55,8 +55,8 @@ export function WebsocketApiTool() {
   const getInitialMethod = (): CommandMethod => {
     for (const group of (commandList as CommandGroup[])) {
       for (const method of group.methods) {
-        if (slug.slice(1) === slugify(method.name) || params.req?.command == method.body.command) {
-          return method;
+        if (params.req?.command === method.body.command) {
+          return method
         }
       }
     }
@@ -73,6 +73,19 @@ export function WebsocketApiTool() {
     JSON.stringify(params.req || currentMethod.body, null, 2)
   );
   streamPausedRef.current = streamPaused;
+
+  useEffect(() => {
+    if (slug) {
+      for (const group of (commandList as CommandGroup[])) {
+        for (const method of group.methods) {
+          if (slug.slice(1) === slugify(method.name)) {
+            setMethod(method)
+            return
+          }
+        }
+      }
+    }
+  }, [slug])
 
   const handleCurrentBodyChange = (value: any) => {
     setCurrentBody(value);


### PR DESCRIPTION
This PR fixes:
1. Hydration error #3278 
2. Functions not updating when navigating using browser back and forward buttons.