### PR TITLE
Add terlocked error code (rippled #6811) and fix AMMClawback error typo (rippled #6946)

### DIFF
--- a/docs/references/protocol/transactions/transaction-results/ter-codes.md
+++ b/docs/references/protocol/transactions/transaction-results/ter-codes.md
@@ -19,6 +19,7 @@ Transactions with `ter` codes have not been applied to the current ledger and ha
 | `terFUNDS_SPENT` | **DEPRECATED.**                                           |
 | `terINSUF_FEE_B` | The account sending the transaction does not have enough XRP to pay the `Fee` specified in the transaction. |
 | `terLAST`        | Used internally only. This code should never be returned. |
+| `terLOCKED`      | A [Multi-Purpose Token (MPT)](../../../../concepts/tokens/fungible-tokens/multi-purpose-tokens.md) in the payment path is locked. |
 | `terNO_ACCOUNT`  | The address sending the transaction is not funded in the ledger (yet). |
 | `terNO_AMM`      | The AMM-related transaction specifies an asset pair that does not currently have an AMM instance. {% amendment-disclaimer name="AMM" /%} |
 | `terNO_AUTH`     | The transaction would involve adding currency issued by an account with `lsfRequireAuth` enabled to a trust line that is not authorized. For example, you placed an offer to buy a currency you aren't authorized to hold. |

--- a/docs/references/protocol/transactions/types/accountset.md
+++ b/docs/references/protocol/transactions/types/accountset.md
@@ -94,7 +94,7 @@ For reference, here are the corresponding ledger flags for each AccountSet flag:
 | AccountSet Flag Name              | Corresponding Ledger Flag         |
 |:----------------------------------|:----------------------------------|
 | `asfAccountTxnID`                 | (None)                            |
-| `asfAllowTrustLineClawback`       | `lsfAllowTrustlineClawback`       |
+| `asfAllowTrustLineClawback`       | `lsfAllowTrustLineClawback`       |
 | `asfAuthorizedNFTokenMinter`      | (None)                            |
 | `asfDefaultRipple`                | `lsfDefaultRipple`                |
 | `asfDepositAuth`                  | `lsfDepositAuth`                  |

--- a/docs/references/protocol/transactions/types/ammclawback.md
+++ b/docs/references/protocol/transactions/types/ammclawback.md
@@ -66,7 +66,7 @@ Besides errors that can occur for all transactions, `AMMClawback` transactions c
 
 | Error Code         | Description |
 |:-------------------|:------------|
-| `tecNO_PERMISSION` | Occurs if you attempt to claw back tokens from an AMM without the `lsfAllowTrustlineClawback` flag enabled, or the `tfClawTwoAssets` flag is enabled when you didn't issue both assets in the AMM. Also occurs if the `Asset` issuer doesn't match `Account`. |
+| `tecNO_PERMISSION` | Occurs if you attempt to claw back tokens from an AMM without the `lsfAllowTrustLineClawback` flag enabled, or the `tfClawTwoAssets` flag is enabled when you didn't issue both assets in the AMM. Also occurs if the `Asset` issuer doesn't match `Account`. |
 | `tecAMM_BALANCE`   | Occurs if the `Holder` doesn't hold any LP tokens from the AMM pool. |
 | `temDISABLED`      | Occurs if the [AMMClawback amendment][] is not enabled. |
 | `temBAD_AMOUNT`    | Occurs if the `Amount` field in the `AMMClawback` transaction is less than or equal to 0, or the `currency` and `issuer` subfields don't match between `Amount` and `Asset`. |


### PR DESCRIPTION
- Added the `terLOCKED` result code to the _ter Codes_ doc as part of 3.2.0 (https://github.com/XRPLF/rippled/pull/6811).
- Fixed a flag-name typo spotted while reviewing 3.2.0 (https://github.com/XRPLF/rippled/pull/6946). The error behavior was already documented correctly.