### PR TITLE
docs: remove redundant field description sentences from credential transactions

### DIFF
--- a/docs/references/protocol/transactions/types/credentialaccept.md
+++ b/docs/references/protocol/transactions/types/credentialaccept.md
@@ -29,8 +29,6 @@ Accept a [credential](../../../../concepts/decentralized-storage/credentials.md)
 
 {% raw-partial file="/docs/_snippets/tx-fields-intro.md" /%}
 
-In addition to the [common fields][], CredentialAccept transactions use the following fields:
-
 | Field            | JSON Type        | [Internal Type][] | Required? | Description |
 |:-----------------|:-----------------|:------------------|:----------|:------------|
 | `Issuer`         | String - [Address][] | AccountID     | Yes       | The address of the issuer that created the credential. |

--- a/docs/references/protocol/transactions/types/credentialdelete.md
+++ b/docs/references/protocol/transactions/types/credentialdelete.md
@@ -29,8 +29,6 @@ Remove a [credential](../../../../concepts/decentralized-storage/credentials.md)
 
 {% raw-partial file="/docs/_snippets/tx-fields-intro.md" /%}
 
-In addition to the [common fields][], CredentialDelete transactions use the following fields:
-
 | Field            | JSON Type            | [Internal Type][] | Required? | Description |
 |:-----------------|:---------------------|:------------------|:----------|:------------|
 | `CredentialType` | String - Hexadecimal | Blob              | Yes       | Arbitrary data defining the type of credential to delete. The minimum length is 1 byte and the maximum length is 256 bytes. |


### PR DESCRIPTION

## Description

This PR removes redundant sentences in the `CredentialAccept` an`CredentialDelete` transaction reference pages.

- The sentence "In addition to the [common fields], ... transactions use the following fields:"

was being manually written even though it is already included in the `tx-fields-intro.md` partial snippet. This resulted in the same sentence appearing twice on the rendered web page.
    
## Changes

- Removed redundant text from `docs/references/protocol/transactions/types/credentialaccept.md` 
- Removed redundant text from `docs/references/protocol/transactions/types/credentialdelete.md`

## Verification

 - Verified that the `tx-fields-intro.md` snippet correctly provides the necessary introductory sentence.
 - Checked for similar redundancies in other `credential*.md` files (none found in `credentialcreate.md`).

## Test

Before
- https://xrpl.org/docs/references/protocol/transactions/types/credentialaccept

<img width="1438" height="818" alt="image" src="https://github.com/user-attachments/assets/31cfa824-bc18-4717-a27c-77941cd930f7" />

- https://xrpl.org/docs/references/protocol/transactions/types/credentialdelete

<img width="1414" height="1268" alt="image" src="https://github.com/user-attachments/assets/db603729-1bc2-4797-ac3f-1ac65c41bbe3" />

After

- http://localhost:4000/docs/references/protocol/transactions/types/credentialaccept

<img width="1486" height="700" alt="image" src="https://github.com/user-attachments/assets/e79c27e5-14c9-43de-8d28-28eb4365c7ce" />

- http://localhost:4000/docs/references/protocol/transactions/types/credentialdelete

<img width="1438" height="1158" alt="image" src="https://github.com/user-attachments/assets/3a850c4b-d00c-4a17-9c67-e5d2e9919ca6" />
