### PR TITLE
Mark SAV and Lending transactions NotDelegable (rippled #6489)

### DIFF
--- a/docs/references/protocol/data-types/permission-values.md
+++ b/docs/references/protocol/data-types/permission-values.md
@@ -49,6 +49,21 @@ The following permissions cannot be delegated:
 | [AccountDelete][]   | `22` |
 | [LedgerStateFix][]  | `54` |
 | [DelegateSet][]     | `65` |
+| [VaultCreate][VaultCreate transaction] {% amendment-disclaimer name="SingleAssetVault" /%} | `66` |
+| [VaultSet][VaultSet transaction] {% amendment-disclaimer name="SingleAssetVault" /%} | `67` |
+| [VaultDelete][VaultDelete transaction] {% amendment-disclaimer name="SingleAssetVault" /%} | `68` |
+| [VaultDeposit][VaultDeposit transaction] {% amendment-disclaimer name="SingleAssetVault" /%} | `69` |
+| [VaultWithdraw][VaultWithdraw transaction] {% amendment-disclaimer name="SingleAssetVault" /%} | `70` |
+| [VaultClawback][VaultClawback transaction] {% amendment-disclaimer name="SingleAssetVault" /%} | `71` |
+| [LoanBrokerSet][LoanBrokerSet transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `75` |
+| [LoanBrokerDelete][LoanBrokerDelete transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `76` |
+| [LoanBrokerCoverDeposit][LoanBrokerCoverDeposit transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `77` |
+| [LoanBrokerCoverWithdraw][LoanBrokerCoverWithdraw transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `78` |
+| [LoanBrokerCoverClawback][LoanBrokerCoverClawback transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `79` |
+| [LoanSet][LoanSet transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `81` |
+| [LoanDelete][LoanDelete transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `82` |
+| [LoanManage][LoanManage transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `83` |
+| [LoanPay][LoanPay transaction] {% amendment-disclaimer name="LendingProtocol" /%} | `85` |
 | [EnableAmendment][] | `101` |
 | [SetFee][]          | `102` |
 | [UNLModify][]       | `103` |


### PR DESCRIPTION
Adds the 15 affected transaction types to the non-delegatable list in _Permission Values_, each with its amendment disclaimer (SingleAssetVault / LendingProtocol) as part of 3.2.0 (https://github.com/XRPLF/rippled/pull/6489).