### PR TITLE
Upgrade Redocly to 0.131.2

### DIFF
--- a/@theme/plugins/blog-posts.js
+++ b/@theme/plugins/blog-posts.js
@@ -7,8 +7,9 @@ import markdoc from '@markdoc/markdoc';
 import moment from "moment";
 
 export function blogPosts() {
-  /** @type {import("@redocly/realm/dist/server/plugins/types").PluginInstance } */
+  /** @type {import("@redocly/realm/dist/server/types").ExternalPlugin } */
   const instance = {
+    id: 'blog-posts',
     processContent: async (actions, { fs, cache }) => {
       try {
         const posts = [];

--- a/@theme/plugins/blog-posts.js
+++ b/@theme/plugins/blog-posts.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { getInnerText } from '@redocly/realm/dist/server/plugins/markdown/markdoc/helpers/get-inner-text.js';
+import { getInnerText } from '@redocly/realm/dist/markdoc/helpers/get-inner-text.js';
 
 import { dirname, relative, join as joinPath } from 'path';
 import markdoc from '@markdoc/markdoc';

--- a/@theme/plugins/code-samples.js
+++ b/@theme/plugins/code-samples.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { getInnerText } from '@redocly/realm/dist/server/plugins/markdown/markdoc/helpers/get-inner-text.js';
+import { getInnerText } from '@redocly/realm/dist/markdoc/helpers/get-inner-text.js';
 
 import { dirname, relative, join as joinPath } from 'path';
 

--- a/@theme/plugins/code-samples.js
+++ b/@theme/plugins/code-samples.js
@@ -5,8 +5,9 @@ import { getInnerText } from '@redocly/realm/dist/markdoc/helpers/get-inner-text
 import { dirname, relative, join as joinPath } from 'path';
 
 export function codeSamples() {
-  /** @type {import("@redocly/realm/dist/server/plugins/types").PluginInstance } */
+  /** @type {import("@redocly/realm/dist/server/types").ExternalPlugin } */
   const instance = {
+    id: 'code-samples',
     processContent: async (actions, { fs, cache }) => {
       try {
         const samples = [];

--- a/@theme/plugins/index-pages.js
+++ b/@theme/plugins/index-pages.js
@@ -3,8 +3,9 @@ import { readSharedData } from '@redocly/realm/dist/server/utils/shared-data.js'
 const INDEX_PAGE_INFO_DATA_KEY = 'index-page-items';
 
 export function indexPages() {
-  /** @type {import("@redocly/realm/dist/server/plugins/types").PluginInstance } */
+  /** @type {import("@redocly/realm/dist/server/types").ExternalPlugin } */
   const instance = {
+    id: 'index-pages',
     // hook that gets executed after all routes were created
     async afterRoutesCreated(actions, { cache }) {
       // get all the routes that are ind pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.130.4",
+        "@redocly/realm": "0.131.0",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -32,6 +32,97 @@
       "devDependencies": {
         "bootstrap": "^4.6.2",
         "sass": "1.26.10"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.63.tgz",
+      "integrity": "sha512-0jwdkN3elC4Q9aT2ALxjXtGGVoye15zYgof6GfvuH1a9QKx9Rj4Wi2vy6SyyLvtSA/lB786dTZgC+cGwe6vzmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.17",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.17.tgz",
+      "integrity": "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.1.tgz",
+      "integrity": "sha512-gh7i4lEvd1CElmefkq7+RoUhNkhP2OTshzVxSt7/Vh2AV5wTPLhduKJMg1c7SFwErytqffO3el/M/LlfCsqzEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.0",
+        "@ai-sdk/provider-utils": "4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.0.tgz",
+      "integrity": "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.1.tgz",
+      "integrity": "sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.0",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -247,22 +338,22 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -290,9 +381,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -344,9 +435,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.18.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
-      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -356,15 +447,24 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
-      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/commands/node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-css": {
@@ -408,9 +508,9 @@
       }
     },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
-      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -475,9 +575,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
-      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -498,9 +598,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
-      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -509,13 +609,13 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
-      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
         "crelt": "^1.0.5"
       }
     },
@@ -541,15 +641,24 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.0.tgz",
-      "integrity": "sha512-yvSchUwHOdupXkd7xJ0ob36jdsSR/I+/C+VbY0ffBiL5NiSTEBDfB1ZGWbbIlDd5xgdUkody+lukAdOxYrOBeg==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@codemirror/view/node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1207,28 +1316,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/momoa": {
@@ -1308,12 +1417,12 @@
       }
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
-      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
       "dependencies": {
-        "@lezer/common": "^1.0.0"
+        "@lezer/common": "^1.3.0"
       }
     },
     "node_modules/@lezer/html": {
@@ -1361,9 +1470,9 @@
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
-      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -1610,9 +1719,9 @@
       "license": "MIT"
     },
     "node_modules/@noble/curves": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -2031,15 +2140,15 @@
       "license": "MIT"
     },
     "node_modules/@redocly/ajv": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.3.tgz",
-      "integrity": "sha512-4P3iZse91TkBiY+Dx5DUgxQ9GXkVJf++cmI0MOyLDxV9b5MUBI4II6ES8zA5JCbO72nKAJxWrw4PUPW+YP3ZDQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2047,17 +2156,17 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.7.2.tgz",
-      "integrity": "sha512-6kbZHYDi8nnvkbvP4GSGttdmCRniPc1snsSSH+/XonqObHrul0fX6EWFEPPKHGXoLbsTQfUA9WbtpF3uVrUbtg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.8.0.tgz",
+      "integrity": "sha512-IcM0VTxgQLaaAJl5EO4ZIxN8c4d/dLPTrp0vsSUr8c3FBvJUG0Qt8/gfzglFyoCoX1r9e1kf+VSCLDR1vjJ1YQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.42.0",
-        "@redocly/openapi-docs": "3.18.2",
-        "@redocly/theme": "0.62.1",
+        "@redocly/config": "0.44.1",
+        "@redocly/openapi-docs": "3.19.0",
+        "@redocly/theme": "0.63.0",
         "jotai": "^2.11.1",
-        "openapi-sampler": "1.7.0",
+        "openapi-sampler": "^1.7.2",
         "react-router-dom": "^6.30.3",
         "styled-components": "5.3.11",
         "web-vitals": "3.3.1"
@@ -2067,28 +2176,28 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.42.0.tgz",
-      "integrity": "sha512-Hvv0Cmcg199OZtTFt58ZMyj+5A0S0WIgb+JHIdKxUKfJuyGUDScFgk8BjEfvpU59UjXinI6O2atrgDHhKqiPMQ==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.44.1.tgz",
+      "integrity": "sha512-l6/ZE+/RBfNDdhzltau6cbW8+k5PgJbJBMqaBrlQlZQlmGBHMxqGyDaon4dPLj0jdi37gsMQ3yf95JBY/vaDSg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.7.1.tgz",
-      "integrity": "sha512-lHiGNVM3wq+k4FokFTUMHSofvv8VH6RXH1bqz6BAzIILaW5kFQsOxkzU738Ij1Z/ZyWJSSOJIsJJoepaZNFAlA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.8.0.tgz",
+      "integrity": "sha512-5bMdd1g9HXe1STlcAJxj0Dvgv+Vxe4A0awho4zd77TTD1YMNOt4D7jOrRyP2fW+5GFZm8y3Am9Oj9I3fZ8v2rw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.42.0",
+        "@redocly/config": "0.44.1",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.62.1",
-        "graphql": "16.9.0",
+        "@redocly/theme": "0.63.0",
+        "graphql": "16.12.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.3",
@@ -2132,132 +2241,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/@redocly/mcp-typescript-sdk/node_modules/@redocly/ajv": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.3.tgz",
+      "integrity": "sha512-4P3iZse91TkBiY+Dx5DUgxQ9GXkVJf++cmI0MOyLDxV9b5MUBI4II6ES8zA5JCbO72nKAJxWrw4PUPW+YP3ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@redocly/mock-server": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.5.11.tgz",
-      "integrity": "sha512-6UMuOXviugFbg+5gp165JsvU7I94UjrJNGEikwN2jRdgnjOvl7Y6djwREKEmLtc80Z5aqAxNBlbmPM0FYbTCzg==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.5.15.tgz",
+      "integrity": "sha512-LTnzwB9qLkjmvXFuowMiRbwnwRmTbSMpH25d606o9qcbwS+X7CkZE/Ffu5O8nhZLubYcgxmfQNfnaD/WszusEw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/ajv": "8.17.4",
-        "@redocly/openapi-core": "2.19.0",
+        "@redocly/ajv": "8.18.0",
+        "@redocly/openapi-core": "2.20.5",
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
-        "fast-xml-parser": "5.3.6",
+        "fast-xml-parser": "5.4.1",
         "js-yaml": "4.1.1",
-        "openapi-sampler": "1.7.0",
+        "openapi-sampler": "^1.7.2",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
         "ts-node": "10.9.2",
         "yargs": "^17.5.1"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/ajv": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/config": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.43.0.tgz",
-      "integrity": "sha512-AbyFKRHKJ2VBmh9nO2lrG9tO2Gu/Lmnfdj4Uwoh7h/a7jWr1104t4fBgQZs/NwgGBAOkGmyQYAvardwyBeRGZA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "2.7.2"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.19.0.tgz",
-      "integrity": "sha512-7E/zxHrns8gJkFYLiYWKhpKZUCQo3r255uLbXKllglu3843BDmbiD0UTcwp9n7a+l2gmmvNjlW44vwZaR0NQAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "^8.17.4",
-        "@redocly/config": "^0.43.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
-        "ajv-formats": "^3.0.1",
-        "colorette": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
-        "picomatch": "^4.0.3",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/@redocly/openapi-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/mock-server/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.15.2.tgz",
-      "integrity": "sha512-SGaucW1OQzK411+uB5bE9cxmJJ1Rr3UHQGl6mnsYTETCTKU1LJ1oIhBtqGep5Cg+JO5Jm865hIVhgf+sZ32Thw==",
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.20.5.tgz",
+      "integrity": "sha512-BqYq+QCo9V/fqDxYJtgkPfJBZ8alwbqGg+F+LZz12vylsQlua07D9uEOR8n3jj7U8YaP9aA6YFljnQvoi1AZpA==",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.17.2",
-        "@redocly/config": "^0.41.4",
-        "ajv": "npm:@redocly/ajv@8.17.2",
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/config": "^0.44.1",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -2269,31 +2296,6 @@
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/@redocly/ajv": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.41.4.tgz",
-      "integrity": "sha512-LaRKXpHyK5GxmgG2n2e8xp2NyUa8qZls3WMAVg5hKO4b2d7X5uU5F2jvH6JUTVdRW/VfStQqan5DQ1uQz7MVzg==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/colorette": {
@@ -2315,25 +2317,25 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.18.2.tgz",
-      "integrity": "sha512-w99WIlXYudMAvMwaN/+TII0RYpr8TSYPojJiCAERX6xS8G0vx3UZPY6Gy2FxUv3/yzNb5VVrS6KpNGxMfg9cqg==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.19.0.tgz",
+      "integrity": "sha512-uafC5z/bdEggeBIUFE/42X4foLUlRMPPhQPRfEywZzVAoB6sJqKn0yLmN4mHfLFzcTxuOODIh3p0/PpT39ng9g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.42.0",
-        "@redocly/openapi-core": "2.15.2",
-        "@redocly/replay": "0.21.2",
+        "@redocly/config": "0.44.1",
+        "@redocly/openapi-core": "2.20.5",
+        "@redocly/replay": "0.22.0",
         "deepmerge": "^4.2.2",
         "dompurify": "3.2.7",
         "fast-deep-equal": "^3.1.3",
-        "fast-xml-parser": "5.3.6",
+        "fast-xml-parser": "5.4.1",
         "jotai": "^2.12.5",
-        "jotai-family": "^1.0.1",
+        "jotai-family": "1.0.1",
         "json-pointer": "^0.6.2",
-        "openapi-sampler": "1.7.0",
+        "openapi-sampler": "^1.7.2",
         "react-router-dom": "^6.30.3",
-        "slugify": "^1.4.4",
+        "slugify": "^1.4.7",
         "stringify-object": "^3.3.0",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
         "swagger2openapi": "^7.0.8",
@@ -2346,16 +2348,16 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@redocly/theme": ">=0.62.0-next.0",
+        "@redocly/theme": ">=0.63.0-next.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
     "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.13.0.tgz",
-      "integrity": "sha512-ghxyUh3oOBSBeYTCsZkMQronJhv7sqdY+vHcewweqAAucrtY4Ic7ameMtC3ADHfdQiKKKXVnfskXdoc8aW4B4A==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.14.0.tgz",
+      "integrity": "sha512-jZTfLlthkOsyc9nJsaNqUdmAXYLgK7zmsxNpRnwCgcw/Jfkwds844ILyutiM9u066zvPhQTzzp0QJcmL/o6iPA==",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "highlight-words-core": "^1.2.2",
@@ -2366,20 +2368,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.15.2.tgz",
-      "integrity": "sha512-ghDqS6O+IZoUnNaCCdFrxwM6l4fxss3wHPJdfdzZNfIU/tEbohNxRf+RYV9AU7+AaeZrQI23ybXs84Gjh5g1/g==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.16.0.tgz",
+      "integrity": "sha512-qRsJdNJR1d7VWB4AzwVRyPKcD6vY23we0d9oPlV++nR5oWYLDWnEnzsijBy70+P7rC7bcJ9zjYw3K++Z75RrGg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.42.0",
-        "@redocly/mock-server": "0.5.11",
-        "@redocly/openapi-docs": "3.18.2"
+        "@redocly/config": "0.44.1",
+        "@redocly/mock-server": "0.5.15",
+        "@redocly/openapi-docs": "3.19.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.130.4",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.130.4.tgz",
-      "integrity": "sha512-jNBzyJPymHvLMvWN/YX3f88XlZuKEIXQngffqJz5WE37N/sKn1Wl4Wuda2wr13NGYWHA42GebEiN0vrrmHtBng==",
+      "version": "0.131.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.131.0.tgz",
+      "integrity": "sha512-FoC7IYcHKZ6WOBmnG0iCYefmqtfImWqmjL6MRCC4fwQ7d/Lmq0pKOcArcsIM+UjQm5Y9aiHYI2unBE22P3AAxQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -2396,17 +2398,17 @@
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/sdk-trace-web": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
-        "@redocly/ajv": "8.17.2",
-        "@redocly/asyncapi-docs": "1.7.2",
-        "@redocly/config": "0.42.0",
-        "@redocly/graphql-docs": "1.7.1",
+        "@redocly/ajv": "8.18.0",
+        "@redocly/asyncapi-docs": "1.8.0",
+        "@redocly/config": "0.44.1",
+        "@redocly/graphql-docs": "1.8.0",
         "@redocly/mcp-typescript-sdk": "1.18.1",
-        "@redocly/openapi-core": "2.15.2",
-        "@redocly/openapi-docs": "3.18.2",
-        "@redocly/portal-legacy-ui": "0.13.0",
-        "@redocly/portal-plugin-mock-server": "0.15.2",
-        "@redocly/realm-asyncapi-sdk": "0.8.1",
-        "@redocly/theme": "0.62.1",
+        "@redocly/openapi-core": "2.20.5",
+        "@redocly/openapi-docs": "3.19.0",
+        "@redocly/portal-legacy-ui": "0.14.0",
+        "@redocly/portal-plugin-mock-server": "0.16.0",
+        "@redocly/realm-asyncapi-sdk": "0.9.0",
+        "@redocly/theme": "0.63.0",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -2427,20 +2429,20 @@
         "fetch-to-node": "^2.1.0",
         "fflate": "0.7.4",
         "flexsearch": "0.7.43",
-        "graphql": "16.9.0",
+        "graphql": "16.12.0",
         "gray-matter": "4.0.3",
-        "hono": "4.11.7",
+        "hono": "4.11.10",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
         "js-yaml": "4.1.1",
         "lru-cache": "11.1.0",
-        "minimatch": "7.4.2",
+        "minimatch": "10.2.1",
         "mri": "1.2.0",
         "nanoid": "5.0.9",
         "node-fetch": "3.3.1",
         "nprogress": "0.2.0",
-        "openapi-sampler": "1.7.0",
+        "openapi-sampler": "^1.7.2",
         "os-browserify": "0.3.0",
         "path-browserify": "1.0.1",
         "picomatch": "2.3.1",
@@ -2465,7 +2467,8 @@
         "ws": "^8.17.1",
         "xml-crypto": "6.0.1",
         "xpath": "0.0.34",
-        "yaml-ast-parser": "0.0.43"
+        "yaml-ast-parser": "0.0.43",
+        "zod": "^3.25.76"
       },
       "bin": {
         "realm": "bin.js"
@@ -2480,26 +2483,10 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.8.1.tgz",
-      "integrity": "sha512-3gDGwb6E7iACkT6uC4C2Opl7GGxBPPl8pJtALDMR24M7/W1WsYGaOABpk/eGK4wox7GgF6OhhmJ+Qoih7zlH6w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.9.0.tgz",
+      "integrity": "sha512-uIgSHxLvtjsLoSyKI4VjvFsb+BchCi+VwY9kir6tgqKwnegQu7GpG8vLlvKk1QdLM9i5aVB00o+4CFLbEESPaA==",
       "license": "SEE LICENSE IN LICENSE"
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/ajv": {
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.2.tgz",
-      "integrity": "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
     },
     "node_modules/@redocly/realm/node_modules/node-fetch": {
       "version": "3.3.1",
@@ -2520,10 +2507,12 @@
       }
     },
     "node_modules/@redocly/replay": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.21.2.tgz",
-      "integrity": "sha512-1tYeNOqjwR71sD6R8RwTCItd0XSN8J00neU8wU3ERY3yZNW1DYekZIlvOoOOfyNHNI7jpiWV5RcDRpnVqfAQow==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.22.0.tgz",
+      "integrity": "sha512-hvRHytajOVL/R/VrQD8BP+6YuocYr4PfVQQJ8+GoaLhiRxGYWq640CGh1o1DzGxd3Os7kSG4Tjt+8tSHoB/LUQ==",
       "dependencies": {
+        "@ai-sdk/google": "3.0.1",
+        "@ai-sdk/provider": "3.0.0",
         "@codemirror/autocomplete": "^6.15.0",
         "@codemirror/lang-html": "^6.4.7",
         "@codemirror/lang-java": "^6.0.2",
@@ -2546,8 +2535,8 @@
         "@opentelemetry/api": "1.9.0",
         "@redocly/hookstate-core": "^4.2.1",
         "@redocly/hookstate-devtools": "^4.2.0",
-        "@redocly/openapi-core": "2.15.2",
-        "@redocly/respect-core": "2.15.2",
+        "@redocly/openapi-core": "2.20.5",
+        "@redocly/respect-core": "2.20.5",
         "@redocly/vscode-json-languageservice": "^3.4.9",
         "@tauri-apps/api": "2.4.1",
         "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
@@ -2555,9 +2544,10 @@
         "@tauri-apps/plugin-opener": "^2.5.2",
         "@uiw/codemirror-theme-material": "^4.21.20",
         "@uiw/react-codemirror": "^4.21.20",
+        "ai": "6.0.111",
         "dayjs": "^1.11.7",
         "drizzle-orm": "^0.36.4",
-        "fast-xml-parser": "5.3.6",
+        "fast-xml-parser": "5.4.1",
         "idb": "^8.0.2",
         "js-yaml": "4.1.1",
         "json-pointer": "^0.6.2",
@@ -2570,11 +2560,11 @@
         "react-resizable-panels": "^3.0.6",
         "react-select": "5.10.1",
         "shellwords": "^1.1.1",
-        "styled-components": "^5.3.11",
-        "usehooks-ts": "^3.1.1"
+        "usehooks-ts": "^3.1.1",
+        "zod": "^3.25.76"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.62.1",
+        "@redocly/theme": "0.63.0",
         "@tanstack/react-query": "5.62.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2708,60 +2698,27 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.15.2.tgz",
-      "integrity": "sha512-Ns/ziN1XCwldvaqbcKaeRnHMyptVwzqIkyK+tQWaVnDV5gBcmFZ2J7pHHr3bc4OpuY8D37aVVN8LxuseiXgNHg==",
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.20.5.tgz",
+      "integrity": "sha512-4mN1fNDKXObLuUp57FW4oZg2dLx6x9pNrBQNQMfsts3R8Ov6zFWHNekIxtO/BKVnItmN6FSGmQRpOwpkb9PaRg==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "8.17.1",
-        "@redocly/openapi-core": "2.15.2",
-        "ajv": "npm:@redocly/ajv@8.17.1",
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/openapi-core": "2.20.5",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
         "json-pointer": "^0.6.2",
         "jsonpath-rfc9535": "1.3.0",
-        "openapi-sampler": "^1.6.2",
+        "openapi-sampler": "^1.7.1",
         "outdent": "^0.8.0",
         "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/@redocly/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@redocly/respect-core/node_modules/picomatch": {
@@ -2777,12 +2734,12 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.62.1.tgz",
-      "integrity": "sha512-1iwcf+/wtfbey5Gfw67s5VtxZFudTg6ZaaY8ViV5Jgqq2PWk+qeuMYzlgeiKACjvx4Uk78hgx8B3cUSfMlh1hQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.63.0.tgz",
+      "integrity": "sha512-43ryxhbuVIUBDjMkwNhQ9enCjNPoOSDrnsWr/EZrvH6Da3jCTg66NCe06qjUX7MUqbz7b9nhzlqlV0EnmPEChQ==",
       "license": "MIT",
       "dependencies": {
-        "@redocly/config": "0.42.0",
+        "@redocly/config": "0.44.1",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-virtual": "3.13.0",
         "@xyflow/react": "^12.8.2",
@@ -2795,7 +2752,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "4.1.1",
         "nprogress": "0.2.0",
-        "openapi-sampler": "1.7.0",
+        "openapi-sampler": "^1.7.2",
         "react-calendar": "5.1.0",
         "react-date-picker": "11.0.0"
       },
@@ -2947,6 +2904,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@styled-system/background": {
@@ -3333,12 +3296,12 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -3348,13 +3311,13 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -3398,9 +3361,9 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.23.14",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.23.14.tgz",
-      "integrity": "sha512-lCseubZqjN9bFwHJdQlZEKEo2yO1tCiMMVL0gu3ZXwhqMdfnd6ky/fUCYbn8aJkW+cXKVwjEVhpKjOphNiHoNw==",
+      "version": "4.25.8",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.8.tgz",
+      "integrity": "sha512-9Rr+liiBmK4xzZHszL+twNRJApthqmITBwDP3emNTtTrkBFN4gHlqfp+nodKmoVt1+bUH1qQCtyqt+7dbDTHiw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -3425,21 +3388,21 @@
       }
     },
     "node_modules/@uiw/codemirror-theme-material": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.4.tgz",
-      "integrity": "sha512-QZwPSc5yhaOQKGT4oKABmgQDjCGwa24HK9tP7E/TauMse8/kIDyAHaocdeUamk6+93fa/Wj6rtAHeakSSGU7AQ==",
+      "version": "4.25.8",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.25.8.tgz",
+      "integrity": "sha512-VlSkd2ZgQ9YXkW0x3fPssyngrPVhy6XAx84wWO55yU/VQHGIHxTr1/0gF2eEcKOy4M/7aQ4EtYzAVVJlSvrUoA==",
       "license": "MIT",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.25.4"
+        "@uiw/codemirror-themes": "4.25.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/@uiw/codemirror-theme-material/node_modules/@uiw/codemirror-themes": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.4.tgz",
-      "integrity": "sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg==",
+      "version": "4.25.8",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.8.tgz",
+      "integrity": "sha512-U6ZSO9A+nsN8zvNddtwhxxpi33J9okb4Li9HdhAItApKjYM22IgC8XSpGfs+ABGfsp1u6NhDSfBR9vAh3oTWXg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -3475,16 +3438,16 @@
       }
     },
     "node_modules/@uiw/react-codemirror": {
-      "version": "4.23.14",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.14.tgz",
-      "integrity": "sha512-/CmlSh8LGUEZCxg/f78MEkEMehKnVklqJvJlL10AXXrO/2xOyPqHb8SK10GhwOqd0kHhHgVYp4+6oK5S+UIEuQ==",
+      "version": "4.25.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.8.tgz",
+      "integrity": "sha512-A0aLOuJZm2yJ+U9GlMFwxwFciztjd5LhcAG4SMqFxdD58wH+sCQXuY4UU5J2hqgS390qAlShtUgREvJPUonbuQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.23.14",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.8",
         "codemirror": "^6.0.0"
       },
       "funding": {
@@ -3496,8 +3459,8 @@
         "@codemirror/theme-one-dark": ">=6.0.0",
         "@codemirror/view": ">=6.0.0",
         "codemirror": ">=6.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3505,6 +3468,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@wojtekmaj/date-utils": {
       "version": "1.5.1",
@@ -3575,12 +3547,12 @@
       }
     },
     "node_modules/@xrplf/secret-numbers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-1.0.0.tgz",
-      "integrity": "sha512-qsCLGyqe1zaq9j7PZJopK+iGTGRbk6akkg6iZXJJgxKwck0C5x5Gnwlb1HKYGOwPKyrXWpV6a2YmcpNpUFctGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+      "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
       "license": "ISC",
       "dependencies": {
-        "@xrplf/isomorphic": "^1.0.0",
+        "@xrplf/isomorphic": "^1.0.1",
         "ripple-keypairs": "^2.0.0"
       }
     },
@@ -3617,9 +3589,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3649,11 +3621,58 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.111",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.111.tgz",
+      "integrity": "sha512-K5aikNm4JGfJkzwIr3yA/qhOYIOIvOqjCxSQjQQ7bWWqm0uuPO2/qgdXL23gYJdTLPPYfvi2TTS+bg2Yp+r2Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.63",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.17",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.17.tgz",
+      "integrity": "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.2.tgz",
-      "integrity": "sha512-rcbDZOfXAgGEJeJ30aWCVVJvxV9ooevb/m1/SFblO2qHs4cqTk178gx7T/vdslf57EA4lTofrwsq5K8rxK9g+g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3684,9 +3703,9 @@
       }
     },
     "node_modules/anser": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.2.tgz",
