### PR TITLE
Upgrade Redocly & remove unused htmltojsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.126.0",
+        "@redocly/realm": "0.130.2",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -31,7 +31,6 @@
       },
       "devDependencies": {
         "bootstrap": "^4.6.2",
-        "htmltojsx": "^0.3.0",
         "sass": "1.26.10"
       }
     },
@@ -49,12 +48,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -63,9 +62,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -111,13 +110,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -139,12 +138,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -182,27 +181,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -212,9 +211,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -230,9 +229,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -248,25 +247,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -276,12 +275,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -300,31 +299,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -332,13 +331,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -398,6 +397,16 @@
         "@lezer/html": "^1.3.12"
       }
     },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
@@ -421,6 +430,19 @@
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
       }
     },
     "node_modules/@codemirror/lang-xml": {
@@ -453,17 +475,26 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
-      "integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
+      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.1.0",
+        "@lezer/common": "^1.5.0",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -541,6 +572,59 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dr.pogodin/react-helmet": {
@@ -691,9 +775,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
-      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
       "cpu": [
         "ppc64"
       ],
@@ -707,9 +791,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
-      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
       "cpu": [
         "arm"
       ],
@@ -723,9 +807,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
-      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
       "cpu": [
         "arm64"
       ],
@@ -739,9 +823,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
-      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
       "cpu": [
         "x64"
       ],
@@ -755,9 +839,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
-      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
       "cpu": [
         "arm64"
       ],
@@ -771,9 +855,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
-      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
       "cpu": [
         "x64"
       ],
@@ -787,9 +871,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
-      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
       "cpu": [
         "arm64"
       ],
@@ -803,9 +887,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
-      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
       "cpu": [
         "x64"
       ],
@@ -819,9 +903,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
-      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
       "cpu": [
         "arm"
       ],
@@ -835,9 +919,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
-      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
       "cpu": [
         "arm64"
       ],
@@ -851,9 +935,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
-      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
       "cpu": [
         "ia32"
       ],
@@ -867,9 +951,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
-      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
       "cpu": [
         "loong64"
       ],
@@ -883,9 +967,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
-      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
       "cpu": [
         "mips64el"
       ],
@@ -899,9 +983,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
-      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
       "cpu": [
         "ppc64"
       ],
@@ -915,9 +999,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
-      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
       "cpu": [
         "riscv64"
       ],
@@ -931,9 +1015,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
-      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
       "cpu": [
         "s390x"
       ],
@@ -947,9 +1031,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
-      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
       "cpu": [
         "x64"
       ],
@@ -963,9 +1047,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
-      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
       "cpu": [
         "arm64"
       ],
@@ -979,9 +1063,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
-      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
       "cpu": [
         "x64"
       ],
@@ -995,9 +1079,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
-      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
       "cpu": [
         "arm64"
       ],
@@ -1011,9 +1095,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
-      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
       "cpu": [
         "x64"
       ],
@@ -1027,9 +1111,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
-      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
       "cpu": [
         "arm64"
       ],
@@ -1043,9 +1127,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
-      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
       "cpu": [
         "x64"
       ],
@@ -1059,9 +1143,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
-      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
       "cpu": [
         "arm64"
       ],
@@ -1075,9 +1159,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
-      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
       "cpu": [
         "ia32"
       ],
@@ -1091,9 +1175,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
-      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
       "cpu": [
         "x64"
       ],
@@ -1123,21 +1207,21 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
       }
     },
@@ -1154,39 +1238,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1240,9 +1291,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/common": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
-      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
@@ -1266,9 +1317,20 @@
       }
     },
     "node_modules/@lezer/html": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
-      "integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -1307,6 +1369,17 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/xml": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
@@ -1319,9 +1392,9 @@
       }
     },
     "node_modules/@lezer/yaml": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.3.tgz",
-      "integrity": "sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -1673,42 +1746,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-document-load": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.47.0.tgz",
-      "integrity": "sha512-CkxA85nMvieX4IWIW7oTTXChHBuBzZ2NV+PyD9cLuzNZgrdks7YzYwCBhsyDVN6ptZ3Wd0S8Ys2Pfr9YgFqoDQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.202.0",
-        "@opentelemetry/sdk-trace-web": "^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.202.0.tgz",
-      "integrity": "sha512-RlLgOJAKs9cQIRXPoLnS6YG8CeQt1gR+WJpzthQlqt4hdgNmfnyB7zZrg1yddECF0K2lPGBqF4s+IqjA4dy3JQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/instrumentation": "0.202.0",
-        "@opentelemetry/sdk-trace-web": "2.0.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.202.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.202.0.tgz",
@@ -1719,24 +1756,6 @@
         "@opentelemetry/instrumentation": "0.202.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "forwarded-parse": "2.1.2"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.202.0.tgz",
-      "integrity": "sha512-N0wZyWpdUviscnhNKbRr2mEEfTtVi0ki7v6Lr9ZsK5mUtg12e9Mf/LsT2Msl7tvyGDGGi8Tmm8ssFrfLOADqDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/instrumentation": "0.202.0",
-        "@opentelemetry/sdk-trace-web": "2.0.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1973,9 +1992,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.0.tgz",
-      "integrity": "sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
+      "integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
@@ -2028,58 +2047,58 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.3.0.tgz",
-      "integrity": "sha512-W1uUyZBNJtlPtdntAi5bx6hd1jkqjttEVh7C5xf9QRPOSUWgY3lK6NR/sGf2TopUlXhT/RKwhc5s+Yrj27PxNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.7.0.tgz",
+      "integrity": "sha512-AHGMZ32iZ+5iIHGmhHWev2QLvypfoFMQU6J+7rpNlAhE7ahoQ/BBmdeH3/ee8qxPnCGtWhjTfB7qIGaUWHDjGQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.35.1",
-        "@redocly/openapi-docs": "3.14.0",
-        "@redocly/theme": "0.58.0",
+        "@redocly/config": "0.42.0",
+        "@redocly/openapi-docs": "3.18.0",
+        "@redocly/theme": "0.62.0",
         "jotai": "^2.11.1",
-        "openapi-sampler": "^1.6.1",
-        "react-router-dom": "^6.21.1",
+        "openapi-sampler": "1.6.2",
+        "react-router-dom": "^6.30.3",
         "styled-components": "5.3.11",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.4"
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.35.1.tgz",
-      "integrity": "sha512-iciIGHQ4EMt8JuBf6RDNKQ4W2xaU293lm2l8omy2jJ/CDZ6/TIzDeQMCcbSYWZtviLCfDhmWknlKjumRSSn63w==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.42.0.tgz",
+      "integrity": "sha512-Hvv0Cmcg199OZtTFt58ZMyj+5A0S0WIgb+JHIdKxUKfJuyGUDScFgk8BjEfvpU59UjXinI6O2atrgDHhKqiPMQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.3.0.tgz",
-      "integrity": "sha512-yk4Ni1id9g2jLRl8bSEtFfaxFWrQlqvhbpzEdtcwdHOyXF8ZtlL+TbbBHfoJofnw9Gk1jXcHD9VSsd3jSBm43A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.7.0.tgz",
+      "integrity": "sha512-UdAuWL77MtzakUXlrWhMimX1U9hzobQyejPGk/3crYLOHFfBvAhvfG1MgSMeqP+Q3C8QB+2Tp46be3EPduP5cA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.35.1",
+        "@redocly/config": "0.42.0",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "^0.58.0-next.0",
-        "graphql": "^16.9.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^6.21.1",
+        "@redocly/theme": "0.62.0",
+        "graphql": "16.9.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
         "styled-components": "^5.3.11"
       }
     },
     "node_modules/@redocly/hookstate-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@redocly/hookstate-core/-/hookstate-core-4.2.0.tgz",
-      "integrity": "sha512-Y7vJWVzpKbigO4aiVZJj/NLkIxpCmhtfUsT81Th9odwMTaaJbEcftD7uCTtMR3R3BiEpUvxarQUhCRv2IB9i6g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@redocly/hookstate-core/-/hookstate-core-4.2.1.tgz",
+      "integrity": "sha512-9AuP8i8APXgKVimZ8ZxUkPeRQsntIon3Bp+evSriXZU2HgDY6EzOFeIlFcI1ngcpXd5Wgi3GrQ7SGzS/qhNL4g==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2094,15 +2113,6 @@
         "redux": "4.2.0",
         "redux-devtools-extension": "2.13.9"
       },
-      "peerDependencies": {
-        "@redocly/hookstate-core": "^4.0.0"
-      }
-    },
-    "node_modules/@redocly/hookstate-localstored": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@redocly/hookstate-localstored/-/hookstate-localstored-4.0.2.tgz",
-      "integrity": "sha512-8oKl/XhNgXVKtSJ97PtWYkxRVeFsHDw7yGKt+N7AbaHQRyZBJZktYUnmJ2blIi6iCPQIMW1Ld+G3MAK5dH6Kfw==",
-      "license": "MIT",
       "peerDependencies": {
         "@redocly/hookstate-core": "^4.0.0"
       }
@@ -2123,36 +2133,70 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.3.9.tgz",
-      "integrity": "sha512-K6LPecxsGvcEJGMq54vx7JjuHZDhicIJDaiyEXGQEnhkXDJol60xMmQNkTiOY1xHdTs6rOwFT+rH5LP4TIa4aQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.5.6.tgz",
+      "integrity": "sha512-FTPunfO7CLCGDRYmGyU09hDYii2cLFaVWmFUXqwqtnHwRIAL8HnJEO5PLmO3gFnqo2wClxCMdqTL89YO1GRI+g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/ajv": "8.11.3",
-        "@redocly/openapi-core": "2.3.1",
+        "@redocly/ajv": "8.17.2",
+        "@redocly/openapi-core": "2.15.2",
         "ajv": "8.17.1",
-        "ajv-formats": "^2.1.1",
-        "js-yaml": "4.1.0",
-        "openapi-sampler": "1.6.1",
+        "ajv-formats": "^3.0.1",
+        "fast-xml-parser": "5.3.4",
+        "js-yaml": "4.1.1",
+        "openapi-sampler": "1.6.2",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
         "ts-node": "10.9.2",
         "yargs": "^17.5.1"
       }
     },
-    "node_modules/@redocly/openapi-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.3.1.tgz",
-      "integrity": "sha512-lCEUq3BB6nwfDbUBEj9OUA46SJRCzD55GmuB4tFZnxIB1+E4FQb8kCD0UMtXh8hHImafpKoNXk5NzcQEuIZWWA==",
+    "node_modules/@redocly/mock-server/node_modules/@redocly/ajv": {
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.2.tgz",
+      "integrity": "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g==",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.31.0",
-        "ajv-formats": "^2.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.15.2.tgz",
+      "integrity": "sha512-SGaucW1OQzK411+uB5bE9cxmJJ1Rr3UHQGl6mnsYTETCTKU1LJ1oIhBtqGep5Cg+JO5Jm865hIVhgf+sZ32Thw==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.17.2",
+        "@redocly/config": "^0.41.4",
+        "ajv": "npm:@redocly/ajv@8.17.2",
+        "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
-        "minimatch": "^10.0.1",
+        "picomatch": "^4.0.3",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
@@ -2161,10 +2205,26 @@
         "npm": ">=10"
       }
     },
+    "node_modules/@redocly/openapi-core/node_modules/@redocly/ajv": {
+      "version": "8.17.4",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
+      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.31.0.tgz",
-      "integrity": "sha512-KPm2v//zj7qdGvClX0YqRNLQ9K7loVJWFEIceNxJIYPXP4hrhNvOLwjmxIkdkai0SdqYqogR2yjM/MjF9/AGdQ==",
+      "version": "0.41.4",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.41.4.tgz",
+      "integrity": "sha512-LaRKXpHyK5GxmgG2n2e8xp2NyUa8qZls3WMAVg5hKO4b2d7X5uU5F2jvH6JUTVdRW/VfStQqan5DQ1uQz7MVzg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -2176,38 +2236,37 @@
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "license": "MIT"
     },
-    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
+    "node_modules/@redocly/openapi-core/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.14.0.tgz",
-      "integrity": "sha512-Y73W1I7+ml8GjJHH1bLSjAmXOq4ScFzPzM+ajzE+0D8jSlC34+G/9o6zIpD0ECY4aYUZoFrXqqKnNAT/Z9fFPg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.18.0.tgz",
+      "integrity": "sha512-2v7cv2I2ecdE/bKq41R2XGDeZUjtTWjbtavDXB2CRQjYtyvdB2xTms413pK/8Orc21BAqzDnOd9w2H1tjPc05Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.35.1",
-        "@redocly/openapi-core": "2.3.1",
-        "@redocly/replay": "0.17.0",
+        "@redocly/config": "0.42.0",
+        "@redocly/openapi-core": "2.15.2",
+        "@redocly/replay": "0.21.0",
         "deepmerge": "^4.2.2",
         "dompurify": "3.2.7",
         "fast-deep-equal": "^3.1.3",
+        "fast-xml-parser": "5.3.4",
         "jotai": "^2.12.5",
+        "jotai-family": "^1.0.1",
         "json-pointer": "^0.6.2",
-        "openapi-sampler": "^1.6.1",
-        "react-router-dom": "^6.21.1",
+        "openapi-sampler": "1.6.2",
+        "react-router-dom": "^6.30.3",
         "slugify": "^1.4.4",
         "stringify-object": "^3.3.0",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
@@ -2221,40 +2280,40 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@redocly/theme": ">=0.58.0-next.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "@redocly/theme": ">=0.62.0-next.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
     "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.9.0.tgz",
-      "integrity": "sha512-1N9Zc89/2CLTMcUdL0zWHTg46zSkEFL91Zx2mlx14Abirzz2vkXV91v1KnPXD/y3PZnEvdlN/ccn9h6Gl4V/sg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.13.0.tgz",
+      "integrity": "sha512-ghxyUh3oOBSBeYTCsZkMQronJhv7sqdY+vHcewweqAAucrtY4Ic7ameMtC3ADHfdQiKKKXVnfskXdoc8aW4B4A==",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "highlight-words-core": "^1.2.2",
-        "react": "^19.1.0",
-        "react-router-dom": "^6.21.1",
+        "react": "^19.2.4",
+        "react-router-dom": "^6.30.3",
         "styled-components": "^4.1.1 || ^5.3.11",
         "styled-system": "^5.1.5"
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.11.0.tgz",
-      "integrity": "sha512-OyTYZ0C4AYu4A83XiE8yHgly8/vBpdIMiRpfbVbexHgdYcDR4eN9bnAjy+c/9Q2Fv9AjdWBhYP7y5udR/Hv5Ag==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.15.0.tgz",
+      "integrity": "sha512-ok5DGdk9IrQA+oKBE9Usrvh7qwkdhbiV2ApELowOeRXQU+jzQbZk1lp5ZJltWyiHkMZb47s7lDA809Rv6bM8JQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.35.1",
-        "@redocly/mock-server": "0.3.9",
-        "@redocly/openapi-docs": "3.14.0"
+        "@redocly/config": "0.42.0",
+        "@redocly/mock-server": "0.5.6",
+        "@redocly/openapi-docs": "3.18.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.126.0.tgz",
-      "integrity": "sha512-cQ6sm/vIHKVj568qh0SsnOHUjgrjNzfeR4WscX3yW+RFF4ExcDuTWIQ3yRYn0x5gBHN8XtmN6rs54bW6O1cBnQ==",
+      "version": "0.130.2",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.130.2.tgz",
+      "integrity": "sha512-hacj/5Ee0C5sc5uukCC43BtlXFHTvKsIYUk6sv7nATgkBo1SAbdv37sHCo/ehzxK86uKs6ZthEoclkLDPWMGQw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -2266,32 +2325,29 @@
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
         "@opentelemetry/instrumentation": "0.202.0",
-        "@opentelemetry/instrumentation-document-load": "0.47.0",
-        "@opentelemetry/instrumentation-fetch": "0.202.0",
         "@opentelemetry/instrumentation-http": "0.202.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.202.0",
         "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/sdk-trace-web": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
-        "@redocly/ajv": "8.11.3",
-        "@redocly/asyncapi-docs": "1.3.0",
-        "@redocly/config": "0.35.1",
-        "@redocly/graphql-docs": "1.3.0",
+        "@redocly/ajv": "8.17.2",
+        "@redocly/asyncapi-docs": "1.7.0",
+        "@redocly/config": "0.42.0",
+        "@redocly/graphql-docs": "1.7.0",
         "@redocly/mcp-typescript-sdk": "1.18.1",
-        "@redocly/openapi-core": "2.3.1",
-        "@redocly/openapi-docs": "3.14.0",
-        "@redocly/portal-legacy-ui": "0.9.0",
-        "@redocly/portal-plugin-mock-server": "0.11.0",
-        "@redocly/realm-asyncapi-sdk": "0.4.0",
-        "@redocly/theme": "0.58.0",
-        "@shikijs/transformers": "^1.22.2",
+        "@redocly/openapi-core": "2.15.2",
+        "@redocly/openapi-docs": "3.18.0",
+        "@redocly/portal-legacy-ui": "0.13.0",
+        "@redocly/portal-plugin-mock-server": "0.15.0",
+        "@redocly/realm-asyncapi-sdk": "0.8.1",
+        "@redocly/theme": "0.62.0",
+        "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
         "@tanstack/react-virtual": "3.13.0",
         "@wojtekmaj/react-datetimerange-picker": "6.0.0",
         "@xmldom/xmldom": "0.8.10",
-        "ajv-formats": "^2.1.1",
+        "ajv-formats": "^3.0.1",
         "anser": "^2.3.2",
         "babel-plugin-styled-components": "2.1.4",
         "chokidar": "3.6.0",
@@ -2300,37 +2356,37 @@
         "dotenv": "16.4.5",
         "drizzle-orm": "^0.44.2",
         "enquirer": "2.3.6",
-        "esbuild": "0.25.10",
+        "esbuild": "0.27.0",
         "escape-carriage": "^1.3.1",
         "fetch-to-node": "^2.1.0",
         "fflate": "0.7.4",
         "flexsearch": "0.7.43",
         "graphql": "16.9.0",
         "gray-matter": "4.0.3",
-        "hono": "4.9.7",
+        "hono": "4.11.7",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "lru-cache": "11.1.0",
         "minimatch": "7.4.2",
         "mri": "1.2.0",
-        "mustache": "4.2.0",
         "nanoid": "5.0.9",
         "node-fetch": "3.3.1",
         "nprogress": "0.2.0",
+        "openapi-sampler": "1.6.2",
         "os-browserify": "0.3.0",
         "path-browserify": "1.0.1",
         "picomatch": "2.3.1",
-        "react": "^19.1.0",
+        "react": "^19.2.4",
         "react-calendar": "5.1.0",
         "react-date-picker": "11.0.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^6.21.1",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
         "react-select": "5.10.1",
         "reactjs-popup": "2.0.6",
-        "semver": "7.6.0",
-        "shiki": "1.24.4",
+        "semver": "7.7.3",
+        "shiki": "3.21.0",
         "simple-git": "3.20.0",
         "sitemap": "7.1.1",
         "stream-http": "3.2.0",
@@ -2353,15 +2409,31 @@
         "npm": ">=10"
       },
       "peerDependencies": {
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.4.0.tgz",
-      "integrity": "sha512-QSl/czxYpWsZfKNJ1ItI242My3AOn8r2kz/TfUHjgF9ayTjCPk4swhhyXrouH4SbmYHaybz40fhC2opSjwFc6Q==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.8.1.tgz",
+      "integrity": "sha512-3gDGwb6E7iACkT6uC4C2Opl7GGxBPPl8pJtALDMR24M7/W1WsYGaOABpk/eGK4wox7GgF6OhhmJ+Qoih7zlH6w==",
       "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@redocly/realm/node_modules/@redocly/ajv": {
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.2.tgz",
+      "integrity": "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/@redocly/realm/node_modules/node-fetch": {
       "version": "3.3.1",
@@ -2382,69 +2454,211 @@
       }
     },
     "node_modules/@redocly/replay": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.17.0.tgz",
-      "integrity": "sha512-jr6rZXb1mro+6x7tJPR2aOSEFwo/4DygbMQkjbCIKnx0D8nIdnNdo6wYO3iJ7A/aysh5Vly+vj6o+daMv7a4vQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.21.0.tgz",
+      "integrity": "sha512-giMqBxFF/QK1E3j9jb0al2OItC0MmvAdygOt5erbZHm++qx2uqSaAjM4Ir4+8om8JS6bT/JSVw+aiCBPZEKr/Q==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.15.0",
         "@codemirror/lang-html": "^6.4.7",
+        "@codemirror/lang-java": "^6.0.2",
+        "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-xml": "^6.0.2",
         "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/legacy-modes": "^6.5.2",
         "@codemirror/lint": "^6.5.0",
+        "@codemirror/search": "^6.5.11",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.25.1",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@lezer/highlight": "^1.1.6",
         "@noble/hashes": "^1.8.0",
-        "@redocly/hookstate-core": "^4.2.0",
+        "@opentelemetry/api": "1.9.0",
+        "@redocly/hookstate-core": "^4.2.1",
         "@redocly/hookstate-devtools": "^4.2.0",
-        "@redocly/hookstate-localstored": "^4.0.2",
-        "@redocly/openapi-core": "2.3.1",
-        "@redocly/respect-core": "2.3.1",
+        "@redocly/openapi-core": "2.15.2",
+        "@redocly/respect-core": "2.15.2",
         "@redocly/vscode-json-languageservice": "^3.4.9",
         "@tauri-apps/api": "2.4.1",
         "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
         "@tauri-apps/plugin-fs": "2.0.0-rc.2",
+        "@tauri-apps/plugin-opener": "^2.5.2",
         "@uiw/codemirror-theme-material": "^4.21.20",
         "@uiw/react-codemirror": "^4.21.20",
         "dayjs": "^1.11.7",
-        "js-yaml": "4.1.0",
+        "drizzle-orm": "^0.36.4",
+        "fast-xml-parser": "5.3.4",
+        "idb": "^8.0.2",
+        "js-yaml": "4.1.1",
         "json-pointer": "^0.6.2",
         "json-schema-typed": "^8.0.1",
         "marked": "^4.0.15",
+        "p-queue": "^7.3.4",
         "path-browserify": "^1.0.1",
         "rc-tooltip": "^6.1.3",
         "react-arborist": "3.4.0",
-        "react-resizable-panels": "2.1.7",
+        "react-resizable-panels": "^3.0.6",
         "react-select": "5.10.1",
+        "shellwords": "^1.1.1",
         "styled-components": "^5.3.11",
         "usehooks-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.58.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^6.21.1",
+        "@redocly/theme": "0.62.0",
+        "@tanstack/react-query": "5.62.3",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
         "styled-components": "^5.3.11"
       }
     },
+    "node_modules/@redocly/replay/node_modules/drizzle-orm": {
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.36.4.tgz",
+      "integrity": "sha512-1OZY3PXD7BR00Gl61UUOFihslDldfH4NFRH2MbP54Yxi0G/PKn4HfO65JYZ7c16DeP3SpM3Aw+VXVG9j6CRSXA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=3",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/react": ">=18",
+        "@types/sql.js": "*",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "react": ">=18",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@redocly/respect-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.3.1.tgz",
-      "integrity": "sha512-4TTuPdiUlK3HcBHxyBza4bQxvpdOqlJyrcdhQgHZr21TFOzS5EJZgcXhnSLusk98sgoUeIMpUMK29VNIgz1xcg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.15.2.tgz",
+      "integrity": "sha512-Ns/ziN1XCwldvaqbcKaeRnHMyptVwzqIkyK+tQWaVnDV5gBcmFZ2J7pHHr3bc4OpuY8D37aVVN8LxuseiXgNHg==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "8.11.2",
-        "@redocly/openapi-core": "2.3.1",
+        "@redocly/ajv": "8.17.1",
+        "@redocly/openapi-core": "2.15.2",
+        "ajv": "npm:@redocly/ajv@8.17.1",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
-        "jest-matcher-utils": "^29.3.1",
         "json-pointer": "^0.6.2",
         "jsonpath-rfc9535": "1.3.0",
-        "openapi-sampler": "^1.6.1",
-        "outdent": "^0.8.0"
+        "openapi-sampler": "^1.6.2",
+        "outdent": "^0.8.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
@@ -2452,29 +2666,57 @@
       }
     },
     "node_modules/@redocly/respect-core/node_modules/@redocly/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/theme": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.58.0.tgz",
-      "integrity": "sha512-HIzs/3wWrmMXAOB2j38w0bFTiYN3m3AZFMq8wyePh0tWjvyfD/TNlzt/eUGvql1/jTAIV7hgODbX9twaIuBZog==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@redocly/respect-core/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==",
+      "license": "MIT",
       "dependencies": {
-        "@redocly/config": "0.35.1",
-        "@redocly/realm-asyncapi-sdk": "0.4.0",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@redocly/theme": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.62.0.tgz",
+      "integrity": "sha512-Kots79sn98MhQaJ/RK9G+H9xHWFqeF4TqeshJiMRwmcyaWhL/B8YNh0AfScP/dTQO7IhCqZT39lGmDwLZiDS/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/config": "0.42.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-virtual": "3.13.0",
         "@xyflow/react": "^12.8.2",
@@ -2487,7 +2729,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "4.1.1",
         "nprogress": "0.2.0",
-        "openapi-sampler": "1.6.1",
+        "openapi-sampler": "1.6.2",
         "react-calendar": "5.1.0",
         "react-date-picker": "11.0.0"
       },
@@ -2495,11 +2737,10 @@
         "@markdoc/markdoc": "0.5.2",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^6.21.1",
-        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
-        "styled-system": "^5.1.5"
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.3",
+        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
     "node_modules/@redocly/theme/node_modules/highlight-words-core": {
@@ -2566,57 +2807,73 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
-      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.21.0.tgz",
+      "integrity": "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
+        "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
-      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.21.0.tgz",
+      "integrity": "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "oniguruma-to-es": "^2.2.0"
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.21.0.tgz",
+      "integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.21.0.tgz",
+      "integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.21.0.tgz",
+      "integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.29.2.tgz",
-      "integrity": "sha512-NHQuA+gM7zGuxGWP9/Ub4vpbwrYCrho9nQCLcCPfOe3Yc7LOYwmSuhElI688oiqIXk9dlZwDiyAG9vPBTuPJMA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.21.0.tgz",
+      "integrity": "sha512-CZwvCWWIiRRiFk9/JKzdEooakAP8mQDtBOQ1TKiCaS2E1bYtyBCOkUzS8akO34/7ufICQ29oeSfkb3tT5KtrhA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.29.2",
-        "@shikijs/types": "1.29.2"
+        "@shikijs/core": "3.21.0",
+        "@shikijs/types": "3.21.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.21.0.tgz",
+      "integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
@@ -2624,12 +2881,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "license": "MIT"
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "license": "MIT"
     },
     "node_modules/@styled-system/background": {
@@ -2874,10 +3125,29 @@
         "@tauri-apps/api": "^2.0.0-rc.4"
       }
     },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener/node_modules/@tauri-apps/api": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
+    },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
@@ -3089,21 +3359,21 @@
       }
     },
     "node_modules/@uiw/codemirror-theme-material": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.2.tgz",
-      "integrity": "sha512-IDN/TN8xul6QduarhQ1khD2WFHyPUYmjxBq8Z8w249ltahFo+QT/H7DcuityTijWgnSg5CRPXHL6CQLDOumZcg==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.4.tgz",
+      "integrity": "sha512-QZwPSc5yhaOQKGT4oKABmgQDjCGwa24HK9tP7E/TauMse8/kIDyAHaocdeUamk6+93fa/Wj6rtAHeakSSGU7AQ==",
       "license": "MIT",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.25.2"
