### PR TITLE
Add support for inactive amendments in tracker

### DIFF
--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -155,7 +155,7 @@ amendment.table.status: ステータス
 amendment.status.enabled: 有効
 amendment.status.eta: 予定
 amendment.status.openForVoting: 投票中
-amendment.status.inactive: 非アクティブ
+amendment.status.inactive: 無効
 amendment.status.inactiveButton: 詳細を取得する
 
 # index.page.tsx

--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -155,6 +155,8 @@ amendment.table.status: ステータス
 amendment.status.enabled: 有効
 amendment.status.eta: 予定
 amendment.status.openForVoting: 投票中
+amendment.status.inactive: 非アクティブ
+amendment.status.inactiveButton: 詳細を取得する
 
 # index.page.tsx
 home.hero.h1part1: ビジネスのための

--- a/@theme/components/Amendments.tsx
+++ b/@theme/components/Amendments.tsx
@@ -416,7 +416,7 @@ export function Badge(props: {
       "in development": "lightgrey",
       "開発中": "lightgrey", // ja: in development
       "inactive": "lightgrey",
-      "非アクティブ": "lightgrey" // ja: inactive
+      "無効": "lightgrey" // ja: inactive
     }
 
     let childstrings = ""

--- a/docs/concepts/accounts/permission-delegation.md
+++ b/docs/concepts/accounts/permission-delegation.md
@@ -10,7 +10,7 @@ status: not_enabled
 
 Permission delegation is the function of granting various permissions to another account to send permissions on behalf of your account. You can use permission delegation to enable flexible security paradigms such as role-based access control, instead of or alongside techniques such as [multi-signing](./multi-signing.md).
 
- {% amendment-disclaimer name="PermissionDelegation" /%}
+{% amendment-disclaimer name="PermissionDelegation" /%}
 
 
 ## Background: The Need for Permission Delegation

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -1684,11 +1684,11 @@ For more information, see the [Payment Channels Tutorial](../docs/tutorials/how-
 | Amendment    | PermissionDelegation |
 |:-------------|:---------------------|
 | Amendment ID | AE6AB9028EEB7299EBB03C7CBCC3F2A4F5FBE00EA28B8223AA3118A0B436C1C5 |
-| Status       | Obsolete |
+| Status       | Disabled |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-Allows accounts to delegate some permissions to other accounts. This amendment is obsolete because a bug was discovered and it was disabled. It will be replaced by `PermissionDelegationV1_1` in a future release.
+Allows accounts to delegate some permissions to other accounts. This amendment was disabled in v2.6.1 due to a bug. It will be replaced by `PermissionDelegationV1_1` in a future release.
 
 Specification: [XLS-75](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0075-permission-delegation).
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -37,6 +37,7 @@ The following is a list of known [amendments](../docs/concepts/networks-and-serv
 
 | Name                              | Introduced | Status                        |
 |:----------------------------------|:-----------|:------------------------------|
+| [PermissionDelegation]            | v2.5.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.6.1" %}Obsolete: Removed in v2.6.1{% /badge %} |
 | [fixNFTokenNegOffer][]            | v1.9.2     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
@@ -1683,7 +1684,7 @@ For more information, see the [Payment Channels Tutorial](../docs/tutorials/how-
 | Amendment    | PermissionDelegation |
 |:-------------|:---------------------|
 | Amendment ID | AE6AB9028EEB7299EBB03C7CBCC3F2A4F5FBE00EA28B8223AA3118A0B436C1C5 |
-| Status       | Disabled |
+| Status       | Obsolete |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -37,7 +37,6 @@ The following is a list of known [amendments](../docs/concepts/networks-and-serv
 
 | Name                              | Introduced | Status                        |
 |:----------------------------------|:-----------|:------------------------------|
-| [PermissionDelegation][]          | v2.5.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [fixNFTokenNegOffer][]            | v1.9.2     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -37,6 +37,7 @@ The following is a list of known [amendments](../docs/concepts/networks-and-serv
 
 | Name                              | Introduced | Status                        |
 |:----------------------------------|:-----------|:------------------------------|
+| [PermissionDelegation][]          | v2.5.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [fixNFTokenNegOffer][]            | v1.9.2     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
@@ -1683,11 +1684,11 @@ For more information, see the [Payment Channels Tutorial](../docs/tutorials/how-
 | Amendment    | PermissionDelegation |
 |:-------------|:---------------------|
 | Amendment ID | AE6AB9028EEB7299EBB03C7CBCC3F2A4F5FBE00EA28B8223AA3118A0B436C1C5 |
-| Status       | Open for Voting |
+| Status       | Obsolete |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-Allows accounts to delegate some permissions to other accounts.
+Allows accounts to delegate some permissions to other accounts. This amendment is obsolete because a bug was discovered and it was disabled. It will be replaced by `PermissionDelegationV1_1` in a future release.
 
 Specification: [XLS-75](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0075-permission-delegation).
 


### PR DESCRIPTION
This PR fixes an issue where missing amendments from the VHS Vote endpoint caused an error. This also includes minor cleanup to the PermissionDelegation info in the known amendments page.

[Example of error](https://xrpl.org/docs/concepts/accounts/permission-delegation)

**Old Behavior**
<img width="1410" height="226" alt="image" src="https://github.com/user-attachments/assets/6dfe2507-00b7-4122-b4d9-8e396b1cf756" />
**New Behavior**
<img width="531" height="37" alt="image" src="https://github.com/user-attachments/assets/a6a9f6b1-dd42-4351-a1cb-1caff6300468" />

The fix now queries the VHS Info endpoint as a secondary check if the first one fails to fetch the amendment. If the amendment is found on this second list, its treated as "Inactive" with a link to get further details on what that means (Obsolete vs In Development). The VHS API doesn't have the info required to programmatically determine if an amendment is inactive due to being in development or obsolete.

@mDuo13 Japanese translations were pulled from google, please check they are correct.