-      "integrity": "sha512-PMqBCBvrOVDRqLGooQb+z+t1Q0PiPyurUQeZRR5uHBOVZcW8B04KMmnT12USnhpNX2wCPagWzLVppQMUG3u0Dw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -3780,30 +3799,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -3838,18 +3841,24 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
+      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/better-ajv-errors": {
@@ -3872,9 +3881,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3903,15 +3912,16 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/bootstrap": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
       "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
       "dev": true,
       "funding": [
         {
@@ -3930,12 +3940,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4070,9 +4083,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
+      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4340,9 +4353,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -4460,15 +4473,15 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4673,9 +4686,9 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.44.6",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.6.tgz",
-      "integrity": "sha512-uy6uarrrEOc9K1u5/uhBFJbdF5VJ5xQ/Yzbecw3eAYOunv5FDeYkR2m8iitocdHBOHbvorviKOW5GVw0U1j4LQ==",
+      "version": "0.44.7",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
+      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
@@ -4824,9 +4837,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.321",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
+      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5006,6 +5019,15 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -5022,6 +5044,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -5046,10 +5074,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -5058,6 +5086,22 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -5189,6 +5233,22 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
       "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -5326,9 +5386,9 @@
       }
     },
     "node_modules/goober": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
       "license": "MIT",
       "peerDependencies": {
         "csstype": "^3.0.10"
@@ -5347,9 +5407,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -5511,9 +5571,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.11.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.10.tgz",
+      "integrity": "sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5555,19 +5615,23 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http2-client": {
@@ -5600,9 +5664,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5644,9 +5708,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
-      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -5847,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/jotai": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.18.0.tgz",
-      "integrity": "sha512-XI38kGWAvtxAZ+cwHcTgJsd+kJOJGf3OfL4XYaXWZMZ7IIY8e53abpIHvtVn1eAgJ5dlgwlGFnP4psrZ/vZbtA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.18.1.tgz",
+      "integrity": "sha512-e0NOzK+yRFwHo7DOp0DS0Ycq74KMEAObDWFGmfEL28PD9nLqBTt3/Ug7jf9ca72x0gC9LQZG9zH+0ISICmy3iA==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -5954,6 +6018,12 @@
       "dependencies": {
         "foreach": "^2.0.4"
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-ts": {
       "version": "2.7.2",
@@ -6388,15 +6458,15 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
-      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
-      "license": "ISC",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6418,9 +6488,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
-      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.1.tgz",
+      "integrity": "sha512-1B9lmAhB9D9/sHaPC1N7wLFEVUoFldxOpOO96lOD1PvJ43vCd0ozDPbu0FEL3++VvawOlDkq8YD373tJmP5JHw==",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -6445,9 +6515,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "license": "MIT",
       "optional": true
     },
@@ -6529,9 +6599,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -6635,25 +6705,45 @@
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
-      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
       "license": "MIT",
       "dependencies": {
         "oniguruma-parser": "^0.12.1",
-        "regex": "^6.0.1",
+        "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.0.tgz",
-      "integrity": "sha512-fWq32F5vqGpgRJYIarC/9Y1wC9tKnRDcCOjsDJ7MIcSv2HsE7kNifcXIZ8FVtNStBUWxYrEk/MKqVF0SwZ5gog==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.2.tgz",
+      "integrity": "sha512-OKytvqB5XIaTgA9xtw8W8UTar+uymW2xPVpFN0NihMtuHPdPTGxBEhGnfFnJW5g/gOSIvkP+H0Xh3XhVI9/n7g==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "fast-xml-parser": "^5.3.4",
+        "fast-xml-parser": "^5.5.1",
         "json-pointer": "0.6.2"
+      }
+    },
+    "node_modules/openapi-sampler/node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/os-browserify": {
@@ -6746,6 +6836,21 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -6896,15 +7001,15 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
@@ -6978,9 +7083,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7156,15 +7261,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-fit": {
@@ -7194,9 +7299,9 @@
       }
     },
     "node_modules/react-hot-toast": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