+        "@uiw/codemirror-themes": "4.25.4"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/@uiw/codemirror-theme-material/node_modules/@uiw/codemirror-themes": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.2.tgz",
-      "integrity": "sha512-WFYxW3OlCkMomXQBlQdGj1JZ011UNCa7xYdmgYqywVc4E8f5VgIzRwCZSBNVjpWGGDBOjc+Z6F65l7gttP16pg==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.4.tgz",
+      "integrity": "sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -3249,12 +3519,12 @@
       }
     },
     "node_modules/@xyflow/react": {
-      "version": "12.8.6",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.8.6.tgz",
-      "integrity": "sha512-SksAm2m4ySupjChphMmzvm55djtgMDPr+eovPDdTnyGvShf73cvydfoBfWDFllooIQ4IaiUL5yfxHRwU0c37EA==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.0.tgz",
+      "integrity": "sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==",
       "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.70",
+        "@xyflow/system": "0.0.74",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
@@ -3264,9 +3534,9 @@
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.70.tgz",
-      "integrity": "sha512-PpC//u9zxdjj0tfTSmZrg3+sRbTz6kop/Amky44U2Dl51sxzDTIUfXMwETOYpmr2dqICWXBIJwXL2a9QWtX2XA==",
+      "version": "0.0.74",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.74.tgz",
+      "integrity": "sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -3314,9 +3584,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "name": "@redocly/ajv",
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.2.tgz",
+      "integrity": "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3330,9 +3601,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3410,16 +3681,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -3429,16 +3690,6 @@
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/asynckit": {
@@ -3462,38 +3713,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3544,22 +3778,12 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.14.tgz",
-      "integrity": "sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ==",
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/better-ajv-errors": {
@@ -3660,19 +3884,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-request": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg==",
-      "dev": true,
-      "engines": [
-        "node"
-      ]
-    },
     "node_modules/browserslist": {
-      "version": "4.26.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
-      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3689,11 +3904,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.9",
-        "caniuse-lite": "^1.0.30001746",
-        "electron-to-chromium": "^1.5.227",
-        "node-releases": "^2.0.21",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3779,16 +3994,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
@@ -3799,9 +4004,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001749",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
-      "integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3817,13 +4022,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -3934,16 +4132,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/codemirror": {
@@ -4085,23 +4273,6 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha512-FUpKc+1FNBsHUr9IsfSGCovr8VuGOiiuzlgCyppKBjJi2jYTOFLN3oiiNRMIvYqbFzF38mqKj4BgcevzU5/kIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssom": "0.3.x"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -4213,19 +4384,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -4236,9 +4394,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.18",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
-      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4256,16 +4414,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/deepmerge": {
@@ -4359,15 +4507,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dnd-core": {
@@ -4606,17 +4745,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/ed25519": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/ed25519/-/ed25519-0.0.4.tgz",
@@ -4630,21 +4758,15 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.233",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.233.tgz",
-      "integrity": "sha512-iUdTQSf7EFXsDdQsp8MwJz5SVk4APEFqXU/S47OtQ0YLqacSwPXdZ5vRlMX3neb07Cy2vgioNuRnWUXFwuslkg==",
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex-xs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/enquirer": {
@@ -4732,9 +4854,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
-      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4744,32 +4866,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.10",
-        "@esbuild/android-arm": "0.25.10",
-        "@esbuild/android-arm64": "0.25.10",
-        "@esbuild/android-x64": "0.25.10",
-        "@esbuild/darwin-arm64": "0.25.10",
-        "@esbuild/darwin-x64": "0.25.10",
-        "@esbuild/freebsd-arm64": "0.25.10",
-        "@esbuild/freebsd-x64": "0.25.10",
-        "@esbuild/linux-arm": "0.25.10",
-        "@esbuild/linux-arm64": "0.25.10",
-        "@esbuild/linux-ia32": "0.25.10",
-        "@esbuild/linux-loong64": "0.25.10",
-        "@esbuild/linux-mips64el": "0.25.10",
-        "@esbuild/linux-ppc64": "0.25.10",
-        "@esbuild/linux-riscv64": "0.25.10",
-        "@esbuild/linux-s390x": "0.25.10",
-        "@esbuild/linux-x64": "0.25.10",
-        "@esbuild/netbsd-arm64": "0.25.10",
-        "@esbuild/netbsd-x64": "0.25.10",
-        "@esbuild/openbsd-arm64": "0.25.10",
-        "@esbuild/openbsd-x64": "0.25.10",
-        "@esbuild/openharmony-arm64": "0.25.10",
-        "@esbuild/sunos-x64": "0.25.10",
-        "@esbuild/win32-arm64": "0.25.10",
-        "@esbuild/win32-ia32": "0.25.10",
-        "@esbuild/win32-x64": "0.25.10"
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
       }
     },
     "node_modules/escalade": {
@@ -4818,13 +4940,6 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -4837,27 +4952,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -4883,9 +4981,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "funding": [
         {
           "type": "github",
@@ -4894,7 +4992,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4966,20 +5064,6 @@
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
     },
-    "node_modules/find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/five-bells-condition": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/five-bells-condition/-/five-bells-condition-5.0.1.tgz",
@@ -5039,31 +5123,6 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
       "license": "MIT"
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -5188,16 +5247,6 @@
         "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -5230,13 +5279,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/graphql": {
       "version": "16.9.0",
@@ -5272,9 +5314,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5283,55 +5325,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5452,20 +5445,13 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.9.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.7.tgz",
-      "integrity": "sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/hotkeys-js": {
       "version": "3.10.1",
@@ -5502,148 +5488,6 @@
         "entities": "^4.4.0"
       }
     },
-    "node_modules/htmltojsx": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/htmltojsx/-/htmltojsx-0.3.0.tgz",
-      "integrity": "sha512-ivWTGWn15hph8NIYRRdU1/KdG5qHXe1FW4Q1w7IcJ8zPK+9CSYnEY9yEiaBm8tBhhkVC8Vs+SmHLcCvsWhyqEg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "jsdom-no-contextify": "~3.1.0",
-        "react": "~15.4.1",
-        "react-dom": "~15.4.1",
-        "yargs": "~4.6.0"
-      },
-      "bin": {
-        "htmltojsx": "src/cli.js"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/htmltojsx/node_modules/yargs": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.6.0.tgz",
-      "integrity": "sha512-KmjJbWBkYiSRUChcOSa4rtBxDXf0j4ISz+tpeNa4LKIBllgKnkemJ3x4yo4Yydp3wPU4/xJTaKTLLZ8V7zhI7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "pkg-conf": "^1.1.2",
-        "read-pkg-up": "^1.0.1",
-        "require-main-filename": "^1.0.1",
-        "string-width": "^1.0.1",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.0"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
-      }
-    },
-    "node_modules/htmltojsx/node_modules/yargs-parser/node_modules/camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -5658,22 +5502,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/http2-client": {
@@ -5721,6 +5549,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -5760,16 +5594,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -5950,76 +5774,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jotai": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.15.0.tgz",
-      "integrity": "sha512-nbp/6jN2Ftxgw0VwoVnOg0m5qYM1rVcfvij+MZx99Z5IK13eGve9FJoCwGv+17JvVthTjhSmNtT5e1coJnr6aw==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.17.1.tgz",
+      "integrity": "sha512-TFNZZDa/0ewCLQyRC/Sq9crtixNj/Xdf/wmj9631xxMuKToVJZDbqcHIYN0OboH+7kh6P6tpIK7uKWClj86PKw==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -6043,6 +5807,18 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jotai-family": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jotai-family/-/jotai-family-1.0.1.tgz",
+      "integrity": "sha512-Zb/79GNDhC/z82R+6qTTpeKW4l4H6ZCApfF5W8G4SH37E4mhbysU7r8DkP0KX94hWvjB/6lt/97nSr3wB+64Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "jotai": ">=2.9.0"
       }
     },
     "node_modules/jquery": {
@@ -6075,139 +5851,15 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsdom-no-contextify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom-no-contextify/-/jsdom-no-contextify-3.1.0.tgz",
-      "integrity": "sha512-djD5JXh841BOTx27kxYJghei3WWIdcJnv7IWfHrj9JnPjsCVaJLfChopLiAi/s+MIBhp0y7equb/BeSgj26IoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browser-request": ">= 0.3.1 < 0.4.0",
-        "cssom": ">= 0.3.0 < 0.4.0",
-        "cssstyle": ">= 0.2.21 < 0.3.0",
-        "htmlparser2": ">= 3.7.3 < 4.0.0",
-        "nwmatcher": ">= 1.3.4 < 2.0.0",
-        "parse5": ">= 1.3.1 < 2.0.0",
-        "request": ">= 2.44.0 < 3.0.0",
-        "xml-name-validator": "^1.0.0",
-        "xmlhttprequest": ">= 1.6.0 < 2.0.0"
-      }
-    },
-    "node_modules/jsdom-no-contextify/node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/jsdom-no-contextify/node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/jsdom-no-contextify/node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/jsdom-no-contextify/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/jsdom-no-contextify/node_modules/domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/jsdom-no-contextify/node_modules/domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/jsdom-no-contextify/node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/jsdom-no-contextify/node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/jsdom-no-contextify/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/jsesc": {
@@ -6237,13 +5889,6 @@
         "foreach": "^2.0.4"
       }
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-to-ts": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
@@ -6265,17 +5910,10 @@
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
-      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6313,22 +5951,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -6346,19 +5968,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6419,47 +6028,10 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
-    "node_modules/load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/load-json-file/node_modules/parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -6582,9 +6154,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -6806,15 +6378,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
-    },
     "node_modules/nan": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
@@ -6900,33 +6463,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
-      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "license": "MIT"
-    },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6941,23 +6481,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-      "license": "MIT"
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/oas-kit-common": {
@@ -7030,16 +6553,6 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7049,21 +6562,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
     "node_modules/oniguruma-to-es": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
-      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.1.1",
-        "regex-recursion": "^5.1.1"
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.6.1.tgz",
-      "integrity": "sha512-s1cIatOqrrhSj2tmJ4abFYZQK6l5v+V4toO5q1Pa0DyN8mtyqy2I+Qrj5W9vOELEtybIMQs/TBZGVO/DtTFK8w==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.6.2.tgz",
+      "integrity": "sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
@@ -7071,24 +6590,41 @@
         "json-pointer": "0.6.2"
       }
     },
+    "node_modules/openapi-sampler/node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/openapi-sampler/node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "license": "MIT"
-    },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/outdent": {
       "version": "0.8.0",
@@ -7103,6 +6639,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pako": {
@@ -7141,30 +6705,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha512-w2jx/0tJzvgKwZa58sj2vAYq/S/K1QJfIB3cWYea/Iu1scFPDQQ3IQiVZTHWtRBwAjv2Yd7S/xeZf3XqLDb3bA==",
-      "dev": true
-    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
-    },
-    "node_modules/path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -7180,13 +6725,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7204,55 +6742,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pkg-conf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-      "integrity": "sha512-9hHgE5+Xai/ChrnahNP8Ke0VNF/s41IZIB/d24eMHEaRamdPg+wwlRm2lTb5wMvE8eTIKrYZsrxfuOwt3dpsIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "load-json-file": "^1.1.0",
-        "object-assign": "^4.0.1",
-        "symbol": "^0.2.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pluralize": {
@@ -7290,38 +6779,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
-    },
-    "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/process-nextick-args": {
@@ -7393,29 +6850,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/psl/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -7423,16 +6857,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/raw-body": {
@@ -7751,16 +7175,16 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/react-resizable-panels": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.7.tgz",
-      "integrity": "sha512-JtT6gI+nURzhMYQYsx8DKkx6bSoOGFp7A3CwMrOb8y5jFHFyqwo9m68UhmXRw57fRVJksFn1TSlm3ywEQ9vMgA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.6.tgz",
+      "integrity": "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
@@ -7912,50 +7336,6 @@
         "react-dom": ">=16"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -8012,21 +7392,20 @@
       }
     },
     "node_modules/regex": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
-      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
       }
     },
     "node_modules/regex-recursion": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
-      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
       "license": "MIT",
       "dependencies": {
-        "regex": "^5.1.1",
         "regex-utilities": "^2.3.0"
       }
     },
@@ -8035,39 +7414,6 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -8100,13 +7446,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -8255,37 +7594,16 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/serialize-query-params": {
       "version": "2.0.2",
@@ -8328,80 +7646,26 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
-    "node_modules/shiki": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.4.tgz",
-      "integrity": "sha512-aVGSFAOAr1v26Hh/+GBIsRVDWJ583XYV7CuNURKRWh9gpGv4OdbisZGq96B9arMYTZhTQkmRF5BrShOSTvNqhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "1.24.4",
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/core": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.4.tgz",
-      "integrity": "sha512-jjLsld+xEEGYlxAXDyGwWsKJ1sw5Pc1pnp4ai2ORpjx2UX08YYTC0NNqQYO1PaghYaR+PvgMOGuvzw2he9sk0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/engine-javascript": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.4.tgz",
-      "integrity": "sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "oniguruma-to-es": "0.8.1"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.4.tgz",
-      "integrity": "sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/types": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.4.tgz",
-      "integrity": "sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/vscode-textmate": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
-      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+    "node_modules/shellwords": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-1.1.1.tgz",
+      "integrity": "sha512-LzESUkEHUuFbjaE7j8uyIjKvySfSFvCF6G4WOygjwSwQj3VuX8hr+v4M252B3twEct6XTWrrNSFu74mTlx4uAQ==",
       "license": "MIT"
     },
-    "node_modules/shiki/node_modules/oniguruma-to-es": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.8.1.tgz",
-      "integrity": "sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==",
+    "node_modules/shiki": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.21.0.tgz",
+      "integrity": "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.0.2",
-        "regex-recursion": "^5.0.0"
+        "@shikijs/core": "3.21.0",
+        "@shikijs/engine-javascript": "3.21.0",
+        "@shikijs/engine-oniguruma": "3.21.0",
+        "@shikijs/langs": "3.21.0",
+        "@shikijs/themes": "3.21.0",
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/should": {
@@ -8538,73 +7802,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "dev": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -8704,19 +7906,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
@@ -8727,9 +7916,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
           "type": "github",
@@ -8900,13 +8089,6 @@
         }
       }
     },
-    "node_modules/symbol": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-      "integrity": "sha512-IUW+ek7apEaW5bFhS6WpYoNtVpNTlNoqB/PH7YiMWQTxSPeXCzG4PILVakwXivJt3ZXWeO1fIJnUd/L9A/VeGA==",
-      "dev": true,
-      "license": "MPLv2.0"
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8932,20 +8114,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/tr46": {
@@ -9031,19 +8199,6 @@
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "license": "MIT"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -9097,9 +8252,9 @@
       "license": "MIT"
     },
     "node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -9136,9 +8291,9 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -9151,9 +8306,9 @@
       }
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -9174,9 +8329,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -9210,16 +8365,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/wojtekmaj/update-input-width?sponsor=1"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/uri-js-replace": {
@@ -9314,54 +8459,10 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "license": "MIT"
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {
@@ -9379,9 +8480,9 @@
       }
     },
     "node_modules/vfile-message": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -9457,9 +8558,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -9475,19 +8576,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/workerpool": {
@@ -9555,23 +8643,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz",
-      "integrity": "sha512-XDmXffxxQs/+0VLW9NB2oSIbSoSINj6dQdhegY3kEM81LOoLr6NfsFE9RR59qrwsKEHaZLxa1MOSahFA0CE9Ow==",
-      "dev": true,
-      "license": "WTFPL"
-    },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/xpath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.130.2",
+        "@redocly/realm": "0.130.4",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -1297,9 +1297,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
-      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
+      "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -2047,17 +2047,17 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.7.0.tgz",
-      "integrity": "sha512-AHGMZ32iZ+5iIHGmhHWev2QLvypfoFMQU6J+7rpNlAhE7ahoQ/BBmdeH3/ee8qxPnCGtWhjTfB7qIGaUWHDjGQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.7.2.tgz",
+      "integrity": "sha512-6kbZHYDi8nnvkbvP4GSGttdmCRniPc1snsSSH+/XonqObHrul0fX6EWFEPPKHGXoLbsTQfUA9WbtpF3uVrUbtg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.42.0",
-        "@redocly/openapi-docs": "3.18.0",
-        "@redocly/theme": "0.62.0",
+        "@redocly/openapi-docs": "3.18.2",
+        "@redocly/theme": "0.62.1",
         "jotai": "^2.11.1",
-        "openapi-sampler": "1.6.2",
+        "openapi-sampler": "1.7.0",
         "react-router-dom": "^6.30.3",
         "styled-components": "5.3.11",
         "web-vitals": "3.3.1"
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.7.0.tgz",
-      "integrity": "sha512-UdAuWL77MtzakUXlrWhMimX1U9hzobQyejPGk/3crYLOHFfBvAhvfG1MgSMeqP+Q3C8QB+2Tp46be3EPduP5cA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.7.1.tgz",
+      "integrity": "sha512-lHiGNVM3wq+k4FokFTUMHSofvv8VH6RXH1bqz6BAzIILaW5kFQsOxkzU738Ij1Z/ZyWJSSOJIsJJoepaZNFAlA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.42.0",
@@ -2087,7 +2087,7 @@
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.62.0",
+        "@redocly/theme": "0.62.1",
         "graphql": "16.9.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2133,18 +2133,18 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.5.6.tgz",
-      "integrity": "sha512-FTPunfO7CLCGDRYmGyU09hDYii2cLFaVWmFUXqwqtnHwRIAL8HnJEO5PLmO3gFnqo2wClxCMdqTL89YO1GRI+g==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.5.11.tgz",
+      "integrity": "sha512-6UMuOXviugFbg+5gp165JsvU7I94UjrJNGEikwN2jRdgnjOvl7Y6djwREKEmLtc80Z5aqAxNBlbmPM0FYbTCzg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/ajv": "8.17.2",
-        "@redocly/openapi-core": "2.15.2",
-        "ajv": "8.17.1",
+        "@redocly/ajv": "8.17.4",
+        "@redocly/openapi-core": "2.19.0",
+        "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
-        "fast-xml-parser": "5.3.4",
+        "fast-xml-parser": "5.3.6",
         "js-yaml": "4.1.1",
-        "openapi-sampler": "1.6.2",
+        "openapi-sampler": "1.7.0",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
         "ts-node": "10.9.2",
@@ -2152,9 +2152,57 @@
       }
     },
     "node_modules/@redocly/mock-server/node_modules/@redocly/ajv": {
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.2.tgz",
-      "integrity": "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g==",
+      "version": "8.17.4",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
+      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/config": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.43.0.tgz",
+      "integrity": "sha512-AbyFKRHKJ2VBmh9nO2lrG9tO2Gu/Lmnfdj4Uwoh7h/a7jWr1104t4fBgQZs/NwgGBAOkGmyQYAvardwyBeRGZA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "2.7.2"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.19.0.tgz",
+      "integrity": "sha512-7E/zxHrns8gJkFYLiYWKhpKZUCQo3r255uLbXKllglu3843BDmbiD0UTcwp9n7a+l2gmmvNjlW44vwZaR0NQAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "^8.17.4",
+        "@redocly/config": "^0.43.0",
+        "ajv": "npm:@redocly/ajv@8.17.4",
+        "ajv-formats": "^3.0.1",
+        "colorette": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "js-yaml": "^4.1.0",
+        "picomatch": "^4.0.3",
+        "pluralize": "^8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.17.4",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
+      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2168,9 +2216,9 @@
       }
     },
     "node_modules/@redocly/mock-server/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2181,6 +2229,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/mock-server/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/mock-server/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@redocly/openapi-core": {
@@ -2249,23 +2315,23 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.18.0.tgz",
-      "integrity": "sha512-2v7cv2I2ecdE/bKq41R2XGDeZUjtTWjbtavDXB2CRQjYtyvdB2xTms413pK/8Orc21BAqzDnOd9w2H1tjPc05Q==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.18.2.tgz",
+      "integrity": "sha512-w99WIlXYudMAvMwaN/+TII0RYpr8TSYPojJiCAERX6xS8G0vx3UZPY6Gy2FxUv3/yzNb5VVrS6KpNGxMfg9cqg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.42.0",
         "@redocly/openapi-core": "2.15.2",
-        "@redocly/replay": "0.21.0",
+        "@redocly/replay": "0.21.2",
         "deepmerge": "^4.2.2",
         "dompurify": "3.2.7",
         "fast-deep-equal": "^3.1.3",
-        "fast-xml-parser": "5.3.4",
+        "fast-xml-parser": "5.3.6",
         "jotai": "^2.12.5",
         "jotai-family": "^1.0.1",
         "json-pointer": "^0.6.2",
-        "openapi-sampler": "1.6.2",
+        "openapi-sampler": "1.7.0",
         "react-router-dom": "^6.30.3",
         "slugify": "^1.4.4",
         "stringify-object": "^3.3.0",
@@ -2300,20 +2366,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.15.0.tgz",
-      "integrity": "sha512-ok5DGdk9IrQA+oKBE9Usrvh7qwkdhbiV2ApELowOeRXQU+jzQbZk1lp5ZJltWyiHkMZb47s7lDA809Rv6bM8JQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.15.2.tgz",
+      "integrity": "sha512-ghDqS6O+IZoUnNaCCdFrxwM6l4fxss3wHPJdfdzZNfIU/tEbohNxRf+RYV9AU7+AaeZrQI23ybXs84Gjh5g1/g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.42.0",
-        "@redocly/mock-server": "0.5.6",
-        "@redocly/openapi-docs": "3.18.0"
+        "@redocly/mock-server": "0.5.11",
+        "@redocly/openapi-docs": "3.18.2"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.130.2",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.130.2.tgz",
-      "integrity": "sha512-hacj/5Ee0C5sc5uukCC43BtlXFHTvKsIYUk6sv7nATgkBo1SAbdv37sHCo/ehzxK86uKs6ZthEoclkLDPWMGQw==",
+      "version": "0.130.4",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.130.4.tgz",
+      "integrity": "sha512-jNBzyJPymHvLMvWN/YX3f88XlZuKEIXQngffqJz5WE37N/sKn1Wl4Wuda2wr13NGYWHA42GebEiN0vrrmHtBng==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -2331,16 +2397,16 @@
         "@opentelemetry/sdk-trace-web": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/ajv": "8.17.2",
-        "@redocly/asyncapi-docs": "1.7.0",
+        "@redocly/asyncapi-docs": "1.7.2",
         "@redocly/config": "0.42.0",
-        "@redocly/graphql-docs": "1.7.0",
+        "@redocly/graphql-docs": "1.7.1",
         "@redocly/mcp-typescript-sdk": "1.18.1",
         "@redocly/openapi-core": "2.15.2",
-        "@redocly/openapi-docs": "3.18.0",
+        "@redocly/openapi-docs": "3.18.2",
         "@redocly/portal-legacy-ui": "0.13.0",
-        "@redocly/portal-plugin-mock-server": "0.15.0",
+        "@redocly/portal-plugin-mock-server": "0.15.2",
         "@redocly/realm-asyncapi-sdk": "0.8.1",
-        "@redocly/theme": "0.62.0",
+        "@redocly/theme": "0.62.1",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -2374,7 +2440,7 @@
         "nanoid": "5.0.9",
         "node-fetch": "3.3.1",
         "nprogress": "0.2.0",
-        "openapi-sampler": "1.6.2",
+        "openapi-sampler": "1.7.0",
         "os-browserify": "0.3.0",
         "path-browserify": "1.0.1",
         "picomatch": "2.3.1",
@@ -2454,9 +2520,9 @@
       }
     },
     "node_modules/@redocly/replay": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.21.0.tgz",
-      "integrity": "sha512-giMqBxFF/QK1E3j9jb0al2OItC0MmvAdygOt5erbZHm++qx2uqSaAjM4Ir4+8om8JS6bT/JSVw+aiCBPZEKr/Q==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.21.2.tgz",
+      "integrity": "sha512-1tYeNOqjwR71sD6R8RwTCItd0XSN8J00neU8wU3ERY3yZNW1DYekZIlvOoOOfyNHNI7jpiWV5RcDRpnVqfAQow==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.15.0",
         "@codemirror/lang-html": "^6.4.7",
@@ -2491,7 +2557,7 @@
         "@uiw/react-codemirror": "^4.21.20",
         "dayjs": "^1.11.7",
         "drizzle-orm": "^0.36.4",
-        "fast-xml-parser": "5.3.4",
+        "fast-xml-parser": "5.3.6",
         "idb": "^8.0.2",
         "js-yaml": "4.1.1",
         "json-pointer": "^0.6.2",
@@ -2508,7 +2574,7 @@
         "usehooks-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.62.0",
+        "@redocly/theme": "0.62.1",
         "@tanstack/react-query": "5.62.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2711,9 +2777,9 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.62.0.tgz",
-      "integrity": "sha512-Kots79sn98MhQaJ/RK9G+H9xHWFqeF4TqeshJiMRwmcyaWhL/B8YNh0AfScP/dTQO7IhCqZT39lGmDwLZiDS/w==",
+      "version": "0.62.1",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.62.1.tgz",
+      "integrity": "sha512-1iwcf+/wtfbey5Gfw67s5VtxZFudTg6ZaaY8ViV5Jgqq2PWk+qeuMYzlgeiKACjvx4Uk78hgx8B3cUSfMlh1hQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/config": "0.42.0",
@@ -2729,7 +2795,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "4.1.1",
         "nprogress": "0.2.0",
-        "openapi-sampler": "1.6.2",
+        "openapi-sampler": "1.7.0",
         "react-calendar": "5.1.0",
         "react-date-picker": "11.0.0"
       },
@@ -3519,12 +3585,12 @@
       }
     },
     "node_modules/@xyflow/react": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.0.tgz",
-      "integrity": "sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==",
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
+      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
       "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.74",
+        "@xyflow/system": "0.0.75",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
@@ -3534,9 +3600,9 @@
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.74",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.74.tgz",
-      "integrity": "sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==",
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
+      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -3572,9 +3638,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -4794,9 +4860,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4981,9 +5047,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -4992,7 +5058,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5781,9 +5847,9 @@
       "license": "MIT"
     },
     "node_modules/jotai": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.17.1.tgz",
-      "integrity": "sha512-TFNZZDa/0ewCLQyRC/Sq9crtixNj/Xdf/wmj9631xxMuKToVJZDbqcHIYN0OboH+7kh6P6tpIK7uKWClj86PKw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.18.0.tgz",
+      "integrity": "sha512-XI38kGWAvtxAZ+cwHcTgJsd+kJOJGf3OfL4XYaXWZMZ7IIY8e53abpIHvtVn1eAgJ5dlgwlGFnP4psrZ/vZbtA==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -6580,45 +6646,15 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.6.2.tgz",
-      "integrity": "sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.0.tgz",
+      "integrity": "sha512-fWq32F5vqGpgRJYIarC/9Y1wC9tKnRDcCOjsDJ7MIcSv2HsE7kNifcXIZ8FVtNStBUWxYrEk/MKqVF0SwZ5gog==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^5.3.4",
         "json-pointer": "0.6.2"
       }
-    },
-    "node_modules/openapi-sampler/node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.1.1"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/openapi-sampler/node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.126.0",
+    "@redocly/realm": "0.130.2",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "bootstrap": "^4.6.2",
-    "htmltojsx": "^0.3.0",
     "sass": "1.26.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.130.2",
+    "@redocly/realm": "0.130.4",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,4668 +1,1575 @@
 /resources/contribute-documentation/tutorial-structure/:
     to: /resources/contribute-documentation/tutorial-guidelines/
-    type: 301
 /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/use-an-escrow-as-a-smart-contract:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditional-escrow
-    type: 301
 /docs/references/protocol/transactions/pseudo-transaction-types/pseudo-transaction-types/:
     to: /docs/references/protocol/transactions/pseudo-transaction-types/
-    type: 301
 /docs/concepts/tokens/transfer-fees/:
     to: /docs/concepts/tokens/fungible-tokens/transfer-fees/
-    type: 301
 /docs/infrastructure/configuration/data-retention/configure-history-sharding/:
     to: /docs/infrastructure/configuration/data-retention/
-    type: 301
 /docs/infrastructure/configuration/data-retention/history-sharding/:
     to: /docs/infrastructure/configuration/data-retention/
-    type: 301
 /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/node_to_shard/:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/crawl_shards/:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/download_shard/:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 /docs/infrastructure/installation/rippled-1-3-migration-instructions/:
     to: /docs/infrastructure/installation/
-    type: 301
 /docs/infrastructure/installation/update-rippled-manually-on-centos-rhel/:
     to: /docs/infrastructure/installation/update-rippled-manually-on-rhel/
-    type: 301
 /docs/infrastructure/installation/install-rippled-on-centos-rhel-with-yum/:
     to: /docs/infrastructure/installation/install-rippled-on-rhel/
-    type: 301
 /docs/concepts/xrpl-sidechains/price-oracles/:
     to: /docs/concepts/decentralized-storage/price-oracles/
