### PR TITLE
Don't use Batch for SAV tutorials setup

### DIFF
--- a/_code-samples/vaults/js/vaultSetup.js
+++ b/_code-samples/vaults/js/vaultSetup.js
@@ -1,9 +1,16 @@
 import xrpl from 'xrpl'
 import fs from 'fs'
 
+// Helper function to extract ticket sequences from a TicketCreate transaction result
+function getTicketSequences(ticketCreateResult) {
+  return ticketCreateResult.result.meta.AffectedNodes
+    .filter(node => node.CreatedNode?.LedgerEntryType === 'Ticket')
+    .map(node => node.CreatedNode.NewFields.TicketSequence)
+}
+
 // Setup script for vault tutorials
 
-process.stdout.write('Setting up tutorial: 0/5\r')
+process.stdout.write('Setting up tutorial: 0/6\r')
 
 const client = new xrpl.Client('wss://s.devnet.rippletest.net:51233')
 await client.connect()
@@ -21,33 +28,37 @@ const [
   client.fundWallet()
 ])
 
-// Step 1: Create MPT issuance, permissioned domain, and credentials in parallel
-process.stdout.write('Setting up tutorial: 1/5\r')
+// Step 1: Create tickets for domain owner and depositor to submit transactions concurrently
+process.stdout.write('Setting up tutorial: 1/6\r')
 
 const credType = 'VaultAccess'
+const [domainOwnerTicketCreateResult, depositorTicketCreateResult] = await Promise.all([
+  client.submitAndWait(
+    {
+      TransactionType: 'TicketCreate',
+      Account: domainOwner.address,
+      TicketCount: 2
+    },
+    { wallet: domainOwner, autofill: true }
+  ),
+  client.submitAndWait(
+    {
+      TransactionType: 'TicketCreate',
+      Account: depositor.address,
+      TicketCount: 2
+    },
+    { wallet: depositor, autofill: true }
+  )
+])
 
-// Create tickets for domain owner to submit transactions concurrently
-const ticketCreateResult = await client.submitAndWait(
-  {
-    TransactionType: 'TicketCreate',
-    Account: domainOwner.address,
-    TicketCount: 2
-  },
-  { wallet: domainOwner, autofill: true }
-)
+// Get the ticket sequences from transaction results
+const domainOwnerTicketSequences = getTicketSequences(domainOwnerTicketCreateResult)
+const depositorTicketSequences = getTicketSequences(depositorTicketCreateResult)
 
-// Get the ticket sequences
-const ticketsResponse = await client.request({
-  command: 'account_objects',
-  account: domainOwner.address,
-  type: 'ticket',
-  ledger_index: 'validated'
-})
-const ticketSequences = ticketsResponse.result.account_objects.map(
-  (obj) => obj.TicketSequence
-)
+// Step 2: Create MPT issuance, permissioned domain, and credentials in parallel
+process.stdout.write('Setting up tutorial: 2/6\r')
 
