### PR TITLE
Empty permissions list is delete-only; add tecNO_ENTRY (rippled #6542)

### DIFF
--- a/docs/references/protocol/transactions/types/delegateset.md
+++ b/docs/references/protocol/transactions/types/delegateset.md
@@ -44,9 +44,9 @@ txIcon: modify
 | Field         | Required? | JSON Type            | Internal Type | Description |
 |:--------------|-----------|----------------------|---------------|-------------|
 | `Authorize`   | Yes       | String - [Address][] | AccountID     | The account being granted permissions, also called the _delegate_. |
-| `Permissions` | Yes       | Array                | Array         | A list of up to 10 [Permission objects](#permission-objects) each specifying a different permission granted to the delegate. The delegate's permissions are updated to match this set of permissions exactly. To revoke all permissions, use an empty array. |
+| `Permissions` | Yes       | Array                | Array         | A list of up to 10 [Permission objects](#permission-objects) each specifying a different permission granted to the delegate. The delegate's permissions are updated to match this set of permissions exactly. To revoke all permissions, use an empty array; this is only valid when a [Delegate ledger entry][] already exists for the delegate. |
 
-If a [Delegate ledger entry][] does not exist to record the granted permissions, this transaction creates one. If it already exists, the transaction updates the set of permissions to match the list in the transaction: any permissions not listed are revoked. If all permissions are revoked, the transaction deletes the Delegate ledger entry.
+If a [Delegate ledger entry][] does not exist to record the granted permissions, this transaction creates one. If it already exists, the transaction updates the set of permissions to match the list in the transaction: any permissions not listed are revoked. If all permissions are revoked, the transaction deletes the Delegate ledger entry. An empty `Permissions` list is only valid for deleting an existing Delegate ledger entry; if no such entry exists, the transaction fails with `tecNO_ENTRY`.
 
 {% admonition type="success" name="Tip" %}
 If you want to delegate more than 10 permissions, consider using [multi-signing](/docs/concepts/accounts/multi-signing.md) instead.
@@ -69,6 +69,7 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 |:--------------------------|:------------|
 | `tecDIR_FULL`             | The sender owns too many items in the ledger already.<br>This error is effectively impossible to receive if {% amendment-disclaimer name="fixDirectoryLimit" compact=true /%} is enabled. |
 | `tecINSUFFICIENT_RESERVE` | The sender does not have enough XRP to meet the [reserve requirement](/docs/concepts/accounts/reserves.md) of creating a new Delegate ledger entry. |
+| `tecNO_ENTRY`             | The `Permissions` list is empty but no [Delegate ledger entry][] exists for the delegate. An empty list is only valid for deleting an existing entry. |
 | `tecNO_PERMISSION`        | At least one permission in the `Permissions` list is not delegatable. See [Permission Values](../../data-types/permission-values.md) for which permissions are not delegatable. |
 | `tecNO_TARGET`            | The account specified in the `Authorize` field does not exist in the ledger. |
 | `temARRAY_TOO_LARGE`      | The `Permissions` list is too large. It cannot contain more than 10 entries. |


### PR DESCRIPTION
Documents the validation change from rippled PR #6542 (XRPLF/rippled#6542), which disallows an empty `Permissions` list when no Delegate ledger entry exists.

Updates _Delegate Set_:
- Clarify the `Permissions` field: empty array to revoke all permissions is only valid when a Delegate entry already exists.
- Note in the explanatory paragraph that an empty list with no existing entry fails with `tecNO_ENTRY`.
- Add a `tecNO_ENTRY` row to the Error Cases table.