### PR TITLE
[feat] Add LinkTextCard and LinkTextDirectory Components

### DIFF
--- a/about/link-text-directory-showcase.page.tsx
+++ b/about/link-text-directory-showcase.page.tsx
@@ -1,0 +1,172 @@
+import * as React from "react";
+import { LinkTextDirectory } from "shared/patterns/LinkTextDirectory";
+import { Divider } from "shared/components/Divider";
+
+export const frontmatter = {
+  seo: {
+    title: 'LinkTextDirectory Component Showcase',
+    description: "A comprehensive showcase of the LinkTextDirectory section pattern with numbered cards, responsive layout, and usage examples.",
+  }
+};
+
+export default function LinkTextDirectoryShowcase() {
+  const handleClick = (message: string) => {
+    console.log(`Button clicked: ${message}`);
+  };
+
+  // Sample cards for demonstrations
+  const sampleCards = [
+    {
+      heading: "Fast Settlement and Low Fees",
+      description: "Settle transactions in 3-5 seconds for a fraction of a cent, ideal for large-scale, high-volume RWA tokenization.",
+      buttons: [
+        { label: "Get Started", href: "/start" },
+        { label: "Learn More", href: "/docs" }
+      ]
+    },
+    {
+      heading: "Secure and Reliable",
+      description: "Built on proven blockchain technology with enterprise-grade security. XRPL has processed billions of transactions since 2012.",
+      buttons: [
+        { label: "Read Documentation", href: "/docs" }
+      ]
+    },
+    {
+      heading: "Developer Friendly",
+      description: "Comprehensive APIs and SDKs for seamless integration. Extensive documentation and active community support.",
+      buttons: [
+        { label: "View API", href: "/api" },
+        { label: "See Examples", href: "/examples" }
+      ]
+    },
+    {
+      heading: "Sustainability First",
+      description: "XRPL is carbon-neutral and energy-efficient. Built for the long-term without compromising on performance.",
+      buttons: [
+        { label: "Sustainability Report", href: "/sustainability" }
+      ]
+    }
+  ];
+
+  return (
+    <div className="landing">
+      <div className="overflow-hidden">
+        {/* Hero Section */}
+        <section className="py-26 text-center">
+          <div className="col-lg-8 mx-auto">
+            <h6 className="eyebrow mb-3">Pattern Showcase</h6>
+            <h1 className="mb-4">LinkTextDirectory Pattern</h1>
+            <p className="longform">
+              A section pattern that displays a numbered list of LinkTextCard components.
+              Features a heading, optional description, and a vertically stacked list of cards
+              with automatic sequential numbering (01, 02, 03...).
+            </p>
+          </div>
+        </section>
+
+        <Divider color="gray" />
+
+        {/* Full Example */}
+        <LinkTextDirectory
+          heading="Explore XRPL Developer Tools"
+          description="XRP Ledger is a compliance-focused blockchain where financial applications come to life. XRP Ledger is a compliance-focused blockchain where financial applications come to life."
+          cards={sampleCards}
+        />
+
+        <Divider color="gray" />
+
+        {/* Shorter Description */}
+        <LinkTextDirectory
+          heading="Key Features"
+          description="Everything you need to build amazing applications on XRPL."
+          cards={sampleCards.slice(0, 3)}
+        />
+
+        <Divider color="gray" />
+
+        {/* Without Description */}
+        <LinkTextDirectory
+          heading="Platform Capabilities"
+          cards={sampleCards.slice(0, 2)}
+        />
+
+        <Divider color="gray" />
+
+        {/* With Click Handlers */}
+        <LinkTextDirectory
+          heading="Interactive Examples"
+          description="Click any button to see the onClick handler in action (check console)."
+          cards={[
+            {
+              heading: "Example Card 1",
+              description: "This card demonstrates onClick handlers for buttons.",
+              buttons: [
+                { label: "Primary Action", onClick: () => handleClick('Primary 1') },
+                { label: "Secondary Action", onClick: () => handleClick('Secondary 1') }
+              ]
+            },
+            {
+              heading: "Example Card 2",
+              description: "Mix of href and onClick for flexible interactions.",
+              buttons: [
+                { label: "Navigate", href: "/docs" },
+                { label: "Fire Event", onClick: () => handleClick('Event fired') }
+              ]
+            }
+          ]}
+        />
+
+        <Divider color="gray" />
+
+        {/* Different Card Counts */}
+        <section className="py-26">
+          <div className="d-flex flex-column-reverse mb-10">
+            <h2 className="h4 mb-8">Different Card Counts</h2>
+            <h6 className="eyebrow mb-3">Responsive Behavior</h6>
+          </div>
+
+          <div className="mb-10">
+            <h6 className="mb-4">1 Card</h6>
+            <LinkTextDirectory
+              heading="Single Feature"
+              description="Layout with single card."
+              cards={sampleCards.slice(0, 1)}
+            />
+          </div>
+
+          <div className="mb-10">
+            <h6 className="mb-4">2 Cards</h6>
+            <LinkTextDirectory
+              heading="Two Features"
+              description="Compact layout with two cards."
+              cards={sampleCards.slice(0, 2)}
+            />
+          </div>
+
+          <div className="mb-10">
+            <h6 className="mb-4">6 Cards</h6>
+            <LinkTextDirectory
+              heading="Extended List"
+              description="Longer list with multiple cards."
+              cards={[
+                ...sampleCards,
+                {
+                  heading: "Low Fees",
+                  description: "Minimal transaction costs make XRPL ideal for micro-transactions.",
+                  buttons: [{ label: "View Fees", href: "/fees" }]
+                },
+                {
+                  heading: "Open Source",
+                  description: "Transparent, community-driven development with no vendor lock-in.",
+                  buttons: [{ label: "GitHub", href: "/github" }]
+                }
+              ]}
+            />
+          </div>
+        </section>
+
+        <Divider color="gray" />
+      </div>
+    </div>
+  );
+}

--- a/shared/patterns/CarouselFeatured/CarouselFeatured.tsx
+++ b/shared/patterns/CarouselFeatured/CarouselFeatured.tsx
@@ -163,15 +163,15 @@ export const CarouselFeatured = React.forwardRef<HTMLElement, CarouselFeaturedPr
                 {/* Bottom section: features + CTA grouped together */}
                 <div className="bds-carousel-featured__bottom">
                   {/* Feature list with dividers */}
