### PR TITLE
Update AI config on site

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -28,10 +28,18 @@ responseHeaders:
       value: noindex
 search:
   engine: typesense
-  ai:
-    hide: true
   filters:
     hide: true
+aiAssistant:
+  hide: false
+mcp:
+  hide: false
+  docs:
+    hide: false
+    name: "xrpl.org MCP server"
+    ignore:
+      - ja/**
+      - es-es/**
 metadataGlobs:
   'docs/**':
     redocly_category: Documentation


### PR DESCRIPTION
This PR updates the `redocly.yaml` file to:

1. Add an AI chatbot to the search bar
2. Exclude Japanese and Spanish from the MCP doc search results. Currently, the MCP server isn't detecting query language and returning language-appropriate responses. Instead, it is returning chunks for all available languages, even from pages that don't technically have a translation. This is cluttering MCP responses with English dupes. Until this issue is resolved, Japanese and Spanish won't be indexed by the MCP server.