### PR TITLE
Add InsumerAPI to Use Cases page

### DIFF
--- a/about/uses.page.tsx
+++ b/about/uses.page.tsx
@@ -23,6 +23,7 @@ const logos = {
     "xrp-toolkit",
     "bithomp",
     "onthedex",
+    "insumerapi",
   ],
   developer_tooling: ["cryptum", "evernode", "threezy", "tokenize"],
   interoperability: ["multichain"],
@@ -170,6 +171,15 @@ const cardsData = [
     category_id: "infrastructure",
     category_name: "Infrastructure",
     link: "https://gatehub.net/markets",
+  },
+  {
+    id: "insumerapi",
+    title: "InsumerAPI",
+    description:
+      "Trust-line eligibility verification for XRPL commerce. Performs issuer-aware reads of RLUSD, USDC, and any trust-line token, evaluates balance thresholds, and returns ECDSA-signed attestations with ledgerIndex and conditionHash for independent verification.",
+    category_id: "infrastructure",
+    category_name: "Infrastructure",
+    link: "https://insumermodel.com/demos/xrpl/",
   },
   {
     id: "gem-wallet",

--- a/static/img/uses/insumerapi.svg
+++ b/static/img/uses/insumerapi.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#0a1628"/>
+  <circle cx="90" cy="100" r="52" fill="none" stroke="#64748b" stroke-width="4" opacity="0.5"/>
+  <circle cx="120" cy="100" r="40" fill="#d4a853" opacity="0.85"/>
+  <text x="100" y="112" font-family="Georgia, serif" font-size="48" font-weight="bold" fill="#0a1628" text-anchor="middle">I</text>
+</svg>


### PR DESCRIPTION
Adds InsumerAPI to the Use Cases & Featured Projects page under Infrastructure. InsumerAPI provides trust-line eligibility verification for XRPL — merchants can verify RLUSD, USDC, or any trust-line token holdings and receive a signed, independently verifiable attestation.

Changes: added entry to infrastructure logos array, card data, and SVG logo.