-                  <div className="bds-carousel-featured__features">
+                  <ul className="bds-carousel-featured__features">
                     {features.map((feature, index) => (
-                      <div key={index} className="bds-carousel-featured__feature">
+                      <li key={index} className="bds-carousel-featured__feature">
                         <Divider color="base" weight="regular" />
                         <p className="bds-carousel-featured__feature-title body-r">{feature.title}</p>
                         <p className="bds-carousel-featured__feature-description label-l">{feature.description}</p>
-                      </div>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
 
                   {/* CTA section with buttons and mobile nav */}
                   <div className="bds-carousel-featured__cta">

--- a/shared/patterns/LinkTextCard/LinkTextCard.scss
+++ b/shared/patterns/LinkTextCard/LinkTextCard.scss
@@ -6,8 +6,6 @@
 // .bds-link-text-card__header   - Header section (number + heading)
 // .bds-link-text-card__content  - Content section (description + buttons)
 
-@import '../../../styles/breakpoints';
-
 // =============================================================================
 // Design Tokens
 // =============================================================================

--- a/shared/patterns/LinkTextCard/LinkTextCard.scss
+++ b/shared/patterns/LinkTextCard/LinkTextCard.scss
@@ -1,0 +1,123 @@
+// BDS LinkTextCard Pattern Styles
+// Brand Design System - Numbered card with heading, description, and CTA buttons
+//
+// Naming Convention: BEM with 'bds' namespace
+// .bds-link-text-card           - Base card container with border-top divider
+// .bds-link-text-card__header   - Header section (number + heading)
+// .bds-link-text-card__content  - Content section (description + buttons)
+
+@import '../../../styles/breakpoints';
+
+// =============================================================================
+// Design Tokens
+// =============================================================================
+
+// Header gap (between number and heading)
+$bds-link-text-card-header-gap-base: 8px;
+$bds-link-text-card-header-gap-md: 12px;
+$bds-link-text-card-header-gap-lg: 16px;
+
+// Content gap (between description and buttons)
+$bds-link-text-card-content-gap-base: 16px;
+$bds-link-text-card-content-gap-md: 24px;
+$bds-link-text-card-content-gap-lg: 32px;
+
+// Card gap (between header and content sections)
+$bds-link-text-card-gap-base: 24px;
+$bds-link-text-card-gap-md: 32px;
+$bds-link-text-card-gap-lg: 40px;
+
+// Padding
+$bds-link-text-card-padding-top-base: 8px;
+$bds-link-text-card-padding-top-md: 12px;
+$bds-link-text-card-padding-top-lg: 16px;
+
+$bds-link-text-card-padding-bottom-base: 24px;
+$bds-link-text-card-padding-bottom-md: 32px;
+$bds-link-text-card-padding-bottom-lg: 40px;
+
+// Border
+$bds-link-text-card-border-width: 1px;
+$bds-link-text-card-border-color: $gray-300;
+
+// Text color
+$bds-link-text-card-number-color: $gray-500;
+
+// Content width at MD+
+$bds-link-text-card-content-width-md: calc(75% - 2px);
+
+// =============================================================================
+// Card Component
+// =============================================================================
+
+.bds-link-text-card {
+  display: flex;
+  flex-direction: column;
+  border-top: $bds-link-text-card-border-width solid $bds-link-text-card-border-color;
+  padding-top: $bds-link-text-card-padding-top-base;
+  padding-bottom: $bds-link-text-card-padding-bottom-base;
+  gap: $bds-link-text-card-gap-base;
+
+  @include media-breakpoint-up(md) {
+    padding-top: $bds-link-text-card-padding-top-md;
+    padding-bottom: $bds-link-text-card-padding-bottom-md;
+    gap: $bds-link-text-card-gap-md;
+  }
+
+  @include media-breakpoint-up(lg) {
+    padding-top: $bds-link-text-card-padding-top-lg;
+    padding-bottom: $bds-link-text-card-padding-bottom-lg;
+    gap: $bds-link-text-card-gap-lg;
+  }
+
+  // Remove padding-bottom for the last card in the list
+  &:last-child {
+    padding-bottom: 0;
+  }
+}
+
+// =============================================================================
+// Header Section (Number + Heading)
+// =============================================================================
+
+.bds-link-text-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: $bds-link-text-card-header-gap-base;
+
+  @include media-breakpoint-up(md) {
+    gap: $bds-link-text-card-header-gap-md;
+    width: $bds-link-text-card-content-width-md;
+  }
+
+  @include media-breakpoint-up(lg) {
+    gap: $bds-link-text-card-header-gap-lg;
+  }
+
+  p {
+    color: $bds-link-text-card-number-color;
+  }
+}
+
+// =============================================================================
+// Content Section (Description + Buttons)
+// =============================================================================
+
+.bds-link-text-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: $bds-link-text-card-content-gap-base;
+
+  @include media-breakpoint-up(md) {
+    gap: $bds-link-text-card-content-gap-md;
+    width: $bds-link-text-card-content-width-md;
+  }
+
+  @include media-breakpoint-up(lg) {
+    gap: $bds-link-text-card-content-gap-lg;
+  }
+
+  p {
+    color: $bds-link-text-card-number-color;
+  }
+}

--- a/shared/patterns/LinkTextCard/LinkTextCard.scss
+++ b/shared/patterns/LinkTextCard/LinkTextCard.scss
@@ -76,12 +76,6 @@ $bds-link-text-card-content-width-md: calc(75% - 2px);
   }
   @include bds-theme-mode(dark) {
     color: $white;
-    h5 {
-      color: $white;
-    }
-    p {
-      color: $white;
-    }
   }
 }
 

--- a/shared/patterns/LinkTextCard/LinkTextCard.scss
+++ b/shared/patterns/LinkTextCard/LinkTextCard.scss
@@ -74,6 +74,15 @@ $bds-link-text-card-content-width-md: calc(75% - 2px);
   &:last-child {
     padding-bottom: 0;
   }
+  @include bds-theme-mode(dark) {
+    color: $white;
+    h5 {
+      color: $white;
+    }
+    p {
+      color: $white;
+    }
+  }
 }
 
 // =============================================================================

