### PR TITLE
Fix redundant text in CredentialCreate ref

### DIFF
--- a/docs/references/protocol/transactions/types/credentialcreate.md
+++ b/docs/references/protocol/transactions/types/credentialcreate.md
@@ -25,8 +25,6 @@ Provisionally issue a [credential](../../../../concepts/decentralized-storage/cr
 
 {% raw-partial file="/docs/_snippets/tx-fields-intro.md" /%}
 
-In addition to the [common fields][], CredentialCreate transactions use the following fields:
-
 | Field            | JSON Type            | [Internal Type][] | Required? | Description |
 |:-----------------|:---------------------|:------------------|:----------|:------------|
 | `Subject`        | String - [Address][] | AccountID         | Yes       | The subject of the credential. |


### PR DESCRIPTION
Fix #3570.

The deleted line is part of the partial already.