-const [mptCreateResult] = await Promise.all([
+const [mptCreateResult, domainSetResult] = await Promise.all([
   client.submitAndWait(
     {
       TransactionType: "MPTokenIssuanceCreate",
@@ -103,7 +114,7 @@ const [mptCreateResult] = await Promise.all([
           },
         },
       ],
-      TicketSequence: ticketSequences[0],
+      TicketSequence: domainOwnerTicketSequences[0],
       Sequence: 0
     },
     { wallet: domainOwner, autofill: true },
@@ -114,7 +125,7 @@ const [mptCreateResult] = await Promise.all([
       Account: domainOwner.address,
       Subject: depositor.address,
       CredentialType: xrpl.convertStringToHex(credType),
-      TicketSequence: ticketSequences[1],
+      TicketSequence: domainOwnerTicketSequences[1],
       Sequence: 0
     },
     { wallet: domainOwner, autofill: true },
@@ -123,39 +134,14 @@ const [mptCreateResult] = await Promise.all([
 
 const mptIssuanceId = mptCreateResult.result.meta.mpt_issuance_id
 
-// Get domain ID
-const domainOwnerObjects = await client.request({
-  command: 'account_objects',
-  account: domainOwner.address,
-  ledger_index: 'validated'
-})
-const domainId = domainOwnerObjects.result.account_objects.find(
-  (node) => node.LedgerEntryType === 'PermissionedDomain'
-).index
-
-// Step 2: Depositor accepts credential, authorizes MPT, and creates vault in parallel
-process.stdout.write('Setting up tutorial: 2/5\r')
-
-// Create tickets for depositor to submit transactions concurrently
-const depositorTicketCreateResult = await client.submitAndWait(
-  {
-    TransactionType: 'TicketCreate',
-    Account: depositor.address,
-    TicketCount: 2
-  },
-  { wallet: depositor, autofill: true }
+// Get domain ID from transaction result
+const domainNode = domainSetResult.result.meta.AffectedNodes.find(
+  (node) => node.CreatedNode?.LedgerEntryType === 'PermissionedDomain'
 )
+const domainId = domainNode.CreatedNode.LedgerIndex
 
-// Get the ticket sequences for depositor
-const depositorTicketsResponse = await client.request({
-  command: 'account_objects',
-  account: depositor.address,
-  type: 'ticket',
-  ledger_index: 'validated'
-})
-const depositorTicketSequences = depositorTicketsResponse.result.account_objects.map(
-  (obj) => obj.TicketSequence
-)
+// Step 3: Depositor accepts credential, authorizes MPT, and creates vault in parallel
+process.stdout.write('Setting up tutorial: 3/6\r')
 
 const [, , vaultCreateResult] = await Promise.all([
   client.submitAndWait(
@@ -227,8 +213,8 @@ const vaultNode = vaultCreateResult.result.meta.AffectedNodes.find(
 const vaultID = vaultNode.CreatedNode.LedgerIndex
 const vaultShareMPTIssuanceId = vaultNode.CreatedNode.NewFields.ShareMPTID
 
-// Step 3: Issuer sends payment to depositor
-process.stdout.write('Setting up tutorial: 3/5\r')
+// Step 4: Issuer sends payment to depositor
+process.stdout.write('Setting up tutorial: 4/6\r')
 
 const paymentResult = await client.submitAndWait(
   {
@@ -249,8 +235,8 @@ if (paymentResult.result.meta.TransactionResult !== 'tesSUCCESS') {
   process.exit(1)
 }
 
-// Step 4: Make an initial deposit so withdraw example has shares to work with
-process.stdout.write('Setting up tutorial: 4/5\r')
+// Step 5: Make an initial deposit so withdraw example has shares to work with
+process.stdout.write('Setting up tutorial: 5/6\r')
 
 const initialDepositResult = await client.submitAndWait(
   {
@@ -271,8 +257,8 @@ if (initialDepositResult.result.meta.TransactionResult !== 'tesSUCCESS') {
   process.exit(1)
 }
 
-// Step 5: Save setup data to file
-process.stdout.write('Setting up tutorial: 5/5\r')
+// Step 6: Save setup data to file
+process.stdout.write('Setting up tutorial: 6/6\r')
 
 const setupData = {
   mptIssuer: {

--- a/docs/concepts/transactions/batch-transactions.md
+++ b/docs/concepts/transactions/batch-transactions.md
@@ -10,6 +10,8 @@ status: not_enabled
 
 XRPL Batch Transactions let you package multiple [transactions](/docs/concepts/transactions) together and execute them as a single unit. It eliminates the risk of partial completion and unexpected outcomes, giving you a more reliable and predictable experience for complex operations. Up to eight transactions can be submitted in a single batch.
 
+{% amendment-disclaimer name="Batch" /%}
+
 ## XRPL Batch Use Cases
 
 Some potential uses for `Batch` include the following.


### PR DESCRIPTION
Since Batch is being disabled in Devnet, we shouldn't use it for our setup scripts. This uses Tickets instead to retain set up speed.

Also noticed we were missing the amendment status badge in the Batch concept doc so I've added it.