--- a/shared/patterns/LinkTextCard/LinkTextCard.tsx
+++ b/shared/patterns/LinkTextCard/LinkTextCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import clsx from 'clsx';
+import { ButtonGroup, ButtonConfig } from '../ButtonGroup';
+
+export interface LinkTextCardProps {
+  /** Card index for numbering (displays as index + 1) */
+  index: number;
+  /** Heading text (required) */
+  heading: string;
+  /** Description text (required) */
+  description: string;
+  /** Array of button configurations (max 2) */
+  buttons: ButtonConfig[];
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * LinkTextCard Component
+ *
+ * A card component that displays a numbered item with heading, description, and action buttons.
+ * Features a top divider, sequential numbering (01, 02, 03...), and up to 2 call-to-action buttons.
+ *
+ * Design:
+ * - Flat HTML structure for minimal DOM depth
+ * - Fixed green button color for brand consistency
+ * - Responsive typography using existing design tokens
+ * - Full light/dark mode support
+ *
+ * @example
+ * // Basic usage
+ * <LinkTextCard
+ *   index={0}
+ *   heading="Fast Settlement and Low Fees"
+ *   description="Settle transactions in 3-5 seconds for a fraction of a cent"
+ *   buttons={[
+ *     { label: "Get Started", href: "/start" },
+ *     { label: "Learn More", href: "/learn" }
+ *   ]}
+ * />
+ *
+ * @example
+ * // Single button
+ * <LinkTextCard
+ *   index={1}
+ *   heading="Secure and Reliable"
+ *   description="Built on proven blockchain technology"
+ *   buttons={[{ label: "Read Docs", href: "/docs" }]}
+ * />
+ */
+export const LinkTextCard: React.FC<LinkTextCardProps> = ({
+  index,
+  heading,
+  description,
+  buttons,
+  className,
+}) => {
+  // Format number with zero padding (01, 02, 03...)
+  const formattedNumber = String(index + 1).padStart(2, '0');
+
+  // Ensure max 2 buttons for proper layout
+  const maxButtons = buttons.slice(0, 2);
+
+  return (
+  <li className={clsx('bds-link-text-card', className)}>
+    <div className="bds-link-text-card__header">
+      <p className="mb-0 body-l">{formattedNumber}</p>
+      <h5 className="mb-0 sh-lg-l">{heading}</h5>
+    </div>
+    <div className="bds-link-text-card__content">
+      <p className="mb-0 body-l">{description}</p>
+      {maxButtons.length > 0 && (
+        <ButtonGroup buttons={maxButtons} color="green" />
+      )}
+    </div>
+  </li>
+  );
+};
+
+export default LinkTextCard;

--- a/shared/patterns/LinkTextCard/README.md
+++ b/shared/patterns/LinkTextCard/README.md
@@ -1,0 +1,196 @@
+# LinkTextCard Component
+
+A numbered card component displaying a heading, description, and call-to-action buttons.
+
+## Overview
+
+LinkTextCard is a pattern component designed for sequential content presentation. Each card displays a numbered label (01, 02, 03...), a heading, description text, and up to 2 action buttons. Perfect for feature lists, step-by-step guides, or numbered content sections.
+
+## Features
+
+- **Sequential Numbering**: Auto-increments based on index prop with zero-padding (01, 02, 03...)
+- **Minimal HTML Structure**: Flat DOM hierarchy for optimal performance
+- **ButtonGroup Integration**: Supports up to 2 buttons (Primary + Tertiary layout)
+- **Fixed Button Color**: Green buttons for brand consistency
+- **Light/Dark Mode**: Full theming support
+- **Responsive Design**: Adaptive spacing and typography across breakpoints
+- **Top Divider**: Border-top styling with theme-aware colors
+
+## Usage
+
+### Basic Usage (2 Buttons)
+
+```tsx
+<LinkTextCard
+  index={0}
+  heading="Fast Settlement and Low Fees"
+  description="Settle transactions in 3-5 seconds for a fraction of a cent, ideal for large-scale, high-volume RWA tokenization"
+  buttons={[
+    { label: "Get Started", href: "/start" },
+    { label: "Learn More", href: "/docs" }
+  ]}
+/>
+```
+
+### Single Button
+
+```tsx
+<LinkTextCard
+  index={1}
+  heading="Secure and Reliable"
+  description="Built on proven blockchain technology with enterprise-grade security"
+  buttons={[
+    { label: "Read Documentation", href: "/docs" }
+  ]}
+/>
+```
+
+### With Click Handlers
+
+```tsx
+<LinkTextCard
+  index={2}
+  heading="Developer Friendly"
+  description="Comprehensive APIs and SDKs for seamless integration"
+  buttons={[
+    { label: "View API", onClick: () => navigate('/api') },
+    { label: "See Examples", href: "/examples" }
+  ]}
+/>
+```
+
+### In a List
+
+```tsx
+{features.map((feature, index) => (
+  <LinkTextCard
+    key={feature.id}
+    index={index}
+    heading={feature.heading}
+    description={feature.description}
+    buttons={feature.buttons}
+  />
+))}
+```
+
+## Props
+
+### LinkTextCardProps
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `index` | `number` | Required | Card index for numbering (displays as index + 1) |
+| `heading` | `string` | Required | Main heading text |
+| `description` | `string` | Required | Description/body text |
+| `buttons` | `ButtonConfig[]` | Required | Array of button configurations (max 2) |
+| `className` | `string` | - | Additional CSS classes |
+
+### ButtonConfig (from ButtonGroup)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | Required | Button text |
+| `href` | `string` | - | Link destination (renders as anchor) |
+| `onClick` | `() => void` | - | Click handler (renders as button) |
+| `forceColor` | `boolean` | `false` | Force color regardless of theme |
+
+**Note**: Only the first 2 buttons will be rendered. Button color is fixed to 'green'.
+
+## Component Structure
+
+```tsx
+<div className="bds-link-text-card">
+  <p className="body-l">01</p>
+  <h3 className="subhead-lg-l">Fast Settlement and Low Fees</h3>
+  <p className="body-l">Settle transactions in 3-5 seconds...</p>
+  <ButtonGroup buttons={[...]} color="green" />
+</div>
+```
+
+**Key Design Decisions:**
+- **Flat Structure**: No nested wrapper divs for minimal DOM depth
+- **Border-Top Divider**: Applied directly to container (no separate element)
+- **Typography Classes**: Uses existing `body-l` and `subhead-lg-l` classes
+- **Flexbox Gap**: Responsive spacing via gap property
+
+## Responsive Spacing
+
+| Breakpoint | Gap | Content Gap | Padding Top |
+|------------|-----|-------------|-------------|
+| Base (< 576px) | 8px | 24px | 8px |
+| MD (576px - 991px) | 12px | 32px | 12px |
+| LG (≥ 992px) | 16px | 40px | 16px |
+
+**Gap**: Space between number, heading, description, and buttons  
+**Content Gap**: Additional space between description and ButtonGroup  
+**Padding Top**: Space from top border to content
+
+## Styling
+
+### CSS Classes
+
+- `.bds-link-text-card` - Main container with flexbox layout
+- Leverages existing typography utilities: `body-l`, `subhead-lg-l`
+
+### Color Variables (Light/Dark Mode)
+
+- `--neutral-300` - Border color
+- `--neutral-500` - Number text color
+- Heading and description colors handled by typography classes
+
+## Number Formatting
+
+The component automatically formats numbers with zero-padding:
+
+```typescript
+index: 0  → "01"
+index: 1  → "02"
+index: 9  → "10"
+index: 99 → "100"
+```
+
+## Button Behavior
+
+### 1-2 Buttons
+- **1 button**: Renders as primary button
+- **2 buttons**: First as primary, second as tertiary
+
+### 3+ Buttons
+If more than 2 buttons are passed, only the first 2 will be rendered (automatically sliced).
+
+## Files
+
+- `LinkTextCard.tsx` - React component with TypeScript
+- `LinkTextCard.scss` - Minimal SCSS with BEM naming
+- `index.ts` - Barrel exports
+- `README.md` - This file
+
+## Related Components
+
+- **ButtonGroup**: Used for rendering action buttons
+- **Button**: Atomic button component used by ButtonGroup
+
+## Import
+
+```tsx
+import { LinkTextCard } from 'shared/patterns/LinkTextCard';
+// or
+import { LinkTextCard, type LinkTextCardProps } from 'shared/patterns/LinkTextCard';
+```
+
+## Design System
+
+Part of the Brand Design System (BDS) with `bds-` namespace prefix.
+
+## Best Practices
+
+1. **Use Sequential Indices**: Pass indices 0, 1, 2... for proper numbering
+2. **Limit Buttons**: Design works best with 1-2 buttons
+3. **Clear Descriptions**: Keep descriptions concise but informative
+4. **Consistent Length**: Try to keep similar text lengths across cards in a group
+
+## Accessibility
+
+- Semantic HTML with proper heading hierarchy (`<h3>`)
+- Button labels should be descriptive
+- Maintains focus order: number → heading → description → buttons

--- a/shared/patterns/LinkTextCard/README.md
+++ b/shared/patterns/LinkTextCard/README.md
@@ -99,44 +99,54 @@ LinkTextCard is a pattern component designed for sequential content presentation
 ## Component Structure
 
 ```tsx
-<div className="bds-link-text-card">
-  <p className="body-l">01</p>
-  <h3 className="subhead-lg-l">Fast Settlement and Low Fees</h3>
-  <p className="body-l">Settle transactions in 3-5 seconds...</p>
-  <ButtonGroup buttons={[...]} color="green" />
-</div>
+<li className="bds-link-text-card">
+  <div className="bds-link-text-card__header">
+    <p className="body-l">01</p>
+    <h5 className="sh-lg-l">Fast Settlement and Low Fees</h5>
+  </div>
+  <div className="bds-link-text-card__content">
+    <p className="body-l">Settle transactions in 3-5 seconds...</p>
+    <ButtonGroup buttons={[...]} color="green" />
+  </div>
+</li>
 ```
 
 **Key Design Decisions:**
-- **Flat Structure**: No nested wrapper divs for minimal DOM depth
+- **List Item Element**: Renders as `<li>` for semantic list markup
+- **Two-Section Layout**: Header (number + heading) and Content (description + buttons)
 - **Border-Top Divider**: Applied directly to container (no separate element)
-- **Typography Classes**: Uses existing `body-l` and `subhead-lg-l` classes
+- **Typography Classes**: Uses existing `body-l` and `sh-lg-l` classes
 - **Flexbox Gap**: Responsive spacing via gap property
+- **75% Width at MD+**: Content is constrained to 75% width on tablet and desktop
 
 ## Responsive Spacing
 
-| Breakpoint | Gap | Content Gap | Padding Top |
-|------------|-----|-------------|-------------|
-| Base (< 576px) | 8px | 24px | 8px |
-| MD (576px - 991px) | 12px | 32px | 12px |
-| LG (≥ 992px) | 16px | 40px | 16px |
+| Breakpoint | Card Gap | Header Gap | Content Gap | Padding Top | Padding Bottom |
+|------------|----------|------------|-------------|-------------|----------------|
+| Base (< 576px) | 24px | 8px | 16px | 8px | 24px |
+| MD (576px - 991px) | 32px | 12px | 24px | 12px | 32px |
+| LG (≥ 992px) | 40px | 16px | 32px | 16px | 40px |
 
-**Gap**: Space between number, heading, description, and buttons  
-**Content Gap**: Additional space between description and ButtonGroup  
+**Card Gap**: Space between header and content sections
+**Header Gap**: Space between number and heading
+**Content Gap**: Space between description and ButtonGroup
 **Padding Top**: Space from top border to content
+**Padding Bottom**: Space after content (removed on last card)
 
 ## Styling
 
 ### CSS Classes
 
-- `.bds-link-text-card` - Main container with flexbox layout
-- Leverages existing typography utilities: `body-l`, `subhead-lg-l`
+- `.bds-link-text-card` - Main list item container with flexbox layout and border-top
+- `.bds-link-text-card__header` - Header section (number + heading)
+- `.bds-link-text-card__content` - Content section (description + buttons)
+- Typography utilities: `body-l`, `sh-lg-l`
 
-### Color Variables (Light/Dark Mode)
+### Color Variables
 
-- `--neutral-300` - Border color
-- `--neutral-500` - Number text color
-- Heading and description colors handled by typography classes
+- `$gray-300` - Border color (light mode)
+- `$gray-500` - Number text color
+- `$white` - Text color in dark mode (applied to entire card)
 
 ## Number Formatting
 
@@ -191,6 +201,9 @@ Part of the Brand Design System (BDS) with `bds-` namespace prefix.
 
 ## Accessibility
 
-- Semantic HTML with proper heading hierarchy (`<h3>`)
+- Semantic HTML: Renders as `<li>` for use within `<ul>` lists
+- Heading hierarchy: Uses `<h5>` for card headings (adjust based on parent context)
 - Button labels should be descriptive
 - Maintains focus order: number → heading → description → buttons
+
+**Note on Heading Semantics**: The component uses `<h5>` inside a list item, which is acceptable when the parent section has appropriate heading hierarchy. The heading level can be adjusted based on your specific use case.

--- a/shared/patterns/LinkTextCard/index.ts
+++ b/shared/patterns/LinkTextCard/index.ts
@@ -1,0 +1,1 @@
+export { LinkTextCard, type LinkTextCardProps } from './LinkTextCard';

--- a/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
+++ b/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
@@ -48,6 +48,15 @@ $bds-link-text-directory-header-margin-lg: 40px;
     padding-left: 0;
     list-style: none;
   }