-      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3",
@@ -7490,12 +7595,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -7532,9 +7637,9 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.4.1.tgz",
-      "integrity": "sha512-ABwQnWE1WBOvya9WIJ/KiogdsulOw5X8IrIZ3wW0Ec1hiWUNitNuI9LhN9XwHhNFuuvZyRAr+SzgFTBTCTfxFg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.7.0.tgz",
+      "integrity": "sha512-gEBqan5muVp+q7jgZ6aUniSyN+e4FKRzn9uFAeFSIW7IgvkezP1cUolNtpahQ+jvaSK/33hxZA7wNmn1mc330g==",
       "license": "ISC",
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",
@@ -7605,15 +7710,18 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/section-matter": {
@@ -7642,9 +7750,9 @@
       }
     },
     "node_modules/serialize-query-params": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
-      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.4.tgz",
+      "integrity": "sha512-y9WzzDj3BsGgKLCh0ugiinufS//YqOfao/yVJjkXA4VLuyNCfHOLU/cbulGPxs3aeCqhvROw7qPL04JSZnCo0w==",
       "license": "ISC"
     },
     "node_modules/set-function-length": {
@@ -7799,18 +7907,18 @@
       "license": "MIT"
     },
     "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.8.tgz",
+      "integrity": "sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
-      "integrity": "sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -7845,9 +7953,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7952,9 +8060,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "funding": [
         {
           "type": "github",
@@ -7964,9 +8072,9 @@
       "license": "MIT"
     },
     "node_modules/style-mod": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
     "node_modules/styled-components": {
@@ -8282,9 +8390,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unist-util-is": {
@@ -8430,12 +8538,12 @@
       }
     },
     "node_modules/use-query-params": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.1.tgz",