-    type: 301
 /docs/concepts/accounts/decentralized-identifiers/:
     to: /docs/concepts/decentralized-storage/decentralized-identifiers/
-    type: 301
 /docs/tutorials/javascript/trade-on-ledger/:
     to: /docs/tutorials/javascript/amm/
-    type: 301
 /docs/tutorials/javascript/trade-on-ledger/earn-passive-income-as-a-liquidity-provider:
     to: /docs/tutorials/javascript/amm/add-assets-to-amm
-    type: 301
 /docs/tutorials/javascript/trade-on-ledger/use-amm-auction-slot-for-lower-fees:
     to: /docs/tutorials/javascript/amm/trade-with-auction-slot
-    type: 301
 /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-recipient:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks
-    type: 301
 /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-sender:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks
-    type: 301
 /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/use-checks:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks
-    type: 301
 /docs/references/http-websocket-apis/public-api-methods/clio-server:
     to: /docs/references/http-websocket-apis/public-api-methods/clio-methods
-    type: 301
 /docs/references/protocol/transactions/transaction-results/transaction-results:
     to: /docs/references/protocol/transactions/transaction-results
-    type: 301
 xrp-ledger-rpc-tool.html:
     to: /resources/dev-tools/rpc-tool
-    type: 301
 xrp-ledger-toml-checker.html:
     to: /resources/dev-tools/xrp-ledger-toml-checker
-    type: 301
 domain-verification-checker.html:
     to: /resources/dev-tools/domain-verification-checker
-    type: 301
 websocket-api-tool.html:
     to: /resources/dev-tools/websocket-api-tool
-    type: 301
 xrp-testnet-faucet.html:
     to: /resources/dev-tools/xrp-faucets
-    type: 301
 xrp-test-net-faucet.html:
     to: /resources/dev-tools/xrp-faucets
-    type: 301
 /resources/xrp-faucets:
     to: /resources/dev-tools/xrp-faucets
-    type: 301
 tx-sender.html:
     to: /resources/dev-tools/tx-sender
-    type: 301
 index.html:
     to: /
-    type: 301
 uses.html:
     to: /about/uses
-    type: 301
 docs.html:
     to: /docs/
-    type: 301
 tutorials.html:
     to: /docs/tutorials/
-    type: 301
 xrp-ledger-overview.html:
     to: /about/
-    type: 301
 xrp-overview.html:
     to: /about/xrp
-    type: 301
 overview.html:
     to: /about/
-    type: 301
 history.html:
     to: /about/history
-    type: 301
 impact.html:
     to: /about/impact
-    type: 301
 carbon-calculator.html:
     to: /about/impact
-    type: 301
 contribute.html:
     to: /community
-    type: 301
 events.html:
     to: /community/events
-    type: 301
 ambassadors.html:
     to: /community/ambassadors
-    type: 301
 developer-funding.html:
     to: /community/developer-funding
-    type: 301
 code-samples.html:
     to: /resources/code-samples
-    type: 301
 dev-tools.html:
     to: /resources/dev-tools/
-    type: 301
 dev-tools-dev-tools.html:
     to: /resources/dev-tools/
-    type: 301
 validator-domain-verifier.html:
     to: /resources/dev-tools/domain-verifier/
-    type: 301
 docs-index.html:
     to: /docs/
-    type: 301
 explore.html:
     to: /about/
-    type: 301
 wallet.html:
     to: /about/xrp
-    type: 301
 exchanges.html:
     to: /about/xrp
-    type: 301
 businesses.html:
     to: /about/uses
-    type: 301
 ripple-txt-validator.html:
     to: /resources/dev-tools/xrp-ledger-toml-checker
-    type: 301
 production-readiness.html:
     to: /docs/tutorials
-    type: 301
 get-started.html:
     to: /docs/tutorials
-    type: 301
 run-rippled-as-a-wallet-server.html:
     to: /docs/infrastructure/configuration/server-modes/run-rippled-as-a-stock-server
-    type: 301
 faq:
     to: /about/faq
-    type: 301
 faq.html:
     to: /about/faq
-    type: 301
 privacy-policy.html:
     to: /about/privacy-policy
-    type: 301
 privacy-policy/:
     to: /about/privacy-policy
-    type: 301
 technical-faq.html:
     to: /about/faq
-    type: 301
 introduction.html:
     to: /docs/introduction/
-    type: 301
 what-is-the-xrp-ledger.html:
     to: /docs/introduction/what-is-the-xrp-ledger
-    type: 301
 what-is-xrp.html:
     to: /docs/introduction/what-is-xrp
-    type: 301
 xrp.html:
     to: /docs/introduction/what-is-xrp
-    type: 301
 crypto-wallets.html:
     to: /docs/introduction/crypto-wallets
-    type: 301
 txn-and-requests.html:
     to: /docs/introduction/transactions-and-requests
-    type: 301
 software-ecosystem.html:
     to: /docs/introduction/software-ecosystem
-    type: 301
 use-cases.html:
     to: /docs/use-cases/
-    type: 301
 payments-uc.html:
     to: /docs/use-cases/payments/
-    type: 301
 peer-to-peer-payments-uc.html:
     to: /docs/use-cases/payments/peer-to-peer-payments-uc
-    type: 301
 restricting-deposits-uc.html:
     to: /docs/use-cases/payments/restricting-deposits-uc
-    type: 301
 escrow-uc.html:
     to: /docs/use-cases/payments/smart-contracts-uc
-    type: 301
 tokenization.html:
     to: /docs/use-cases/tokenization/
-    type: 301
 stablecoin-issuer.html:
     to: /docs/use-cases/tokenization/stablecoin-issuer
-    type: 301
 nft-mkt-overview.html:
     to: /docs/use-cases/tokenization/nft-mkt-overview
-    type: 301
 nftoken-marketplace.html:
     to: /docs/use-cases/tokenization/nftoken-marketplace
-    type: 301
 authorized-minter.html:
     to: /docs/use-cases/tokenization/authorized-minter
-    type: 301
 digital-artist.html:
     to: /docs/use-cases/tokenization/digital-artist
-    type: 301
 defi-uc.html:
     to: /docs/use-cases/defi/
-    type: 301
 algorithmic-trading.html:
     to: /docs/use-cases/defi/algorithmic-trading
-    type: 301
 list-xrp-as-an-exchange.html:
     to: /docs/use-cases/defi/list-xrp-as-an-exchange
-    type: 301
 concepts.html:
     to: /docs/concepts/
-    type: 301
 networks-and-servers.html:
     to: /docs/concepts/networks-and-servers/
-    type: 301
 xrpl-servers.html:
     to: /docs/concepts/networks-and-servers/
-    type: 301
 rippled-server-modes.html:
     to: /docs/concepts/networks-and-servers/rippled-server-modes
-    type: 301
 clustering.html:
     to: /docs/concepts/networks-and-servers/clustering
-    type: 301
 ledger-history.html:
     to: /docs/concepts/networks-and-servers/ledger-history
-    type: 301
 peer-protocol.html:
     to: /docs/concepts/networks-and-servers/peer-protocol
-    type: 301
 transaction-censorship-detection.html:
     to: /docs/concepts/networks-and-servers/transaction-censorship-detection
-    type: 301
 parallel-networks.html:
     to: /docs/concepts/networks-and-servers/parallel-networks
-    type: 301
 amendments.html:
     to: /docs/concepts/networks-and-servers/amendments
-    type: 301
 the-clio-server.html:
     to: /docs/concepts/networks-and-servers/the-clio-server
-    type: 301
 consensus.html:
     to: /docs/concepts/consensus-protocol/
-    type: 301
 consensus-structure.html:
     to: /docs/concepts/consensus-protocol/consensus-structure
-    type: 301
 consensus-principles-and-rules.html:
     to: /docs/concepts/consensus-protocol/consensus-principles-and-rules
-    type: 301
 consensus-protections.html:
     to: /docs/concepts/consensus-protocol/consensus-protections
-    type: 301
 invariant-checking.html:
     to: /docs/concepts/consensus-protocol/invariant-checking
-    type: 301
 fee-voting.html:
     to: /docs/concepts/consensus-protocol/fee-voting
-    type: 301
 negative-unl.html:
     to: /docs/concepts/consensus-protocol/negative-unl
-    type: 301
 consensus-research.html:
     to: /docs/concepts/consensus-protocol/consensus-research
-    type: 301
 ledgers.html:
     to: /docs/concepts/ledgers/
-    type: 301
 ledger-structure.html:
     to: /docs/concepts/ledgers/ledger-structure
-    type: 301
 open-closed-validated-ledgers.html:
     to: /docs/concepts/ledgers/open-closed-validated-ledgers
-    type: 301
 ledger-close-times.html:
     to: /docs/concepts/ledgers/ledger-close-times
-    type: 301
 transactions.html:
     to: /docs/concepts/transactions/
-    type: 301
 fees.html:
     to: /docs/concepts/transactions/fees
-    type: 301
 reliable-transaction-submission.html:
     to: /docs/concepts/transactions/reliable-transaction-submission
-    type: 301
 secure-signing.html:
     to: /docs/concepts/transactions/secure-signing
-    type: 301
 source-and-destination-tags.html:
     to: /docs/concepts/transactions/source-and-destination-tags
-    type: 301
 transaction-cost.html:
     to: /docs/concepts/transactions/transaction-cost
-    type: 301
 transaction-queue.html:
     to: /docs/concepts/transactions/transaction-queue
-    type: 301
 finality-of-results.html:
     to: /docs/concepts/transactions/finality-of-results/
-    type: 301
 look-up-transaction-results.html:
     to: /docs/concepts/transactions/finality-of-results/look-up-transaction-results
-    type: 301
 transaction-malleability.html:
     to: /docs/concepts/transactions/finality-of-results/transaction-malleability
-    type: 301
 canceling-a-transaction.html:
     to: /docs/concepts/transactions/finality-of-results/canceling-a-transaction
-    type: 301
 payment-types.html:
     to: /docs/concepts/payment-types/
-    type: 301
 direct-xrp-payments.html:
     to: /docs/concepts/payment-types/direct-xrp-payments
-    type: 301
 cross-currency-payments.html:
     to: /docs/concepts/payment-types/cross-currency-payments
-    type: 301
 checks.html:
     to: /docs/concepts/payment-types/checks
-    type: 301
 escrow.html:
     to: /docs/concepts/payment-types/escrow
-    type: 301
 partial-payments.html:
     to: /docs/concepts/payment-types/partial-payments
-    type: 301
 payment-channels.html:
     to: /docs/concepts/payment-types/payment-channels
-    type: 301
 robustly-monitoring-for-payments.html:
     to: /docs/concepts/payment-types/robustly-monitoring-for-payments
-    type: 301
 sending-payments-to-customers.html:
     to: /docs/concepts/payment-types/sending-payments-to-customers
-    type: 301
 bouncing-payments.html:
     to: /docs/concepts/payment-types/bouncing-payments
-    type: 301
 tokens.html:
     to: /docs/concepts/tokens/
-    type: 301
 trust-lines-and-issuing.html:
     to: /docs/concepts/tokens/fungible-tokens/
-    type: 301
 authorized-trust-lines.html:
     to: /docs/concepts/tokens/fungible-tokens/authorized-trust-lines
-    type: 301
 stablecoins.html:
     to: /docs/concepts/tokens/fungible-tokens/stablecoins/
-    type: 301
 stablecoin-settings.html:
     to: /docs/concepts/tokens/fungible-tokens/stablecoins/settings
-    type: 301
 stablecoin-configuration.html:
     to: /docs/concepts/tokens/fungible-tokens/stablecoins/configuration
-    type: 301
 stablecoin-precautions.html:
     to: /docs/concepts/tokens/fungible-tokens/stablecoins/precautions
-    type: 301
 stablecoin-compliance-guidelines.html:
     to: /docs/concepts/tokens/fungible-tokens/stablecoins/compliance-guidelines
-    type: 301
 clawing-back-tokens.html:
     to: /docs/concepts/tokens/fungible-tokens/clawing-back-tokens
-    type: 301
 freezes.html:
     to: /docs/concepts/tokens/fungible-tokens/freezes
-    type: 301
 common-misconceptions-about-freezes.html:
     to: /docs/concepts/tokens/fungible-tokens/common-misconceptions-about-freezes
-    type: 301
 paths.html:
     to: /docs/concepts/tokens/fungible-tokens/paths
-    type: 301
 rippling.html:
     to: /docs/concepts/tokens/fungible-tokens/rippling
-    type: 301
 non-fungible-tokens.html:
     to: /docs/concepts/tokens/nfts/
-    type: 301
 nft-storage.html:
     to: /docs/concepts/tokens/nfts/payload-storage
-    type: 301
 non-fungible-token-transfers.html:
     to: /docs/concepts/tokens/nfts/trading
-    type: 301
 nft-reserve-requirements.html:
     to: /docs/concepts/tokens/nfts/reserve-requirements
-    type: 301
 nftoken-batch-minting.html:
     to: /docs/concepts/tokens/nfts/batch-minting
-    type: 301
 nftoken-authorized-minting.html:
     to: /docs/concepts/tokens/nfts/authorizing-another-minter
-    type: 301
 nftoken-auctions.html:
     to: /docs/concepts/tokens/nfts/running-an-nft-auction
-    type: 301
 nft-collections.html:
     to: /docs/concepts/tokens/nfts/collections
-    type: 301
 nft-fixed-supply.html:
     to: /docs/concepts/tokens/nfts/guaranteeing-a-fixed-supply
-    type: 301
 nft-apis.html:
     to: /docs/concepts/tokens/nfts/nft-apis
-    type: 301
 transfer-fees.html:
     to: /docs/concepts/tokens/transfer-fees
-    type: 301
 demurrage.html:
     to: /docs/concepts/tokens/fungible-tokens/demurrage
-    type: 301
 decentralized-exchange.html:
     to: /docs/concepts/tokens/decentralized-exchange/
-    type: 301
 offers.html:
     to: /docs/concepts/tokens/decentralized-exchange/offers
-    type: 301
 autobridging.html:
     to: /docs/concepts/tokens/decentralized-exchange/autobridging
-    type: 301
 ticksize.html:
     to: /docs/concepts/tokens/decentralized-exchange/ticksize
-    type: 301
 automated-market-makers.html:
     to: /docs/concepts/tokens/decentralized-exchange/automated-market-makers
-    type: 301
 accounts.html:
     to: /docs/concepts/accounts/
-    type: 301
 account-types.html:
     to: /docs/concepts/accounts/account-types
-    type: 301
 deleting-accounts.html:
     to: /docs/concepts/accounts/deleting-accounts
-    type: 301
 reserves.html:
     to: /docs/concepts/accounts/reserves
-    type: 301
 addresses.html:
     to: /docs/concepts/accounts/addresses
-    type: 301
 cryptographic-keys.html:
     to: /docs/concepts/accounts/cryptographic-keys
-    type: 301
 multi-signing.html:
     to: /docs/concepts/accounts/multi-signing
-    type: 301
 depositauth.html:
     to: /docs/concepts/accounts/depositauth
-    type: 301
 tickets.html:
     to: /docs/concepts/accounts/tickets
-    type: 301
 decentralized-identifiers.html:
     to: /docs/concepts/accounts/decentralized-identifiers
-    type: 301
 intro-to-consensus.html:
     to: /docs/concepts/consensus-protocol/
-    type: 301
 set-up-secure-signing.html:
     to: /docs/concepts/transactions/secure-signing
-    type: 301
 transaction-basics.html:
     to: /docs/concepts/transactions/
-    type: 301
 become-an-xrp-ledger-gateway.html:
     to: /docs/use-cases/tokenization/stablecoin-issuer
-    type: 301
 consensus-network.html:
     to: /docs/concepts/consensus-protocol/
-    type: 301
 complex-payment-types.html:
     to: /docs/concepts/payment-types/
-    type: 301
 about-canceling-a-transaction.html:
     to: /docs/concepts/transactions/finality-of-results/canceling-a-transaction
-    type: 301
 issuing-and-operational-addresses.html:
     to: /docs/concepts/accounts/account-types
-    type: 301
 issued-currencies.html:
     to: /docs/concepts/tokens/
-    type: 301
 issued-currencies-overview.html:
     to: /docs/concepts/tokens/
-    type: 301
 federated-sidechains.html:
     to: /docs/concepts/xrpl-sidechains/cross-chain-bridges
-    type: 301
 xrpl-interoperability.html:
     to: /docs/concepts/xrpl-sidechains/cross-chain-bridges
-    type: 301
 intro-to-evm-sidechain.html:
     to: https://docs.xrplevm.org/docs/evm-sidechain/intro-to-evm-sidechain/
-    type: 301
 the-rippled-server.html:
     to: /docs/concepts/networks-and-servers/
-    type: 301
 nft-concepts.html:
     to: /docs/concepts/tokens/nfts/
-    type: 301
 nft-conceptual-overview.html:
     to: /docs/concepts/tokens/nfts/
-    type: 301
 xrpl-sidechains.html:
     to: /docs/concepts/xrpl-sidechains/
-    type: 301
 cross-chain-bridges.html:
     to: /docs/concepts/xrpl-sidechains/cross-chain-bridges
-    type: 301
 witness-servers.html:
     to: /docs/concepts/xrpl-sidechains/witness-servers
-    type: 301
 public-servers.html:
     to: /docs/tutorials/public-servers
-    type: 301
 python.html:
     to: /docs/tutorials/python/
-    type: 301
 get-started-using-python.html:
     to: /docs/tutorials/python/get-started
-    type: 301
 docs/tutorials/python/get-started/:
     to: docs/tutorials/python/build-apps/get-started/
-    type: 301
 modular-tutorials-in-python.html:
     to: /docs/tutorials/python/
-    type: 301
 send-payments-using-python.html:
     to: /docs/tutorials/python/send-payments
-    type: 301
 py-create-accounts-send-xrp.html:
     to: /docs/tutorials/python/send-payments/create-accounts-send-xrp
-    type: 301
 py-create-trustline-send-currency.html:
     to: /docs/tutorials/python/send-payments/create-trustline-send-currency
-    type: 301
 py-create-time-based-escrows.html:
     to: /docs/tutorials/python/send-payments/create-time-based-escrows
-    type: 301
 py-mint-and-burn-nfts.html:
     to: /docs/tutorials/python/nfts/mint-and-burn-nfts
-    type: 301
 py-transfer-nfts.html:
     to: /docs/tutorials/python/nfts/transfer-nfts
-    type: 301
 py-broker-sale.html:
     to: /docs/tutorials/python/nfts/broker-sale
-    type: 301
 py-authorize-minter.html:
     to: /docs/tutorials/python/nfts/authorize-minter
-    type: 301
 py-batch-minting.html:
     to: /docs/tutorials/python/nfts/batch-minting
-    type: 301
 build-a-desktop-wallet-in-python.html:
     to: /docs/tutorials/python/build-apps/build-a-desktop-wallet-in-python
-    type: 301
 javascript.html:
     to: /docs/tutorials/javascript/
-    type: 301
 get-started-using-javascript.html:
     to: /docs/tutorials/javascript/build-apps/get-started
-    type: 301
 docs/tutorials/javascript/get-started:
     to: docs/tutorials/javascript/build-apps/get-started/
-    type: 301
 docs/tutorials/javascript/get-started/:
     to: docs/tutorials/javascript/build-apps/get-started/
-    type: 301
 get-started-using-node-js.html:
     to: /docs/tutorials/javascript/build-apps/get-started
-    type: 301
 get-started-with-rippleapi-for-javascript.html:
     to: /docs/tutorials/javascript/build-apps/get-started
-    type: 301
 modular-tutorials-in-javascript.html:
     to: /docs/tutorials/javascript/
-    type: 301
 send-payments-using-javascript.html:
     to: /docs/tutorials/javascript/send-payments
-    type: 301
 create-accounts-send-xrp-using-javascript.html:
     to: /docs/tutorials/javascript/send-payments/create-accounts-send-xrp
-    type: 301
 create-trustline-send-currency-using-javascript.html:
     to: /docs/tutorials/javascript/send-payments/create-trustline-send-currency
-    type: 301
 create-time-based-escrows-using-javascript.html:
     to: /docs/tutorials/javascript/send-payments/create-time-based-escrows
-    type: 301
 create-conditional-escrows-using-javascript.html:
     to: /docs/tutorials/javascript/send-payments/create-conditional-escrows
-    type: 301
 nfts-using-javascript.html:
     to: /docs/tutorials/javascript/nfts-using-javascript/
-    type: 301
 nfts-using-python.html:
     to: /docs/tutorials/python/nfts
-    type: 301
 mint-and-burn-nfts-using-javascript.html:
     to: /docs/tutorials/javascript/nfts/mint-and-burn-nfts
-    type: 301
 transfer-nfts-using-javascript.html:
     to: /docs/tutorials/javascript/nfts/transfer-nfts
-    type: 301
 broker-an-nft-sale-using-javascript.html:
     to: /docs/tutorials/javascript/nfts/broker-an-nft-sale
-    type: 301
 assign-an-authorized-minter-using-javascript.html:
     to: /docs/tutorials/javascript/nfts/assign-an-authorized-minter
-    type: 301
 batch-mint-nfts-using-javascript.html:
     to: /docs/tutorials/javascript/nfts/batch-mint-nfts
-    type: 301
 build-a-browser-wallet-in-javascript.html:
     to: /docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
 build-a-browser-wallet-using-javascript.html:
     to: /docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
 docs/tutorials/javascript/build-a-browser-wallet-in-javascript:
     to: docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
 docs/tutorials/javascript/build-a-browser-wallet-in-javascript/:
     to: docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
 build-a-desktop-wallet-in-javascript.html:
     to: /docs/tutorials/javascript/build-apps/build-a-desktop-wallet-in-javascript
-    type: 301
 docs/tutorials/javascript/build-a-desktop-wallet-in-javascript:
     to: /docs/tutorials/javascript/build-apps/build-a-desktop-wallet-in-javascript
-    type: 301
 docs/tutorials/javascript/build-a-desktop-wallet-in-javascript/:
     to: /docs/tutorials/javascript/build-apps/build-a-desktop-wallet-in-javascript
-    type: 301
 java.html:
     to: /docs/tutorials/java/
-    type: 301
 get-started-using-java.html:
     to: /docs/tutorials/java/build-apps/get-started
-    type: 301
 docs/tutorials/java/get-started:
     to: /docs/tutorials/java/build-apps/get-started
-    type: 301
 docs/tutorials/java/get-started/:
     to: /docs/tutorials/java/build-apps/get-started
-    type: 301
 php.html:
     to: /docs/tutorials/php
-    type: 301
 get-started-using-php.html:
     to: /docs/tutorials/php/build-apps/get-started
-    type: 301
 http-websocket-apis-tutorials.html:
     to: /docs/tutorials/http-websocket-apis/
-    type: 301
 get-started-with-the-rippled-api.html:
     to: /docs/tutorials/http-websocket-apis/build-apps/get-started
-    type: 301
 get-started-using-http-websocket-apis.html:
     to: /docs/tutorials/http-websocket-apis/build-apps/get-started/
-    type: 301
 docs/tutorials/http-websocket-apis/get-started:
     to: /docs/tutorials/http-websocket-apis/build-apps/get-started/
-    type: 301
 docs/tutorials/http-websocket-apis/get-started/:
-    to: /docs/tutorials/http-websocket-apis/build-apps/get-started/
-    type: 301         
+    to: /docs/tutorials/http-websocket-apis/build-apps/get-started/         
 monitor-incoming-payments-with-websocket.html:
     to: /docs/tutorials/http-websocket-apis/build-apps/monitor-incoming-payments-with-websocket
-    type: 301
 tasks.html:
     to: /docs/tutorials/how-tos/
-    type: 301
 manage-account-settings.html:
     to: /docs/tutorials/how-tos/manage-account-settings/
-    type: 301
 assign-a-regular-key-pair.html:
     to: /docs/tutorials/how-tos/manage-account-settings/assign-a-regular-key-pair
-    type: 301
 change-or-remove-a-regular-key-pair.html:
     to: /docs/tutorials/how-tos/manage-account-settings/change-or-remove-a-regular-key-pair
-    type: 301
 disable-master-key-pair.html:
     to: /docs/tutorials/how-tos/manage-account-settings/disable-master-key-pair
-    type: 301
 set-up-multi-signing.html:
     to: /docs/tutorials/how-tos/manage-account-settings/set-up-multi-signing
-    type: 301
 send-a-multi-signed-transaction.html:
     to: /docs/tutorials/how-tos/manage-account-settings/send-a-multi-signed-transaction
-    type: 301
 require-destination-tags.html:
     to: /docs/tutorials/how-tos/manage-account-settings/require-destination-tags
-    type: 301
 offline-account-setup.html:
     to: /docs/tutorials/how-tos/manage-account-settings/offline-account-setup
-    type: 301
 use-tickets.html:
     to: /docs/tutorials/how-tos/manage-account-settings/use-tickets
-    type: 301
 send-xrp.html:
     to: /docs/tutorials/how-tos/send-xrp
-    type: 301
 use-specialized-payment-types.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/
-    type: 301
 use-complex-payment-types.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/
-    type: 301
 use-escrows.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/
-    type: 301
 send-a-time-held-escrow.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-time-held-escrow
-    type: 301
 send-a-conditionally-held-escrow.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditional-escrow
-    type: 301
 cancel-an-expired-escrow.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/cancel-an-expired-escrow
-    type: 301
 look-up-escrows.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/look-up-escrows
-    type: 301
 use-an-escrow-as-a-smart-contract.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditional-escrow
-    type: 301
 use-payment-channels.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels
-    type: 301
 open-a-payment-channel-to-enable-an-inter-exchange-network.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/open-a-payment-channel-to-enable-an-inter-exchange-network
-    type: 301
 use-checks.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/use-checks
-    type: 301
 send-a-check.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/send-a-check
-    type: 301
 cash-a-check-for-an-exact-amount.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/cash-a-check-for-an-exact-amount
-    type: 301
 cash-a-check-for-a-flexible-amount.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/cash-a-check-for-a-flexible-amount
-    type: 301
 cancel-a-check.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/cancel-a-check
-    type: 301
 look-up-checks-by-sender.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-sender
-    type: 301
 look-up-checks-by-recipient.html:
     to: /docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-recipient
-    type: 301
 use-tokens.html:
     to: /docs/tutorials/how-tos/use-tokens/
-    type: 301
 issue-a-fungible-token.html:
     to: /docs/tutorials/how-tos/use-tokens/issue-a-fungible-token
-    type: 301
 trade-in-the-decentralized-exchange.html:
     to: /docs/tutorials/how-tos/use-tokens/trade-in-the-decentralized-exchange
-    type: 301
 enable-no-freeze.html:
     to: /docs/tutorials/how-tos/use-tokens/enable-no-freeze
-    type: 301
 enact-global-freeze.html:
     to: /docs/tutorials/how-tos/use-tokens/enact-global-freeze
-    type: 301
 freeze-a-trust-line.html:
     to: /docs/tutorials/how-tos/use-tokens/freeze-a-trust-line
-    type: 301
 create-an-automated-market-maker.html:
     to: /docs/tutorials/how-tos/use-tokens/create-an-automated-market-maker
-    type: 301
 use-simple-xrp-payments.html:
     to: /docs/tutorials/how-tos/send-xrp
-    type: 301
 cancel-or-skip-a-transaction.html:
     to: /docs/concepts/transactions/finality-of-results/canceling-a-transaction
-    type: 301
 evm-sidechains.html:
     to: https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
-    type: 301
 get-started-evm-sidechain.html:
     to: https://opensource.ripple.com/docs/evm-sidechain/get-started-evm-sidechain/
-    type: 301
 connect-metamask-to-xrpl-evm-sidechain.html:
     to: https://opensource.ripple.com/docs/evm-sidechain/connect-metamask-to-xrpl-evm-sidechain/
-    type: 301
 join-evm-sidechain-devnet.html:
     to: https://opensource.ripple.com/docs/evm-sidechain/join-evm-sidechain-devnet/
-    type: 301
 evm-sidechain-validator-security.html:
     to: https://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-validator-security/
-    type: 301
 evm-sidechain-run-a-validator-node.html:
     to: https://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-run-a-validator-node/
-    type: 301
 use-xrpl-sidechains.html:
     to: /docs/tutorials/how-tos/use-xrpl-sidechains/
