### PR TITLE
Fix JS and Go code samples rendering issue

### DIFF
--- a/_code-samples/calculate-reserves/go/calculate_reserves.go
+++ b/_code-samples/calculate-reserves/go/calculate_reserves.go
@@ -1,4 +1,6 @@
+
 // Set up client ----------------------
+
 package main
 
 import (

--- a/_code-samples/calculate-reserves/js/calculate_reserves.js
+++ b/_code-samples/calculate-reserves/js/calculate_reserves.js
@@ -1,3 +1,4 @@
+
 // Set up client ----------------------
 
 import xrpl from 'xrpl'


### PR DESCRIPTION
The comments in the first JS and Go code samples were not rendering correctly. 
<img width="478" height="174" alt="Screenshot 2026-04-08 at 9 55 11 AM" src="https://github.com/user-attachments/assets/92d56866-c515-42b2-bf1d-41b278943056" />
<img width="505" height="169" alt="Screenshot 2026-04-08 at 9 55 16 AM" src="https://github.com/user-attachments/assets/3dc45cb5-cd84-4144-98ce-de2f160d0eb7" />

Added blank lines at the beginning of the files to fix it. 
<img width="695" height="209" alt="Screenshot 2026-04-08 at 9 57 21 AM" src="https://github.com/user-attachments/assets/1eb3af3c-e513-495b-b1c6-1cadf2c07758" />
<img width="564" height="192" alt="Screenshot 2026-04-08 at 9 57 27 AM" src="https://github.com/user-attachments/assets/a5055974-7358-40a0-bbb7-25294ab52d1c" />
