### PR TITLE
Document server definitions formats and flags section (rippled #6321)

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions.md
+++ b/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_definitions.md
@@ -8,9 +8,11 @@ labels:
 ---
 # server_definitions
 
-[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/rpc/handlers/ServerInfo.cpp#L42 "Source")
+[[Source]](https://github.com/XRPLF/rippled/blob/master/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp#L385 "Source")
 
 The `server_definitions` command returns an SDK-compatible `definitions.json`, generated from the `rippled` instance currently running. You can use this to query a node in a network, quickly receiving the definitions necessary to serialize/deserialize its binary data.
+
+The response also includes the `TRANSACTION_FORMATS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, `LEDGER_ENTRY_FLAGS`, and `ACCOUNT_SET_FLAGS` sections, which describe the fields and flags of each transaction and ledger object type. {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %}
 
 You can also generate the same definitions without a running server using the [`--definitions`](../../../../infrastructure/commandline-usage.md) command-line flag.
 
@@ -101,7 +103,90 @@ An example of a successful response:
         }
       ]
       ...
-    ]
+    ],
+    "TRANSACTION_FORMATS": {
+      "common": [
+        {
+          "name": "TransactionType",
+          "optionality": 0
+        },
+        {
+          "name": "Flags",
+          "optionality": 1
+        },
+        {
+          "name": "SourceTag",
+          "optionality": 1
+        }
+        ...
+      ],
+      "AccountSet": [
+        {
+          "name": "EmailHash",
+          "optionality": 1
+        },
+        ...
+        {
+          "name": "SetFlag",
+          "optionality": 1
+        }
+        ...
+      ]
+      ...
+    },
+    "LEDGER_ENTRY_FORMATS": {
+      "common": [
+        {
+          "name": "LedgerIndex",
+          "optionality": 1
+        },
+        {
+          "name": "LedgerEntryType",
+          "optionality": 0
+        },
+        {
+          "name": "Flags",
+          "optionality": 0
+        }
+      ],
+      "DID": [
+        {
+          "name": "Account",
+          "optionality": 0
+        },
+        {
+          "name": "DIDDocument",
+          "optionality": 1
+        }
+        ...
+      ]
+      ...
+    },
+    "TRANSACTION_FLAGS": {
+      "universal": {
+        "tfFullyCanonicalSig": 2147483648,
+        "tfInnerBatchTxn": 1073741824
+      },
+      "AccountSet": {
+        "tfRequireDestTag": 65536,
+        "tfOptionalDestTag": 131072
+        ...
+      }
+      ...
+    },
+    "LEDGER_ENTRY_FLAGS": {
+      "AccountRoot": {
+        "lsfDisallowXRP": 524288
+        ...
+      }
+      ...
+    },
+    "ACCOUNT_SET_FLAGS": {
+      "asfRequireDest": 1,
+      "asfRequireAuth": 2,
+      "asfDisallowXRP": 3
+      ...
+    }
   }
 }
 ```
@@ -109,7 +194,7 @@ An example of a successful response:
 
 {% /tabs %}
 
-To see a full `definitions.json` file and descriptions of the top-level fields, see: [Definitions File](../../../protocol/binary-format.md#definitions-file).
+To see a full `definitions.json` file and descriptions of the top-level fields—including the `TRANSACTION_FORMATS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, `LEDGER_ENTRY_FLAGS`, and `ACCOUNT_SET_FLAGS` sections—see: [Definitions File](../../../protocol/binary-format.md#definitions-file).
 
 
 ## Possible Errors

--- a/docs/references/protocol/binary-format.md
+++ b/docs/references/protocol/binary-format.md
@@ -70,13 +70,18 @@ You can also use the [server_definitions API method](../http-websocket-apis/publ
 
 The following table defines the top-level fields from the definitions file:
 
-| Field                 | Contents                                             |
-|:----------------------|:-----------------------------------------------------|
-| `TYPES`               | Map of data types to their ["type code"](#type-codes) for constructing field IDs and sorting fields in canonical order. Codes below 1 should not appear in actual data; codes above 10000 represent special "high-level" object types such as "Transaction" that cannot be serialized inside other objects. See the [Type List](#type-list) for details of how to serialize each type. |
-| `LEDGER_ENTRY_TYPES`  | Map of [ledger objects](ledger-data/ledger-entry-types/index.md) to their data type. These appear in ledger state data, and in the "affected nodes" section of processed transactions' [metadata](transactions/metadata.md). |
-| `FIELDS`              | A sorted array of tuples representing all fields that may appear in transactions, ledger objects, or other data. The first member of each tuple is the string name of the field and the second member is an object with that field's properties. (See the "Field properties" table below for definitions of those fields.) |
-| `TRANSACTION_RESULTS` | Map of [transaction result codes](transactions/transaction-results/index.md) to their numeric values. Result types not included in ledgers have negative values; `tesSUCCESS` has numeric value 0; [`tec`-class codes](transactions/transaction-results/tec-codes.md) represent failures that are included in ledgers. |
-| `TRANSACTION_TYPES`   | Map of all [transaction types](transactions/types/index.md) to their numeric values. |
+| Field                  | Contents                                              |
+|:-----------------------|:------------------------------------------------------|
+| `TYPES`                | Map of data types to their ["type code"](#type-codes) for constructing field IDs and sorting fields in canonical order. Codes below 1 should not appear in actual data; codes above 10000 represent special "high-level" object types such as "Transaction" that cannot be serialized inside other objects. See the [Type List](#type-list) for details of how to serialize each type. |
+| `LEDGER_ENTRY_TYPES`   | Map of [ledger objects](ledger-data/ledger-entry-types/index.md) to their data type. These appear in ledger state data, and in the "affected nodes" section of processed transactions' [metadata](transactions/metadata.md). |
+| `FIELDS`               | A sorted array of tuples representing all fields that may appear in transactions, ledger objects, or other data. The first member of each tuple is the string name of the field and the second member is an object with that field's properties. (See the "Field properties" table below for definitions of those fields.) |
+| `TRANSACTION_RESULTS`  | Map of [transaction result codes](transactions/transaction-results/index.md) to their numeric values. Result types not included in ledgers have negative values; `tesSUCCESS` has numeric value 0; [`tec`-class codes](transactions/transaction-results/tec-codes.md) represent failures that are included in ledgers. |
+| `TRANSACTION_TYPES`    | Map of all [transaction types](transactions/types/index.md) to their numeric values. |
+| `TRANSACTION_FORMATS`  | Map of each [transaction type](transactions/types/index.md) to an array of objects describing that type's fields and whether each is required. (See the "Format field objects" table below.) {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
+| `LEDGER_ENTRY_FORMATS` | Map of each [ledger object type](ledger-data/ledger-entry-types/index.md) to an array of objects describing that type's fields and whether each is required. (See the "Format field objects" table below.) {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
+| `TRANSACTION_FLAGS`    | Map of each [transaction type](transactions/types/index.md) to an object mapping the names of its supported [transaction flags](transactions/common-fields.md#flags-field) to their numeric values. The `universal` entry lists the flags that apply to all transaction types. {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
+| `LEDGER_ENTRY_FLAGS`   | Map of each [ledger object type](ledger-data/ledger-entry-types/index.md) to an object mapping the names of that type's flags to their numeric values. {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
+| `ACCOUNT_SET_FLAGS`    | Map of [AccountSet flag](transactions/types/accountset.md#accountset-flags) (`asf`) names to their numeric values, for use in the `SetFlag` and `ClearFlag` fields of an [AccountSet transaction](transactions/types/accountset.md). {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
 
 For purposes of serializing transactions for signing and submitting, the `FIELDS`, `TYPES`, and `TRANSACTION_TYPES` fields are necessary.
 
@@ -89,6 +94,21 @@ The field definition objects in the `FIELDS` array have the following fields:
 | `isSerialized`   | Boolean | If `true`, this field should be encoded into serialized binary data. When this field is `false`, the field is typically reconstructed on demand rather than stored. |
 | `isSigningField` | Boolean | If `true` this field should be serialized when preparing a transaction for signing. If `false`, this field should be omitted from the data to be signed. (It may not be part of transactions at all.) |
 | `type`           | String  | The internal data type of this field. This maps to a key in the `TYPES` map, which gives the [type code](#type-codes) for this field. |
+
+Each `TRANSACTION_FORMATS` and `LEDGER_ENTRY_FORMATS` array contains one entry per field specific to that transaction or ledger object type. Each entry has these properties:
+
+| Field         | Type   | Contents                                          |
+|:--------------|:-------|:--------------------------------------------------|
+| `name`        | String | The name of the field. This matches the field name in the `FIELDS` array. |
+| `optionality` | Number | A code indicating whether the field is required when creating this transaction or ledger object type. See the table below for the meaning of each value. |
+
+The `optionality` field uses the following values:
+
+| Value | Meaning                                                          |
+|:------|:----------------------------------------------------------------|
+| `0`   | **Required.** The field must be present.                        |
+| `1`   | **Optional.** The field may be omitted.                         |
+| `2`   | **Default.** The field is optional and can be omitted to use the default. If included, it must be set to a non-default value. |
 
 ### Field IDs
 

--- a/docs/references/protocol/binary-format.md
+++ b/docs/references/protocol/binary-format.md
@@ -74,16 +74,18 @@ The following table defines the top-level fields from the definitions file:
 |:-----------------------|:------------------------------------------------------|
 | `TYPES`                | Map of data types to their ["type code"](#type-codes) for constructing field IDs and sorting fields in canonical order. Codes below 1 should not appear in actual data; codes above 10000 represent special "high-level" object types such as "Transaction" that cannot be serialized inside other objects. See the [Type List](#type-list) for details of how to serialize each type. |
 | `LEDGER_ENTRY_TYPES`   | Map of [ledger objects](ledger-data/ledger-entry-types/index.md) to their data type. These appear in ledger state data, and in the "affected nodes" section of processed transactions' [metadata](transactions/metadata.md). |
-| `FIELDS`               | A sorted array of tuples representing all fields that may appear in transactions, ledger objects, or other data. The first member of each tuple is the string name of the field and the second member is an object with that field's properties. (See the "Field properties" table below for definitions of those fields.) |
+| `FIELDS`               | A sorted array of tuples representing all fields that may appear in transactions, ledger objects, or other data. The first member of each tuple is the string name of the field and the second member is an object with that field's properties. (See [Field properties](#field-properties) for definitions of those fields.) |
 | `TRANSACTION_RESULTS`  | Map of [transaction result codes](transactions/transaction-results/index.md) to their numeric values. Result types not included in ledgers have negative values; `tesSUCCESS` has numeric value 0; [`tec`-class codes](transactions/transaction-results/tec-codes.md) represent failures that are included in ledgers. |
 | `TRANSACTION_TYPES`    | Map of all [transaction types](transactions/types/index.md) to their numeric values. |
-| `TRANSACTION_FORMATS`  | Map of each [transaction type](transactions/types/index.md) to an array of objects describing that type's fields and whether each is required. (See the "Format field objects" table below.) {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
-| `LEDGER_ENTRY_FORMATS` | Map of each [ledger object type](ledger-data/ledger-entry-types/index.md) to an array of objects describing that type's fields and whether each is required. (See the "Format field objects" table below.) {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
+| `TRANSACTION_FORMATS`  | Map of each [transaction type](transactions/types/index.md) to an array of objects describing that type's fields and whether each is required. (See [Format field objects](#format-field-objects) for the properties of each object.) {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
+| `LEDGER_ENTRY_FORMATS` | Map of each [ledger object type](ledger-data/ledger-entry-types/index.md) to an array of objects describing that type's fields and whether each is required. (See [Format field objects](#format-field-objects) for the properties of each object.) {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
 | `TRANSACTION_FLAGS`    | Map of each [transaction type](transactions/types/index.md) to an object mapping the names of its supported [transaction flags](transactions/common-fields.md#flags-field) to their numeric values. The `universal` entry lists the flags that apply to all transaction types. {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
 | `LEDGER_ENTRY_FLAGS`   | Map of each [ledger object type](ledger-data/ledger-entry-types/index.md) to an object mapping the names of that type's flags to their numeric values. {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
 | `ACCOUNT_SET_FLAGS`    | Map of [AccountSet flag](transactions/types/accountset.md#accountset-flags) (`asf`) names to their numeric values, for use in the `SetFlag` and `ClearFlag` fields of an [AccountSet transaction](transactions/types/accountset.md). {% badge href="https://github.com/XRPLF/rippled/releases/tag/3.2.0" %}New in: rippled 3.2.0{% /badge %} |
 
 For purposes of serializing transactions for signing and submitting, the `FIELDS`, `TYPES`, and `TRANSACTION_TYPES` fields are necessary.
+
+#### Field properties
 
 The field definition objects in the `FIELDS` array have the following fields:
 
@@ -95,12 +97,16 @@ The field definition objects in the `FIELDS` array have the following fields:
 | `isSigningField` | Boolean | If `true` this field should be serialized when preparing a transaction for signing. If `false`, this field should be omitted from the data to be signed. (It may not be part of transactions at all.) |
 | `type`           | String  | The internal data type of this field. This maps to a key in the `TYPES` map, which gives the [type code](#type-codes) for this field. |
 
+#### Format field objects
+
 Each `TRANSACTION_FORMATS` and `LEDGER_ENTRY_FORMATS` array contains one entry per field specific to that transaction or ledger object type. Each entry has these properties:
 
 | Field         | Type   | Contents                                          |
 |:--------------|:-------|:--------------------------------------------------|
 | `name`        | String | The name of the field. This matches the field name in the `FIELDS` array. |
-| `optionality` | Number | A code indicating whether the field is required when creating this transaction or ledger object type. See the table below for the meaning of each value. |
+| `optionality` | Number | A code indicating whether the field is required when creating this transaction or ledger object type. (See [Optionality values](#optionality-values) for the meaning of each value.) |
+
+#### Optionality values
 
 The `optionality` field uses the following values:
 


### PR DESCRIPTION
Documents the five new `server_definitions` response sections from 3.2.0 (https://github.com/XRPLF/rippled/pull/6321): `TRANSACTION_FORMATS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, `LEDGER_ENTRY_FLAGS`, and `ACCOUNT_SET_FLAGS`: 
- Added them to the Definitions File reference and to the `server_definitions` example response.
- Fixes the page's broken `[[Source]]` link. 