-      "integrity": "sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.2.tgz",
+      "integrity": "sha512-OwGab8u8/x2xZp9uSyBsx0kXlkR9IR436zbygsYVGikPYY3OJosvve6IJVGwIJPcfyb/YHwvPrUNu65/JR++Kw==",
       "license": "ISC",
       "dependencies": {
-        "serialize-query-params": "^2.0.2"
+        "serialize-query-params": "^2.0.3"
       },
       "peerDependencies": {
         "@reach/router": "^1.2.1",
@@ -8638,9 +8746,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -8691,19 +8799,20 @@
       }
     },
     "node_modules/xrpl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.3.0.tgz",
-      "integrity": "sha512-MW/VyWyTGNmfmt5EaPexKb7ojcnobdzaqtm5UC9NErtlq7IgayqAZpMI26ptOzQolGndK7vOk8U0iOBpMSykJQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.6.0.tgz",
+      "integrity": "sha512-0nXZfqDHRJ6bsDv1WtA9MdCYalMtXuxVa9mtLdqT3xypRKf2LwT5DbuGL/kHcVfuqk3B+ly+SFARlrnX+LHtRQ==",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.3.1",
         "@scure/bip39": "^1.2.1",
         "@xrplf/isomorphic": "^1.0.1",
-        "@xrplf/secret-numbers": "^1.0.0",
+        "@xrplf/secret-numbers": "^2.0.0",
         "bignumber.js": "^9.0.0",
         "eventemitter3": "^5.0.1",