+  @include bds-theme-mode(dark) {
+    color: $white;
+    h2 {
+      color: $white;
+    }
+    p {
+      color: $white;
+    }
+  }
 }
 
 // =============================================================================

--- a/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
+++ b/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
@@ -1,0 +1,80 @@
+// BDS LinkTextDirectory Pattern Styles
+// Brand Design System - Section with heading and list of numbered cards
+//
+// Naming Convention: BEM with 'bds' namespace
+// .bds-link-text-directory         - Base section container
+// .bds-link-text-directory__header - Header section (heading + description)
+
+@import '../../../styles/breakpoints';
+
+// =============================================================================
+// Design Tokens
+// =============================================================================
+
+// Section padding
+$bds-link-text-directory-padding-base: 24px;
+$bds-link-text-directory-padding-md: 32px;
+$bds-link-text-directory-padding-lg: 40px;
+
+// Header gap (between heading and description)
+$bds-link-text-directory-header-gap-base: 8px;
+$bds-link-text-directory-header-gap-md: 8px;
+$bds-link-text-directory-header-gap-lg: 16px;
+
+// Header margin-bottom (space before cards list)
+$bds-link-text-directory-header-margin-base: 24px;
+$bds-link-text-directory-header-margin-md: 32px;
+$bds-link-text-directory-header-margin-lg: 40px;
+
+// =============================================================================
+// Section Container
+// =============================================================================
+
+.bds-link-text-directory {
+  padding-top: $bds-link-text-directory-padding-base;
+  padding-bottom: $bds-link-text-directory-padding-base;
+
+  @include media-breakpoint-up(md) {
+    padding-top: $bds-link-text-directory-padding-md;
+    padding-bottom: $bds-link-text-directory-padding-md;
+  }
+
+  @include media-breakpoint-up(lg) {
+    padding-top: $bds-link-text-directory-padding-lg;
+    padding-bottom: $bds-link-text-directory-padding-lg;
+  }
+
+  ul {
+    padding-left: 0;
+    list-style: none;
+  }
+}
+
+// =============================================================================
+// Header Section
+// =============================================================================
+
+.bds-link-text-directory__header {
+  gap: $bds-link-text-directory-header-gap-base;
+  margin-bottom: $bds-link-text-directory-header-margin-base;
+
+  @include media-breakpoint-up(md) {
+    gap: $bds-link-text-directory-header-gap-md;
+    margin-bottom: $bds-link-text-directory-header-margin-md;
+  }
+
+  @include media-breakpoint-up(lg) {
+    gap: $bds-link-text-directory-header-gap-lg;
+    margin-bottom: $bds-link-text-directory-header-margin-lg;
+  }
+  h2 {
+    margin-bottom: 8px;
+
+    @include media-breakpoint-up(lg) {
+      margin-bottom: 16px;
+    }
+  }
+  p {
+    margin-bottom: 0;
+  }
+}

