### PR TITLE
Add link button functionality and styles

### DIFF
--- a/about/button-showcase-primary.page.tsx
+++ b/about/button-showcase-primary.page.tsx
@@ -178,6 +178,28 @@ export default function ButtonShowcase() {
         </div>
       </section>
 
+      {/* Link Buttons */}
+      <section className="container-new py-26">
+        <div className="d-flex flex-column-reverse">
+          <h2 className="h4 mb-8">Link Buttons</h2>
+          <h6 className="eyebrow mb-3">Navigation</h6>
+        </div>
+        <p className="mb-4 text-muted">
+          Buttons can function as links by passing an <code>href</code> prop. They render as anchor elements wrapped in a Redocly Link component for routing support.
+        </p>
+        <div className="d-flex flex-wrap align-items-center">
+          <Button variant="primary" href="/docs" className="me-4 mb-4">
+            View Documentation
+          </Button>
+          <Button variant="primary" href="https://xrpl.org" target="_blank" className="me-4 mb-4">
+            Visit XRPL.org
+          </Button>
+          <Button variant="primary" color="black" href="/about" className="mb-4">
+            About Us
+          </Button>
+        </div>
+      </section>
+
       {/* Without Icon */}
       <section className="container-new py-26">
         <div className="d-flex flex-column-reverse">
@@ -330,6 +352,16 @@ export default function ButtonShowcase() {
 // Form integration
 <Button variant="primary" type="submit">
   Submit Form
+</Button>
+
+// Link button (internal navigation)
+<Button variant="primary" href="/docs">
+  View Documentation
+</Button>
+
+// Link button (external, opens in new tab)
+<Button variant="primary" href="https://xrpl.org" target="_blank">
+  Visit XRPL.org
 </Button>`}</code>
           </pre>
         </div>

--- a/shared/components/Button/Button.md
+++ b/shared/components/Button/Button.md
@@ -8,6 +8,7 @@ The Button component is a scalable, accessible button implementation following t
 
 - **Three Variants**: Primary (solid), Secondary (outline), Tertiary (text-only)
 - **Two Color Themes**: Green (default) and Black
+- **Link Support**: Can render as anchor elements for navigation via `href` prop
 - **Animated Arrow Icon**: Optional icon with smooth hover animations
 - **Full State Support**: Enabled, Hover, Focus, Active, and Disabled states
 - **Responsive Design**: Adaptive padding and spacing across breakpoints
@@ -34,6 +35,12 @@ interface ButtonProps {
   className?: string;
   /** Whether to show the arrow icon */
   showIcon?: boolean;
+  /** Accessibility label - defaults to button text if not provided */
+  ariaLabel?: string;
+  /** URL to navigate to - renders as a Link instead of button */
+  href?: string;
+  /** Link target - only applies when href is provided */
+  target?: '_self' | '_blank';
 }
 ```
 
@@ -45,6 +52,9 @@ interface ButtonProps {
 - `type`: `'button'`
 - `className`: `''`
 - `showIcon`: `true`
+- `ariaLabel`: (derived from children text)
+- `href`: `undefined`
+- `target`: `'_self'`
 
 ## Variants
 
@@ -119,6 +129,91 @@ The black theme provides an alternative color scheme:
 ```tsx
 <Button variant="primary" color="black" onClick={handleClick}>
   Dark Button
+</Button>
+```
+
+## Link Buttons
+
+The Button component can render as an anchor element for navigation by passing the `href` prop. When `href` is provided, the button is wrapped in a Redocly `Link` component for proper routing support within the application.
+
+### How It Works
+
+- When `href` is provided and button is not disabled, renders as `<Link>` (anchor element)
+- When `href` is not provided or button is disabled, renders as `<button>` element
+- All visual styles and animations remain identical regardless of element type
+- The Redocly Link component handles internal routing and external link handling
+
+### Internal Navigation
+
+For navigating within the application:
+
+```tsx
+<Button variant="primary" href="/docs">
+  View Documentation
+</Button>
+
+<Button variant="secondary" href="/about">
+  About Us
+</Button>
+```
+
+### External Links
+
+For external URLs, use `target="_blank"` to open in a new tab:
+
+```tsx
+<Button variant="primary" href="https://xrpl.org" target="_blank">
+  Visit XRPL.org
+</Button>
+```
+
+### Link with Click Handler
+
+You can combine `href` with `onClick` for tracking or additional logic:
+
+```tsx
+<Button 
+  variant="primary" 
+  href="/signup" 
+  onClick={() => trackEvent('signup_click')}
+>
+  Sign Up
+</Button>
+```
+
+### Disabled Link Buttons
+
+When `disabled={true}` and `href` is provided, the component renders as a `<button>` element instead of a link to prevent navigation:
+
+```tsx
+<Button variant="primary" href="/checkout" disabled>
+  Checkout (Unavailable)
+</Button>
+```
+
+### All Variants as Links
+
+All button variants support link functionality:
+
+```tsx
+{/* Primary link button */}
+<Button variant="primary" href="/get-started">
+  Get Started
+</Button>
+
+{/* Secondary link button */}
+<Button variant="secondary" href="/learn-more">
+  Learn More
+</Button>
+
+{/* Tertiary link button */}
+<Button variant="tertiary" href="/view-details">
+  View Details
+</Button>
+
+{/* Black theme link button */}
+<Button variant="primary" color="black" href="/dashboard">
+  Dashboard
 </Button>
 ```
 
@@ -323,6 +418,34 @@ import { Button } from 'shared/components/Button';
 </Button>
 ```
 
+### Link Buttons
+
+```tsx
+{/* Internal navigation */}
+<Button variant="primary" href="/docs">
+  View Documentation
+</Button>
+
+{/* External link (opens in new tab) */}
+<Button variant="primary" href="https://xrpl.org" target="_blank">
+  Visit XRPL.org
+</Button>
+
+{/* Link with click tracking */}
+<Button 
+  variant="secondary" 
+  href="/signup"
+  onClick={() => analytics.track('signup_button')}
+>
+  Sign Up
+</Button>
+
+{/* Black theme link button */}
+<Button variant="primary" color="black" href="/dashboard">
+  Go to Dashboard
+</Button>
+```
+
 ### Visual Hierarchy
 
 ```tsx
@@ -350,10 +473,11 @@ import { Button } from 'shared/components/Button';
 
 ### Screen Reader Support
 
-- Semantic `<button>` element
-- Button label announced
+- Semantic `<button>` element (or `<a>` for link buttons)
+- Button label announced via `aria-label` attribute
 - `aria-disabled` attribute for disabled state
 - Icon marked with `aria-hidden="true"`
+- Link buttons use proper anchor semantics for navigation
 
 ### Color Contrast
 
@@ -397,6 +521,9 @@ The component uses design tokens from the XRPL Brand Design System:
 6. **Handle disabled states**: Always provide feedback when actions are unavailable
 7. **Test keyboard navigation**: Ensure all buttons are accessible via keyboard
 8. **Consider context**: Choose color theme based on background and design context
+9. **Use `href` for navigation**: When the button navigates to a new page, use the `href` prop instead of `onClick` with router navigation
+10. **Use `target="_blank"` for external links**: Always open external URLs in a new tab for better UX
+11. **Combine `href` with `onClick` for tracking**: When you need both navigation and analytics tracking
 
 ## Implementation Details
 
@@ -425,12 +552,40 @@ The icon is automatically hidden when:
 
 This ensures disabled buttons don't show interactive elements.
 
+### Link Rendering Logic
+
+The component conditionally renders as different elements:
+
+```typescript
+// Render as Link when href is provided and not disabled
+if (href && !disabled) {
+  return (
+    <Link to={href} target={target} className={classNames}>
+      {content}
+    </Link>
+  );
+}
+
+// Otherwise render as button
+return (
+  <button type={type} className={classNames} disabled={disabled}>
+    {content}
+  </button>
+);
+```
+
+This ensures:
+- Link buttons use proper anchor semantics for navigation
+- Disabled state always renders as a button to prevent navigation
+- Visual styles remain consistent across both element types
+
 ### State Management
 
 The component manages states through CSS classes and props:
 - **Disabled**: Controlled via `disabled` prop and `aria-disabled` attribute
 - **Hover/Focus**: Handled by CSS `:hover` and `:focus-visible` pseudo-classes
 - **Active**: Handled by CSS `:active` pseudo-class
+- **Link vs Button**: Determined by presence of `href` prop
 
 ## Browser Support
 

--- a/shared/components/Button/Button.scss
+++ b/shared/components/Button/Button.scss
@@ -84,6 +84,141 @@ $bds-btn-transition-timing: cubic-bezier(0.98, 0.12, 0.12, 0.98);
 // - On unhover: background empties top-to-bottom
 // - Each variant defines its own ::before background-color
 
+// Anchor reset for link-based buttons
+// Override global anchor styles (e.g., html.light a:not(.bds-link))
+// Using !important to ensure button styles win over global anchor rules
+// that are loaded later in the CSS cascade
+html.light,
+html.dark {
+  a.bds-btn {
+    text-decoration: none !important;
+    
+    &:hover,
+    &:focus,
+    &:focus-visible,
+    &:active,
+    &:visited {
+      text-decoration: none !important;
+    }
+
+    // Primary green link button - ensure correct text color and background
+    &.bds-btn--primary.bds-btn--green {
+      color: $bds-btn-primary-text !important;
+      background-color: $bds-btn-primary-bg !important;
+      
+      &:hover,
+      &:focus,
+      &:focus-visible,
+      &:active,
+      &:visited {
+        color: $bds-btn-primary-text !important;
+        background-color: $bds-btn-primary-bg !important;
+      }
+    }
+
+    // Primary black link button - ensure white text and icon
+    &.bds-btn--primary.bds-btn--black {
+      color: $bds-btn-primary-black-text !important;
+      background-color: $bds-btn-primary-black-bg !important;
+      
+      .bds-btn__icon,
+      .bds-btn__icon-line,
+      .bds-btn__icon-chevron {
+        color: $bds-btn-primary-black-text !important;
+        stroke: $bds-btn-primary-black-text !important;
+      }
+      
+      &:hover,
+      &:focus,
+      &:focus-visible,
+      &:active,
+      &:visited {
+        color: $bds-btn-primary-black-text !important;
+        background-color: $bds-btn-primary-black-bg !important;
+        
+        .bds-btn__icon,
+        .bds-btn__icon-line,
+        .bds-btn__icon-chevron {
+          color: $bds-btn-primary-black-text !important;
+          stroke: $bds-btn-primary-black-text !important;
+        }
+      }
+    }
+
+    // Secondary green link button
+    &.bds-btn--secondary.bds-btn--green {
+      color: $bds-btn-secondary-text !important;
+      background-color: $bds-btn-secondary-bg !important;
+      
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        color: $bds-btn-secondary-text-hover !important;
+        background-color: $bds-btn-secondary-bg-hover !important;
+      }
+      
+      &:active,
+      &:visited {
+        color: $bds-btn-secondary-text !important;
+        background-color: $bds-btn-secondary-bg !important;
+      }
+    }
+
+    // Secondary black link button
+    &.bds-btn--secondary.bds-btn--black {
+      color: $bds-btn-secondary-black-text !important;
+      background-color: transparent !important;
+      
+      &:hover,
+      &:focus,
+      &:focus-visible,
+      &:active,
+      &:visited {
+        color: $bds-btn-secondary-black-text !important;
+        background-color: $bds-btn-secondary-black-bg-hover !important;
+      }
+      
+      &:active,
+      &:visited {
+        background-color: transparent !important;
+      }
+    }
+
+    // Tertiary green link button
+    &.bds-btn--tertiary.bds-btn--green {
+      color: $bds-btn-tertiary-text !important;
+      background-color: $bds-btn-tertiary-bg !important;
+      
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        color: $bds-btn-tertiary-text-hover !important;
+      }
+      
+      &:active,
+      &:visited {
+        color: $bds-btn-tertiary-text !important;
+        background-color: $bds-btn-tertiary-bg !important;
+      }
+    }
+
+    // Tertiary black link button
+    &.bds-btn--tertiary.bds-btn--black {
+      color: $bds-btn-tertiary-black-text !important;
+      background-color: transparent !important;
+      
+      &:hover,
+      &:focus,
+      &:focus-visible,
+      &:active,
+      &:visited {
+        color: $bds-btn-tertiary-black-text !important;
+        background-color: transparent !important;
+      }
+    }
+  }
+}
+
 .bds-btn {
   // Layout
   display: inline-flex;
@@ -743,6 +878,39 @@ $bds-btn-transition-timing: cubic-bezier(0.98, 0.12, 0.12, 0.98);
 // =============================================================================
 
 html.dark {
+  // Anchor link button color overrides for dark mode
+  a.bds-btn {
+    // Secondary green link button - dark mode
+    &.bds-btn--secondary.bds-btn--green {
+      color: $green-300;
+      
+      &:hover,
+      &:focus {
+        color: $green-200;
+      }
+      
+      &:active,
+      &:visited {
+        color: $green-300;
+      }
+    }
+
+    // Tertiary green link button - dark mode
+    &.bds-btn--tertiary.bds-btn--green {
+      color: $green-300;
+      
+      &:hover,
+      &:focus {
+        color: $green-200;
+      }
+      
+      &:active,
+      &:visited {
+        color: $green-300;
+      }
+    }
+  }
+
   .bds-btn--primary {
     // Focus State (keyboard navigation) - with icon - Desktop
     &:focus-visible:not(:disabled):not(.bds-btn--disabled):not(.bds-btn--no-icon) {

--- a/shared/components/Button/Button.tsx
+++ b/shared/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
+import { Link } from '@redocly/theme/components/Link/Link';
 
 export interface ButtonProps {
   /** Button variant - determines visual style */
@@ -20,6 +21,10 @@ export interface ButtonProps {
   showIcon?: boolean;
   /** Accessibility label - defaults to button text if not provided */
   ariaLabel?: string;
+  /** URL to navigate to - renders as a Link instead of button */
+  href?: string;
+  /** Link target - only applies when href is provided */
+  target?: '_self' | '_blank';
 }
 
 /**
@@ -101,6 +106,8 @@ export const Button: React.FC<ButtonProps> = ({
   className = '',
   showIcon = true,
   ariaLabel,
+  href,
+  target = '_self',
 }) => {
   // Hide icon when disabled (per design spec)
   const shouldShowIcon = showIcon && !disabled;
@@ -120,6 +127,29 @@ export const Button: React.FC<ButtonProps> = ({
     className
   );
 
+  // Inner content shared between button and link
+  const content = (
+    <>
+      <span className="bds-btn__label">{children}</span>
+      {shouldShowIcon && <ArrowIcon />}
+    </>
+  );
+
+  // Render as Link when href is provided
+  if (href && !disabled) {
+    return (
+      <Link
+        to={href}
+        target={target}
+        className={classNames}
+        onClick={onClick}
+        aria-label={buttonAriaLabel}
+      >
+        {content}
+      </Link>
+    );
+  }
+
   return (
     <button
       type={type}
@@ -129,8 +159,7 @@ export const Button: React.FC<ButtonProps> = ({
       aria-disabled={disabled}
       aria-label={buttonAriaLabel}
     >
-      <span className="bds-btn__label">{children}</span>
-      {shouldShowIcon && <ArrowIcon />}
+      {content}
     </button>
   );
 };

--- a/static/css/devportal2024-v1.css
+++ b/static/css/devportal2024-v1.css
@@ -11145,6 +11145,153 @@ button[disabled=disabled] {
   right: 0;
 }
 
+html.light a.bds-btn,
+html.dark a.bds-btn {
+  text-decoration: none !important;
+}
+html.light a.bds-btn:hover, html.light a.bds-btn:focus, html.light a.bds-btn:focus-visible, html.light a.bds-btn:active, html.light a.bds-btn:visited,
+html.dark a.bds-btn:hover,
+html.dark a.bds-btn:focus,
+html.dark a.bds-btn:focus-visible,
+html.dark a.bds-btn:active,
+html.dark a.bds-btn:visited {
+  text-decoration: none !important;
+}
+html.light a.bds-btn.bds-btn--primary.bds-btn--green,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--green {
+  color: #141414 !important;
+  background-color: #21E46B !important;
+}
+html.light a.bds-btn.bds-btn--primary.bds-btn--green:hover, html.light a.bds-btn.bds-btn--primary.bds-btn--green:focus, html.light a.bds-btn.bds-btn--primary.bds-btn--green:focus-visible, html.light a.bds-btn.bds-btn--primary.bds-btn--green:active, html.light a.bds-btn.bds-btn--primary.bds-btn--green:visited,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--green:hover,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--green:focus,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--green:focus-visible,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--green:active,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--green:visited {
+  color: #141414 !important;
+  background-color: #21E46B !important;
+}
+html.light a.bds-btn.bds-btn--primary.bds-btn--black,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black {
+  color: #FFFFFF !important;
+  background-color: #141414 !important;
+}
+html.light a.bds-btn.bds-btn--primary.bds-btn--black .bds-btn__icon,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black .bds-btn__icon-line,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black .bds-btn__icon-chevron,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black .bds-btn__icon,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black .bds-btn__icon-line,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black .bds-btn__icon-chevron {
+  color: #FFFFFF !important;
+  stroke: #FFFFFF !important;
+}
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:hover, html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus, html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible, html.light a.bds-btn.bds-btn--primary.bds-btn--black:active, html.light a.bds-btn.bds-btn--primary.bds-btn--black:visited,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:hover,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:active,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:visited {
+  color: #FFFFFF !important;
+  background-color: #141414 !important;
+}
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:hover .bds-btn__icon,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:hover .bds-btn__icon-line,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:hover .bds-btn__icon-chevron, html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus .bds-btn__icon,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus .bds-btn__icon-line,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus .bds-btn__icon-chevron, html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible .bds-btn__icon,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible .bds-btn__icon-line,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible .bds-btn__icon-chevron, html.light a.bds-btn.bds-btn--primary.bds-btn--black:active .bds-btn__icon,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:active .bds-btn__icon-line,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:active .bds-btn__icon-chevron, html.light a.bds-btn.bds-btn--primary.bds-btn--black:visited .bds-btn__icon,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:visited .bds-btn__icon-line,
+html.light a.bds-btn.bds-btn--primary.bds-btn--black:visited .bds-btn__icon-chevron,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:hover .bds-btn__icon,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:hover .bds-btn__icon-line,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:hover .bds-btn__icon-chevron,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus .bds-btn__icon,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus .bds-btn__icon-line,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus .bds-btn__icon-chevron,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible .bds-btn__icon,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible .bds-btn__icon-line,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:focus-visible .bds-btn__icon-chevron,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:active .bds-btn__icon,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:active .bds-btn__icon-line,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:active .bds-btn__icon-chevron,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:visited .bds-btn__icon,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:visited .bds-btn__icon-line,
+html.dark a.bds-btn.bds-btn--primary.bds-btn--black:visited .bds-btn__icon-chevron {
+  color: #FFFFFF !important;
+  stroke: #FFFFFF !important;
+}
+html.light a.bds-btn.bds-btn--secondary.bds-btn--green,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green {
+  color: #0DAA3E !important;
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--secondary.bds-btn--green:hover, html.light a.bds-btn.bds-btn--secondary.bds-btn--green:focus, html.light a.bds-btn.bds-btn--secondary.bds-btn--green:focus-visible,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:hover,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:focus,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:focus-visible {
+  color: #078139 !important;
+  background-color: #EAFCF1 !important;
+}
+html.light a.bds-btn.bds-btn--secondary.bds-btn--green:active, html.light a.bds-btn.bds-btn--secondary.bds-btn--green:visited,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:active,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:visited {
+  color: #0DAA3E !important;
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--secondary.bds-btn--black,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black {
+  color: #141414 !important;
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--secondary.bds-btn--black:hover, html.light a.bds-btn.bds-btn--secondary.bds-btn--black:focus, html.light a.bds-btn.bds-btn--secondary.bds-btn--black:focus-visible, html.light a.bds-btn.bds-btn--secondary.bds-btn--black:active, html.light a.bds-btn.bds-btn--secondary.bds-btn--black:visited,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:hover,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:focus,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:focus-visible,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:active,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:visited {
+  color: #141414 !important;
+  background-color: rgba(20, 20, 20, 0.15) !important;
+}
+html.light a.bds-btn.bds-btn--secondary.bds-btn--black:active, html.light a.bds-btn.bds-btn--secondary.bds-btn--black:visited,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:active,
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--black:visited {
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--tertiary.bds-btn--green,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green {
+  color: #0DAA3E !important;
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--tertiary.bds-btn--green:hover, html.light a.bds-btn.bds-btn--tertiary.bds-btn--green:focus, html.light a.bds-btn.bds-btn--tertiary.bds-btn--green:focus-visible,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:hover,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:focus,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:focus-visible {
+  color: #078139 !important;
+}
+html.light a.bds-btn.bds-btn--tertiary.bds-btn--green:active, html.light a.bds-btn.bds-btn--tertiary.bds-btn--green:visited,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:active,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:visited {
+  color: #0DAA3E !important;
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--tertiary.bds-btn--black,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--black {
+  color: #141414 !important;
+  background-color: transparent !important;
+}
+html.light a.bds-btn.bds-btn--tertiary.bds-btn--black:hover, html.light a.bds-btn.bds-btn--tertiary.bds-btn--black:focus, html.light a.bds-btn.bds-btn--tertiary.bds-btn--black:focus-visible, html.light a.bds-btn.bds-btn--tertiary.bds-btn--black:active, html.light a.bds-btn.bds-btn--tertiary.bds-btn--black:visited,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--black:hover,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--black:focus,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--black:focus-visible,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--black:active,
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--black:visited {
+  color: #141414 !important;
+  background-color: transparent !important;
+}
+
 .bds-btn {
   display: inline-flex;
   align-items: center;
@@ -11554,6 +11701,24 @@ button[disabled=disabled] {
   }
 }
 
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green {
+  color: #21E46B;
+}
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:hover, html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:focus {
+  color: #70EE97;
+}
+html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:active, html.dark a.bds-btn.bds-btn--secondary.bds-btn--green:visited {
+  color: #21E46B;
+}
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green {
+  color: #21E46B;
+}
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:hover, html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:focus {
+  color: #70EE97;
+}
+html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:active, html.dark a.bds-btn.bds-btn--tertiary.bds-btn--green:visited {
+  color: #21E46B;
+}
 html.dark .bds-btn--primary:focus-visible:not(:disabled):not(.bds-btn--disabled):not(.bds-btn--no-icon) {
   outline: 2px solid #FFFFFF;
   outline-offset: 2px;
@@ -15910,14 +16075,14 @@ html.light .bds-tile-logo--disabled .bds-tile-logo__image {
   text-decoration: none;
 }
 .bds-card-icon:focus {
-  outline: 2px solid #000000;
+  outline: 2px solid #141414;
   outline-offset: 1px;
 }
 .bds-card-icon:focus:not(:focus-visible) {
   outline: none;
 }
 .bds-card-icon:focus-visible {
-  outline: 2px solid #000000;
+  outline: 2px solid #141414;
   outline-offset: 2px;
 }
 
@@ -15976,7 +16141,7 @@ html.light .bds-tile-logo--disabled .bds-tile-logo__image {
 .bds-card-icon__label {
   font-family: "Booton", "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-weight: 400;
-  color: #000000;
+  color: #141414;
   margin-bottom: 0;
   font-size: 16px;
   line-height: 26.1px;
@@ -15992,7 +16157,7 @@ html.light .bds-tile-logo--disabled .bds-tile-logo__image {
 
 .bds-card-icon__arrow {
   flex-shrink: 0;
-  color: #000000;
+  color: #141414;
 }
 
 .bds-card-icon:hover .bds-card-icon__arrow .bds-link-icon--internal:not(.bds-link-icon--disabled) svg .arrow-horizontal,
@@ -16082,7 +16247,7 @@ html.dark .bds-card-icon--green {
 }
 html.dark .bds-card-icon--green .bds-card-icon__label,
 html.dark .bds-card-icon--green .bds-card-icon__arrow {
-  color: #000000;
+  color: #141414;
 }
 html.dark .bds-card-icon--green .bds-card-icon__overlay {
   background-color: #70EE97;
@@ -16116,17 +16281,17 @@ html.dark .bds-card-icon--disabled.bds-card-icon--green .bds-card-icon__icon-img
 }
 
 html.light .bds-card-icon:focus {
-  outline-color: #000000;
+  outline-color: #141414;
 }
 html.light .bds-card-icon:focus-visible {
-  outline-color: #000000;
+  outline-color: #141414;
 }
 html.light .bds-card-icon--neutral {
   background-color: #E6EAF0;
 }
 html.light .bds-card-icon--neutral .bds-card-icon__label,
 html.light .bds-card-icon--neutral .bds-card-icon__arrow {
-  color: #000000;
+  color: #141414;
 }
 html.light .bds-card-icon--neutral .bds-card-icon__overlay {
   background-color: #CAD4DF;
@@ -16140,7 +16305,7 @@ html.light .bds-card-icon--green {
 }
 html.light .bds-card-icon--green .bds-card-icon__label,
 html.light .bds-card-icon--green .bds-card-icon__arrow {
-  color: #000000;
+  color: #141414;
 }
 html.light .bds-card-icon--green .bds-card-icon__overlay {
   background-color: #21E46B;


### PR DESCRIPTION
- Introduced link button support in the Button component, allowing buttons to render as anchor elements when an `href` prop is provided.
- Updated Button showcase to demonstrate link buttons for internal and external navigation.
- Enhanced Button SCSS styles to ensure proper appearance and behavior for link buttons in both light and dark themes.
- Added documentation for link button usage in the Button showcase.