+        "fast-json-stable-stringify": "^2.1.0",
         "ripple-address-codec": "^5.0.0",
-        "ripple-binary-codec": "^2.4.0",
+        "ripple-binary-codec": "^2.7.0",
         "ripple-keypairs": "^2.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.131.0",
+        "@redocly/realm": "0.131.1",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@codemirror/lang-yaml": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
-      "integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -1406,9 +1406,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
-      "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -2156,14 +2156,14 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.8.0.tgz",
-      "integrity": "sha512-IcM0VTxgQLaaAJl5EO4ZIxN8c4d/dLPTrp0vsSUr8c3FBvJUG0Qt8/gfzglFyoCoX1r9e1kf+VSCLDR1vjJ1YQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.8.1.tgz",
+      "integrity": "sha512-bdGauPRUbkXBFYH8HpUaeBMG3gwR0yDF5ZH3VbHxtEe542WOBVhO79QxQEs4PnErc6sCPxje9nynxKtM/NUWrQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.44.1",
-        "@redocly/openapi-docs": "3.19.0",
+        "@redocly/openapi-docs": "3.19.1",
         "@redocly/theme": "0.63.0",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
@@ -2305,9 +2305,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.19.0.tgz",
-      "integrity": "sha512-uafC5z/bdEggeBIUFE/42X4foLUlRMPPhQPRfEywZzVAoB6sJqKn0yLmN4mHfLFzcTxuOODIh3p0/PpT39ng9g==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.19.1.tgz",
+      "integrity": "sha512-fGOH1292T8D1FkrOasVNqgFevnCDjDoS1dcSNt+fCwkh7+2/hCh8hF9EdIt3J0rqWoKqos1DQw1RKHGseo/dMQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
@@ -2327,7 +2327,7 @@
         "@redocly/openapi-core": "2.20.5",
         "@redocly/replay": "0.22.0",
         "deepmerge": "^4.2.2",