--- a/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
+++ b/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
@@ -50,12 +50,6 @@ $bds-link-text-directory-header-margin-lg: 40px;
   }
   @include bds-theme-mode(dark) {
     color: $white;
-    h2 {
-      color: $white;
-    }
-    p {
-      color: $white;
-    }
   }
 }
 
@@ -64,6 +58,8 @@ $bds-link-text-directory-header-margin-lg: 40px;
 // =============================================================================
 
 .bds-link-text-directory__header {
+  display: flex;
+  flex-direction: column;
   gap: $bds-link-text-directory-header-gap-base;
   margin-bottom: $bds-link-text-directory-header-margin-base;
 
@@ -76,14 +72,7 @@ $bds-link-text-directory-header-margin-lg: 40px;
     gap: $bds-link-text-directory-header-gap-lg;
     margin-bottom: $bds-link-text-directory-header-margin-lg;
   }
-  h2 {
-    margin-bottom: 8px;
-
-    @include media-breakpoint-up(lg) {
-      margin-bottom: 16px;
-    }
-  }
-  p {
+  h2, p {
     margin-bottom: 0;
   }
 }

--- a/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
+++ b/shared/patterns/LinkTextDirectory/LinkTextDirectory.scss
@@ -5,8 +5,6 @@
 // .bds-link-text-directory         - Base section container
 // .bds-link-text-directory__header - Header section (heading + description)
 
-@import '../../../styles/breakpoints';
-
 // =============================================================================
 // Design Tokens
 // =============================================================================