-    type: 301
 set-up-xrp-xrp-bridge.html:
     to: /docs/tutorials/how-tos/use-xrpl-sidechains/set-up-xrp-xrp-bridge
-    type: 301
 set-up-iou-iou-bridge.html:
     to: /docs/tutorials/how-tos/use-xrpl-sidechains/set-up-iou-iou-bridge
-    type: 301
 submit-cross-chain-transactions.html:
     to: /docs/tutorials/how-tos/use-xrpl-sidechains/submit-cross-chain-transaction
-    type: 301
 references.html:
     to: /docs/references/
-    type: 301
 protocol-reference.html:
     to: /docs/references/protocol/
-    type: 301
 basic-data-types.html:
     to: /docs/references/protocol/data-types/basic-data-types
-    type: 301
 base58-encodings.html:
     to: /docs/references/protocol/data-types/base58-encodings
-    type: 301
 currency-formats.html:
     to: /docs/references/protocol/data-types/currency-formats
-    type: 301
 nftoken.html:
     to: /docs/references/protocol/data-types/nftoken
-    type: 301
 ledger-data-formats.html:
     to: /docs/references/protocol/ledger-data/
-    type: 301
 ledger-header.html:
     to: /docs/references/protocol/ledger-data/ledger-header
-    type: 301
 ledger-entry-common-fields.html:
     to: /docs/references/protocol/ledger-data/common-fields
-    type: 301
 ledger-entry-types.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/
-    type: 301
 ledger-object-types.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/
-    type: 301
 ledger-object-ids.html:
     to: /docs/references/protocol/ledger-data/common-fields
-    type: 301
 accountroot.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/accountroot
-    type: 301
 amendments-object.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/amendments
-    type: 301
 amm.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/amm
-    type: 301
 bridge.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/bridge
-    type: 301
 check.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/check
-    type: 301
 depositpreauth-object.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth
-    type: 301
 did.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/did
-    type: 301
 directorynode.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/directorynode
-    type: 301
 escrow-object.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/escrow
-    type: 301
 feesettings.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/feesettings
-    type: 301
 ledgerhashes.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes
-    type: 301
 negativeunl.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/negativeunl
-    type: 301
 nftokenoffer.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/nftokenoffer
-    type: 301
 nftokenpage.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/nftokenpage
-    type: 301
 offer.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/offer
-    type: 301
 paychannel.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/paychannel
-    type: 301
 ripplestate.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/ripplestate
-    type: 301
 signerlist.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/signerlist
-    type: 301
 ticket.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/ticket
-    type: 301
 xchainownedclaimid.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid
-    type: 301
 xchainownedcreateaccountclaimid.html:
     to: /docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid
-    type: 301
 transaction-formats.html:
     to: /docs/references/protocol/transactions/
-    type: 301
 transaction-common-fields.html:
     to: /docs/references/protocol/transactions/common-fields
-    type: 301
 transaction-types.html:
     to: /docs/references/protocol/transactions/types/
-    type: 301
 accountset.html:
     to: /docs/references/protocol/transactions/types/accountset
-    type: 301
 accountdelete.html:
     to: /docs/references/protocol/transactions/types/accountdelete
-    type: 301
 ammbid.html:
     to: /docs/references/protocol/transactions/types/ammbid
-    type: 301
 ammcreate.html:
     to: /docs/references/protocol/transactions/types/ammcreate
-    type: 301
 ammdelete.html:
     to: /docs/references/protocol/transactions/types/ammdelete
-    type: 301
 ammdeposit.html:
     to: /docs/references/protocol/transactions/types/ammdeposit
-    type: 301
 ammvote.html:
     to: /docs/references/protocol/transactions/types/ammvote
-    type: 301
 ammwithdraw.html:
     to: /docs/references/protocol/transactions/types/ammwithdraw
-    type: 301
 checkcancel.html:
     to: /docs/references/protocol/transactions/types/checkcancel
-    type: 301
 checkcash.html:
     to: /docs/references/protocol/transactions/types/checkcash
-    type: 301
 checkcreate.html:
     to: /docs/references/protocol/transactions/types/checkcreate
-    type: 301
 clawback.html:
     to: /docs/references/protocol/transactions/types/clawback
-    type: 301
 depositpreauth.html:
     to: /docs/references/protocol/transactions/types/depositpreauth
-    type: 301
 diddelete.html:
     to: /docs/references/protocol/transactions/types/diddelete
-    type: 301
 didset.html:
     to: /docs/references/protocol/transactions/types/didset
-    type: 301
 escrowcancel.html:
     to: /docs/references/protocol/transactions/types/escrowcancel
-    type: 301
 escrowcreate.html:
     to: /docs/references/protocol/transactions/types/escrowcreate
-    type: 301
 escrowfinish.html:
     to: /docs/references/protocol/transactions/types/escrowfinish
-    type: 301
 nftokenacceptoffer.html:
     to: /docs/references/protocol/transactions/types/nftokenacceptoffer
-    type: 301
 nftokenburn.html:
     to: /docs/references/protocol/transactions/types/nftokenburn
-    type: 301
 nftokencanceloffer.html:
     to: /docs/references/protocol/transactions/types/nftokencanceloffer
-    type: 301
 nftokencreateoffer.html:
     to: /docs/references/protocol/transactions/types/nftokencreateoffer
-    type: 301
 nftokenmint.html:
     to: /docs/references/protocol/transactions/types/nftokenmint
-    type: 301
 offercancel.html:
     to: /docs/references/protocol/transactions/types/offercancel
-    type: 301
 offercreate.html:
     to: /docs/references/protocol/transactions/types/offercreate
-    type: 301
 payment.html:
     to: /docs/references/protocol/transactions/types/payment
-    type: 301
 paymentchannelclaim.html:
     to: /docs/references/protocol/transactions/types/paymentchannelclaim
-    type: 301
 paymentchannelcreate.html:
     to: /docs/references/protocol/transactions/types/paymentchannelcreate
-    type: 301
 paymentchannelfund.html:
     to: /docs/references/protocol/transactions/types/paymentchannelfund
-    type: 301
 setregularkey.html:
     to: /docs/references/protocol/transactions/types/setregularkey
-    type: 301
 signerlistset.html:
     to: /docs/references/protocol/transactions/types/signerlistset
-    type: 301
 ticketcreate.html:
     to: /docs/references/protocol/transactions/types/ticketcreate
-    type: 301
 trustset.html:
     to: /docs/references/protocol/transactions/types/trustset
-    type: 301
 xchainaccountcreatecommit.html:
     to: /docs/references/protocol/transactions/types/xchainaccountcreatecommit
-    type: 301
 xchainaddaccountcreateattestation.html:
     to: /docs/references/protocol/transactions/types/xchainaddaccountcreateattestation
-    type: 301
 xchainaddclaimattestation.html:
     to: /docs/references/protocol/transactions/types/xchainaddclaimattestation
-    type: 301
 xchainclaim.html:
     to: /docs/references/protocol/transactions/types/xchainclaim
-    type: 301
 xchaincommit.html:
     to: /docs/references/protocol/transactions/types/xchaincommit
-    type: 301
 xchaincreatebridge.html:
     to: /docs/references/protocol/transactions/types/xchaincreatebridge
-    type: 301
 xchaincreateclaimid.html:
     to: /docs/references/protocol/transactions/types/xchaincreateclaimid
-    type: 301
 xchainmodifybridge.html:
     to: /docs/references/protocol/transactions/types/xchainmodifybridge
-    type: 301
 pseudo-transaction-types.html:
     to: /docs/references/protocol/transactions/pseudo-transaction-types/pseudo-transaction-types
-    type: 301
 enableamendment.html:
     to: /docs/references/protocol/transactions/pseudo-transaction-types/enableamendment
-    type: 301
 setfee.html:
     to: /docs/references/protocol/transactions/pseudo-transaction-types/setfee
-    type: 301
 unlmodify.html:
     to: /docs/references/protocol/transactions/pseudo-transaction-types/unlmodify
-    type: 301
 transaction-results.html:
     to: /docs/references/protocol/transactions/transaction-results/transaction-results
-    type: 301
 tec-codes.html:
     to: /docs/references/protocol/transactions/transaction-results/tec-codes
-    type: 301
 tef-codes.html:
     to: /docs/references/protocol/transactions/transaction-results/tef-codes
-    type: 301
 tel-codes.html:
     to: /docs/references/protocol/transactions/transaction-results/tel-codes
-    type: 301
 tem-codes.html:
     to: /docs/references/protocol/transactions/transaction-results/tem-codes
-    type: 301
 ter-codes.html:
     to: /docs/references/protocol/transactions/transaction-results/ter-codes
-    type: 301
 tes-success.html:
     to: /docs/references/protocol/transactions/transaction-results/tes-success
-    type: 301
 transaction-metadata.html:
     to: /docs/references/protocol/transactions/metadata
-    type: 301
 modifying-the-ledger.html:
     to: /docs/references/protocol/transactions/
-    type: 301
 serialization.html:
     to: /docs/references/protocol/binary-format
-    type: 301
 client-libraries.html:
     to: /docs/references/client-libraries
-    type: 301
 rippleapi-reference.html:
     to: https://js.xrpl.org/
-    type: 301
 xrpljs2-migration-guide.html:
     to: /docs/references/xrpljs2-migration-guide
-    type: 301
 http-websocket-apis.html:
     to: /docs/references/http-websocket-apis/
-    type: 301
 rippled-api.html:
     to: /docs/references/http-websocket-apis/
-    type: 301
 api-conventions.html:
     to: /docs/references/http-websocket-apis/api-conventions/
-    type: 301
 request-formatting.html:
     to: /docs/references/http-websocket-apis/api-conventions/request-formatting
-    type: 301
 response-formatting.html:
     to: /docs/references/http-websocket-apis/api-conventions/response-formatting
-    type: 301
 error-formatting.html:
     to: /docs/references/http-websocket-apis/api-conventions/error-formatting
-    type: 301
 markers-and-pagination.html:
     to: /docs/references/http-websocket-apis/api-conventions/markers-and-pagination
-    type: 301
 rate-limiting.html:
     to: /docs/references/http-websocket-apis/api-conventions/rate-limiting
-    type: 301
 rippled-server-states.html:
     to: /docs/references/http-websocket-apis/api-conventions/rippled-server-states
-    type: 301
 ctid.html:
     to: /docs/references/http-websocket-apis/api-conventions/ctid
-    type: 301
 public-api-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/
-    type: 301
 public-rippled-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/
-    type: 301
 account-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/
-    type: 301
 account_channels.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_channels
-    type: 301
 account_currencies.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_currencies
-    type: 301
 account_info.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_info
-    type: 301
 account_lines.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines
-    type: 301
 account_nfts.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_nfts
-    type: 301
 account_objects.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects
-    type: 301
 account_offers.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_offers
-    type: 301
 account_tx.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx
-    type: 301
 gateway_balances.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/gateway_balances
-    type: 301
 noripple_check.html:
     to: /docs/references/http-websocket-apis/public-api-methods/account-methods/noripple_check
-    type: 301
 ledger-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/ledger-methods/
-    type: 301
 ledger.html:
     to: /docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger
-    type: 301
 ledger_closed.html:
     to: /docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_closed
-    type: 301
 ledger_current.html:
     to: /docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_current
-    type: 301
 ledger_data.html:
     to: /docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data
-    type: 301
 ledger_entry.html:
     to: /docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry
-    type: 301
 transaction-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/transaction-methods/
-    type: 301
 submit.html:
     to: /docs/references/http-websocket-apis/public-api-methods/transaction-methods/submit
-    type: 301
 submit_multisigned.html:
     to: /docs/references/http-websocket-apis/public-api-methods/transaction-methods/submit_multisigned
-    type: 301
 transaction_entry.html:
     to: /docs/references/http-websocket-apis/public-api-methods/transaction-methods/transaction_entry
-    type: 301
 tx.html:
     to: /docs/references/http-websocket-apis/public-api-methods/transaction-methods/tx
-    type: 301
 tx_history.html:
     to: /docs/references/http-websocket-apis/public-api-methods/transaction-methods/tx_history
-    type: 301
 path-and-order-book-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/
-    type: 301
 amm_info.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info
-    type: 301
 book_offers.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_offers
-    type: 301
 deposit_authorized.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/deposit_authorized
-    type: 301
 nft_buy_offers.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers
-    type: 301
 nft_sell_offers.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_sell_offers
-    type: 301
 path_find.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/path_find
-    type: 301
 ripple_path_find.html:
     to: /docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/ripple_path_find
-    type: 301
 payment-channel-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/
-    type: 301
 channel_authorize.html:
     to: /docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_authorize
-    type: 301
 channel_verify.html:
     to: /docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify
-    type: 301
 subscription-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/subscription-methods/
-    type: 301
 subscribe.html:
     to: /docs/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe
-    type: 301
 unsubscribe.html:
     to: /docs/references/http-websocket-apis/public-api-methods/subscription-methods/unsubscribe
-    type: 301
 server-info-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/server-info-methods/
-    type: 301
 fee.html:
     to: /docs/references/http-websocket-apis/public-api-methods/server-info-methods/fee
-    type: 301
 manifest.html:
     to: /docs/references/http-websocket-apis/public-api-methods/server-info-methods/manifest
-    type: 301
 server_definitions.html:
     to: /docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions
-    type: 301
 server_info.html:
     to: /docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_info
-    type: 301
 server_state.html:
     to: /docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_state
-    type: 301
 clio-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/clio-server/
-    type: 301
 server_info-clio.html:
     to: /docs/references/http-websocket-apis/public-api-methods/clio-methods/server_info-clio
-    type: 301
 ledger-clio.html:
     to: /docs/references/http-websocket-apis/public-api-methods/clio-methods/ledger-clio
-    type: 301
 nft_history.html:
     to: /docs/references/http-websocket-apis/public-api-methods/clio-methods/nft_history
-    type: 301
 nft_info.html:
     to: /docs/references/http-websocket-apis/public-api-methods/clio-methods/nft_info
-    type: 301
 utility-methods.html:
     to: /docs/references/http-websocket-apis/public-api-methods/utility-methods/
-    type: 301
 json.html:
     to: /docs/references/http-websocket-apis/public-api-methods/utility-methods/json
-    type: 301
 ping.html:
     to: /docs/references/http-websocket-apis/public-api-methods/utility-methods/ping
-    type: 301
 random.html:
     to: /docs/references/http-websocket-apis/public-api-methods/utility-methods/random
-    type: 301
 admin-api-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/
-    type: 301
 admin-rippled-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/
-    type: 301
 key-generation-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/key-generation-methods/
-    type: 301
 validation_create.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/key-generation-methods/validation_create
-    type: 301
 wallet_propose.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/key-generation-methods/wallet_propose
-    type: 301
 logging-and-data-management-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 can_delete.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/can_delete
-    type: 301
 crawl_shards.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 download_shard.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 ledger_cleaner.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/ledger_cleaner
-    type: 301
 ledger_request.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/ledger_request
-    type: 301
 log_level.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/log_level
-    type: 301
 logrotate.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/logrotate
-    type: 301
 node_to_shard.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
 server-control-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/server-control-methods/
-    type: 301
 ledger_accept.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/server-control-methods/ledger_accept
-    type: 301
 stop.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/server-control-methods/stop
-    type: 301
 validation_seed.html:
     to: /docs/references/http-websocket-apis/public-api-methods/
-    type: 301
 signing-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/signing-methods/
-    type: 301
 sign.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/signing-methods/sign
-    type: 301
 sign_for.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/signing-methods/sign_for
-    type: 301
 peer-management-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/
-    type: 301
 connect.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/connect
-    type: 301
 peer_reservations_add.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peer_reservations_add
-    type: 301
 peer_reservations_del.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peer_reservations_del
-    type: 301
 peer_reservations_list.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peer_reservations_list
-    type: 301
 peers.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peers
-    type: 301
 status-and-debugging-methods.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/
-    type: 301
 consensus_info.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/consensus_info
-    type: 301
 feature.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/feature
-    type: 301
 fetch_info.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/fetch_info
-    type: 301
 get_counts.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/get_counts
-    type: 301
 print.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/print
-    type: 301
 validator_info.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/validator_info
-    type: 301
 validator_list_sites.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/validator_list_sites
-    type: 301
 validators.html:
     to: /docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/validators
-    type: 301
 peer-port-methods.html:
     to: /docs/references/http-websocket-apis/peer-port-methods/
-    type: 301
 health-check.html:
     to: /docs/references/http-websocket-apis/peer-port-methods/health-check
-    type: 301
 peer-crawler.html:
     to: /docs/references/http-websocket-apis/peer-port-methods/peer-crawler
-    type: 301
 validator-list.html:
     to: /docs/references/http-websocket-apis/peer-port-methods/validator-list
-    type: 301
 xrp-api.html:
     to: https://xpring-eng.github.io/xrp-api/
-    type: 301
 data-api.html:
     to: /docs/references/data-api
-    type: 301
 xrp-ledger-toml.html:
     to: /docs/references/xrp-ledger-toml
-    type: 301
 infrastructure.html:
     to: /docs/infrastructure/
-    type: 301
 commandline-usage.html:
     to: /docs/infrastructure/commandline-usage
-    type: 301
 install-rippled.html:
     to: /docs/infrastructure/installation/
-    type: 301
 system-requirements.html:
     to: /docs/infrastructure/installation/system-requirements
-    type: 301
 install-rippled-on-centos-rhel-with-yum.html:
     to: /docs/infrastructure/installation/install-rippled-on-rhel
-    type: 301
 install-rippled-on-ubuntu.html:
     to: /docs/infrastructure/installation/install-rippled-on-ubuntu
-    type: 301
 install-clio-on-ubuntu.html:
     to: /docs/infrastructure/installation/install-clio-on-ubuntu
-    type: 301
 update-rippled-automatically-on-linux.html:
     to: /docs/infrastructure/installation/update-rippled-automatically-on-linux
-    type: 301
 update-rippled-manually-on-centos-rhel.html:
     to: /docs/infrastructure/installation/update-rippled-manually-on-rhel
-    type: 301
 update-rippled-manually-on-ubuntu.html:
     to: /docs/infrastructure/installation/update-rippled-manually-on-ubuntu
-    type: 301
 build-on-linux-mac-windows.html:
     to: /docs/infrastructure/installation/build-on-linux-mac-windows
-    type: 301
 build-run-rippled-in-reporting-mode.html:
     to: /docs/infrastructure/installation/build-run-rippled-in-reporting-mode
-    type: 301
 capacity-planning.html:
     to: /docs/infrastructure/installation/capacity-planning
-    type: 301
 rippled-1-3-migration-instructions.html:
     to: /docs/infrastructure/installation/rippled-1-3-migration-instructions
-    type: 301
 configure-rippled.html:
     to: /docs/infrastructure/configuration/
-    type: 301
 server-modes.html:
     to: /docs/infrastructure/configuration/server-modes/
-    type: 301
 run-rippled-as-a-validator.html:
     to: /docs/infrastructure/configuration/server-modes/run-rippled-as-a-validator
-    type: 301
 run-rippled-as-a-stock-server.html:
     to: /docs/infrastructure/configuration/server-modes/run-rippled-as-a-stock-server
-    type: 301
 data-retention.html:
     to: /docs/infrastructure/configuration/data-retention/
-    type: 301
 configure-full-history.html:
     to: /docs/infrastructure/configuration/data-retention/configure-full-history
-    type: 301
 online-deletion.html:
     to: /docs/infrastructure/configuration/data-retention/online-deletion
-    type: 301
 configure-online-deletion.html:
     to: /docs/infrastructure/configuration/data-retention/configure-online-deletion
-    type: 301
 configure-advisory-deletion.html:
     to: /docs/infrastructure/configuration/data-retention/configure-advisory-deletion
-    type: 301
 history-sharding.html:
     to: /docs/infrastructure/configuration/data-retention/history-sharding
-    type: 301
 configure-history-sharding.html:
     to: /docs/infrastructure/configuration/data-retention/configure-history-sharding
-    type: 301
 configure-peering.html:
     to: /docs/infrastructure/configuration/peering/
-    type: 301
 cluster-rippled-servers.html:
     to: /docs/infrastructure/configuration/peering/cluster-rippled-servers
-    type: 301
 configure-a-private-server.html:
     to: /docs/infrastructure/configuration/peering/configure-a-private-server
-    type: 301
 configure-the-peer-crawler.html:
     to: /docs/infrastructure/configuration/peering/configure-the-peer-crawler
-    type: 301
 enable-link-compression.html:
     to: /docs/infrastructure/configuration/peering/enable-link-compression
-    type: 301
 forward-ports-for-peering.html:
     to: /docs/infrastructure/configuration/peering/forward-ports-for-peering
-    type: 301
 manually-connect-to-a-specific-peer.html:
     to: /docs/infrastructure/configuration/peering/manually-connect-to-a-specific-peer
-    type: 301
 set-max-number-of-peers.html:
     to: /docs/infrastructure/configuration/peering/set-max-number-of-peers
-    type: 301
 use-a-peer-reservation.html:
     to: /docs/infrastructure/configuration/peering/use-a-peer-reservation
-    type: 301
 configure-amendment-voting.html:
     to: /docs/infrastructure/configuration/configure-amendment-voting
-    type: 301
 configure-statsd.html:
     to: /docs/infrastructure/configuration/configure-statsd
-    type: 301
 connect-your-rippled-to-the-xrp-test-net.html:
     to: /docs/infrastructure/configuration/connect-your-rippled-to-the-xrp-test-net
-    type: 301
 configure-grpc.html:
     to: /docs/infrastructure/configuration/configure-grpc
-    type: 301
 enable-public-signing.html:
     to: /docs/infrastructure/configuration/enable-public-signing
-    type: 301
 use-stand-alone-mode.html:
     to: /docs/infrastructure/testing-and-auditing/
-    type: 301
 start-a-new-genesis-ledger-in-stand-alone-mode.html:
     to: /docs/infrastructure/testing-and-auditing/start-a-new-genesis-ledger-in-stand-alone-mode
-    type: 301
 load-a-saved-ledger-in-stand-alone-mode.html:
     to: /docs/infrastructure/testing-and-auditing/load-a-saved-ledger-in-stand-alone-mode
-    type: 301
 advance-the-ledger-in-stand-alone-mode.html:
     to: /docs/infrastructure/testing-and-auditing/advance-the-ledger-in-stand-alone-mode
-    type: 301
 test-amendments.html:
     to: /docs/infrastructure/testing-and-auditing/test-amendments
-    type: 301
 private-network-with-docker.html:
     to: /docs/infrastructure/testing-and-auditing/run-private-network-with-docker
-    type: 301
 troubleshoot-the-rippled-server.html:
     to: /docs/infrastructure/troubleshooting/
-    type: 301
 diagnosing-problems.html:
     to: /docs/infrastructure/troubleshooting/diagnosing-problems
-    type: 301
 health-check-interventions.html:
     to: /docs/infrastructure/troubleshooting/health-check-interventions
-    type: 301
 understanding-log-messages.html:
     to: /docs/infrastructure/troubleshooting/understanding-log-messages
-    type: 301
 server-doesnt-sync.html:
     to: /docs/infrastructure/troubleshooting/server-doesnt-sync
-    type: 301
 server-is-amendment-blocked.html:
     to: /docs/infrastructure/troubleshooting/server-is-amendment-blocked
-    type: 301
 server-wont-start.html:
     to: /docs/infrastructure/troubleshooting/server-wont-start
-    type: 301
 fix-sqlite-tx-db-page-size-issue.html:
     to: /docs/infrastructure/troubleshooting/fix-sqlite-tx-db-page-size-issue
-    type: 301
 manage-the-rippled-server.html:
     to: /docs/infrastructure/installation/install-rippled-on-ubuntu
-    type: 301
 build-run-rippled-ubuntu.html:
     to: /docs/infrastructure/installation/build-on-linux-mac-windows
-    type: 301
 build-run-rippled-macos.html:
     to: /docs/infrastructure/installation/build-on-linux-mac-windows
-    type: 301
 update-rippled-automatically-on-centos-rhel.html:
     to: /docs/infrastructure/installation/update-rippled-automatically-on-linux
-    type: 301
 install-rippled-on-ubuntu-with-alien.html:
     to: /docs/infrastructure/installation/install-rippled-on-ubuntu
-    type: 301
 run-a-rippled-validator.html:
     to: /docs/infrastructure/configuration/server-modes/run-rippled-as-a-validator
-    type: 301
 list-xrp-in-your-exchange.html:
     to: /docs/use-cases/defi/list-xrp-as-an-exchange
-    type: 301
 contribute-code-to-rippled.html:
     to: /resources/contribute-code
-    type: 301
 contribute-code-to-ripple-lib.html:
     to: /resources/contribute-code
-    type: 301
 contribute-code-flow.html:
     to: /resources/contribute-code
-    type: 301
 resources.html:
     to: /resources/
-    type: 301
 known-amendments.html:
     to: /resources/known-amendments
-    type: 301
 contribute-code.html:
     to: /resources/contribute-code
-    type: 301
 create-custom-transactors.html:
     to: /resources/contribute-code/create-custom-transactors
-    type: 301
 contribute-documentation.html:
     to: /resources/contribute-documentation/
-    type: 301
 documentation-translations.html:
     to: /resources/contribute-documentation/documentation-translations
-    type: 301
 creating-diagrams.html:
     to: /resources/contribute-documentation/creating-diagrams
-    type: 301
 tutorial-guidelines.html:
     to: /resources/contribute-documentation/tutorial-guidelines
-    type: 301
 tutorial-structure.html:
     to: /resources/contribute-documentation/tutorial-guidelines
-    type: 301
 report-a-scam.html:
     to: /contributing/report-a-scam
-    type: 301
 wallets.html:
     to: /docs/introduction/crypto-wallets
-    type: 301
 blog/2014:
     to: /blog
-    type: 301
 blog/2015:
     to: /blog
-    type: 301
 
 blog/2020:
     to: /blog
-    type: 301
 blog/2021:
     to: /blog
-    type: 301
 blog/2024/rippled-2.2.0.html:
     to: /blog/2024/rippled-2.2.0
-    type: 301
 blog/2024/rippled-2.1.0.html:
     to: /blog/2024/rippled-2.1.0
-    type: 301
 blog/2024/clio-2.1.0.html:
     to: /blog/2024/clio-2.1.0
-    type: 301
 blog/2024/rippled-2.0.1.html:
     to: /blog/2024/rippled-2.0.1
-    type: 301
 blog/2024/web3auth.html:
     to: /blog/2024/web3auth
-    type: 301
 blog/2024/rippled-2.0.0.html:
     to: /blog/2024/rippled-2.0.0
-    type: 301
 blog/2023/decommissioning-amm-devnet.html:
     to: /blog/2023/decommissioning-amm-devnet
-    type: 301
 blog/2023/gemwallet-update.html:
     to: /blog/2023/gemwallet-update
-    type: 301
 blog/2023/clio-2.0.0.html:
     to: /blog/2023/clio-2.0.0
-    type: 301
 blog/2023/santiment.html:
     to: /blog/2023/santiment
-    type: 301
 blog/2023/data-api-v2-deprecated.html:
     to: /blog/2023/data-api-v2-deprecated
-    type: 301
 blog/2023/devnet-reset-scheduled-sep-19-2023.html:
     to: /blog/2023/devnet-reset-scheduled-sep-19-2023
-    type: 301
 blog/2023/rippled-1.12.0.html:
     to: /blog/2023/rippled-1.12.0
-    type: 301
 blog/2023/upcoming-devnet-reset.html:
     to: /blog/2023/upcoming-devnet-reset
-    type: 301
 blog/2023/blockdaemon.html:
     to: /blog/2023/blockdaemon
-    type: 301
 blog/2023/disallowincoming-and-others-expected.html:
     to: /blog/2023/disallowincoming-and-others-expected
-    type: 301
 blog/2023/xrp-toolkit.html:
     to: /blog/2023/xrp-toolkit
-    type: 301
 blog/2023/summarizing-xrpl-docs-iav3.html:
     to: /blog/2023/summarizing-xrpl-docs-iav3
-    type: 301
 blog/2023/xrpl-py-2.0-release.html:
     to: /blog/2023/xrpl-py-2.0-release
-    type: 301
 blog/2023/fieldboss.html:
     to: /blog/2023/fieldboss