-        "dompurify": "3.2.7",
+        "dompurify": "3.3.3",
         "fast-deep-equal": "^3.1.3",
         "fast-xml-parser": "5.4.1",
         "jotai": "^2.12.5",
@@ -2368,20 +2368,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.16.0.tgz",
-      "integrity": "sha512-qRsJdNJR1d7VWB4AzwVRyPKcD6vY23we0d9oPlV++nR5oWYLDWnEnzsijBy70+P7rC7bcJ9zjYw3K++Z75RrGg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.16.1.tgz",
+      "integrity": "sha512-aDLqVrSuJtTBxtN6arD/WfuV9RZNvS/m9ZeOnkM/xoOOLWkPAFeGNDY073UYvu8haRaOt+lGdlyKoSY46Ja6PQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.44.1",
         "@redocly/mock-server": "0.5.15",
-        "@redocly/openapi-docs": "3.19.0"
+        "@redocly/openapi-docs": "3.19.1"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.131.0.tgz",
-      "integrity": "sha512-FoC7IYcHKZ6WOBmnG0iCYefmqtfImWqmjL6MRCC4fwQ7d/Lmq0pKOcArcsIM+UjQm5Y9aiHYI2unBE22P3AAxQ==",
+      "version": "0.131.1",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.131.1.tgz",
+      "integrity": "sha512-fW7y38nZJyiuMj5qxhjiqTQwE/4PTaGdb2HCIf9QoKanLmIdcdywLVDAcHOZ0wgCBdEmGR7WAsDBV72WHfZgdA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -2399,14 +2399,14 @@
         "@opentelemetry/sdk-trace-web": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/asyncapi-docs": "1.8.0",
