### PR TITLE
Update Node.js version requirement in contribution guide

### DIFF
--- a/resources/contribute-documentation/index.md
+++ b/resources/contribute-documentation/index.md
@@ -54,7 +54,7 @@ If your PR is not yet ready to be merged, [mark it as a draft](https://github.bl
 
 ## Redocly Setup
 
-The portal is built using Redocly Realm, which is currently in closed beta. Installing it for local development requires Node.js (version 20 recommended) and NPM.
+The portal is built using Redocly Realm, which is currently in closed beta. Installing it for local development requires Node.js (version 22 or later) and NPM. Earlier versions, including Node.js 20, fail at startup because Realm relies on `Promise.withResolvers`, which is only available in Node.js 22+.
 
 You can install Realm and other necessary dependencies using NPM from the repository top:
 


### PR DESCRIPTION
## Summary
The contribution guide currently states Node.js 20 is recommended, but `@redocly/realm@0.132.1` (the version pinned in `package.json`) calls `Promise.withResolvers`, which is only available in Node.js 21+ — effectively Node.js 22 LTS for users. Running `npm start` on Node 20 fails at startup with:

    TypeError: Promise.withResolvers is not a function
        at J.load (.../@redocly/realm/dist/server/fs/cache.js)

This PR updates `resources/contribute-documentation/index.md` to require Node.js 22 or later and explains the underlying reason so future contributors don't hit the same wall.

## Test plan
- [x] Reproduced the failure on Node v20.19.0
- [x] Verified `npm start` succeeds on Node v22.22.3 (2,403 pages, no errors)

## Notes / possible follow-ups
- The Japanese mirror at `@l10n/ja/resources/contribute-documentation/index.md` still says バージョン20が推奨. Happy to update in this PR or leave for a follow-up — whichever the i18n team prefers.
- Could also add an `.nvmrc` file or an `engines` field to `package.json` so the requirement surfaces during `npm i` rather than as a runtime crash. Out of scope here, but happy to do as a separate PR.