-    type: 301
 blog/2023/rippled-1.11.0.html:
     to: /blog/2023/rippled-1.11.0
-    type: 301
 blog/2023/ciso.html:
     to: /blog/2023/ciso
-    type: 301
 blog/2023/edge.html:
     to: /blog/2023/edge
-    type: 301
 blog/2023/xrpcafe.html:
     to: /blog/2023/xrpcafe
-    type: 301
 blog/2023/chispend.html:
     to: /blog/2023/chispend
-    type: 301
 blog/2023/rippled-1.10.0.html:
     to: /blog/2023/rippled-1.10.0
-    type: 301
 blog/2023/bei-api.html:
     to: /blog/2023/bei-api
-    type: 301
 blog/2023/zoetic.html:
     to: /blog/2023/zoetic
-    type: 301
 blog/2023/mandla-money.html:
     to: /blog/2023/mandla-money
-    type: 301
 blog/2023/nft-devnet-decommission.html:
     to: /blog/2023/nft-devnet-decommission
-    type: 301
 blog/2023/aesthetes.html:
     to: /blog/2023/aesthetes
-    type: 301
 blog/2023/stably.html:
     to: /blog/2023/stably
-    type: 301
 blog/2022/introducing-xrpl-py-2.0.0beta.html:
     to: /blog/2022/introducing-xrpl-py-2.0.0beta
-    type: 301
 blog/2022/nftmaster.html:
     to: /blog/2022/nftmaster
-    type: 301
 blog/2022/xpmarket.html:
     to: /blog/2022/xpmarket
-    type: 301
 blog/2022/ziggurat.html:
     to: /blog/2022/ziggurat
-    type: 301
 blog/2022/gemwallet.html:
     to: /blog/2022/gemwallet
-    type: 301
 blog/2022/cryptoiso20022interop.html:
     to: /blog/2022/cryptoiso20022interop
-    type: 301
 blog/2022/non-fungible-tokens-are-now-available.html:
     to: /blog/2022/non-fungible-tokens-are-now-available
-    type: 301
 blog/2022/dev-reflections-relaunch.html:
     to: /blog/2022/dev-reflections-relaunch
-    type: 301
 blog/2022/expandedsignerlist-enabled-and-nfts-approaching.html:
     to: /blog/2022/expandedsignerlist-enabled-and-nfts-approaching
-    type: 301
 blog/2022/introducing-learning-portal.html:
     to: /blog/2022/introducing-learning-portal
-    type: 301
 blog/2022/rippled-1.9.4.html:
     to: /blog/2022/rippled-1.9.4
-    type: 301
 blog/2022/get-ready-for-nfts.html:
     to: /blog/2022/get-ready-for-nfts
-    type: 301
 blog/2022/rippled-1.9.3.html:
     to: /blog/2022/rippled-1.9.3
-    type: 301
 blog/2022/rippled-1.9.2.html:
     to: /blog/2022/rippled-1.9.2
-    type: 301
 blog/2022/clio-1.0.0.html:
     to: /blog/2022/clio-1.0.0
-    type: 301
 blog/2022/rippled-1.9.1.html:
     to: /blog/2022/rippled-1.9.1
-    type: 301
 blog/2022/rippled-1.9.0.html:
     to: /blog/2022/rippled-1.9.0
-    type: 301
 blog/2022/introducing-clio.html:
     to: /blog/2022/introducing-clio
-    type: 301
 blog/2022/nft-devnet-reset.html:
     to: /blog/2022/nft-devnet-reset
-    type: 301
 blog/2022/rippled-1.8.5.html:
     to: /blog/2022/rippled-1.8.5
-    type: 301
 blog/2022/rippled-1.8.4.html:
     to: /blog/2022/rippled-1.8.4
-    type: 301
 blog/2021/rippled-1.8.2.html:
     to: /blog/2021/rippled-1.8.2
-    type: 301
 blog/2021/rippled-1.8.1.html:
     to: /blog/2021/rippled-1.8.1
-    type: 301
 blog/2021/five-upcoming-amendments.html:
     to: /blog/2021/five-upcoming-amendments
-    type: 301
 blog/2021/introducing-xrpl-js.html:
     to: /blog/2021/introducing-xrpl-js
-    type: 301
 blog/2021/sidechain-engineering-preview.html:
     to: /blog/2021/sidechain-engineering-preview
-    type: 301
 blog/2021/reserves-lowered.html:
     to: /blog/2021/reserves-lowered
-    type: 301
 blog/2021/rippled-1.7.3.html:
     to: /blog/2021/rippled-1.7.3
-    type: 301
 blog/2021/ripple-lib-drops-lodash-browsers.html:
     to: /blog/2021/ripple-lib-drops-lodash-browsers
-    type: 301
 blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation.html:
     to: /blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation
-    type: 301
 blog/2021/rippled-1.7.2.html:
     to: /blog/2021/rippled-1.7.2
-    type: 301
 blog/2021/introducing-xrpl4j.html:
     to: /blog/2021/introducing-xrpl4j
-    type: 301
 blog/2021/xrpl-node-configurator.html:
     to: /blog/2021/xrpl-node-configurator
-    type: 301
 blog/2021/introducing-xrpl-py-for-pythonistas.html:
     to: /blog/2021/introducing-xrpl-py-for-pythonistas
-    type: 301
 blog/2021/three-amendments-expected.html:
     to: /blog/2021/three-amendments-expected
-    type: 301
 blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying.html:
     to: /blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying
-    type: 301
 blog/2021/community-spotlight-developing-wallet-protect.html:
     to: /blog/2021/community-spotlight-developing-wallet-protect
-    type: 301
 blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security.html:
     to: /blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security
-    type: 301
 blog/2021/rippled-1.7.0.html:
     to: /blog/2021/rippled-1.7.0
-    type: 301
 blog/2020/rippled-1.6.0.html:
     to: /blog/2020/rippled-1.6.0
-    type: 301
 blog/2020/moving-devnet-to-vl.html:
     to: /blog/2020/moving-devnet-to-vl
-    type: 301
 blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled.html:
     to: /blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled
-    type: 301
 blog/2020/developer-reflections-xrp-toolkit.html:
     to: /blog/2020/developer-reflections-xrp-toolkit
-    type: 301
 blog/2020/requirefullycanonicalsig-expected.html:
     to: /blog/2020/requirefullycanonicalsig-expected
-    type: 301
 blog/2020/checks-enabled.html:
     to: /blog/2020/checks-enabled
-    type: 301
 blog/2020/checks-expected.html:
     to: /blog/2020/checks-expected
-    type: 301
 blog/2020/developer-reflections-xrplorer.html:
     to: /blog/2020/developer-reflections-xrplorer
-    type: 301
 blog/2020/deletableaccounts-enabled.html:
     to: /blog/2020/deletableaccounts-enabled
-    type: 301
 blog/2020/get-ready-for-deletable-accounts.html:
     to: /blog/2020/get-ready-for-deletable-accounts
-    type: 301
 blog/2020/developer-reflections-xrpscan.html:
     to: /blog/2020/developer-reflections-xrpscan
-    type: 301
 blog/2020/two-fixes-enabled.html:
     to: /blog/2020/two-fixes-enabled
-    type: 301
 blog/2020/deletableaccounts-expected.html:
     to: /blog/2020/deletableaccounts-expected
-    type: 301
 blog/2020/testnet-amendments-rippled-1.5.0.html:
     to: /blog/2020/testnet-amendments-rippled-1.5.0
-    type: 301
 blog/2020/rippled-1.5.0.html:
     to: /blog/2020/rippled-1.5.0
-    type: 301
 blog/2020/running-an-xrp-ledger-validator.html:
     to: /blog/2020/running-an-xrp-ledger-validator
-    type: 301
 blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority.html:
     to: /blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority
-    type: 301
 blog/2020/rippled-1.4.0-upgrade-advisory.html:
     to: /blog/2020/rippled-1.4.0-upgrade-advisory
-    type: 301
 blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected.html:
     to: /blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected
-    type: 301
 blog/2019/rippled-1.4.0.html:
     to: /blog/2019/rippled-1.4.0
-    type: 301
 blog/2019/xrpl-devnet-launch.html:
     to: /blog/2019/xrpl-devnet-launch
-    type: 301
 blog/2019/fixmasterkeyasregularkey-enabled.html:
     to: /blog/2019/fixmasterkeyasregularkey-enabled
-    type: 301
 blog/2019/fixmasterkeyasregularkey-1day.html:
     to: /blog/2019/fixmasterkeyasregularkey-1day
-    type: 301
 blog/2019/fixmasterkeyasregularkey-expected.html:
     to: /blog/2019/fixmasterkeyasregularkey-expected
-    type: 301
 blog/2019/testnet-reset.html:
     to: /blog/2019/testnet-reset
-    type: 301
 blog/2019/rippled-1.3.1.html:
     to: /blog/2019/rippled-1.3.1
-    type: 301
 blog/2019/labeling-the-internet-of-value.html:
     to: /blog/2019/labeling-the-internet-of-value
-    type: 301
 blog/2019/discover-xrp-ledger-explorer.html:
     to: /blog/2019/discover-xrp-ledger-explorer
-    type: 301
 blog/2019/websocket-tool-update.html:
     to: /blog/2019/websocket-tool-update
-    type: 301
 blog/2019/welcome-to-xrpl-org.html:
     to: /blog/2019/welcome-to-xrpl-org
-    type: 301
 blog/2019/multisignreserve-enabled.html:
     to: /blog/2019/multisignreserve-enabled
-    type: 301
 blog/2019/rippled-1.2.4.html:
     to: /blog/2019/rippled-1.2.4
-    type: 301
 blog/2019/secure-development-practices.html:
     to: /blog/2019/secure-development-practices
-    type: 301
 blog/2019/multisignreserve-expected.html:
     to: /blog/2019/multisignreserve-expected
-    type: 301
 blog/2019/corrections-to-data-api-xrp-charts-metrics.html:
     to: /blog/2019/corrections-to-data-api-xrp-charts-metrics
-    type: 301
 blog/2019/interledger-checkin.html:
     to: /blog/2019/interledger-checkin
-    type: 301
 blog/2019/fixtakerdryofferremoval-enabled.html:
     to: /blog/2019/fixtakerdryofferremoval-enabled
-    type: 301
 blog/2019/rippled-1.2.3.html:
     to: /blog/2019/rippled-1.2.3
-    type: 301
 blog/2019/fix1578-enabled.html:
     to: /blog/2019/fix1578-enabled
-    type: 301
 blog/2019/fix1578-expected.html:
     to: /blog/2019/fix1578-expected
-    type: 301
 blog/2019/rippled-1.2.2.html:
     to: /blog/2019/rippled-1.2.2
-    type: 301
 blog/2019/rippled-1.2.1.html:
     to: /blog/2019/rippled-1.2.1
-    type: 301
 blog/2019/rippled-1.2.0.html:
     to: /blog/2019/rippled-1.2.0
-    type: 301
 blog/2019/statement-on-the-biased-nonce-sense-paper.html:
     to: /blog/2019/statement-on-the-biased-nonce-sense-paper
-    type: 301
 blog/2018/rippled-1.1.2.html:
     to: /blog/2018/rippled-1.1.2
-    type: 301
 blog/2018/introducing-history-sharding.html:
     to: /blog/2018/introducing-history-sharding
-    type: 301
 blog/2018/data-api-validations-changes.html:
     to: /blog/2018/data-api-validations-changes
-    type: 301
 blog/2018/rippled-1.1.1.html:
     to: /blog/2018/rippled-1.1.1
-    type: 301
 blog/2018/depositpreauth-fix1515-enabled.html:
     to: /blog/2018/depositpreauth-fix1515-enabled
-    type: 301
 blog/2018/rippled-1.1.0.html:
     to: /blog/2018/rippled-1.1.0
-    type: 301
 blog/2018/ripple-lib-1.0.0.html:
     to: /blog/2018/ripple-lib-1.0.0
-    type: 301
 blog/2018/fix1571-enabled.html:
     to: /blog/2018/fix1571-enabled
-    type: 301
 blog/2018/rippled-1.0.1.html:
     to: /blog/2018/rippled-1.0.1
-    type: 301
 blog/2018/fix1543-fix1571-fix1623-voting.html:
     to: /blog/2018/fix1543-fix1571-fix1623-voting
-    type: 301
 blog/2018/rippled-1.0.0.html:
     to: /blog/2018/rippled-1.0.0
-    type: 301
 blog/2018/depositauth-fix1513-available.html:
     to: /blog/2018/depositauth-fix1513-available
-    type: 301
 blog/2018/rippled-0.90.1.html:
     to: /blog/2018/rippled-0.90.1
-    type: 301
 blog/2018/rippled-0.90.0.html:
     to: /blog/2018/rippled-0.90.0
-    type: 301
 blog/2018/rippled-validator-key-replacement.html:
     to: /blog/2018/rippled-validator-key-replacement
-    type: 301
 blog/2018/rippled-boost166-warning.html:
     to: /blog/2018/rippled-boost166-warning
-    type: 301
 blog/2018/rippled-0.81.0.html:
     to: /blog/2018/rippled-0.81.0
-    type: 301
 blog/2017/explanation-of-ripples-xrp-escrow.html:
     to: /blog/2017/explanation-of-ripples-xrp-escrow
-    type: 301
 blog/2017/rippled-0.80.2.html:
     to: /blog/2017/rippled-0.80.2
-    type: 301
 blog/2017/rippled-0.80.0.html:
     to: /blog/2017/rippled-0.80.0
-    type: 301
 blog/2017/decent-strategy-update.html:
     to: /blog/2017/decent-strategy-update
-    type: 301
 blog/2017/high-scalability-xrp-ledger.html:
     to: /blog/2017/high-scalability-xrp-ledger
-    type: 301
 blog/2017/rippled-0.70.2.html:
     to: /blog/2017/rippled-0.70.2
-    type: 301
 blog/2017/invariant-checking.html:
     to: /blog/2017/invariant-checking
-    type: 301
 blog/2017/rippled-0.70.1.html:
     to: /blog/2017/rippled-0.70.1
-    type: 301
 blog/2017/rippled-0.70.0.html:
     to: /blog/2017/rippled-0.70.0
-    type: 301
 blog/2017/rippled-0.60.3.html:
     to: /blog/2017/rippled-0.60.3
-    type: 301
 blog/2017/rippled-0.60.2-2-rpm.html:
     to: /blog/2017/rippled-0.60.2-2-rpm
-    type: 301
 blog/2017/rippled-0.60.2.html:
     to: /blog/2017/rippled-0.60.2
-    type: 301
 blog/2017/rippled-0.60.1.html:
     to: /blog/2017/rippled-0.60.1
-    type: 301
 blog/2017/escrow-paychan-fix1368-reminder.html:
     to: /blog/2017/escrow-paychan-fix1368-reminder
-    type: 301
 blog/2017/rippled-0.60.0.html:
     to: /blog/2017/rippled-0.60.0
-    type: 301
 blog/2017/trust-line-quality-sendmax.html:
     to: /blog/2017/trust-line-quality-sendmax
-    type: 301
 blog/2017/rippled-0.50.3.html:
     to: /blog/2017/rippled-0.50.3
-    type: 301
 blog/2017/ripple-consensus-ledger-can-sustain-1000-transactions-per-second.html:
     to: /blog/2017/ripple-consensus-ledger-can-sustain-1000-transactions-per-second
-    type: 301
 blog/2017/ticksize-available.html:
     to: /blog/2017/ticksize-available
-    type: 301
 blog/2017/ticksize-3days.html:
     to: /blog/2017/ticksize-3days
-    type: 301
 blog/2017/ticksize-7days.html:
     to: /blog/2017/ticksize-7days
-    type: 301
 blog/2017/ticksize-voting.html:
     to: /blog/2017/ticksize-voting
-    type: 301
 blog/2017/rippled-0.50.2.html:
     to: /blog/2017/rippled-0.50.2
-    type: 301
 blog/2017/rippled-0.50.0.html:
     to: /blog/2017/rippled-0.50.0
-    type: 301
 blog/2017/data-api-load-balancing-test.html:
     to: /blog/2017/data-api-load-balancing-test
-    type: 301
 blog/2017/response-to-china-cert-report.html:
     to: /blog/2017/response-to-china-cert-report
-    type: 301
 blog/2017/rippled-0.40.1.html:
     to: /blog/2017/rippled-0.40.1
-    type: 301
 blog/2016/rippled-0.40.0.html:
     to: /blog/2016/rippled-0.40.0
-    type: 301
 blog/2016/flow-available.html:
     to: /blog/2016/flow-available
-    type: 301
 blog/2016/flow-reminder.html:
     to: /blog/2016/flow-reminder
-    type: 301
 blog/2016/flow-voting.html:
     to: /blog/2016/flow-voting
-    type: 301
 blog/2016/rippled-0.33.0-hf1.html:
     to: /blog/2016/rippled-0.33.0-hf1
-    type: 301
 blog/2016/rippled-0.33.0.html:
     to: /blog/2016/rippled-0.33.0
-    type: 301
 blog/2016/testnet-ledger-reset.html:
     to: /blog/2016/testnet-ledger-reset
-    type: 301
 blog/2016/flowv2-vetoed.html:
     to: /blog/2016/flowv2-vetoed
-    type: 301
 blog/2016/flowv2-voting.html:
     to: /blog/2016/flowv2-voting
-    type: 301
 blog/2016/rippled-0.32.1.html:
     to: /blog/2016/rippled-0.32.1
-    type: 301
 blog/2016/trustsetauth-available.html:
     to: /blog/2016/trustsetauth-available
-    type: 301
 blog/2016/trustsetauth-reminder.html:
     to: /blog/2016/trustsetauth-reminder
-    type: 301
 blog/2016/trustsetauth-voting.html:
     to: /blog/2016/trustsetauth-voting
-    type: 301
 blog/2016/multisign-available.html:
     to: /blog/2016/multisign-available
-    type: 301
 blog/2016/rippled-0.32.0.html:
     to: /blog/2016/rippled-0.32.0
-    type: 301
 blog/2016/multisign-reminder.html:
     to: /blog/2016/multisign-reminder
-    type: 301
 blog/2016/data-api-v2.2.html:
     to: /blog/2016/data-api-v2.2
-    type: 301
 blog/2016/introducing-rippleapi.html:
     to: /blog/2016/introducing-rippleapi
-    type: 301
 blog/2016/rippled-0.31.2-updates.html:
     to: /blog/2016/rippled-0.31.2-updates
-    type: 301
 blog/2016/rippled-0.30.1.html:
     to: /blog/2016/rippled-0.30.1
-    type: 301
 blog/2015/correction-to-ripple-white-paper.html:
     to: /blog/2015/correction-to-ripple-white-paper
-    type: 301
 blog/2015/validator-registry.html:
     to: /blog/2015/validator-registry
-    type: 301
 blog/2015/introducing-the-data-api.html:
     to: /blog/2015/introducing-the-data-api
-    type: 301
 blog/2015/gatewayd-no-longer-available.html:
     to: /blog/2015/gatewayd-no-longer-available
-    type: 301
 blog/2015/ripple-charts-update-payment-volume-and-issued-value.html:
     to: /blog/2015/ripple-charts-update-payment-volume-and-issued-value
-    type: 301
 blog/2015/do-you-have-what-it-takes-to-be-a-gateway.html:
     to: /blog/2015/do-you-have-what-it-takes-to-be-a-gateway
-    type: 301
 blog/2015/calculating-balance-changes-for-a-transaction.html:
     to: /blog/2015/calculating-balance-changes-for-a-transaction
-    type: 301
 blog/2014/turn-your-exchange-into-a-ripple-gateway.html:
     to: /blog/2014/turn-your-exchange-into-a-ripple-gateway
-    type: 301
 blog/2014/why-the-stellar-forking-issue-does-not-affect-ripple.html:
     to: /blog/2014/why-the-stellar-forking-issue-does-not-affect-ripple
-    type: 301
 blog/2014/release-notes-3-december-2014.html:
     to: /blog/2014/release-notes-3-december-2014
-    type: 301
 blog/2014/release-notes-19-november-2014.html:
     to: /blog/2014/release-notes-19-november-2014
-    type: 301
 blog/2014/ripplerest-1.3-release.html:
     to: /blog/2014/ripplerest-1.3-release
-    type: 301
 blog/2014/release-notes-29-october-2014.html:
     to: /blog/2014/release-notes-29-october-2014
-    type: 301
 blog/2014/gateway-advisory-on-partial-payment-flag.html:
     to: /blog/2014/gateway-advisory-on-partial-payment-flag
-    type: 301
 blog/2014/release-notes-14-october-2014.html:
     to: /blog/2014/release-notes-14-october-2014
-    type: 301
 blog/2014/how-ripple-labs-supports-gateways.html:
     to: /blog/2014/how-ripple-labs-supports-gateways
-    type: 301
 blog/2014/biweekly-release-notes-17-september-2014.html:
     to: /blog/2014/biweekly-release-notes-17-september-2014
-    type: 301
 blog/2014/biweekly-release-notes-3-september-2014.html:
     to: /blog/2014/biweekly-release-notes-3-september-2014
-    type: 301
 blog/2014/use-of-cpp14-in-rippled.html:
     to: /blog/2014/use-of-cpp14-in-rippled
-    type: 301
 blog/2014/biweekly-release-notes-14-august-2014.html:
     to: /blog/2014/biweekly-release-notes-14-august-2014
-    type: 301
 blog/2014/dev-portal-adds-rippled-apis.html:
     to: /blog/2014/dev-portal-adds-rippled-apis
-    type: 301
 blog/2014/biweekly-release-notes-31-july-2014.html:
     to: /blog/2014/biweekly-release-notes-31-july-2014
-    type: 301
 blog/2014/xrp-giveaway-for-developers.html:
     to: /blog/2014/xrp-giveaway-for-developers
-    type: 301
 blog/2014/ripple-labs-bounty-program-moves-to-bountysource.html:
     to: /blog/2014/ripple-labs-bounty-program-moves-to-bountysource
-    type: 301
 blog/2014/introducing-offer-autobridging.html:
     to: /blog/2014/introducing-offer-autobridging
-    type: 301
 blog/2014/curves-with-a-twist.html:
     to: /blog/2014/curves-with-a-twist
-    type: 301
 blog/2014/introducing-ripple-names.html:
     to: /blog/2014/introducing-ripple-names
-    type: 301
 blog/2014.html:
     to: /blog/
-    type: 301
 blog/2015.html:
     to: /blog/
-    type: 301
 blog/2016.html:
     to: /blog/
-    type: 301
 blog/2017.html:
     to: /blog/
-    type: 301
 blog/2018.html:
     to: /blog/
-    type: 301
 blog/2019.html:
     to: /blog/
-    type: 301
 blog/2020.html:
     to: /blog/
-    type: 301
 blog/2021.html:
     to: /blog/
-    type: 301
 blog/2022.html:
     to: /blog/
-    type: 301
 blog/2023.html:
     to: /blog/
-    type: 301
 blog/2024.html:
     to: /blog/
-    type: 301
 blog/label/developer-reflections.html:
     to: /blog/
-    type: 301
 code_of_conduct/:
     to: /code-of-conduct
-    type: 301
 code_of_conduct:
     to: /code-of-conduct
-    type: 301
 code_of_conduct.ja/:
     to: /ja/code-of-conduct
-    type: 301
 code_of_conduct.ja:
     to: /ja/code-of-conduct