+        "@redocly/asyncapi-docs": "1.8.1",
         "@redocly/config": "0.44.1",
         "@redocly/graphql-docs": "1.8.0",
         "@redocly/mcp-typescript-sdk": "1.18.1",
         "@redocly/openapi-core": "2.20.5",
-        "@redocly/openapi-docs": "3.19.0",
+        "@redocly/openapi-docs": "3.19.1",
         "@redocly/portal-legacy-ui": "0.14.0",
-        "@redocly/portal-plugin-mock-server": "0.16.0",
+        "@redocly/portal-plugin-mock-server": "0.16.1",
         "@redocly/realm-asyncapi-sdk": "0.9.0",
         "@redocly/theme": "0.63.0",
         "@shikijs/transformers": "3.21.0",
@@ -2431,13 +2431,13 @@
         "flexsearch": "0.7.43",
         "graphql": "16.12.0",
         "gray-matter": "4.0.3",
-        "hono": "4.11.10",
+        "hono": "4.12.8",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
         "js-yaml": "4.1.1",
         "lru-cache": "11.1.0",
-        "minimatch": "10.2.1",
+        "minimatch": "10.2.4",
         "mri": "1.2.0",
         "nanoid": "5.0.9",
         "node-fetch": "3.3.1",
@@ -2455,7 +2455,7 @@
         "reactjs-popup": "2.0.6",
         "semver": "7.7.3",
         "shiki": "3.21.0",
