### PR TITLE
Update reserve values (rippled #6382)

### DIFF
--- a/docs/concepts/transactions/transaction-cost.md
+++ b/docs/concepts/transactions/transaction-cost.md
@@ -30,9 +30,10 @@ Some transactions have different transaction costs:
 | [Key Reset Transaction](#key-reset-transaction) | 0 |
 | [Multi-signed Transaction](../accounts/multi-signing.md) | 10 drops × (1 + Number of Signatures Provided) |
 | [EscrowFinish Transaction with Fulfillment](../../references/protocol/transactions/types/escrowfinish.md) | 10 drops × (33 + (Fulfillment size in bytes ÷ 16)) |
-| [AccountDelete Transaction](../accounts/deleting-accounts.md) | 2,000,000 drops |
-| [AMMCreate Transaction](../tokens/decentralized-exchange/automated-market-makers.md) | 2,000,000 drops |
+| [AccountDelete Transaction](../accounts/deleting-accounts.md) | 200,000 drops |
+| [AMMCreate Transaction](../tokens/decentralized-exchange/automated-market-makers.md) | 200,000 drops |
 
+<!-- RESERVES_REMINDER: update cost in drops if reserves change -->
 
 ## Beneficiaries of the Transaction Cost
 

--- a/docs/infrastructure/testing-and-auditing/start-a-new-genesis-ledger-in-stand-alone-mode.md
+++ b/docs/infrastructure/testing-and-auditing/start-a-new-genesis-ledger-in-stand-alone-mode.md
@@ -26,7 +26,7 @@ In a genesis ledger, the [genesis address](../../concepts/accounts/addresses.md#
 
 ## Settings in New Genesis Ledgers
 
-In a new genesis ledger, the hard-coded default [Reserve](../../concepts/accounts/reserves.md) is **10 XRP** minimum for funding a new address, with an increment of **2 XRP** per object in the ledger. These values are higher than the current reserve requirements of the production network. (See also: [Fee Voting](../../concepts/consensus-protocol/fee-voting.md))
+In a new genesis ledger, the hard-coded default [Reserve](../../concepts/accounts/reserves.md) is **1 XRP** minimum for funding a new address, with an increment of **0.2 XRP** per object in the ledger. The production network's reserve requirements are set separately through [Fee Voting](../../concepts/consensus-protocol/fee-voting.md).
 
 By default, a new genesis ledger has no [amendments](../../concepts/networks-and-servers/amendments.md) enabled. If you start a new genesis ledger with `--start`, the genesis ledger contains an [EnableAmendment pseudo-transaction](../../references/protocol/transactions/pseudo-transaction-types/enableamendment.md) to turn on all amendments natively supported by the `rippled` server, except for amendments that you explicitly disable in the config file. The effects of those amendments are available starting from the very next ledger version. (Reminder: in stand-alone mode, you must [advance the ledger manually](advance-the-ledger-in-stand-alone-mode.md).)
 


### PR DESCRIPTION
Updates docs for the new default base/owner reserve of 1 XRP / 0.2 XRP in rippled 3.2.0 (https://github.com/XRPLF/rippled/pull/6382).
- _Start a New Genesis Ledger in Standalone Mode_: default reserve now **1 XRP** base / **0.2 XRP** owner increment; dropped the stale "higher than production" note (the default now matches mainnet) and pointed to Fee Voting.
- _Transaction Cost_: AccountDelete/AMMCreate special cost updated to **200,000 drops** (0.2 XRP). It equals the owner reserve increment, and this table was missed when the other reserve pages moved to 0.2 XRP.