-    type: 301
-
-# Japanese
-/ja/resources/contribute-documentation/tutorial-structure/:
-    to: /ja/resources/contribute-documentation/tutorial-guidelines/
-    type: 301
-/ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/use-an-escrow-as-a-smart-contract:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditional-escrow
-    type: 301
-/ja/docs/references/protocol/transactions/pseudo-transaction-types/pseudo-transaction-types/:
-    to: /ja/docs/references/protocol/transactions/pseudo-transaction-types/
-    type: 301
-/ja/docs/concepts/tokens/transfer-fees/:
-    to: /ja/docs/concepts/tokens/fungible-tokens/transfer-fees/
-    type: 301
-/ja/docs/infrastructure/configuration/data-retention/configure-history-sharding/:
-    to: /ja/docs/infrastructure/configuration/data-retention/
-    type: 301
-/ja/docs/infrastructure/configuration/data-retention/history-sharding/:
-    to: /ja/docs/infrastructure/configuration/data-retention/
-    type: 301
-/ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/node_to_shard/:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
-/ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/crawl_shards/:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
-/ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/download_shard/:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
-/ja/docs/infrastructure/installation/rippled-1-3-migration-instructions/:
-    to: /ja/docs/infrastructure/installation/
-    type: 301
-/ja/docs/infrastructure/installation/update-rippled-manually-on-centos-rhel/:
-    to: /ja/docs/infrastructure/installation/update-rippled-manually-on-rhel/
-    type: 301
-/ja/docs/infrastructure/installation/install-rippled-on-centos-rhel-with-yum/:
-    to: /ja/docs/infrastructure/installation/install-rippled-on-rhel/
-    type: 301
-/ja/docs/tutorials/javascript/trade-on-ledger/earn-passive-income-as-a-liquidity-provider:
-    to: /ja/docs/tutorials/javascript/amm/add-assets-to-amm
-    type: 301
-/ja/docs/tutorials/javascript/trade-on-ledger/use-amm-auction-slot-for-lower-fees:
-    to: /ja/docs/tutorials/javascript/amm/trade-with-auction-slot
-    type: 301
-/ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-recipient:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks
-    type: 301
-/ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-sender:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks
-    type: 301
-/ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/use-checks:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks
-    type: 301
-/ja/docs/references/protocol/transactions/transaction-results/transaction-results:
-    to: /ja/docs/references/protocol/transactions/transaction-results
-    type: 301
-/ja/xrp-ledger-rpc-tool.html:
-    to: /ja/resources/dev-tools/rpc-tool
-    type: 301
-/ja/xrp-ledger-toml-checker.html:
-    to: /ja/resources/dev-tools/xrp-ledger-toml-checker
-    type: 301
-/ja/domain-verification-checker.html:
-    to: /ja/resources/dev-tools/domain-verification-checker
-    type: 301
-/ja/websocket-api-tool.html:
-    to: /ja/resources/dev-tools/websocket-api-tool
-    type: 301
-/ja/xrp-testnet-faucet.html:
-    to: /ja/resources/dev-tools/xrp-faucets
-    type: 301
-/ja/xrp-test-net-faucet.html:
-    to: /ja/resources/dev-tools/xrp-faucets
-    type: 301
-/ja/resources/xrp-test-net-faucets:
-    to: /ja/resources/dev-tools/xrp-faucets
-    type: 301
-/ja/tx-sender.html:
-    to: /ja/resources/dev-tools/tx-sender
-    type: 301
-/ja/index.html:
-    to: /ja/
-    type: 301
-/ja/uses.html:
-    to: /ja/about/uses
-    type: 301
-/ja/docs.html:
-    to: /ja/docs/
-    type: 301
-/ja/tutorials.html:
-    to: /ja/docs/tutorials/
-    type: 301
-/ja/xrp-ledger-overview.html:
-    to: /ja/about/
-    type: 301
-/ja/xrp-overview.html:
-    to: /ja/about/xrp
-    type: 301
-/ja/overview.html:
-    to: /ja/about/
-    type: 301
-/ja/history.html:
-    to: /ja/about/history
-    type: 301
-/ja/impact.html:
-    to: /ja/about/impact
-    type: 301
-/ja/impact:
-    to: /ja/about/impact
-    type: 301
-/ja/carbon-calculator.html:
-    to: /ja/about/impact
-    type: 301
-/ja/contribute.html:
-    to: /ja/community
-    type: 301
-/ja/events.html:
-    to: /ja/community/events
-    type: 301
-/ja/ambassadors.html:
-    to: /ja/community/ambassadors
-    type: 301
-/ja/developer-funding.html:
-    to: /ja/community/developer-funding
-    type: 301
-/ja/code-samples.html:
-    to: /ja/resources/code-samples
-    type: 301
-/ja/dev-tools.html:
-    to: /ja/resources/dev-tools/
-    type: 301
-/ja/dev-tools-dev-tools.html:
-    to: /ja/resources/dev-tools/
-    type: 301
-/ja/validator-domain-verifier.html:
-    to: /ja/resources/dev-tools/domain-verifier/
-    type: 301
-/ja/docs-index.html:
-    to: /ja/docs/
-    type: 301
-/ja/explore.html:
-    to: /ja/about/
-    type: 301
-/ja/wallet.html:
-    to: /ja/about/xrp
-    type: 301
-/ja/exchanges.html:
-    to: /ja/about/xrp
-    type: 301
-/ja/businesses.html:
-    to: /ja/about/uses
-    type: 301
-/ja/ripple-txt-validator.html:
-    to: /ja/resources/dev-tools/xrp-ledger-toml-checker
-    type: 301
-/ja/production-readiness.html:
-    to: /ja/docs/tutorials
-    type: 301
-/ja/get-started.html:
-    to: /ja/docs/tutorials
-    type: 301
-/ja/run-rippled-as-a-wallet-server.html:
-    to: /ja/docs/infrastructure/configuration/server-modes/run-rippled-as-a-stock-server
-    type: 301
-/ja/faq.html:
-    to: /ja/about/faq
-    type: 301
-/ja/faq:
-    to: /ja/about/faq
-    type: 301
-/ja/privacy-policy.html:
-    to: /ja/about/privacy-policy
-    type: 301
-/ja/privacy-policy/:
-    to: /ja/about/privacy-policy
-    type: 301
-/ja/technical-faq.html:
-    to: /ja/about/faq
-    type: 301
-/ja/introduction.html:
-    to: /ja/docs/introduction/
-    type: 301
-/ja/what-is-the-xrp-ledger.html:
-    to: /ja/docs/introduction/what-is-the-xrp-ledger
-    type: 301
-/ja/what-is-xrp.html:
-    to: /ja/docs/introduction/what-is-xrp
-    type: 301
-/ja/xrp.html:
-    to: /ja/docs/introduction/what-is-xrp
-    type: 301
-/ja/crypto-wallets.html:
-    to: /ja/docs/introduction/crypto-wallets
-    type: 301
-/ja/txn-and-requests.html:
-    to: /ja/docs/introduction/transactions-and-requests
-    type: 301
-/ja/software-ecosystem.html:
-    to: /ja/docs/introduction/software-ecosystem
-    type: 301
-/ja/use-cases.html:
-    to: /ja/docs/use-cases/
-    type: 301
-/ja/payments-uc.html:
-    to: /ja/docs/use-cases/payments/
-    type: 301
-/ja/peer-to-peer-payments-uc.html:
-    to: /ja/docs/use-cases/payments/peer-to-peer-payments-uc
-    type: 301
-/ja/restricting-deposits-uc.html:
-    to: /ja/docs/use-cases/payments/restricting-deposits-uc
-    type: 301
-/ja/escrow-uc.html:
-    to: /ja/docs/use-cases/payments/smart-contracts-uc
-    type: 301
-/ja/tokenization.html:
-    to: /ja/docs/use-cases/tokenization/
-    type: 301
-/ja/stablecoin-issuer.html:
-    to: /ja/docs/use-cases/tokenization/stablecoin-issuer
-    type: 301
-/ja/nft-mkt-overview.html:
-    to: /ja/docs/use-cases/tokenization/nft-mkt-overview
-    type: 301
-/ja/nftoken-marketplace.html:
-    to: /ja/docs/use-cases/tokenization/nftoken-marketplace
-    type: 301
-/ja/authorized-minter.html:
-    to: /ja/docs/use-cases/tokenization/authorized-minter
-    type: 301
-/ja/digital-artist.html:
-    to: /ja/docs/use-cases/tokenization/digital-artist
-    type: 301
-/ja/defi-uc.html:
-    to: /ja/docs/use-cases/defi/
-    type: 301
-/ja/algorithmic-trading.html:
-    to: /ja/docs/use-cases/defi/algorithmic-trading
-    type: 301
-/ja/list-xrp-as-an-exchange.html:
-    to: /ja/docs/use-cases/defi/list-xrp-as-an-exchange
-    type: 301
-/ja/concepts.html:
-    to: /ja/docs/concepts/
-    type: 301
-/ja/networks-and-servers.html:
-    to: /ja/docs/concepts/networks-and-servers/
-    type: 301
-/ja/xrpl-servers.html:
-    to: /ja/docs/concepts/networks-and-servers/
-    type: 301
-/ja/rippled-server-modes.html:
-    to: /ja/docs/concepts/networks-and-servers/rippled-server-modes
-    type: 301
-/ja/clustering.html:
-    to: /ja/docs/concepts/networks-and-servers/clustering
-    type: 301
-/ja/ledger-history.html:
-    to: /ja/docs/concepts/networks-and-servers/ledger-history
-    type: 301
-/ja/peer-protocol.html:
-    to: /ja/docs/concepts/networks-and-servers/peer-protocol
-    type: 301
-/ja/transaction-censorship-detection.html:
-    to: /ja/docs/concepts/networks-and-servers/transaction-censorship-detection
-    type: 301
-/ja/parallel-networks.html:
-    to: /ja/docs/concepts/networks-and-servers/parallel-networks
-    type: 301
-/ja/amendments.html:
-    to: /ja/docs/concepts/networks-and-servers/amendments
-    type: 301
-/ja/the-clio-server.html:
-    to: /ja/docs/concepts/networks-and-servers/the-clio-server
-    type: 301
-/ja/consensus.html:
-    to: /ja/docs/concepts/consensus-protocol/
-    type: 301
-/ja/consensus-structure.html:
-    to: /ja/docs/concepts/consensus-protocol/consensus-structure
-    type: 301
-/ja/consensus-principles-and-rules.html:
-    to: /ja/docs/concepts/consensus-protocol/consensus-principles-and-rules
-    type: 301
-/ja/consensus-protections.html:
-    to: /ja/docs/concepts/consensus-protocol/consensus-protections
-    type: 301
-/ja/invariant-checking.html:
-    to: /ja/docs/concepts/consensus-protocol/invariant-checking
-    type: 301
-/ja/fee-voting.html:
-    to: /ja/docs/concepts/consensus-protocol/fee-voting
-    type: 301
-/ja/negative-unl.html:
-    to: /ja/docs/concepts/consensus-protocol/negative-unl
-    type: 301
-/ja/consensus-research.html:
-    to: /ja/docs/concepts/consensus-protocol/consensus-research
-    type: 301
-/ja/ledgers.html:
-    to: /ja/docs/concepts/ledgers/
-    type: 301
-/ja/ledger-structure.html:
-    to: /ja/docs/concepts/ledgers/ledger-structure
-    type: 301
-/ja/open-closed-validated-ledgers.html:
-    to: /ja/docs/concepts/ledgers/open-closed-validated-ledgers
-    type: 301
-/ja/ledger-close-times.html:
-    to: /ja/docs/concepts/ledgers/ledger-close-times
-    type: 301
-/ja/transactions.html:
-    to: /ja/docs/concepts/transactions/
-    type: 301
-/ja/fees.html:
-    to: /ja/docs/concepts/transactions/fees
-    type: 301
-/ja/reliable-transaction-submission.html:
-    to: /ja/docs/concepts/transactions/reliable-transaction-submission
-    type: 301
-/ja/secure-signing.html:
-    to: /ja/docs/concepts/transactions/secure-signing
-    type: 301
-/ja/source-and-destination-tags.html:
-    to: /ja/docs/concepts/transactions/source-and-destination-tags
-    type: 301
-/ja/transaction-cost.html:
-    to: /ja/docs/concepts/transactions/transaction-cost
-    type: 301
-/ja/transaction-queue.html:
-    to: /ja/docs/concepts/transactions/transaction-queue
-    type: 301
-/ja/finality-of-results.html:
-    to: /ja/docs/concepts/transactions/finality-of-results/
-    type: 301
-/ja/look-up-transaction-results.html:
-    to: /ja/docs/concepts/transactions/finality-of-results/look-up-transaction-results
-    type: 301
-/ja/transaction-malleability.html:
-    to: /ja/docs/concepts/transactions/finality-of-results/transaction-malleability
-    type: 301
-/ja/canceling-a-transaction.html:
-    to: /ja/docs/concepts/transactions/finality-of-results/canceling-a-transaction
-    type: 301
-/ja/payment-types.html:
-    to: /ja/docs/concepts/payment-types/
-    type: 301
-/ja/direct-xrp-payments.html:
-    to: /ja/docs/concepts/payment-types/direct-xrp-payments
-    type: 301
-/ja/cross-currency-payments.html:
-    to: /ja/docs/concepts/payment-types/cross-currency-payments
-    type: 301
-/ja/checks.html:
-    to: /ja/docs/concepts/payment-types/checks
-    type: 301
-/ja/escrow.html:
-    to: /ja/docs/concepts/payment-types/escrow
-    type: 301
-/ja/partial-payments.html:
-    to: /ja/docs/concepts/payment-types/partial-payments
-    type: 301
-/ja/payment-channels.html:
-    to: /ja/docs/concepts/payment-types/payment-channels
-    type: 301
-/ja/robustly-monitoring-for-payments.html:
-    to: /ja/docs/concepts/payment-types/robustly-monitoring-for-payments
-    type: 301
-/ja/sending-payments-to-customers.html:
-    to: /ja/docs/concepts/payment-types/sending-payments-to-customers
-    type: 301
-/ja/bouncing-payments.html:
-    to: /ja/docs/concepts/payment-types/bouncing-payments
-    type: 301
-/ja/tokens.html:
-    to: /ja/docs/concepts/tokens/
-    type: 301
-/ja/trust-lines-and-issuing.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/
-    type: 301
-/ja/authorized-trust-lines.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/authorized-trust-lines
-    type: 301
-/ja/stablecoins.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/stablecoins/
-    type: 301
-/ja/stablecoin-settings.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/stablecoins/settings
-    type: 301
-/ja/stablecoin-configuration.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/stablecoins/configuration
-    type: 301
-/ja/stablecoin-precautions.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/stablecoins/precautions
-    type: 301
-/ja/stablecoin-compliance-guidelines.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/stablecoins/compliance-guidelines
-    type: 301
-/ja/clawing-back-tokens.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/clawing-back-tokens
-    type: 301
-/ja/freezes.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/freezes
-    type: 301
-/ja/common-misconceptions-about-freezes.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/common-misconceptions-about-freezes
-    type: 301
-/ja/paths.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/paths
-    type: 301
-/ja/rippling.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/rippling
-    type: 301
-/ja/non-fungible-tokens.html:
-    to: /ja/docs/concepts/tokens/nfts/
-    type: 301
-/ja/nft-storage.html:
-    to: /ja/docs/concepts/tokens/nfts/payload-storage
-    type: 301
-/ja/non-fungible-token-transfers.html:
-    to: /ja/docs/concepts/tokens/nfts/trading
-    type: 301
-/ja/nft-reserve-requirements.html:
-    to: /ja/docs/concepts/tokens/nfts/reserve-requirements
-    type: 301
-/ja/nftoken-batch-minting.html:
-    to: /ja/docs/concepts/tokens/nfts/batch-minting
-    type: 301
-/ja/nftoken-authorized-minting.html:
-    to: /ja/docs/concepts/tokens/nfts/authorizing-another-minter
-    type: 301
-/ja/nftoken-auctions.html:
-    to: /ja/docs/concepts/tokens/nfts/running-an-nft-auction
-    type: 301
-/ja/nft-collections.html:
-    to: /ja/docs/concepts/tokens/nfts/collections
-    type: 301
-/ja/nft-fixed-supply.html:
-    to: /ja/docs/concepts/tokens/nfts/guaranteeing-a-fixed-supply
-    type: 301
-/ja/nft-apis.html:
-    to: /ja/docs/concepts/tokens/nfts/nft-apis
-    type: 301
-/ja/transfer-fees.html:
-    to: /ja/docs/concepts/tokens/transfer-fees
-    type: 301
-/ja/demurrage.html:
-    to: /ja/docs/concepts/tokens/fungible-tokens/demurrage
-    type: 301
-/ja/decentralized-exchange.html:
-    to: /ja/docs/concepts/tokens/decentralized-exchange/
-    type: 301
-/ja/offers.html:
-    to: /ja/docs/concepts/tokens/decentralized-exchange/offers
-    type: 301
-/ja/autobridging.html:
-    to: /ja/docs/concepts/tokens/decentralized-exchange/autobridging
-    type: 301
-/ja/ticksize.html:
-    to: /ja/docs/concepts/tokens/decentralized-exchange/ticksize
-    type: 301
-/ja/automated-market-makers.html:
-    to: /ja/docs/concepts/tokens/decentralized-exchange/automated-market-makers
-    type: 301
-/ja/accounts.html:
-    to: /ja/docs/concepts/accounts/
-    type: 301
-/ja/account-types.html:
-    to: /ja/docs/concepts/accounts/account-types
-    type: 301
-/ja/deleting-accounts.html:
-    to: /ja/docs/concepts/accounts/deleting-accounts
-    type: 301
-/ja/reserves.html:
-    to: /ja/docs/concepts/accounts/reserves
-    type: 301
-/ja/addresses.html:
-    to: /ja/docs/concepts/accounts/addresses
-    type: 301
-/ja/cryptographic-keys.html:
-    to: /ja/docs/concepts/accounts/cryptographic-keys
-    type: 301
-/ja/multi-signing.html:
-    to: /ja/docs/concepts/accounts/multi-signing
-    type: 301
-/ja/depositauth.html:
-    to: /ja/docs/concepts/accounts/depositauth
-    type: 301
-/ja/tickets.html:
-    to: /ja/docs/concepts/accounts/tickets
-    type: 301
-/ja/decentralized-identifiers.html:
-    to: /ja/docs/concepts/accounts/decentralized-identifiers
-    type: 301
-/ja/intro-to-consensus.html:
-    to: /ja/docs/concepts/consensus-protocol/
-    type: 301
-/ja/set-up-secure-signing.html:
-    to: /ja/docs/concepts/transactions/secure-signing
-    type: 301
-/ja/transaction-basics.html:
-    to: /ja/docs/concepts/transactions/
-    type: 301
-/ja/become-an-xrp-ledger-gateway.html:
-    to: /ja/docs/use-cases/tokenization/stablecoin-issuer
-    type: 301
-/ja/consensus-network.html:
-    to: /ja/docs/concepts/consensus-protocol/
-    type: 301
-/ja/complex-payment-types.html:
-    to: /ja/docs/concepts/payment-types/
-    type: 301
-/ja/about-canceling-a-transaction.html:
-    to: /ja/docs/concepts/transactions/finality-of-results/canceling-a-transaction
-    type: 301
-/ja/issuing-and-operational-addresses.html:
-    to: /ja/docs/concepts/accounts/account-types
-    type: 301
-/ja/issued-currencies.html:
-    to: /ja/docs/concepts/tokens/
-    type: 301
-/ja/issued-currencies-overview.html:
-    to: /ja/docs/concepts/tokens/
-    type: 301
-/ja/federated-sidechains.html:
-    to: https://opensource.ripple.com/docs/xls-38d-cross-chain-bridge/cross-chain-bridges/
-    type: 301
-/ja/xrpl-interoperability.html:
-    to: https://opensource.ripple.com/docs/xls-38d-cross-chain-bridge/cross-chain-bridges/
-    type: 301
-/ja/intro-to-evm-sidechain.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
-    type: 301
-/ja/the-rippled-server.html:
-    to: /ja/docs/concepts/networks-and-servers/
-    type: 301
-/ja/nft-concepts.html:
-    to: /ja/docs/concepts/tokens/nfts/
-    type: 301
-/ja/nft-conceptual-overview.html:
-    to: /ja/docs/concepts/tokens/nfts/
-    type: 301
-/ja/xrpl-sidechains.html:
-    to: /ja/docs/concepts/xrpl-sidechains/
-    type: 301
-/ja/cross-chain-bridges.html:
-    to: /ja/docs/concepts/xrpl-sidechains/cross-chain-bridges
-    type: 301
-/ja/witness-servers.html:
-    to: /ja/docs/concepts/xrpl-sidechains/witness-servers
-    type: 301
-/ja/public-servers.html:
-    to: /ja/docs/tutorials/public-servers
-    type: 301
-/ja/python.html:
-    to: /ja/docs/tutorials/python/
-    type: 301
-/ja/get-started-using-python.html:
-    to: /ja/docs/tutorials/python/get-started
-    type: 301
-/ja/docs/tutorials/python/get-started/:
-    to: /ja/docs/tutorials/python/build-apps/get-started/
-    type: 301
-/ja/modular-tutorials-in-python.html:
-    to: /ja/docs/tutorials/python/
-    type: 301
-/ja/send-payments-using-python.html:
-    to: /ja/docs/tutorials/python/send-payments
-    type: 301
-/ja/py-create-accounts-send-xrp.html:
-    to: /ja/docs/tutorials/python/send-payments/create-accounts-send-xrp
-    type: 301
-/ja/py-create-trustline-send-currency.html:
-    to: /ja/docs/tutorials/python/send-payments/create-trustline-send-currency
-    type: 301
-/ja/py-create-time-based-escrows.html:
-    to: /ja/docs/tutorials/python/send-payments/create-time-based-escrows
-    type: 301
-/ja/py-mint-and-burn-nfts.html:
-    to: /ja/docs/tutorials/python/nfts/mint-and-burn-nfts
-    type: 301
-/ja/py-transfer-nfts.html:
-    to: /ja/docs/tutorials/python/nfts/transfer-nfts
-    type: 301
-/ja/py-broker-sale.html:
-    to: /ja/docs/tutorials/python/nfts/broker-sale
-    type: 301
-/ja/py-authorize-minter.html:
-    to: /ja/docs/tutorials/python/nfts/authorize-minter
-    type: 301
-/ja/py-batch-minting.html:
-    to: /ja/docs/tutorials/python/nfts/batch-minting
-    type: 301
-/ja/build-a-desktop-wallet-in-python.html:
-    to: /ja/docs/tutorials/python/build-apps/build-a-desktop-wallet-in-python
-    type: 301
-/ja/javascript.html:
-    to: /ja/docs/tutorials/javascript/
-    type: 301
-/ja/get-started-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/build-apps/get-started
-    type: 301
-/ja/docs/tutorials/javascript/get-started:
-    to: /ja/docs/tutorials/javascript/build-apps/get-started/
-    type: 301
-/ja/docs/tutorials/javascript/get-started/:
-    to: /ja/docs/tutorials/javascript/build-apps/get-started/
-    type: 301
-/ja/get-started-using-node-js.html:
-    to: /ja/docs/tutorials/javascript/build-apps/get-started
-    type: 301
-/ja/get-started-with-rippleapi-for-javascript.html:
-    to: /ja/docs/tutorials/javascript/build-apps/get-started
-    type: 301
-/ja/modular-tutorials-in-javascript.html:
-    to: /ja/docs/tutorials/javascript/
-    type: 301
-/ja/send-payments-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/send-payments
-    type: 301
-/ja/create-accounts-send-xrp-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/send-payments/create-accounts-send-xrp
-    type: 301
-/ja/create-trustline-send-currency-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/send-payments/create-trustline-send-currency
-    type: 301
-/ja/create-time-based-escrows-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/send-payments/create-time-based-escrows
-    type: 301
-/ja/create-conditional-escrows-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/send-payments/create-conditional-escrows
-    type: 301
-/ja/nfts-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/nfts-using-javascript/
-    type: 301
-/ja/nfts-using-python.html:
-    to: /ja/docs/tutorials/python/nfts
-    type: 301
-/ja/mint-and-burn-nfts-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/nfts/mint-and-burn-nfts
-    type: 301
-/ja/transfer-nfts-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/nfts/transfer-nfts
-    type: 301
-/ja/broker-an-nft-sale-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/nfts/broker-an-nft-sale
-    type: 301
-/ja/assign-an-authorized-minter-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/nfts/assign-an-authorized-minter
-    type: 301
-/ja/batch-mint-nfts-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/nfts/batch-mint-nfts
-    type: 301
-/ja/build-a-browser-wallet-in-javascript.html:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
-/ja/build-a-browser-wallet-using-javascript.html:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
-/ja/docs/tutorials/javascript/build-a-browser-wallet-in-javascript:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
-/ja/docs/tutorials/javascript/build-a-browser-wallet-in-javascript/:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-browser-wallet-in-javascript/
-    type: 301
-/ja/build-a-desktop-wallet-in-javascript.html:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-desktop-wallet-in-javascript
-    type: 301
-/ja/docs/tutorials/javascript/build-a-desktop-wallet-in-javascript:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-desktop-wallet-in-javascript
-    type: 301
-/ja/docs/tutorials/javascript/build-a-desktop-wallet-in-javascript/:
-    to: /ja/docs/tutorials/javascript/build-apps/build-a-desktop-wallet-in-javascript
-    type: 301
-/ja/java.html:
-    to: /ja/docs/tutorials/java/
-    type: 301
-/ja/get-started-using-java.html:
-    to: /ja/docs/tutorials/java/build-apps/get-started
-    type: 301
-/ja/docs/tutorials/java/get-started:
-    to: /ja/docs/tutorials/java/build-apps/get-started
-    type: 301
-/ja/docs/tutorials/java/get-started/:
-    to: /ja/docs/tutorials/java/build-apps/get-started
-    type: 301
-/ja/php.html:
-    to: /ja/docs/tutorials/php
-    type: 301
-/ja/get-started-using-php.html:
-    to: /ja/docs/tutorials/php/build-apps/get-started
-    type: 301
-/ja/http-websocket-apis-tutorials.html:
-    to: /ja/docs/tutorials/http-websocket-apis/
-    type: 301
-/ja/get-started-with-the-rippled-api.html:
-    to: /ja/docs/tutorials/http-websocket-apis/build-apps/get-started
-    type: 301
-/ja/get-started-using-http-websocket-apis.html:
-    to: /ja/docs/tutorials/http-websocket-apis/build-apps/get-started/
-    type: 301
-/ja/docs/tutorials/http-websocket-apis/get-started:
-    to: /ja/docs/tutorials/http-websocket-apis/build-apps/get-started/
-    type: 301
-/ja/docs/tutorials/http-websocket-apis/get-started/:
-    to: /ja/docs/tutorials/http-websocket-apis/build-apps/get-started/
-    type: 301         
-/ja/monitor-incoming-payments-with-websocket.html:
-    to: /ja/docs/tutorials/http-websocket-apis/build-apps/monitor-incoming-payments-with-websocket
-    type: 301
-/ja/tasks.html:
-    to: /ja/docs/tutorials/how-tos/
-    type: 301
-/ja/manage-account-settings.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/
-    type: 301
-/ja/assign-a-regular-key-pair.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/assign-a-regular-key-pair
-    type: 301
-/ja/change-or-remove-a-regular-key-pair.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/change-or-remove-a-regular-key-pair
-    type: 301
-/ja/disable-master-key-pair.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/disable-master-key-pair
-    type: 301
-/ja/set-up-multi-signing.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/set-up-multi-signing
-    type: 301
-/ja/send-a-multi-signed-transaction.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/send-a-multi-signed-transaction
-    type: 301
-/ja/require-destination-tags.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/require-destination-tags
-    type: 301
-/ja/offline-account-setup.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/offline-account-setup
-    type: 301
-/ja/use-tickets.html:
-    to: /ja/docs/tutorials/how-tos/manage-account-settings/use-tickets
-    type: 301
-/ja/send-xrp.html:
-    to: /ja/docs/tutorials/how-tos/send-xrp
-    type: 301
-/ja/use-specialized-payment-types.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/
-    type: 301
-/ja/use-complex-payment-types.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/
-    type: 301
-/ja/use-escrows.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/
-    type: 301
-/ja/send-a-time-held-escrow.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-time-held-escrow
-    type: 301
-/ja/send-a-conditionally-held-escrow.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditional-escrow
-    type: 301
-/ja/cancel-an-expired-escrow.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/cancel-an-expired-escrow
-    type: 301
-/ja/look-up-escrows.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/look-up-escrows
-    type: 301
-/ja/use-an-escrow-as-a-smart-contract.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-escrows/send-a-conditional-escrow
-    type: 301
-/ja/use-payment-channels.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-payment-channels
-    type: 301
-/ja/open-a-payment-channel-to-enable-an-inter-exchange-network.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/open-a-payment-channel-to-enable-an-inter-exchange-network
-    type: 301
-/ja/use-checks.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/use-checks
-    type: 301
-/ja/send-a-check.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/send-a-check
-    type: 301
-/ja/cash-a-check-for-an-exact-amount.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/cash-a-check-for-an-exact-amount
-    type: 301
-/ja/cash-a-check-for-a-flexible-amount.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/cash-a-check-for-a-flexible-amount
-    type: 301
-/ja/cancel-a-check.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/cancel-a-check
-    type: 301
-/ja/look-up-checks-by-sender.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-sender
-    type: 301
-/ja/look-up-checks-by-recipient.html:
-    to: /ja/docs/tutorials/how-tos/use-specialized-payment-types/use-checks/look-up-checks-by-recipient
-    type: 301
-/ja/use-tokens.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/
-    type: 301
-/ja/issue-a-fungible-token.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/issue-a-fungible-token
-    type: 301
-/ja/trade-in-the-decentralized-exchange.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/trade-in-the-decentralized-exchange
-    type: 301
-/ja/enable-no-freeze.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/enable-no-freeze
-    type: 301
-/ja/enact-global-freeze.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/enact-global-freeze
-    type: 301
-/ja/freeze-a-trust-line.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/freeze-a-trust-line
-    type: 301
-/ja/create-an-automated-market-maker.html:
-    to: /ja/docs/tutorials/how-tos/use-tokens/create-an-automated-market-maker
-    type: 301
-/ja/use-simple-xrp-payments.html:
-    to: /ja/docs/tutorials/how-tos/send-xrp
-    type: 301
-/ja/cancel-or-skip-a-transaction.html:
-    to: /ja/docs/concepts/transactions/finality-of-results/canceling-a-transaction
-    type: 301
-/ja/evm-sidechains.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/
-    type: 301
-/ja/get-started-evm-sidechain.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/get-started-evm-sidechain/
-    type: 301
-/ja/connect-metamask-to-xrpl-evm-sidechain.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/connect-metamask-to-xrpl-evm-sidechain/
-    type: 301
-/ja/join-evm-sidechain-devnet.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/join-evm-sidechain-devnet/
-    type: 301
-/ja/evm-sidechain-validator-security.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-validator-security/
-    type: 301
-/ja/evm-sidechain-run-a-validator-node.html:
-    to: https://opensource.ripple.com/docs/evm-sidechain/evm-sidechain-run-a-validator-node/
-    type: 301
-/ja/use-xrpl-sidechains.html:
-    to: /ja/docs/tutorials/how-tos/use-xrpl-sidechains/
-    type: 301
-/ja/set-up-xrp-xrp-bridge.html:
-    to: /ja/docs/tutorials/how-tos/use-xrpl-sidechains/set-up-xrp-xrp-bridge
-    type: 301
-/ja/set-up-iou-iou-bridge.html:
-    to: /ja/docs/tutorials/how-tos/use-xrpl-sidechains/set-up-iou-iou-bridge
-    type: 301
-/ja/submit-cross-chain-transactions.html:
-    to: /ja/docs/tutorials/how-tos/use-xrpl-sidechains/submit-cross-chain-transaction
-    type: 301
-/ja/references.html:
-    to: /ja/docs/references/
-    type: 301
-/ja/protocol-reference.html:
-    to: /ja/docs/references/protocol/
-    type: 301
-/ja/basic-data-types.html:
-    to: /ja/docs/references/protocol/data-types/basic-data-types
-    type: 301
-/ja/base58-encodings.html:
-    to: /ja/docs/references/protocol/data-types/base58-encodings
-    type: 301
-/ja/currency-formats.html:
-    to: /ja/docs/references/protocol/data-types/currency-formats
-    type: 301
-/ja/nftoken.html:
-    to: /ja/docs/references/protocol/data-types/nftoken
-    type: 301
-/ja/ledger-data-formats.html:
-    to: /ja/docs/references/protocol/ledger-data/
-    type: 301
-/ja/ledger-header.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-header
-    type: 301
-/ja/ledger-entry-common-fields.html:
-    to: /ja/docs/references/protocol/ledger-data/common-fields
-    type: 301
-/ja/ledger-entry-types.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/
-    type: 301
-/ja/ledger-object-types.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/
-    type: 301
-/ja/ledger-object-ids.html:
-    to: /ja/docs/references/protocol/ledger-data/common-fields
-    type: 301
-/ja/accountroot.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/accountroot
-    type: 301
-/ja/amendments-object.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/amendments
-    type: 301
-/ja/amm.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/amm
-    type: 301
-/ja/bridge.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/bridge
-    type: 301
-/ja/check.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/check
-    type: 301
-/ja/depositpreauth-object.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/depositpreauth
-    type: 301
-/ja/did.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/did
-    type: 301
-/ja/directorynode.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/directorynode
-    type: 301
-/ja/escrow-object.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/escrow
-    type: 301
-/ja/feesettings.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/feesettings
-    type: 301
-/ja/ledgerhashes.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/ledgerhashes
-    type: 301
-/ja/negativeunl.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/negativeunl
-    type: 301
-/ja/nftokenoffer.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/nftokenoffer
-    type: 301
-/ja/nftokenpage.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/nftokenpage
-    type: 301
-/ja/offer.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/offer
-    type: 301
-/ja/paychannel.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/paychannel
-    type: 301
-/ja/ripplestate.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate
-    type: 301
-/ja/signerlist.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/signerlist
-    type: 301
-/ja/ticket.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/ticket
-    type: 301
-/ja/xchainownedclaimid.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedclaimid
-    type: 301
-/ja/xchainownedcreateaccountclaimid.html:
-    to: /ja/docs/references/protocol/ledger-data/ledger-entry-types/xchainownedcreateaccountclaimid
-    type: 301
-/ja/transaction-formats.html:
-    to: /ja/docs/references/protocol/transactions/
-    type: 301
-/ja/transaction-common-fields.html:
-    to: /ja/docs/references/protocol/transactions/common-fields
-    type: 301
-/ja/transaction-types.html:
-    to: /ja/docs/references/protocol/transactions/types/
-    type: 301
-/ja/accountset.html:
-    to: /ja/docs/references/protocol/transactions/types/accountset
-    type: 301
-/ja/accountdelete.html:
-    to: /ja/docs/references/protocol/transactions/types/accountdelete
-    type: 301
-/ja/ammbid.html:
-    to: /ja/docs/references/protocol/transactions/types/ammbid
-    type: 301
-/ja/ammcreate.html:
-    to: /ja/docs/references/protocol/transactions/types/ammcreate
-    type: 301
-/ja/ammdelete.html:
-    to: /ja/docs/references/protocol/transactions/types/ammdelete
-    type: 301
-/ja/ammdeposit.html:
-    to: /ja/docs/references/protocol/transactions/types/ammdeposit
-    type: 301
-/ja/ammvote.html:
-    to: /ja/docs/references/protocol/transactions/types/ammvote
-    type: 301
-/ja/ammwithdraw.html:
-    to: /ja/docs/references/protocol/transactions/types/ammwithdraw
-    type: 301
-/ja/checkcancel.html:
-    to: /ja/docs/references/protocol/transactions/types/checkcancel
-    type: 301
-/ja/checkcash.html:
-    to: /ja/docs/references/protocol/transactions/types/checkcash
-    type: 301
-/ja/checkcreate.html:
-    to: /ja/docs/references/protocol/transactions/types/checkcreate
-    type: 301
-/ja/clawback.html:
-    to: /ja/docs/references/protocol/transactions/types/clawback
-    type: 301
-/ja/depositpreauth.html:
-    to: /ja/docs/references/protocol/transactions/types/depositpreauth
-    type: 301
-/ja/diddelete.html:
-    to: /ja/docs/references/protocol/transactions/types/diddelete
-    type: 301
-/ja/didset.html:
-    to: /ja/docs/references/protocol/transactions/types/didset
-    type: 301
-/ja/escrowcancel.html:
-    to: /ja/docs/references/protocol/transactions/types/escrowcancel
-    type: 301
-/ja/escrowcreate.html:
-    to: /ja/docs/references/protocol/transactions/types/escrowcreate
-    type: 301
-/ja/escrowfinish.html:
-    to: /ja/docs/references/protocol/transactions/types/escrowfinish
-    type: 301
-/ja/nftokenacceptoffer.html:
-    to: /ja/docs/references/protocol/transactions/types/nftokenacceptoffer
-    type: 301
-/ja/nftokenburn.html:
-    to: /ja/docs/references/protocol/transactions/types/nftokenburn
-    type: 301
-/ja/nftokencanceloffer.html:
-    to: /ja/docs/references/protocol/transactions/types/nftokencanceloffer
-    type: 301
-/ja/nftokencreateoffer.html:
-    to: /ja/docs/references/protocol/transactions/types/nftokencreateoffer
-    type: 301
-/ja/nftokenmint.html:
-    to: /ja/docs/references/protocol/transactions/types/nftokenmint
-    type: 301
-/ja/offercancel.html:
-    to: /ja/docs/references/protocol/transactions/types/offercancel
-    type: 301
-/ja/offercreate.html:
-    to: /ja/docs/references/protocol/transactions/types/offercreate
-    type: 301
-/ja/payment.html:
-    to: /ja/docs/references/protocol/transactions/types/payment
-    type: 301
-/ja/paymentchannelclaim.html:
-    to: /ja/docs/references/protocol/transactions/types/paymentchannelclaim
-    type: 301
-/ja/paymentchannelcreate.html:
-    to: /ja/docs/references/protocol/transactions/types/paymentchannelcreate
-    type: 301
-/ja/paymentchannelfund.html:
-    to: /ja/docs/references/protocol/transactions/types/paymentchannelfund
-    type: 301
-/ja/setregularkey.html:
-    to: /ja/docs/references/protocol/transactions/types/setregularkey
-    type: 301
-/ja/signerlistset.html:
-    to: /ja/docs/references/protocol/transactions/types/signerlistset
-    type: 301
-/ja/ticketcreate.html:
-    to: /ja/docs/references/protocol/transactions/types/ticketcreate
-    type: 301
-/ja/trustset.html:
-    to: /ja/docs/references/protocol/transactions/types/trustset
-    type: 301
-/ja/xchainaccountcreatecommit.html:
-    to: /ja/docs/references/protocol/transactions/types/xchainaccountcreatecommit
-    type: 301
-/ja/xchainaddaccountcreateattestation.html:
-    to: /ja/docs/references/protocol/transactions/types/xchainaddaccountcreateattestation
-    type: 301
-/ja/xchainaddclaimattestation.html:
-    to: /ja/docs/references/protocol/transactions/types/xchainaddclaimattestation
-    type: 301
-/ja/xchainclaim.html:
-    to: /ja/docs/references/protocol/transactions/types/xchainclaim
-    type: 301
-/ja/xchaincommit.html:
-    to: /ja/docs/references/protocol/transactions/types/xchaincommit
-    type: 301
-/ja/xchaincreatebridge.html:
-    to: /ja/docs/references/protocol/transactions/types/xchaincreatebridge
-    type: 301
-/ja/xchaincreateclaimid.html:
-    to: /ja/docs/references/protocol/transactions/types/xchaincreateclaimid
-    type: 301
-/ja/xchainmodifybridge.html:
-    to: /ja/docs/references/protocol/transactions/types/xchainmodifybridge
-    type: 301
-/ja/pseudo-transaction-types.html:
-    to: /ja/docs/references/protocol/transactions/pseudo-transaction-types/pseudo-transaction-types
-    type: 301
-/ja/enableamendment.html:
-    to: /ja/docs/references/protocol/transactions/pseudo-transaction-types/enableamendment
-    type: 301
-/ja/setfee.html:
-    to: /ja/docs/references/protocol/transactions/pseudo-transaction-types/setfee
-    type: 301
-/ja/unlmodify.html:
-    to: /ja/docs/references/protocol/transactions/pseudo-transaction-types/unlmodify
-    type: 301
-/ja/transaction-results.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/transaction-results
-    type: 301
-/ja/tec-codes.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/tec-codes
-    type: 301
-/ja/tef-codes.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/tef-codes
-    type: 301
-/ja/tel-codes.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/tel-codes
-    type: 301
-/ja/tem-codes.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/tem-codes
-    type: 301
-/ja/ter-codes.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/ter-codes
-    type: 301
-/ja/tes-success.html:
-    to: /ja/docs/references/protocol/transactions/transaction-results/tes-success
-    type: 301
-/ja/transaction-metadata.html:
-    to: /ja/docs/references/protocol/transactions/metadata
-    type: 301
-/ja/modifying-the-ledger.html:
-    to: /ja/docs/references/protocol/transactions/
-    type: 301
-/ja/serialization.html:
-    to: /ja/docs/references/protocol/binary-format
-    type: 301
-/ja/client-libraries.html:
-    to: /ja/docs/references/client-libraries
-    type: 301
-/ja/rippleapi-reference.html:
-    to: https://js.xrpl.org/
-    type: 301
-/ja/xrpljs2-migration-guide.html:
-    to: /ja/docs/references/xrpljs2-migration-guide
-    type: 301
-/ja/http-websocket-apis.html:
-    to: /ja/docs/references/http-websocket-apis/
-    type: 301
-/ja/rippled-api.html:
-    to: /ja/docs/references/http-websocket-apis/
-    type: 301
-/ja/api-conventions.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/
-    type: 301
-/ja/request-formatting.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/request-formatting
-    type: 301
-/ja/response-formatting.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/response-formatting
-    type: 301
-/ja/error-formatting.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/error-formatting
-    type: 301
-/ja/markers-and-pagination.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/markers-and-pagination
-    type: 301
-/ja/rate-limiting.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/rate-limiting
-    type: 301
-/ja/rippled-server-states.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/rippled-server-states
-    type: 301
-/ja/ctid.html:
-    to: /ja/docs/references/http-websocket-apis/api-conventions/ctid
-    type: 301
-/ja/public-api-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/
-    type: 301
-/ja/public-rippled-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/
-    type: 301
-/ja/account-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/
-    type: 301
-/ja/account_channels.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_channels
-    type: 301
-/ja/account_currencies.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_currencies
-    type: 301
-/ja/account_info.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_info
-    type: 301
-/ja/account_lines.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines
-    type: 301
-/ja/account_nfts.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_nfts
-    type: 301
-/ja/account_objects.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects
-    type: 301
-/ja/account_offers.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_offers
-    type: 301
-/ja/account_tx.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx
-    type: 301
-/ja/gateway_balances.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/gateway_balances
-    type: 301
-/ja/noripple_check.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/account-methods/noripple_check
-    type: 301
-/ja/ledger-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/ledger-methods/
-    type: 301
-/ja/ledger.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger
-    type: 301
-/ja/ledger_closed.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_closed
-    type: 301
-/ja/ledger_current.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_current
-    type: 301
-/ja/ledger_data.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_data
-    type: 301
-/ja/ledger_entry.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry
-    type: 301
-/ja/transaction-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/transaction-methods/
-    type: 301
-/ja/submit.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/transaction-methods/submit
-    type: 301
-/ja/submit_multisigned.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/transaction-methods/submit_multisigned
-    type: 301
-/ja/transaction_entry.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/transaction-methods/transaction_entry
-    type: 301
-/ja/tx.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/transaction-methods/tx
-    type: 301
-/ja/tx_history.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/transaction-methods/tx_history
-    type: 301
-/ja/path-and-order-book-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/
-    type: 301
-/ja/amm_info.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/amm_info
-    type: 301
-/ja/book_offers.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/book_offers
-    type: 301
-/ja/deposit_authorized.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/deposit_authorized
-    type: 301
-/ja/nft_buy_offers.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_buy_offers
-    type: 301
-/ja/nft_sell_offers.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/nft_sell_offers
-    type: 301
-/ja/path_find.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/path_find
-    type: 301
-/ja/ripple_path_find.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/path-and-order-book-methods/ripple_path_find
-    type: 301
-/ja/payment-channel-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/
-    type: 301
-/ja/channel_authorize.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_authorize
-    type: 301
-/ja/channel_verify.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify
-    type: 301
-/ja/subscription-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/subscription-methods/
-    type: 301
-/ja/subscribe.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/subscription-methods/subscribe
-    type: 301
-/ja/unsubscribe.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/subscription-methods/unsubscribe
-    type: 301
-/ja/server-info-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/server-info-methods/
-    type: 301
-/ja/fee.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/server-info-methods/fee
-    type: 301
-/ja/manifest.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/server-info-methods/manifest
-    type: 301
-/ja/server_definitions.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions
-    type: 301
-/ja/server_info.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_info
-    type: 301
-/ja/server_state.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_state
-    type: 301
-/ja/clio-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/clio-server/
-    type: 301
-/ja/server_info-clio.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/clio-methods/server_info-clio
-    type: 301
-/ja/ledger-clio.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/clio-methods/ledger-clio
-    type: 301
-/ja/nft_history.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/clio-methods/nft_history
-    type: 301
-/ja/nft_info.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/clio-methods/nft_info
-    type: 301
-/ja/utility-methods.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/utility-methods/
-    type: 301
-/ja/json.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/utility-methods/json
-    type: 301
-/ja/ping.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/utility-methods/ping
-    type: 301
-/ja/random.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/utility-methods/random
-    type: 301
-/ja/admin-api-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/
-    type: 301
-/ja/admin-rippled-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/
-    type: 301
-/ja/key-generation-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/key-generation-methods/
-    type: 301
-/ja/validation_create.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/key-generation-methods/validation_create
-    type: 301
-/ja/wallet_propose.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/key-generation-methods/wallet_propose
-    type: 301
-/ja/logging-and-data-management-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/
-    type: 301
-/ja/can_delete.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/can_delete
-    type: 301
-/ja/crawl_shards.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/crawl_shards
-    type: 301
-/ja/download_shard.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/download_shard
-    type: 301
-/ja/ledger_cleaner.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/ledger_cleaner
-    type: 301
-/ja/ledger_request.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/ledger_request
-    type: 301
-/ja/log_level.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/log_level
-    type: 301
-/ja/logrotate.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/logrotate
-    type: 301
-/ja/node_to_shard.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/logging-and-data-management-methods/node_to_shard
-    type: 301
-/ja/server-control-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/server-control-methods/
-    type: 301
-/ja/ledger_accept.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/server-control-methods/ledger_accept
-    type: 301
-/ja/stop.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/server-control-methods/stop
-    type: 301
-/ja/validation_seed.html:
-    to: /ja/docs/references/http-websocket-apis/public-api-methods/
-    type: 301
-/ja/signing-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/signing-methods/
-    type: 301
-/ja/sign.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/signing-methods/sign
-    type: 301
-/ja/sign_for.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/signing-methods/sign_for
-    type: 301
-/ja/peer-management-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/
-    type: 301
-/ja/connect.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/connect
-    type: 301
-/ja/peer_reservations_add.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peer_reservations_add
-    type: 301
-/ja/peer_reservations_del.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peer_reservations_del
-    type: 301
-/ja/peer_reservations_list.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peer_reservations_list
-    type: 301
-/ja/peers.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/peer-management-methods/peers
-    type: 301
-/ja/status-and-debugging-methods.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/
-    type: 301
-/ja/consensus_info.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/consensus_info
-    type: 301
-/ja/feature.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/feature
-    type: 301
-/ja/fetch_info.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/fetch_info
-    type: 301
-/ja/get_counts.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/get_counts
-    type: 301
-/ja/print.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/print
-    type: 301
-/ja/validator_info.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/validator_info
-    type: 301
-/ja/validator_list_sites.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/validator_list_sites
-    type: 301
-/ja/validators.html:
-    to: /ja/docs/references/http-websocket-apis/admin-api-methods/status-and-debugging-methods/validators
-    type: 301
-/ja/peer-port-methods.html:
-    to: /ja/docs/references/http-websocket-apis/peer-port-methods/
-    type: 301
-/ja/health-check.html:
-    to: /ja/docs/references/http-websocket-apis/peer-port-methods/health-check
-    type: 301
-/ja/peer-crawler.html:
-    to: /ja/docs/references/http-websocket-apis/peer-port-methods/peer-crawler
-    type: 301
-/ja/validator-list.html:
-    to: /ja/docs/references/http-websocket-apis/peer-port-methods/validator-list
-    type: 301
-/ja/xrp-api.html:
-    to: https://xpring-eng.github.io/xrp-api/
-    type: 301
-/ja/data-api.html:
-    to: /ja/docs/references/data-api
-    type: 301
-/ja/xrp-ledger-toml.html:
-    to: /ja/docs/references/xrp-ledger-toml
-    type: 301
-/ja/infrastructure.html:
-    to: /ja/docs/infrastructure/
-    type: 301
-/ja/commandline-usage.html:
-    to: /ja/docs/infrastructure/commandline-usage
-    type: 301
-/ja/install-rippled.html:
-    to: /ja/docs/infrastructure/installation/
-    type: 301
-/ja/system-requirements.html:
-    to: /ja/docs/infrastructure/installation/system-requirements
-    type: 301
-/ja/install-rippled-on-centos-rhel-with-yum.html:
-    to: /ja/docs/infrastructure/installation/install-rippled-on-rhel
-    type: 301
-/ja/install-rippled-on-ubuntu.html:
-    to: /ja/docs/infrastructure/installation/install-rippled-on-ubuntu
-    type: 301
-/ja/install-clio-on-ubuntu.html:
-    to: /ja/docs/infrastructure/installation/install-clio-on-ubuntu
-    type: 301
-/ja/update-rippled-automatically-on-linux.html:
-    to: /ja/docs/infrastructure/installation/update-rippled-automatically-on-linux
-    type: 301
-/ja/update-rippled-manually-on-centos-rhel.html:
-    to: /ja/docs/infrastructure/installation/update-rippled-manually-on-centos-rhel
-    type: 301
-/ja/update-rippled-manually-on-ubuntu.html:
-    to: /ja/docs/infrastructure/installation/update-rippled-manually-on-ubuntu
-    type: 301
-/ja/build-on-linux-mac-windows.html:
-    to: /ja/docs/infrastructure/installation/build-on-linux-mac-windows
-    type: 301
-/ja/build-run-rippled-in-reporting-mode.html:
-    to: /ja/docs/infrastructure/installation/build-run-rippled-in-reporting-mode
-    type: 301
-/ja/capacity-planning.html:
-    to: /ja/docs/infrastructure/installation/capacity-planning
-    type: 301
-/ja/rippled-1-3-migration-instructions.html:
-    to: /ja/docs/infrastructure/installation/rippled-1-3-migration-instructions
-    type: 301
-/ja/configure-rippled.html:
-    to: /ja/docs/infrastructure/configuration/
-    type: 301
-/ja/server-modes.html:
-    to: /ja/docs/infrastructure/configuration/server-modes/
-    type: 301
-/ja/run-rippled-as-a-validator.html:
-    to: /ja/docs/infrastructure/configuration/server-modes/run-rippled-as-a-validator
-    type: 301
-/ja/run-rippled-as-a-stock-server.html:
-    to: /ja/docs/infrastructure/configuration/server-modes/run-rippled-as-a-stock-server
-    type: 301
-/ja/data-retention.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/
-    type: 301
-/ja/configure-full-history.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/configure-full-history
-    type: 301
-/ja/online-deletion.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/online-deletion
-    type: 301
-/ja/configure-online-deletion.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/configure-online-deletion
-    type: 301
-/ja/configure-advisory-deletion.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/configure-advisory-deletion
-    type: 301
-/ja/history-sharding.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/history-sharding
-    type: 301
-/ja/configure-history-sharding.html:
-    to: /ja/docs/infrastructure/configuration/data-retention/configure-history-sharding
-    type: 301
-/ja/configure-peering.html:
-    to: /ja/docs/infrastructure/configuration/peering/
-    type: 301
-/ja/cluster-rippled-servers.html:
-    to: /ja/docs/infrastructure/configuration/peering/cluster-rippled-servers
-    type: 301
-/ja/configure-a-private-server.html:
-    to: /ja/docs/infrastructure/configuration/peering/configure-a-private-server
-    type: 301
-/ja/configure-the-peer-crawler.html:
-    to: /ja/docs/infrastructure/configuration/peering/configure-the-peer-crawler
-    type: 301
-/ja/enable-link-compression.html:
-    to: /ja/docs/infrastructure/configuration/peering/enable-link-compression
-    type: 301
-/ja/forward-ports-for-peering.html:
-    to: /ja/docs/infrastructure/configuration/peering/forward-ports-for-peering
-    type: 301
-/ja/manually-connect-to-a-specific-peer.html:
-    to: /ja/docs/infrastructure/configuration/peering/manually-connect-to-a-specific-peer
-    type: 301
-/ja/set-max-number-of-peers.html:
-    to: /ja/docs/infrastructure/configuration/peering/set-max-number-of-peers
-    type: 301
-/ja/use-a-peer-reservation.html:
-    to: /ja/docs/infrastructure/configuration/peering/use-a-peer-reservation
-    type: 301
-/ja/configure-amendment-voting.html:
-    to: /ja/docs/infrastructure/configuration/configure-amendment-voting
-    type: 301
-/ja/configure-statsd.html:
-    to: /ja/docs/infrastructure/configuration/configure-statsd
-    type: 301
-/ja/connect-your-rippled-to-the-xrp-test-net.html:
-    to: /ja/docs/infrastructure/configuration/connect-your-rippled-to-the-xrp-test-net
-    type: 301
-/ja/configure-grpc.html:
-    to: /ja/docs/infrastructure/configuration/configure-grpc
-    type: 301
-/ja/enable-public-signing.html:
-    to: /ja/docs/infrastructure/configuration/enable-public-signing
-    type: 301
-/ja/use-stand-alone-mode.html:
-    to: /ja/docs/infrastructure/testing-and-auditing/
-    type: 301
-/ja/start-a-new-genesis-ledger-in-stand-alone-mode.html:
-    to: /ja/docs/infrastructure/testing-and-auditing/start-a-new-genesis-ledger-in-stand-alone-mode
-    type: 301
-/ja/load-a-saved-ledger-in-stand-alone-mode.html:
-    to: /ja/docs/infrastructure/testing-and-auditing/load-a-saved-ledger-in-stand-alone-mode
-    type: 301
-/ja/advance-the-ledger-in-stand-alone-mode.html:
-    to: /ja/docs/infrastructure/testing-and-auditing/advance-the-ledger-in-stand-alone-mode
-    type: 301
-/ja/test-amendments.html:
-    to: /ja/docs/infrastructure/testing-and-auditing/test-amendments
-    type: 301
-/ja/private-network-with-docker.html:
-    to: /ja/docs/infrastructure/testing-and-auditing/run-private-network-with-docker
-    type: 301
-/ja/troubleshoot-the-rippled-server.html:
-    to: /ja/docs/infrastructure/troubleshooting/
-    type: 301
-/ja/diagnosing-problems.html:
-    to: /ja/docs/infrastructure/troubleshooting/diagnosing-problems
-    type: 301
-/ja/health-check-interventions.html:
-    to: /ja/docs/infrastructure/troubleshooting/health-check-interventions
-    type: 301
-/ja/understanding-log-messages.html:
-    to: /ja/docs/infrastructure/troubleshooting/understanding-log-messages
-    type: 301
-/ja/server-doesnt-sync.html:
-    to: /ja/docs/infrastructure/troubleshooting/server-doesnt-sync
-    type: 301
-/ja/server-is-amendment-blocked.html:
-    to: /ja/docs/infrastructure/troubleshooting/server-is-amendment-blocked
-    type: 301
-/ja/server-wont-start.html:
-    to: /ja/docs/infrastructure/troubleshooting/server-wont-start
-    type: 301
-/ja/fix-sqlite-tx-db-page-size-issue.html:
-    to: /ja/docs/infrastructure/troubleshooting/fix-sqlite-tx-db-page-size-issue
-    type: 301
-/ja/manage-the-rippled-server.html:
-    to: /ja/docs/infrastructure/installation/install-rippled-on-ubuntu
-    type: 301
-/ja/build-run-rippled-ubuntu.html:
-    to: /ja/docs/infrastructure/installation/build-on-linux-mac-windows
-    type: 301
-/ja/build-run-rippled-macos.html:
-    to: /ja/docs/infrastructure/installation/build-on-linux-mac-windows
-    type: 301
-/ja/update-rippled-automatically-on-centos-rhel.html:
-    to: /ja/docs/infrastructure/installation/update-rippled-automatically-on-linux
-    type: 301
-/ja/install-rippled-on-ubuntu-with-alien.html:
-    to: /ja/docs/infrastructure/installation/install-rippled-on-ubuntu
-    type: 301
-/ja/run-a-rippled-validator.html:
-    to: /ja/docs/infrastructure/configuration/server-modes/run-rippled-as-a-validator
-    type: 301
-/ja/list-xrp-in-your-exchange.html:
-    to: /ja/docs/use-cases/defi/list-xrp-as-an-exchange
-    type: 301
-/ja/contribute-code-to-rippled.html:
-    to: /ja/resources/contribute-code
-    type: 301
-/ja/contribute-code-to-ripple-lib.html:
-    to: /ja/resources/contribute-code
-    type: 301
-/ja/contribute-code-flow.html:
-    to: /ja/resources/contribute-code
-    type: 301
-/ja/resources.html:
-    to: /ja/resources/
-    type: 301
-/ja/known-amendments.html:
-    to: /ja/resources/known-amendments
-    type: 301
-/ja/contribute-code.html:
-    to: /ja/resources/contribute-code
-    type: 301
-/ja/create-custom-transactors.html:
-    to: /ja/resources/contribute-code/create-custom-transactors
-    type: 301
-/ja/contribute-documentation.html:
-    to: /ja/resources/contribute-documentation/
-    type: 301
-/ja/documentation-translations.html:
-    to: /ja/resources/contribute-documentation/documentation-translations
-    type: 301
-/ja/creating-diagrams.html:
-    to: /ja/resources/contribute-documentation/creating-diagrams
-    type: 301
-/ja/tutorial-guidelines.html:
-    to: /ja/resources/contribute-documentation/tutorial-guidelines
-    type: 301
-/ja/tutorial-structure.html:
-    to: /ja/resources/contribute-documentation/tutorial-guidelines
-    type: 301
-/ja/report-a-scam.html:
-    to: /ja/contributing/report-a-scam
-    type: 301
-/ja/wallets.html:
-    to: /ja/docs/introduction/crypto-wallets
-    type: 301
-/ja/blog/2024/rippled-2.2.0.html:
-    to: /ja/blog/2024/rippled-2.2.0
-    type: 301
-/ja/blog/2024/rippled-2.1.0.html:
-    to: /ja/blog/2024/rippled-2.1.0
-    type: 301
-/ja/blog/2024/clio-2.1.0.html:
-    to: /ja/blog/2024/clio-2.1.0
-    type: 301
-/ja/blog/2024/rippled-2.0.1.html:
-    to: /ja/blog/2024/rippled-2.0.1
-    type: 301
-/ja/blog/2024/web3auth.html:
-    to: /ja/blog/2024/web3auth
-    type: 301
-/ja/blog/2024/rippled-2.0.0.html:
-    to: /ja/blog/2024/rippled-2.0.0
-    type: 301
-/ja/blog/2023/decommissioning-amm-devnet.html:
-    to: /ja/blog/2023/decommissioning-amm-devnet
-    type: 301
-/ja/blog/2023/gemwallet-update.html:
-    to: /ja/blog/2023/gemwallet-update
-    type: 301
-/ja/blog/2023/clio-2.0.0.html:
-    to: /ja/blog/2023/clio-2.0.0
-    type: 301
-/ja/blog/2023/santiment.html:
-    to: /ja/blog/2023/santiment
-    type: 301
-/ja/blog/2023/data-api-v2-deprecated.html:
-    to: /ja/blog/2023/data-api-v2-deprecated
-    type: 301
-/ja/blog/2023/devnet-reset-scheduled-sep-19-2023.html:
-    to: /ja/blog/2023/devnet-reset-scheduled-sep-19-2023
-    type: 301
-/ja/blog/2023/rippled-1.12.0.html:
-    to: /ja/blog/2023/rippled-1.12.0
-    type: 301
-/ja/blog/2023/upcoming-devnet-reset.html:
-    to: /ja/blog/2023/upcoming-devnet-reset
-    type: 301
-/ja/blog/2023/blockdaemon.html:
-    to: /ja/blog/2023/blockdaemon
-    type: 301
-/ja/blog/2023/disallowincoming-and-others-expected.html:
-    to: /ja/blog/2023/disallowincoming-and-others-expected
-    type: 301
-/ja/blog/2023/xrp-toolkit.html:
-    to: /ja/blog/2023/xrp-toolkit
-    type: 301
-/ja/blog/2023/summarizing-xrpl-docs-iav3.html:
-    to: /ja/blog/2023/summarizing-xrpl-docs-iav3
-    type: 301
-/ja/blog/2023/xrpl-py-2.0-release.html:
-    to: /ja/blog/2023/xrpl-py-2.0-release
-    type: 301
-/ja/blog/2023/fieldboss.html:
-    to: /ja/blog/2023/fieldboss
-    type: 301
-/ja/blog/2023/rippled-1.11.0.html:
-    to: /ja/blog/2023/rippled-1.11.0
-    type: 301
-/ja/blog/2023/ciso.html:
-    to: /ja/blog/2023/ciso
-    type: 301
-/ja/blog/2023/edge.html:
-    to: /ja/blog/2023/edge
-    type: 301
-/ja/blog/2023/xrpcafe.html:
-    to: /ja/blog/2023/xrpcafe
-    type: 301
-/ja/blog/2023/chispend.html:
-    to: /ja/blog/2023/chispend
-    type: 301
-/ja/blog/2023/rippled-1.10.0.html:
-    to: /ja/blog/2023/rippled-1.10.0
-    type: 301
-/ja/blog/2023/bei-api.html:
-    to: /ja/blog/2023/bei-api
-    type: 301
-/ja/blog/2023/zoetic.html:
-    to: /ja/blog/2023/zoetic
-    type: 301
-/ja/blog/2023/mandla-money.html:
-    to: /ja/blog/2023/mandla-money
-    type: 301
-/ja/blog/2023/nft-devnet-decommission.html:
-    to: /ja/blog/2023/nft-devnet-decommission
-    type: 301
-/ja/blog/2023/aesthetes.html:
-    to: /ja/blog/2023/aesthetes
-    type: 301
-/ja/blog/2023/stably.html:
-    to: /ja/blog/2023/stably
-    type: 301
-/ja/blog/2022/introducing-xrpl-py-2.0.0beta.html:
-    to: /ja/blog/2022/introducing-xrpl-py-2.0.0beta
-    type: 301
-/ja/blog/2022/nftmaster.html:
-    to: /ja/blog/2022/nftmaster
-    type: 301
-/ja/blog/2022/xpmarket.html:
-    to: /ja/blog/2022/xpmarket
-    type: 301
-/ja/blog/2022/ziggurat.html:
-    to: /ja/blog/2022/ziggurat
-    type: 301
-/ja/blog/2022/gemwallet.html:
-    to: /ja/blog/2022/gemwallet
-    type: 301
-/ja/blog/2022/cryptoiso20022interop.html:
-    to: /ja/blog/2022/cryptoiso20022interop
-    type: 301
-/ja/blog/2022/non-fungible-tokens-are-now-available.html:
-    to: /ja/blog/2022/non-fungible-tokens-are-now-available
-    type: 301
-/ja/blog/2022/dev-reflections-relaunch.html:
-    to: /ja/blog/2022/dev-reflections-relaunch
-    type: 301
-/ja/blog/2022/expandedsignerlist-enabled-and-nfts-approaching.html:
-    to: /ja/blog/2022/expandedsignerlist-enabled-and-nfts-approaching
-    type: 301
-/ja/blog/2022/introducing-learning-portal.html:
-    to: /ja/blog/2022/introducing-learning-portal
-    type: 301
-/ja/blog/2022/rippled-1.9.4.html:
-    to: /ja/blog/2022/rippled-1.9.4
-    type: 301
-/ja/blog/2022/get-ready-for-nfts.html:
-    to: /ja/blog/2022/get-ready-for-nfts
-    type: 301
-/ja/blog/2022/rippled-1.9.3.html:
-    to: /ja/blog/2022/rippled-1.9.3
-    type: 301
-/ja/blog/2022/rippled-1.9.2.html:
-    to: /ja/blog/2022/rippled-1.9.2
-    type: 301
-/ja/blog/2022/clio-1.0.0.html:
-    to: /ja/blog/2022/clio-1.0.0
-    type: 301
-/ja/blog/2022/rippled-1.9.1.html:
-    to: /ja/blog/2022/rippled-1.9.1
-    type: 301
-/ja/blog/2022/rippled-1.9.0.html:
-    to: /ja/blog/2022/rippled-1.9.0
-    type: 301
-/ja/blog/2022/introducing-clio.html:
-    to: /ja/blog/2022/introducing-clio
-    type: 301
-/ja/blog/2022/nft-devnet-reset.html:
-    to: /ja/blog/2022/nft-devnet-reset
-    type: 301
-/ja/blog/2022/rippled-1.8.5.html:
-    to: /ja/blog/2022/rippled-1.8.5
-    type: 301
-/ja/blog/2022/rippled-1.8.4.html:
-    to: /ja/blog/2022/rippled-1.8.4
-    type: 301
-/ja/blog/2021/rippled-1.8.2.html:
-    to: /ja/blog/2021/rippled-1.8.2
-    type: 301
-/ja/blog/2021/rippled-1.8.1.html:
-    to: /ja/blog/2021/rippled-1.8.1
-    type: 301
-/ja/blog/2021/five-upcoming-amendments.html:
-    to: /ja/blog/2021/five-upcoming-amendments
-    type: 301
-/ja/blog/2021/introducing-xrpl-js.html:
-    to: /ja/blog/2021/introducing-xrpl-js
-    type: 301
-/ja/blog/2021/sidechain-engineering-preview.html:
-    to: /ja/blog/2021/sidechain-engineering-preview
-    type: 301
-/ja/blog/2021/reserves-lowered.html:
-    to: /ja/blog/2021/reserves-lowered
-    type: 301
-/ja/blog/2021/rippled-1.7.3.html:
-    to: /ja/blog/2021/rippled-1.7.3
-    type: 301
-/ja/blog/2021/ripple-lib-drops-lodash-browsers.html:
-    to: /ja/blog/2021/ripple-lib-drops-lodash-browsers
-    type: 301
-/ja/blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation.html:
-    to: /ja/blog/2021/xrpl-grants-funding-the-next-phase-of-open-decentralized-innovation
-    type: 301
-/ja/blog/2021/rippled-1.7.2.html:
-    to: /ja/blog/2021/rippled-1.7.2
-    type: 301
-/ja/blog/2021/introducing-xrpl4j.html:
-    to: /ja/blog/2021/introducing-xrpl4j
-    type: 301
-/ja/blog/2021/xrpl-node-configurator.html:
-    to: /ja/blog/2021/xrpl-node-configurator
-    type: 301
-/ja/blog/2021/introducing-xrpl-py-for-pythonistas.html:
-    to: /ja/blog/2021/introducing-xrpl-py-for-pythonistas
-    type: 301
-/ja/blog/2021/three-amendments-expected.html:
-    to: /ja/blog/2021/three-amendments-expected
-    type: 301
-/ja/blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying.html:
-    to: /ja/blog/2021/message-routing-optimizations-pt-1-proposal-validation-relaying
-    type: 301
-/ja/blog/2021/community-spotlight-developing-wallet-protect.html:
-    to: /ja/blog/2021/community-spotlight-developing-wallet-protect
-    type: 301
-/ja/blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security.html:
-    to: /ja/blog/2021/road-to-xrp-ledger-1-7-improving-efficiency-and-security
-    type: 301
-/ja/blog/2021/rippled-1.7.0.html:
-    to: /ja/blog/2021/rippled-1.7.0
-    type: 301
-/ja/blog/2020/rippled-1.6.0.html:
-    to: /ja/blog/2020/rippled-1.6.0
-    type: 301
-/ja/blog/2020/moving-devnet-to-vl.html:
-    to: /ja/blog/2020/moving-devnet-to-vl
-    type: 301
-/ja/blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled.html:
-    to: /ja/blog/2020/requirefullycanonicalsig-fixqualityupperbound-flowcross-enabled
-    type: 301
-/ja/blog/2020/developer-reflections-xrp-toolkit.html:
-    to: /ja/blog/2020/developer-reflections-xrp-toolkit
-    type: 301
-/ja/blog/2020/requirefullycanonicalsig-expected.html:
-    to: /ja/blog/2020/requirefullycanonicalsig-expected
-    type: 301
-/ja/blog/2020/checks-enabled.html:
-    to: /ja/blog/2020/checks-enabled
-    type: 301
-/ja/blog/2020/checks-expected.html:
-    to: /ja/blog/2020/checks-expected
-    type: 301
-/ja/blog/2020/developer-reflections-xrplorer.html:
-    to: /ja/blog/2020/developer-reflections-xrplorer
-    type: 301
-/ja/blog/2020/deletableaccounts-enabled.html:
-    to: /ja/blog/2020/deletableaccounts-enabled
-    type: 301
-/ja/blog/2020/get-ready-for-deletable-accounts.html:
-    to: /ja/blog/2020/get-ready-for-deletable-accounts
-    type: 301
-/ja/blog/2020/developer-reflections-xrpscan.html:
-    to: /ja/blog/2020/developer-reflections-xrpscan
-    type: 301
-/ja/blog/2020/two-fixes-enabled.html:
-    to: /ja/blog/2020/two-fixes-enabled
-    type: 301
-/ja/blog/2020/deletableaccounts-expected.html:
-    to: /ja/blog/2020/deletableaccounts-expected
-    type: 301
-/ja/blog/2020/testnet-amendments-rippled-1.5.0.html:
-    to: /ja/blog/2020/testnet-amendments-rippled-1.5.0
-    type: 301
-/ja/blog/2020/rippled-1.5.0.html:
-    to: /ja/blog/2020/rippled-1.5.0
-    type: 301
-/ja/blog/2020/running-an-xrp-ledger-validator.html:
-    to: /ja/blog/2020/running-an-xrp-ledger-validator
-    type: 301
-/ja/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority.html:
-    to: /ja/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-lost-majority
-    type: 301
-/ja/blog/2020/rippled-1.4.0-upgrade-advisory.html:
-    to: /ja/blog/2020/rippled-1.4.0-upgrade-advisory
-    type: 301
-/ja/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected.html:
-    to: /ja/blog/2020/fixcheckthreading-fixpaychanrecipientownerdir-expected
-    type: 301
-/ja/blog/2019/rippled-1.4.0.html:
-    to: /ja/blog/2019/rippled-1.4.0
-    type: 301
-/ja/blog/2019/xrpl-devnet-launch.html:
-    to: /ja/blog/2019/xrpl-devnet-launch
-    type: 301
-/ja/blog/2019/fixmasterkeyasregularkey-enabled.html:
-    to: /ja/blog/2019/fixmasterkeyasregularkey-enabled
-    type: 301
-/ja/blog/2019/fixmasterkeyasregularkey-1day.html:
-    to: /ja/blog/2019/fixmasterkeyasregularkey-1day
-    type: 301
-/ja/blog/2019/fixmasterkeyasregularkey-expected.html:
-    to: /ja/blog/2019/fixmasterkeyasregularkey-expected
-    type: 301
-/ja/blog/2019/testnet-reset.html:
-    to: /ja/blog/2019/testnet-reset
-    type: 301
-/ja/blog/2019/rippled-1.3.1.html:
-    to: /ja/blog/2019/rippled-1.3.1
-    type: 301
-/ja/blog/2019/labeling-the-internet-of-value.html:
-    to: /ja/blog/2019/labeling-the-internet-of-value
-    type: 301
-/ja/blog/2019/discover-xrp-ledger-explorer.html:
-    to: /ja/blog/2019/discover-xrp-ledger-explorer
-    type: 301
-/ja/blog/2019/websocket-tool-update.html:
-    to: /ja/blog/2019/websocket-tool-update
-    type: 301
-/ja/blog/2019/welcome-to-xrpl-org.html:
-    to: /ja/blog/2019/welcome-to-xrpl-org
-    type: 301
-/ja/blog/2019/multisignreserve-enabled.html:
-    to: /ja/blog/2019/multisignreserve-enabled
-    type: 301
-/ja/blog/2019/rippled-1.2.4.html:
-    to: /ja/blog/2019/rippled-1.2.4
-    type: 301
-/ja/blog/2019/secure-development-practices.html:
-    to: /ja/blog/2019/secure-development-practices
-    type: 301
-/ja/blog/2019/multisignreserve-expected.html:
-    to: /ja/blog/2019/multisignreserve-expected
-    type: 301
-/ja/blog/2019/corrections-to-data-api-xrp-charts-metrics.html:
-    to: /ja/blog/2019/corrections-to-data-api-xrp-charts-metrics
-    type: 301
-/ja/blog/2019/interledger-checkin.html:
-    to: /ja/blog/2019/interledger-checkin
-    type: 301
-/ja/blog/2019/fixtakerdryofferremoval-enabled.html:
-    to: /ja/blog/2019/fixtakerdryofferremoval-enabled
-    type: 301
-/ja/blog/2019/rippled-1.2.3.html:
-    to: /ja/blog/2019/rippled-1.2.3
-    type: 301
-/ja/blog/2019/fix1578-enabled.html:
-    to: /ja/blog/2019/fix1578-enabled
-    type: 301
-/ja/blog/2019/fix1578-expected.html:
-    to: /ja/blog/2019/fix1578-expected
-    type: 301
-/ja/blog/2019/rippled-1.2.2.html:
-    to: /ja/blog/2019/rippled-1.2.2
-    type: 301
-/ja/blog/2019/rippled-1.2.1.html:
-    to: /ja/blog/2019/rippled-1.2.1
-    type: 301
-/ja/blog/2019/rippled-1.2.0.html:
-    to: /ja/blog/2019/rippled-1.2.0
-    type: 301
-/ja/blog/2019/statement-on-the-biased-nonce-sense-paper.html:
-    to: /ja/blog/2019/statement-on-the-biased-nonce-sense-paper
-    type: 301
-/ja/blog/2018/rippled-1.1.2.html:
-    to: /ja/blog/2018/rippled-1.1.2
-    type: 301
-/ja/blog/2018/introducing-history-sharding.html:
-    to: /ja/blog/2018/introducing-history-sharding
-    type: 301
-/ja/blog/2018/data-api-validations-changes.html:
-    to: /ja/blog/2018/data-api-validations-changes
-    type: 301
-/ja/blog/2018/rippled-1.1.1.html:
-    to: /ja/blog/2018/rippled-1.1.1
-    type: 301
-/ja/blog/2018/depositpreauth-fix1515-enabled.html:
-    to: /ja/blog/2018/depositpreauth-fix1515-enabled
-    type: 301
-/ja/blog/2018/rippled-1.1.0.html:
-    to: /ja/blog/2018/rippled-1.1.0
-    type: 301
-/ja/blog/2018/ripple-lib-1.0.0.html:
-    to: /ja/blog/2018/ripple-lib-1.0.0
-    type: 301
-/ja/blog/2018/fix1571-enabled.html:
-    to: /ja/blog/2018/fix1571-enabled
-    type: 301
-/ja/blog/2018/rippled-1.0.1.html:
-    to: /ja/blog/2018/rippled-1.0.1
-    type: 301
-/ja/blog/2018/fix1543-fix1571-fix1623-voting.html:
-    to: /ja/blog/2018/fix1543-fix1571-fix1623-voting
-    type: 301
-/ja/blog/2018/rippled-1.0.0.html:
-    to: /ja/blog/2018/rippled-1.0.0
-    type: 301
-/ja/blog/2018/depositauth-fix1513-available.html:
-    to: /ja/blog/2018/depositauth-fix1513-available
-    type: 301
-/ja/blog/2018/rippled-0.90.1.html:
-    to: /ja/blog/2018/rippled-0.90.1
-    type: 301
-/ja/blog/2018/rippled-0.90.0.html:
-    to: /ja/blog/2018/rippled-0.90.0
-    type: 301
-/ja/blog/2018/rippled-validator-key-replacement.html:
-    to: /ja/blog/2018/rippled-validator-key-replacement
-    type: 301
-/ja/blog/2018/rippled-boost166-warning.html:
-    to: /ja/blog/2018/rippled-boost166-warning
-    type: 301
-/ja/blog/2018/rippled-0.81.0.html:
-    to: /ja/blog/2018/rippled-0.81.0
-    type: 301
-/ja/blog/2017/explanation-of-ripples-xrp-escrow.html:
-    to: /ja/blog/2017/explanation-of-ripples-xrp-escrow
-    type: 301
-/ja/blog/2017/rippled-0.80.2.html:
-    to: /ja/blog/2017/rippled-0.80.2
-    type: 301
-/ja/blog/2017/rippled-0.80.0.html:
-    to: /ja/blog/2017/rippled-0.80.0
-    type: 301
-/ja/blog/2017/decent-strategy-update.html:
-    to: /ja/blog/2017/decent-strategy-update
-    type: 301
-/ja/blog/2017/high-scalability-xrp-ledger.html:
-    to: /ja/blog/2017/high-scalability-xrp-ledger
-    type: 301
-/ja/blog/2017/rippled-0.70.2.html:
-    to: /ja/blog/2017/rippled-0.70.2
-    type: 301
-/ja/blog/2017/invariant-checking.html:
-    to: /ja/blog/2017/invariant-checking
-    type: 301
-/ja/blog/2017/rippled-0.70.1.html:
-    to: /ja/blog/2017/rippled-0.70.1
-    type: 301
-/ja/blog/2017/rippled-0.70.0.html:
-    to: /ja/blog/2017/rippled-0.70.0
-    type: 301
-/ja/blog/2017/rippled-0.60.3.html:
-    to: /ja/blog/2017/rippled-0.60.3
-    type: 301
-/ja/blog/2017/rippled-0.60.2-2-rpm.html:
-    to: /ja/blog/2017/rippled-0.60.2-2-rpm
-    type: 301
-/ja/blog/2017/rippled-0.60.2.html:
-    to: /ja/blog/2017/rippled-0.60.2
-    type: 301
-/ja/blog/2017/rippled-0.60.1.html:
-    to: /ja/blog/2017/rippled-0.60.1
-    type: 301
-/ja/blog/2017/escrow-paychan-fix1368-reminder.html:
-    to: /ja/blog/2017/escrow-paychan-fix1368-reminder
-    type: 301
-/ja/blog/2017/rippled-0.60.0.html:
-    to: /ja/blog/2017/rippled-0.60.0
-    type: 301
-/ja/blog/2017/trust-line-quality-sendmax.html:
-    to: /ja/blog/2017/trust-line-quality-sendmax
-    type: 301
-/ja/blog/2017/rippled-0.50.3.html:
-    to: /ja/blog/2017/rippled-0.50.3
-    type: 301
-/ja/blog/2017/ripple-consensus-ledger-can-sustain-1000-transactions-per-second.html:
-    to: /ja/blog/2017/ripple-consensus-ledger-can-sustain-1000-transactions-per-second
-    type: 301
-/ja/blog/2017/ticksize-available.html:
-    to: /ja/blog/2017/ticksize-available
-    type: 301
-/ja/blog/2017/ticksize-3days.html:
-    to: /ja/blog/2017/ticksize-3days
-    type: 301
-/ja/blog/2017/ticksize-7days.html:
-    to: /ja/blog/2017/ticksize-7days
-    type: 301
-/ja/blog/2017/ticksize-voting.html:
-    to: /ja/blog/2017/ticksize-voting
-    type: 301
-/ja/blog/2017/rippled-0.50.2.html:
-    to: /ja/blog/2017/rippled-0.50.2
-    type: 301
-/ja/blog/2017/rippled-0.50.0.html:
-    to: /ja/blog/2017/rippled-0.50.0
-    type: 301
-/ja/blog/2017/data-api-load-balancing-test.html:
-    to: /ja/blog/2017/data-api-load-balancing-test
-    type: 301
-/ja/blog/2017/response-to-china-cert-report.html:
-    to: /ja/blog/2017/response-to-china-cert-report
-    type: 301
-/ja/blog/2017/rippled-0.40.1.html:
-    to: /ja/blog/2017/rippled-0.40.1
-    type: 301
-/ja/blog/2016/rippled-0.40.0.html:
-    to: /ja/blog/2016/rippled-0.40.0
-    type: 301
-/ja/blog/2016/flow-available.html:
-    to: /ja/blog/2016/flow-available
-    type: 301
-/ja/blog/2016/flow-reminder.html:
-    to: /ja/blog/2016/flow-reminder
-    type: 301
-/ja/blog/2016/flow-voting.html:
-    to: /ja/blog/2016/flow-voting
-    type: 301
-/ja/blog/2016/rippled-0.33.0-hf1.html:
-    to: /ja/blog/2016/rippled-0.33.0-hf1
-    type: 301
-/ja/blog/2016/rippled-0.33.0.html:
-    to: /ja/blog/2016/rippled-0.33.0
-    type: 301
-/ja/blog/2016/testnet-ledger-reset.html:
-    to: /ja/blog/2016/testnet-ledger-reset
-    type: 301
-/ja/blog/2016/flowv2-vetoed.html:
-    to: /ja/blog/2016/flowv2-vetoed
-    type: 301
-/ja/blog/2016/flowv2-voting.html:
-    to: /ja/blog/2016/flowv2-voting
-    type: 301
-/ja/blog/2016/rippled-0.32.1.html:
-    to: /ja/blog/2016/rippled-0.32.1
-    type: 301
-/ja/blog/2016/trustsetauth-available.html:
-    to: /ja/blog/2016/trustsetauth-available
-    type: 301
-/ja/blog/2016/trustsetauth-reminder.html:
-    to: /ja/blog/2016/trustsetauth-reminder
-    type: 301
-/ja/blog/2016/trustsetauth-voting.html:
-    to: /ja/blog/2016/trustsetauth-voting
-    type: 301
-/ja/blog/2016/multisign-available.html:
-    to: /ja/blog/2016/multisign-available
-    type: 301
-/ja/blog/2016/rippled-0.32.0.html:
-    to: /ja/blog/2016/rippled-0.32.0
-    type: 301
-/ja/blog/2016/multisign-reminder.html:
-    to: /ja/blog/2016/multisign-reminder
-    type: 301
-/ja/blog/2016/data-api-v2.2.html:
-    to: /ja/blog/2016/data-api-v2.2
-    type: 301
-/ja/blog/2016/introducing-rippleapi.html:
-    to: /ja/blog/2016/introducing-rippleapi
-    type: 301
-/ja/blog/2016/rippled-0.31.2-updates.html:
-    to: /ja/blog/2016/rippled-0.31.2-updates
-    type: 301
-/ja/blog/2016/rippled-0.30.1.html:
-    to: /ja/blog/2016/rippled-0.30.1
-    type: 301
-/ja/blog/2015/correction-to-ripple-white-paper.html:
-    to: /ja/blog/2015/correction-to-ripple-white-paper
-    type: 301
-/ja/blog/2015/validator-registry.html:
-    to: /ja/blog/2015/validator-registry
-    type: 301
-/ja/blog/2015/introducing-the-data-api.html:
-    to: /ja/blog/2015/introducing-the-data-api
-    type: 301
-/ja/blog/2015/gatewayd-no-longer-available.html:
-    to: /ja/blog/2015/gatewayd-no-longer-available
-    type: 301
-/ja/blog/2015/ripple-charts-update-payment-volume-and-issued-value.html:
-    to: /ja/blog/2015/ripple-charts-update-payment-volume-and-issued-value
-    type: 301
-/ja/blog/2015/do-you-have-what-it-takes-to-be-a-gateway.html:
-    to: /ja/blog/2015/do-you-have-what-it-takes-to-be-a-gateway
-    type: 301
-/ja/blog/2015/calculating-balance-changes-for-a-transaction.html:
-    to: /ja/blog/2015/calculating-balance-changes-for-a-transaction
-    type: 301
-/ja/blog/2014/turn-your-exchange-into-a-ripple-gateway.html:
-    to: /ja/blog/2014/turn-your-exchange-into-a-ripple-gateway
-    type: 301
-/ja/blog/2014/why-the-stellar-forking-issue-does-not-affect-ripple.html:
-    to: /ja/blog/2014/why-the-stellar-forking-issue-does-not-affect-ripple
-    type: 301
-/ja/blog/2014/release-notes-3-december-2014.html:
-    to: /ja/blog/2014/release-notes-3-december-2014
-    type: 301
-/ja/blog/2014/release-notes-19-november-2014.html:
-    to: /ja/blog/2014/release-notes-19-november-2014
-    type: 301
-/ja/blog/2014/ripplerest-1.3-release.html:
-    to: /ja/blog/2014/ripplerest-1.3-release
-    type: 301
-/ja/blog/2014/release-notes-29-october-2014.html:
-    to: /ja/blog/2014/release-notes-29-october-2014
-    type: 301
-/ja/blog/2014/gateway-advisory-on-partial-payment-flag.html:
-    to: /ja/blog/2014/gateway-advisory-on-partial-payment-flag
-    type: 301
-/ja/blog/2014/release-notes-14-october-2014.html:
-    to: /ja/blog/2014/release-notes-14-october-2014
-    type: 301
-/ja/blog/2014/how-ripple-labs-supports-gateways.html:
-    to: /ja/blog/2014/how-ripple-labs-supports-gateways
-    type: 301
-/ja/blog/2014/biweekly-release-notes-17-september-2014.html:
-    to: /ja/blog/2014/biweekly-release-notes-17-september-2014
-    type: 301
-/ja/blog/2014/biweekly-release-notes-3-september-2014.html:
-    to: /ja/blog/2014/biweekly-release-notes-3-september-2014
-    type: 301
-/ja/blog/2014/use-of-cpp14-in-rippled.html:
-    to: /ja/blog/2014/use-of-cpp14-in-rippled
-    type: 301
-/ja/blog/2014/biweekly-release-notes-14-august-2014.html:
-    to: /ja/blog/2014/biweekly-release-notes-14-august-2014
-    type: 301
-/ja/blog/2014/dev-portal-adds-rippled-apis.html:
-    to: /ja/blog/2014/dev-portal-adds-rippled-apis
-    type: 301
-/ja/blog/2014/biweekly-release-notes-31-july-2014.html:
-    to: /ja/blog/2014/biweekly-release-notes-31-july-2014
-    type: 301
-/ja/blog/2014/xrp-giveaway-for-developers.html:
-    to: /ja/blog/2014/xrp-giveaway-for-developers
-    type: 301
-/ja/blog/2014/ripple-labs-bounty-program-moves-to-bountysource.html:
-    to: /ja/blog/2014/ripple-labs-bounty-program-moves-to-bountysource
-    type: 301
-/ja/blog/2014/introducing-offer-autobridging.html:
-    to: /ja/blog/2014/introducing-offer-autobridging
-    type: 301
-/ja/blog/2014/curves-with-a-twist.html:
-    to: /ja/blog/2014/curves-with-a-twist
-    type: 301
-/ja/blog/2014/introducing-ripple-names.html:
-    to: /ja/blog/2014/introducing-ripple-names
-    type: 301
-/ja/code_of_conduct/:
-    to: /ja/code-of-conduct
-    type: 301
-/ja/code_of_conduct:
-    to: /ja/code-of-conduct
-    type: 301
-# code_of_conduct.ja/:
-#     to: /ja/code-of-conduct
-#     type: 301
-# code_of_conduct.ja:
-#     to: /ja/code-of-conduct
-#     type: 301


### PR DESCRIPTION
- Update to the latest Redocly version (0.130.4). (**Updated**)
- Remove the `htmltojsx` devDependency that was the source of all the alerts about critical security vulnerabilities. As far as I know we don't actually use it now—Roman had it in the initial version of our Redocly config file, so maybe it was used for some migration scripts or something and it's been carried over unchanged since then, but as far as I can tell nothing references it and nothing broke when I removed it.
- Remove now-redundant redirects for Japanese pages. In the new Redocly version, these work implicitly. (e.g. `/ja/rippling.html` → `/ja/docs/concepts/tokens/fungible-tokens/rippling` works based on the `/rippling.html`→ `/docs/concepts/tokens/fungible-tokens/rippling` redirect without needing a separate entry for the Japanese version.)
- Remove many instances of `type: 301` from the redirects file. This field is optional and the default is 301. I am hoping that by removing this we will have fewer merge conflicts later because the diff won't find "matching" lines in the middle of a change.

Tested and working in local dev:

- Homepage
- Code Samples page 
- All the built-in dev tools
- Translated pages, switching between them
- Search - results seem a little less good than on production but it's not outright broken
- :new: Implicit redirects for localized files