-        "simple-git": "3.20.0",
+        "simple-git": "3.32.3",
         "sitemap": "7.1.1",
         "stream-http": "3.2.0",
         "styled-components": "5.3.11",
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/@redocly/respect-core/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4651,9 +4651,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5571,9 +5571,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.11.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.10.tgz",
-      "integrity": "sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5911,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/jotai": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.18.1.tgz",
-      "integrity": "sha512-e0NOzK+yRFwHo7DOp0DS0Ycq74KMEAObDWFGmfEL28PD9nLqBTt3/Ug7jf9ca72x0gC9LQZG9zH+0ISICmy3iA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.19.0.tgz",
+      "integrity": "sha512-r2wwxEXP1F2JteDLZEOPoIpAHhV89paKsN5GWVYndPNMMP/uVZDcC+fNj0A8NjKgaPWzdyO8Vp8YcYKe0uCEqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -6458,15 +6458,15 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7867,14 +7867,14 @@
       "license": "MIT"
     },
     "node_modules/simple-git": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.20.0.tgz",
-      "integrity": "sha512-ozK8tl2hvLts8ijTs18iFruE+RoqmC/mqZhjs/+V7gS5W68JpJ3+FCTmLVqmR59MaUQ52MfGQuWsIqfsTbbJ0Q==",
+      "version": "3.32.3",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.3.tgz",
+      "integrity": "sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
+        "debug": "^4.4.0"
       },
       "funding": {
         "type": "github",
@@ -8350,9 +8350,9 @@
       "license": "Unlicense"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -8844,9 +8844,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.131.1",
+        "@redocly/realm": "0.131.2",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.131.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.131.1.tgz",
-      "integrity": "sha512-fW7y38nZJyiuMj5qxhjiqTQwE/4PTaGdb2HCIf9QoKanLmIdcdywLVDAcHOZ0wgCBdEmGR7WAsDBV72WHfZgdA==",
+      "version": "0.131.2",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.131.2.tgz",
+      "integrity": "sha512-ig0I+UGQvW1wc1uFCEyJ+sKlleXfZxcDqpaqkYpbJ2wX8g54UGllyrkQSblpdAxUCFy3Y5LB1YLJ6259gltELg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.131.0",
+    "@redocly/realm": "0.131.1",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.131.1",
+    "@redocly/realm": "0.131.2",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.130.4",
+    "@redocly/realm": "0.131.0",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",


### PR DESCRIPTION
[Full Redocly changelog for this release](https://redocly.com/docs/realm/changelog#Realm@0.131.0)

Notable Redocly changes for this release (compared with 0.130.x):

- Fix several security alerts
- New AI-powered search and MCP server features
- Improvements to the "Markdown for LLMs" export of a page (for example, `code-snippet` contents are no longer omitted)
- Sidebar badge functionality (follow-up: #3545)
- Plugin imports need to change or it crashes on startup. This PR fixes them, but is not backwards compatible with older Redocly versions, so if you're switching between branches you'll need to `npm i` the matching version for the branch.
- **Known Issue:** In local dev mode, pressing "q" to stop the server stops working after you use it a little bit. As a workaround, use Ctrl-C to interrupt it instead.