### PR TITLE
Clarify delegate multi signing rules (rippled #7064)

### DIFF
--- a/docs/concepts/accounts/permission-delegation.md
+++ b/docs/concepts/accounts/permission-delegation.md
@@ -32,6 +32,8 @@ A delegate can send transactions that execute as if they were sent by the delega
 - A regular key pair that the delegate has authorized
 - A multi-signing list that the delegate has authorized
 
+When a delegate multi-signs a transaction, the signatures are validated against their own signer list, not the delegator's. As with any multi-signed transaction, the delegate cannot be one of its own signers.
+
 The delegate can only send transactions that match the permissions it has. Permissions come in two types:
 
 - **Transaction Type Permissions** - Permission to send transactions of a specific [transaction type](/docs/references/protocol/transactions/types/index.md). Some types cannot be delegated.


### PR DESCRIPTION
Adds a clarifying note to the Permission Delegation concept doc explaining how multi-signing interacts with delegation, based on (https://github.com/XRPLF/rippled/pull/7064).