--- a/shared/patterns/LinkTextDirectory/LinkTextDirectory.tsx
+++ b/shared/patterns/LinkTextDirectory/LinkTextDirectory.tsx
@@ -89,7 +89,7 @@ export const LinkTextDirectory: React.FC<LinkTextDirectoryProps> = ({
           <ul className="list-none pl-0">
           {cards.map((card, index) => (
             <LinkTextCard
-              key={index}
+              key={card.heading || index}
               index={index}
               heading={card.heading}
               description={card.description}

--- a/shared/patterns/LinkTextDirectory/LinkTextDirectory.tsx
+++ b/shared/patterns/LinkTextDirectory/LinkTextDirectory.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import clsx from 'clsx';
+import { LinkTextCard } from '../LinkTextCard';
+import { ButtonConfig } from '../ButtonGroup';
+import { PageGrid, PageGridRow, PageGridCol } from 'shared/components/PageGrid/page-grid';
+
+export interface LinkTextCardData {
+  /** Heading text for the card */
+  heading: string;
+  /** Description text for the card */
+  description: string;
+  /** Array of button configurations (max 2) */
+  buttons: ButtonConfig[];
+}
+
+export interface LinkTextDirectoryProps {
+  /** Section heading (required) */
+  heading: string;
+  /** Optional description text */
+  description?: string;
+  /** Array of card data to display */
+  cards: LinkTextCardData[];
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * LinkTextDirectory Component
+ *
+ * A section pattern that displays a numbered list of LinkTextCard components.
+ * Features a heading, optional description, and a vertically stacked list of cards
+ * with automatic sequential numbering (01, 02, 03...).
+ *
+ * Layout:
+ * - Header section with heading + description
+ * - Responsive vertical spacing between cards
+ * - Desktop: Right-aligned cards with 40px gaps
+ * - Tablet: Left-aligned cards with 32px gaps
+ * - Mobile: Left-aligned cards with 24px gaps
+ *
+ * @example
+ * // Basic usage
+ * <LinkTextDirectory
+ *   heading="Explore XRPL Developer Tools"
+ *   description="XRP Ledger is a compliance-focused blockchain where financial applications come to life"
+ *   cards={[
+ *     {
+ *       heading: "Fast Settlement and Low Fees",
+ *       description: "Settle transactions in 3-5 seconds for a fraction of a cent",
+ *       buttons: [
+ *         { label: "Get Started", href: "/start" },
+ *         { label: "Learn More", href: "/docs" }
+ *       ]
+ *     },
+ *     {
+ *       heading: "Secure and Reliable",
+ *       description: "Built on proven blockchain technology",
+ *       buttons: [{ label: "Read Docs", href: "/docs" }]
+ *     }
+ *   ]}
+ * />
+ *
+ * @example
+ * // Without description
+ * <LinkTextDirectory
+ *   heading="Features"
+ *   cards={cardData}
+ * />
+ */
+export const LinkTextDirectory: React.FC<LinkTextDirectoryProps> = ({
+  heading,
+  description,
+  cards,
+  className,
+}) => {
+  return (
+    <PageGrid className={clsx('bds-link-text-directory', className)}>
+      {/* Header Section */}
+      <PageGridRow>
+        <PageGridCol className="bds-link-text-directory__header" span={{ base: 12, md: 6, lg: 8}}>
+          <h2 className="h-md">{heading}</h2>
+          {description && <p className="body-l">{description}</p>}
+        </PageGridCol>
+      </PageGridRow>
+
+      {/* Cards List */}
+      <PageGridRow className="bds-link-text-directory__list">
+        <PageGridCol span={{ base: 12, md: 8, lg: 8}} offset={{ lg: 4 }}>
+          <ul className="list-none pl-0">
+          {cards.map((card, index) => (
+            <LinkTextCard
+              key={index}
+              index={index}
+              heading={card.heading}
+              description={card.description}
+              buttons={card.buttons}
+            />
+          ))}
+          </ul>
+        </PageGridCol>
+      </PageGridRow >
+    </PageGrid>
+  );
+};
+
+export default LinkTextDirectory;

--- a/shared/patterns/LinkTextDirectory/README.md
+++ b/shared/patterns/LinkTextDirectory/README.md
@@ -1,0 +1,263 @@
+# LinkTextDirectory Component
+
+A section pattern that displays a numbered list of LinkTextCard components with a heading and optional description.
+
+## Overview
+
+LinkTextDirectory is a section-level pattern that combines a header (heading + description) with a vertically stacked list of LinkTextCard components. Each card is automatically numbered sequentially (01, 02, 03...), making it perfect for feature lists, step-by-step guides, or numbered content sections.
+
+## Features
+
+- **Automatic Numbering**: Cards are numbered sequentially starting from 01
+- **Responsive Layout**: Adaptive spacing and alignment across breakpoints
+- **Desktop Right-Alignment**: Cards are right-aligned on desktop for visual interest
+- **Minimal HTML Structure**: Flat, efficient DOM hierarchy
+- **Light/Dark Mode**: Full theming support
+- **Flexible Content**: Supports any number of cards
+
+## Layout Behavior
+
+| Breakpoint | Card Alignment | Gap Between Cards | Header Gap |
+|------------|----------------|-------------------|------------|
+| Base (< 576px) | Left | 24px | 8px |
+| MD (576px - 991px) | Left | 32px | 8px |
+| LG (≥ 992px) | Right | 40px | 16px |
+
+**Desktop Behavior**: Cards are right-aligned using `align-items: flex-end`, creating a visually distinct layout compared to mobile/tablet.
+
+## Usage
+
+### Basic Usage
+
+```tsx
+<LinkTextDirectory
+  heading="Explore XRPL Developer Tools"
+  description="XRP Ledger is a compliance-focused blockchain where financial applications come to life"
+  cards={[
+    {
+      heading: "Fast Settlement and Low Fees",
+      description: "Settle transactions in 3-5 seconds for a fraction of a cent, ideal for large-scale, high-volume RWA tokenization",
+      buttons: [
+        { label: "Get Started", href: "/start" },
+        { label: "Learn More", href: "/docs" }
+      ]
+    },
+    {
+      heading: "Secure and Reliable",
+      description: "Built on proven blockchain technology with enterprise-grade security",
+      buttons: [
+        { label: "Read Documentation", href: "/docs" }
+      ]
+    },
+    {
+      heading: "Developer Friendly",
+      description: "Comprehensive APIs and SDKs for seamless integration",
+      buttons: [
+        { label: "View API", href: "/api" },
+        { label: "See Examples", href: "/examples" }
+      ]
+    }
+  ]}
+/>
+```
+
+### Without Description
+
+```tsx
+<LinkTextDirectory
+  heading="Key Features"
+  cards={featuresList}
+/>
+```
+
+### With Dynamic Data
+
+```tsx
+const features = [
+  {
+    heading: "Feature One",
+    description: "Description for feature one",
+    buttons: [{ label: "Learn More", href: "/feature-1" }]
+  },
+  // ... more features
+];
+
+<LinkTextDirectory
+  heading="Platform Features"
+  description="Everything you need to build amazing applications"
+  cards={features}
+/>
+```
+
+## Props
+
+### LinkTextDirectoryProps
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `heading` | `string` | Required | Section heading |
+| `description` | `string` | - | Optional description text |
+| `cards` | `LinkTextCardData[]` | Required | Array of card data |
+| `className` | `string` | - | Additional CSS classes |
+
+### LinkTextCardData
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `heading` | `string` | Required | Card heading |
+| `description` | `string` | Required | Card description |
+| `buttons` | `ButtonConfig[]` | Required | Array of button configs (max 2) |
+
+### ButtonConfig (from ButtonGroup)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | Required | Button text |
+| `href` | `string` | - | Link destination |
+| `onClick` | `() => void` | - | Click handler |
+
+## Component Structure
+
+```tsx
+<section className="bds-link-text-directory">
+  <div className="bds-link-text-directory__header">
+    <h2 className="h-md">{heading}</h2>
+    <p className="body-l">{description}</p>
+  </div>
+  
+  <div className="bds-link-text-directory__list">
+    {cards.map((card, index) => (
+      <LinkTextCard
+        index={index}
+        heading={card.heading}
+        description={card.description}
+        buttons={card.buttons}
+      />
+    ))}
+  </div>
+</section>
+```
+
+**Key Design Decisions:**
+- **Flat Structure**: Minimal nesting for optimal performance
+- **Typography Classes**: Uses existing `h-md` and `body-l` utility classes
+- **Flexbox Layout**: Simple flex column with gap for spacing
+- **Desktop Alignment**: `align-items: flex-end` on desktop only
+
+## Responsive Spacing
+
+The component uses responsive gaps for visual hierarchy:
+
+```scss
+// Mobile: Compact spacing
+gap: 24px;
+
+// Tablet: Medium spacing
+gap: 32px;
+
+// Desktop: Spacious layout
+gap: 40px;
+```
+
+## Styling
+
+### CSS Classes
+
+- `.bds-link-text-directory` - Main section container
+- `.bds-link-text-directory__header` - Header section wrapper
+- `.bds-link-text-directory__list` - Cards list container
+
+### Typography
+
+- **Heading**: `h-md` class (responsive heading)
+- **Description**: `body-l` class (large body text)
+- Card content uses LinkTextCard's built-in typography
+
+## Card Numbering
+
+Cards are automatically numbered based on their array index:
+
+```typescript
+cards[0] → LinkTextCard(index: 0) → displays "01"
+cards[1] → LinkTextCard(index: 1) → displays "02"
+cards[2] → LinkTextCard(index: 2) → displays "03"
+// ... and so on
+```
+
+## Files
+
+- `LinkTextDirectory.tsx` - React component
+- `LinkTextDirectory.scss` - SCSS styles
+- `index.ts` - Barrel exports
+- `README.md` - This file
+
+## Related Components
+
+- **LinkTextCard**: Used for each card in the list
+- **ButtonGroup**: Used by LinkTextCard for action buttons
+
+## Import
+
+```tsx
+import { LinkTextDirectory } from 'shared/patterns/LinkTextDirectory';
+// or
+import { 
+  LinkTextDirectory, 
+  type LinkTextDirectoryProps,
+  type LinkTextCardData 
+} from 'shared/patterns/LinkTextDirectory';
+```
+
+## Design System
+
+Part of the Brand Design System (BDS) with `bds-` namespace prefix.
+
+## Best Practices
+
+1. **Consistent Card Content**: Try to keep similar text lengths across cards for visual balance
+2. **Limit Cards**: 3-6 cards works best for readability
+3. **Clear Descriptions**: Keep descriptions concise but informative
+4. **Button Labels**: Use clear, action-oriented button labels
+5. **Logical Ordering**: Order cards by priority or logical sequence
+
+## Accessibility
+
+- Semantic HTML with proper heading hierarchy (`<h2>` for section, `<h3>` for cards)
+- Sequential tab order through cards and buttons
+- ARIA-compliant button and link elements (via ButtonGroup)
+- Maintains focus order: heading → description → card 1 → card 2 → etc.
+
+## Example with All Features
+
+```tsx
+<LinkTextDirectory
+  heading="Why Choose XRPL"
+  description="The most efficient blockchain for real-world applications"
+  cards={[
+    {
+      heading: "Lightning Fast",
+      description: "Process thousands of transactions per second with sub-3-second finality",
+      buttons: [
+        { label: "View Benchmarks", href: "/performance" },
+        { label: "Try Demo", onClick: () => openDemo() }
+      ]
+    },
+    {
+      heading: "Cost Effective",
+      description: "Minimal transaction fees make XRPL perfect for micro-transactions and high-volume use cases",
+      buttons: [
+        { label: "See Pricing", href: "/pricing" }
+      ]
+    },
+    {
+      heading: "Battle Tested",
+      description: "Over 10 years of continuous operation with billions of transactions processed",
+      buttons: [
+        { label: "Read Case Studies", href: "/case-studies" },
+        { label: "View Stats", href: "/statistics" }
+      ]
+    }
+  ]}
+  className="my-custom-class"
+/>
+```

--- a/shared/patterns/LinkTextDirectory/README.md
+++ b/shared/patterns/LinkTextDirectory/README.md
@@ -119,59 +119,74 @@ const features = [
 ## Component Structure
 
 ```tsx
-<section className="bds-link-text-directory">
-  <div className="bds-link-text-directory__header">
-    <h2 className="h-md">{heading}</h2>
-    <p className="body-l">{description}</p>
-  </div>
-  
-  <div className="bds-link-text-directory__list">
-    {cards.map((card, index) => (
-      <LinkTextCard
-        index={index}
-        heading={card.heading}
-        description={card.description}
-        buttons={card.buttons}
-      />
-    ))}
-  </div>
-</section>
+<PageGrid className="bds-link-text-directory">
+  <PageGridRow>
+    <PageGridCol className="bds-link-text-directory__header" span={{ base: 12, md: 6, lg: 8 }}>
+      <h2 className="h-md">{heading}</h2>
+      <p className="body-l">{description}</p>
+    </PageGridCol>
+  </PageGridRow>
+
+  <PageGridRow>
+    <PageGridCol span={{ base: 12, md: 8, lg: 8 }} offset={{ lg: 4 }}>
+      <ul>
+        {cards.map((card, index) => (
+          <LinkTextCard
+            key={index}
+            index={index}
+            heading={card.heading}
+            description={card.description}
+            buttons={card.buttons}
+          />
+        ))}
+      </ul>
+    </PageGridCol>
+  </PageGridRow>
+</PageGrid>
 ```
 
 **Key Design Decisions:**
-- **Flat Structure**: Minimal nesting for optimal performance
+- **PageGrid Integration**: Uses PageGrid system for responsive layout
 - **Typography Classes**: Uses existing `h-md` and `body-l` utility classes
-- **Flexbox Layout**: Simple flex column with gap for spacing
-- **Desktop Alignment**: `align-items: flex-end` on desktop only
+- **Flexbox Header**: Header uses flexbox with gap for spacing between heading and description
+- **Desktop Right-Alignment**: Cards offset by 4 columns at LG breakpoint (right-aligned)
+- **Semantic List**: Cards wrapped in `<ul>` with each card as `<li>`
 
 ## Responsive Spacing
 
-The component uses responsive gaps for visual hierarchy:
+| Breakpoint | Section Padding | Header Gap | Header Margin-Bottom |
+|------------|-----------------|------------|----------------------|
+| Base (< 576px) | 24px | 8px | 24px |
+| MD (576px - 991px) | 32px | 8px | 32px |
+| LG (≥ 992px) | 40px | 16px | 40px |
 
-```scss
-// Mobile: Compact spacing
-gap: 24px;
-
-// Tablet: Medium spacing
-gap: 32px;
-
-// Desktop: Spacious layout
-gap: 40px;
-```
+**Section Padding**: Top and bottom padding on the entire section
+**Header Gap**: Space between heading and description (via flexbox gap)
+**Header Margin-Bottom**: Space between header and cards list
 
 ## Styling
 
 ### CSS Classes
 
-- `.bds-link-text-directory` - Main section container
-- `.bds-link-text-directory__header` - Header section wrapper
-- `.bds-link-text-directory__list` - Cards list container
+- `.bds-link-text-directory` - Main PageGrid container with section padding
+- `.bds-link-text-directory__header` - Header section (flexbox column with gap)
 
 ### Typography
 
 - **Heading**: `h-md` class (responsive heading)
 - **Description**: `body-l` class (large body text)
 - Card content uses LinkTextCard's built-in typography
+
+### Grid Layout
+
+- **Header Column**: `span={{ base: 12, md: 6, lg: 8 }}`
+- **Cards Column**: `span={{ base: 12, md: 8, lg: 8 }}` with `offset={{ lg: 4 }}`
+- Cards are right-aligned on desktop via the 4-column offset
+
+### Dark Mode
+
+- Text color changes to white in dark mode
+- Applied to entire section via `bds-theme-mode(dark)` mixin
 
 ## Card Numbering
 
@@ -222,10 +237,39 @@ Part of the Brand Design System (BDS) with `bds-` namespace prefix.
 
 ## Accessibility
 
-- Semantic HTML with proper heading hierarchy (`<h2>` for section, `<h3>` for cards)
+- Semantic HTML with proper heading hierarchy (`<h2>` for section, `<h5>` for cards)
+- Semantic list structure: `<ul>` containing `<li>` elements
 - Sequential tab order through cards and buttons
 - ARIA-compliant button and link elements (via ButtonGroup)
 - Maintains focus order: heading → description → card 1 → card 2 → etc.
+
+## Best Practices for React Keys
+
+When mapping over cards, use a stable identifier instead of array index:
+
+```tsx
+// ❌ Avoid using index as key
+{cards.map((card, index) => (
+  <LinkTextCard key={index} ... />
+))}
+
+// ✅ Better: Use a unique identifier
+{cards.map((card, index) => (
+  <LinkTextCard key={card.id || card.heading} ... />
+))}
+
+// ✅ Best: Add an id field to LinkTextCardData
+interface LinkTextCardData {
+  id: string;  // Unique identifier
+  heading: string;
+  description: string;
+  buttons: ButtonConfig[];
+}
+
+{cards.map((card) => (
+  <LinkTextCard key={card.id} ... />
+))}
+```
 
 ## Example with All Features
 

--- a/shared/patterns/LinkTextDirectory/index.ts
+++ b/shared/patterns/LinkTextDirectory/index.ts
@@ -1,0 +1,1 @@
+export { LinkTextDirectory, type LinkTextDirectoryProps, type LinkTextCardData } from './LinkTextDirectory';

--- a/static/css/devportal2024-v1.css
+++ b/static/css/devportal2024-v1.css
@@ -22362,6 +22362,15 @@ html.dark .bds-tile-link--disabled.bds-tile-link--lilac .bds-tile-link__arrow {
 .bds-link-text-card:last-child {
   padding-bottom: 0;
 }
+html.dark .bds-link-text-card {
+  color: #FFFFFF;
+}
+html.dark .bds-link-text-card h5, html.dark .bds-link-text-card .h5 {
+  color: #FFFFFF;
+}
+html.dark .bds-link-text-card p {
+  color: #FFFFFF;
+}
 
 .bds-link-text-card__header {
   display: flex;
@@ -22422,6 +22431,15 @@ html.dark .bds-tile-link--disabled.bds-tile-link--lilac .bds-tile-link__arrow {
 .bds-link-text-directory ul {
   padding-left: 0;
   list-style: none;
+}
+html.dark .bds-link-text-directory {
+  color: #FFFFFF;
+}
+html.dark .bds-link-text-directory h2, html.dark .bds-link-text-directory .h2 {
+  color: #FFFFFF;
+}
+html.dark .bds-link-text-directory p {
+  color: #FFFFFF;
 }
 
 .bds-link-text-directory__header {

--- a/static/css/devportal2024-v1.css
+++ b/static/css/devportal2024-v1.css
@@ -22365,12 +22365,6 @@ html.dark .bds-tile-link--disabled.bds-tile-link--lilac .bds-tile-link__arrow {
 html.dark .bds-link-text-card {
   color: #FFFFFF;
 }
-html.dark .bds-link-text-card h5, html.dark .bds-link-text-card .h5 {
-  color: #FFFFFF;
-}
-html.dark .bds-link-text-card p {
-  color: #FFFFFF;
-}
 
 .bds-link-text-card__header {
   display: flex;
@@ -22435,14 +22429,10 @@ html.dark .bds-link-text-card p {
 html.dark .bds-link-text-directory {
   color: #FFFFFF;
 }
-html.dark .bds-link-text-directory h2, html.dark .bds-link-text-directory .h2 {
-  color: #FFFFFF;
-}
-html.dark .bds-link-text-directory p {
-  color: #FFFFFF;
-}
 
 .bds-link-text-directory__header {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
   margin-bottom: 24px;
 }
@@ -22458,15 +22448,7 @@ html.dark .bds-link-text-directory p {
     margin-bottom: 40px;
   }
 }
-.bds-link-text-directory__header h2, .bds-link-text-directory__header .h2 {
-  margin-bottom: 8px;
-}
-@media (min-width: 992px) {
-  .bds-link-text-directory__header h2, .bds-link-text-directory__header .h2 {
-    margin-bottom: 16px;
-  }
-}
-.bds-link-text-directory__header p {
+.bds-link-text-directory__header h2, .bds-link-text-directory__header .h2, .bds-link-text-directory__header p {
   margin-bottom: 0;
 }
 

--- a/static/css/devportal2024-v1.css
+++ b/static/css/devportal2024-v1.css
@@ -22337,6 +22337,121 @@ html.dark .bds-tile-link--disabled.bds-tile-link--lilac .bds-tile-link__arrow {
   }
 }
 
+.bds-link-text-card {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid #CAD4DF;
+  padding-top: 8px;
+  padding-bottom: 24px;
+  gap: 24px;
+}
+@media (min-width: 576px) {
+  .bds-link-text-card {
+    padding-top: 12px;
+    padding-bottom: 32px;
+    gap: 32px;
+  }
+}
+@media (min-width: 992px) {
+  .bds-link-text-card {
+    padding-top: 16px;
+    padding-bottom: 40px;
+    gap: 40px;
+  }
+}
+.bds-link-text-card:last-child {
+  padding-bottom: 0;
+}
+
+.bds-link-text-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+@media (min-width: 576px) {
+  .bds-link-text-card__header {
+    gap: 12px;
+    width: calc(75% - 2px);
+  }
+}
+@media (min-width: 992px) {
+  .bds-link-text-card__header {
+    gap: 16px;
+  }
+}
+.bds-link-text-card__header p {
+  color: #72777E;
+}
+
+.bds-link-text-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+@media (min-width: 576px) {
+  .bds-link-text-card__content {
+    gap: 24px;
+    width: calc(75% - 2px);
+  }
+}
+@media (min-width: 992px) {
+  .bds-link-text-card__content {
+    gap: 32px;
+  }
+}
+.bds-link-text-card__content p {
+  color: #72777E;
+}
+
+.bds-link-text-directory {
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+@media (min-width: 576px) {
+  .bds-link-text-directory {
+    padding-top: 32px;
+    padding-bottom: 32px;
+  }
+}
+@media (min-width: 992px) {
+  .bds-link-text-directory {
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+}
+.bds-link-text-directory ul {
+  padding-left: 0;
+  list-style: none;
+}
+
+.bds-link-text-directory__header {
+  gap: 8px;
+  margin-bottom: 24px;
+}
+@media (min-width: 576px) {
+  .bds-link-text-directory__header {
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+}
+@media (min-width: 992px) {
+  .bds-link-text-directory__header {
+    gap: 16px;
+    margin-bottom: 40px;
+  }
+}
+.bds-link-text-directory__header h2, .bds-link-text-directory__header .h2 {
+  margin-bottom: 8px;
+}
+@media (min-width: 992px) {
+  .bds-link-text-directory__header h2, .bds-link-text-directory__header .h2 {
+    margin-bottom: 16px;
+  }
+}
+.bds-link-text-directory__header p {
+  margin-bottom: 0;
+}
+
 pre {
   color: #FFFFFF;
   background-color: #232325;

--- a/styles/xrpl.scss
+++ b/styles/xrpl.scss
@@ -119,6 +119,8 @@ $line-height-base: 1.5;
 @import "../shared/patterns/StandardCardGroupSection/_standard-card-group-section.scss";
 @import "../shared/patterns/TileLinks/TileLink.scss";
 @import "../shared/patterns/LinkSmallGrid/LinkSmallGrid.scss";
+@import "../shared/patterns/LinkTextCard/LinkTextCard.scss";
+@import "../shared/patterns/LinkTextDirectory/LinkTextDirectory.scss";
 @import "_code-tabs.scss";
 @import "_code-walkthrough.scss";
 @import "_diagrams.scss";


### PR DESCRIPTION
This PR introduces two new components for displaying numbered, sequential content: LinkTextCard (atomic component) and LinkTextDirectory (section pattern). LinkTextCard renders a numbered card with heading, description, and up to 2 CTA buttons, while LinkTextDirectory displays a responsive grid of these cards with automatic sequential numbering (01, 02, 03...). Both components feature full light/dark mode support, responsive spacing, and comprehensive documentation.

New Components:

LinkTextCard - Numbered card component with border-top divider, green CTA buttons, and responsive layout (75% width at MD+)
LinkTextDirectory - Section pattern with PageGrid integration, right-aligned cards at desktop (4-column offset), and flexible header with optional description
Comprehensive README documentation for both components with usage examples, props tables, and best practices
Showcase page demonstrating all variants and responsive behaviors
Technical Highlights:

Clean SCSS with all values extracted to variables following BEM naming convention
Semantic HTML using <ul> and <li> elements for proper list structure
Responsive spacing: 24px/32px/40px gaps across base/MD/LG breakpoints
Dark mode support via bds-theme-mode mixin
Minor improvement to CarouselFeatured component (changed features from <div> to semantic <ul>/<li>)