### PR TITLE
Update retired known amendments (rippled #5919-6056)

### DIFF
--- a/@theme/components/Amendments.tsx
+++ b/@theme/components/Amendments.tsx
@@ -12,6 +12,7 @@ type Amendment = {
   date?: string
   id: string
   eta?: string
+  deprecated?: boolean
 }
 
 type AmendmentsResponse = {
@@ -51,6 +52,14 @@ function writeAmendmentsCache(amendments: Amendment[]) {
   } catch {
     // Ignore quota or serialization errors
   }
+}
+
+// Obsolete amendments (deprecated and never enabled, e.g. Batch) are documented
+// in the "Obsolete and Retired Amendments" section, not the live Mainnet Status
+// table, so filter them out here. Deprecated amendments that are enabled keep
+// their functionality and remain in the table as Enabled.
+function isObsolete(amendment: Amendment): boolean {
+  return Boolean(amendment.deprecated) && !amendment.tx_hash
 }
 
 // Sort amendments table by status, then chronologically, then alphabetically
@@ -100,7 +109,7 @@ export function AmendmentsTable() {
         const cached = readAmendmentsCache()
 
         if (cached) {
-          setAmendments(sortAmendments(cached))
+          setAmendments(sortAmendments(cached.filter(a => !isObsolete(a))))
           return // Use current cache (fresh)
         }
         // 2. Fetch new data if cache is stale
@@ -113,7 +122,7 @@ export function AmendmentsTable() {
         const data: AmendmentsResponse = await response.json()
         writeAmendmentsCache(data.amendments)
 
-        setAmendments(sortAmendments(data.amendments))
+        setAmendments(sortAmendments(data.amendments.filter(a => !isObsolete(a))))
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch amendments')
       } finally {

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -32,25 +32,62 @@ The following is a list of [amendments](../docs/concepts/networks-and-servers/am
 This list is updated manually. If you're working on an amendment and have a private network to test the changes, you can edit this page to add your in-development amendment to this list. For more information on contributing to the XRP Ledger, see [Contribute Code to the XRP Ledger](contribute-code/index.md).
 {% /admonition %}
 
+## Obsolete and Retired Amendments
 
-## Obsolete Amendments
+The following amendments are no longer tracked as amendments by the core server. They fall into two categories:
 
-The following is a list of known [amendments](../docs/concepts/networks-and-servers/amendments.md) that have been removed in a previous version of the core server, or are obsolete and have been marked for removal.
+- **Retired** (_Retired in &lt;version&gt;_): The amendment was enabled on Mainnet for more than two years and then retired per [XLS-11d](https://github.com/XRPLF/XRPL-Standards/discussions/19). Its functionality is now a permanent part of the core protocol, and it remains fully active. Only the amendment toggle and pre-amendment code have been removed.
+- **Obsolete** (_Removed in &lt;version&gt;_): The amendment's code was removed before it became a permanent part of the protocol because it was superseded, vetoed, or never enabled. This functionality is not available.
 
-| Name                              | Introduced | Status                        |
-|:----------------------------------|:-----------|:------------------------------|
-| [fixBatchInnerSigs]               | v3.1.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.1.1" %}Obsolete: Removed in v3.1.1{% /badge %} |
-| [Batch]                           | v2.5.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.1.1" %}Obsolete: Removed in v3.1.1{% /badge %} |
-| [PermissionDelegation]            | v2.5.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.6.1" %}Obsolete: Removed in v2.6.1{% /badge %} |
-| [fixNFTokenNegOffer][]            | v1.9.2     | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [CryptoConditionsSuite][]         | v0.60.0    | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [OwnerPaysFee][]                  | v0.33.0    | {% badge href="https://xrpl.org/blog/2017/rippled-0.80.0" %}Obsolete: Removed in v0.80.0{% /badge %} |
-| [SHAMapV2][]                      | v0.32.1    | {% badge href="https://xrpl.org/blog/2019/rippled-1.4.0.html" %}Obsolete: Removed in v1.4.0{% /badge %} |
-| [Tickets][]                       | v0.30.1    | {% badge href="https://xrpl.org/blog/2018/rippled-0.90.0.html" %}Obsolete: Removed in v0.90.0{% /badge %} |
-| [SusPay][]                        | v0.31.0    | {% badge href="https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features" %}Obsolete: Removed in v0.60.0{% /badge %} |
-| [FlowV2][]                        | v0.32.1    | {% badge href="https://xrpl.org/blog/2016/flowv2-vetoed.html" %}Obsolete: Removed in v0.33.0{% /badge %} |
+| Name                            | Introduced | Status |
+|:--------------------------------|:-----------|:-------|
+| [fixBatchInnerSigs][]           | v3.1.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.1.1" %}Removed in v3.1.1{% /badge %} |
+| [PermissionDelegation][]        | v2.5.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.6.1" %}Removed in v2.6.1{% /badge %} |
+| [Batch][]                       | v2.5.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.1.1" %}Removed in v3.1.1{% /badge %} |
+| [fixReducedOffersV1][]          | v1.12.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixNFTokenRemint][]            | v1.11.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixTrustLinesToSelf][]         | v1.10.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixNonFungibleTokensV1_2][]    | v1.10.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [ImmediateOfferKilled][]        | v1.10.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [DisallowIncoming][]            | v1.10.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixNFTokenNegOffer][]          | v1.9.2     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Removed in v3.2.0{% /badge %} |
+| [NonFungibleTokensV1_1][]       | v1.9.2     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixNFTokenDirV1][]             | v1.9.1     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Removed in v3.2.0{% /badge %} |
+| [ExpandedSignerList][]          | v1.9.1     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [NonFungibleTokensV1][]         | v1.9.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Removed in v3.2.0{% /badge %} |
+| [CheckCashMakesTrustLine][]     | v1.8.1     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [NegativeUNL][]                 | v1.7.3     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixRmSmallIncreasedQOffers][]  | v1.7.2     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixSTAmountCanonicalize][]     | v1.7.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [TicketBatch][]                 | v1.7.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [FlowSortStrands][]             | v1.7.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixAmendmentMajorityCalc][]    | v1.6.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1781][]                     | v1.6.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [HardenedValidations][]         | v1.6.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixQualityUpperBound][]        | v1.5.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [RequireFullyCanonicalSig][]    | v1.5.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixPayChanRecipientOwnerDir][] | v1.4.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixCheckThreading][]           | v1.4.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [DeletableAccounts][]           | v1.4.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixMasterKeyAsRegularKey][]    | v1.3.1     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fixTakerDryOfferRemoval][]     | v1.2.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1578][]                     | v1.2.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [MultiSignReserve][]            | v1.2.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1515][]                     | v1.1.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [DepositPreauth][]              | v1.1.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1623][]                     | v1.0.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1571][]                     | v1.0.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1543][]                     | v1.0.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [fix1513][]                     | v0.90.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [DepositAuth][]                 | v0.90.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [Checks][]                      | v0.90.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [CryptoConditionsSuite][]       | v0.60.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Removed in v3.2.0{% /badge %} |
+| [OwnerPaysFee][]                | v0.33.0    | {% badge href="https://xrpl.org/blog/2017/rippled-0.80.0" %}Removed in v0.80.0{% /badge %} |
+| [Flow][]                        | v0.33.0    | {% badge href="https://xrpl.org/blog/2026/rippled-3.2.0" %}Retired in v3.2.0{% /badge %} |
+| [SHAMapV2][]                    | v0.32.1    | {% badge href="https://xrpl.org/blog/2019/rippled-1.4.0.html" %}Removed in v1.4.0{% /badge %} |
+| [FlowV2][]                      | v0.32.1    | {% badge href="https://xrpl.org/blog/2016/flowv2-vetoed.html" %}Removed in v0.33.0{% /badge %} |
+| [SusPay][]                      | v0.31.0    | {% badge href="https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features" %}Removed in v0.60.0{% /badge %} |
+| [Tickets][]                     | v0.30.1    | {% badge href="https://xrpl.org/blog/2018/rippled-0.90.0.html" %}Removed in v0.90.0{% /badge %} |
 
 
 ## Details about Known Amendments
@@ -128,9 +165,9 @@ This amendment was disabled in v3.1.1 due to a bug. It will be replaced by `Batc
 | Amendment    | CheckCashMakesTrustLine |
 |:-------------|:------------------------|
 | Amendment ID | 98DECF327BF79997AEC178323AD51A830E457BFC6D454DAF3E46E5EC42DC619F |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Adjusts the [CheckCash transaction][] so that cashing a [Check](../docs/concepts/payment-types/checks.md) for an issued token automatically creates a [trust line](../docs/concepts/tokens/fungible-tokens/index.md) to hold the token. The new behavior is similar to how the [OfferCreate transaction][] behaves when users buy tokens in the decentralized exchange: the automatic trust line has a limit value of 0. This removes the setup step of setting up a trust line before receiving a token via a Check. (Checks that send XRP are unaffected.)
 
@@ -145,9 +182,9 @@ This amendment does not change the fact that you cannot force anyone to hold tok
 | Amendment    | Checks |
 |:-------------|:-------|
 | Amendment ID | 157D2D480E006395B76F948E3E07A45A05FE10230D88A7993C71F97AE4B1F2D1 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Introduces "Checks" to the XRP Ledger. Checks work similarly to personal paper checks. The sender signs a transaction to create a Check for a specific maximum amount and destination. Later, the destination can cash the Check to receive up to the specified amount. The actual movement of money only occurs when the Check is cashed, so cashing the Check may fail depending on the sender's current balance and the available liquidity. If cashing the Check fails, the Check object remains in the ledger so it may be successfully cashed later.
 
@@ -279,9 +316,9 @@ This amendment enables issuers to deep freeze trustlines from interacting with p
 | Amendment    | DeletableAccounts |
 |:-------------|:------------------|
 | Amendment ID | 30CD365592B8EE40489BA01AE2F7555CAC9C983145871DC82A42A31CF5BAE7D9 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Makes it possible to delete [accounts](../docs/concepts/accounts/index.md).
 
@@ -296,9 +333,9 @@ With this amendment, new accounts start with their `Sequence` numbers equal to t
 | Amendment    | DepositAuth |
 |:-------------|:------------|
 | Amendment ID | F64E1EABBE79D55B3BB82020516CEC2C582A98A6BFE20FBE9BB6A0D233418064 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Adds a new account flag, `DepositAuth`, which lets an account strictly reject any incoming money from transactions sent by other accounts. Businesses can use this flag to comply with strict regulations that require due diligence before receiving money from any source.
 
@@ -315,9 +352,9 @@ Also fixes a bug in the EscrowCreate and PaymentChannelCreate transactions where
 | Amendment    | DepositPreauth |
 |:-------------|:---------------|
 | Amendment ID | 3CBC5C4E630A1B82380295CDA84B32B49DD066602E74E39B85EF64137FA65194 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Provides users of [deposit authorization](../docs/concepts/accounts/depositauth.md) with a way to preauthorize specific senders so those senders are allowed to send payments directly.
 
@@ -356,9 +393,9 @@ Adds several new transaction result codes.
 | Amendment    | DisallowIncoming |
 |:-------------|:-----------------|
 | Amendment ID | 47C3002ABA31628447E8E9A8B315FAA935CE30183F9A9B86845E469CA2CDC3DF |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Provides options to categorically block incoming Checks, Payment Channels, NFTokenOffers, and trust lines from reaching your account. When an account has these options enabled, other accounts cannot create those types of objects with the account as the destination.
 
@@ -449,9 +486,9 @@ Provides "suspended payments" for XRP for escrow within the XRP Ledger, includin
 | Amendment    | ExpandedSignerList |
 |:-------------|:-------------------|
 | Amendment ID | B2A4DB846F0891BF2C76AB2F2ACC8F5B4EC64437135C6E56F3F859DE5FFD5856 |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 This amendment expands the maximum signer list size and allows each signer to have optional data associated with it. The additional data can be used to identify the signer, which may be useful for smart contracts, or for identifying who controls a key in a large organization: for example, you could store an IPv6 address or the identifier of a Hardware Security Module (HSM).
 
@@ -547,9 +584,9 @@ With this amendment, the transactions fail with a more appropriate result code, 
 | Amendment    | fix1513 |
 |:-------------|:--------|
 | Amendment ID | 67A34F2CF55BFC0F93AACD5B281413176FEE195269FA6D95219A2DF738671172 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes a bug that resulted in transaction processing not using new `STAmountCalcSwitchovers` code when the `FeeEscalation` amendment is enabled.
 
@@ -562,9 +599,9 @@ With this amendment, the new `STAmountCalcSwitchovers` code applies, which may c
 | Amendment    | fix1515 |
 |:-------------|:--------|
 | Amendment ID | 5D08145F0A4983F23AFFFF514E83FAD355C5ABFBB6CAB76FB5BC8519FF5F33BE |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes how Payment transactions consume offers to remove a minor difference in how payment processing and offer processing consume liquidity. (Also affects how OfferCreate transactions are processed if [FlowCross][] is enabled.)
 
@@ -611,9 +648,9 @@ This amendment changes how validators negotiate the close time of the consensus 
 | Amendment    | fix1543 |
 |:-------------|:--------|
 | Amendment ID | CA7C02118BA27599528543DFE77BA6838D1B0F43B447D4D7F53523CE6A0E9AC2 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Enforces reserved flag ranges on some transaction types that did not correctly enforce them already. Transactions of the affected types are now considered invalid if they enable undefined or unknown flags, or flags from the reserved range. (Transactions unaffected by this change already correctly enforce the same rules.)
 
@@ -631,9 +668,9 @@ The affected transaction types are:
 | Amendment    | fix1571 |
 |:-------------|:--------|
 | Amendment ID | 7117E2EC2DBF119CA55181D69819F1999ECEE1A0225A7FD2B9ED47940968479C |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes Escrow to fix the following issues:
 
@@ -647,9 +684,9 @@ Changes Escrow to fix the following issues:
 | Amendment    | fix1578 |
 |:-------------|:--------|
 | Amendment ID | FBD513F1B893AC765B78F250E6FFA6A11B573209D1842ADC787C850696741288 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes the result codes returned by two transaction types:
 
@@ -663,9 +700,9 @@ Changes the result codes returned by two transaction types:
 | Amendment    | fix1623 |
 |:-------------|:--------|
 | Amendment ID | 58BE9B5968C4DA7C59BA900961828B113E5490699B21877DEF9A31E9D0FE5D5F |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Adds delivered amount to metadata for CheckCash transactions cashed for a flexible amount. (Has no effect unless the [Checks](#checks) amendment is enabled.)
 
@@ -680,9 +717,9 @@ The fix1623 amendment has no effect on [CheckCash transactions][] for a fixed am
 | Amendment    | fix1781 |
 |:-------------|:--------|
 | Amendment ID | 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes a bug where certain XRP endpoints were not checked when detecting circular paths.
 
@@ -697,9 +734,9 @@ With this amendment, those payments fail with the [`temBAD_PATH_LOOP` result cod
 | Amendment    | fixAmendmentMajorityCalc |
 |:-------------|:-------------------------|
 | Amendment ID | 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes a bug that could cause an amendment to achieve a majority and later activate with support of slightly less than 80% of trusted validators due to rounding semantics.
 
@@ -803,9 +840,9 @@ This amendment was disabled in v3.1.1 due to a bug. It will be replaced by `Batc
 | Amendment    | fixCheckThreading |
 |:-------------|:------------------|
 | Amendment ID | 8F81B066ED20DAECA20DF57187767685EEF3980B228E0667A650BAF24426D3B4 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes the way Checks transactions affect account metadata, so that Checks are properly added to the [account](../docs/concepts/accounts/index.md) history of the receiving account. (Specifically, they update the `PreviousTxnID` and `PreviousTxnLedgerSeq` fields of the receiving account's [AccountRoot object](../docs/references/protocol/ledger-data/ledger-entry-types/accountroot.md), which can be used to trace the "thread" of transactions that affected the account and the objects it owns.)
 
@@ -1036,9 +1073,9 @@ Adds flag checks for `CredentialCreate`, `CredentialAccept`, `CredentialDelete`,
 | Amendment    | fixMasterKeyAsRegularKey |
 |:-------------|:-------------------------|
 | Amendment ID | C4483A1896170C66C098DEA5B0E024309C60DC960DE5F01CD7AF986AA3D9AD37 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes a bug where accounts can set their regular key pair to match their master key pair, but cannot send transactions signed by the key if the master key is disabled.
 
@@ -1113,9 +1150,9 @@ Without this amendment, it is possible in specific circumstances to delete the l
 | Amendment    | fixNFTokenRemint |
 |:-------------|:-----------------|
 | Amendment ID | AE35ABDEFBDE520372B31C957020B34A7A4A9DC3115A69803A44016477C84D6E |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Amendment `fixNFTokenRemint` would change the way NFT sequence numbers are constructed to prevent a situation where the same NFT could be minted more than once with the same sequence number, creating a possible collision scenario. This amendment would change the construction of NFT sequence numbers to:
 
@@ -1147,9 +1184,9 @@ This amendment adds a check to the `NFTokenAcceptOffer` transactor to see if the
 | Amendment    | fixNonFungibleTokensV1_2 |
 |:-------------|:-------------------------|
 | Amendment ID | 73761231F7F3D94EC3D8C63D91BDD0D89045C6F71B917D1925C01253515A6669 |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Amendment `fixNonFungibleTokensV1_2` is a combination of bug fixes that have been individually merged into feature/nft-fixes through the pull request process.
 
@@ -1203,9 +1240,9 @@ Without this amendment, transactions can create a payment channel whose `CancelA
 | Amendment    | fixPayChanRecipientOwnerDir |
 |:-------------|:----------------------------|
 | Amendment ID | 621A0B264970359869E3C0363A899909AAB7A887C8B73519E4ECF952D33258A8 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes the [PaymentChannelCreate transaction][] type so that it adds new [payment channels](../docs/concepts/payment-types/payment-channels.md) to the recipient's [owner directory](../docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md). Without this amendment, new payment channels are added only to the sender's owner directory; with this amendment enabled, newly-created payment channels are added to both owner directories. Existing payment channels are unchanged.
 
@@ -1250,9 +1287,9 @@ This amendment ensures asset pairs follow a canonical order at all times, so you
 | Amendment    | fixQualityUpperBound |
 |:-------------|:---------------------|
 | Amendment ID | 89308AF3B8B10B7192C4E613E1D2E4D9BA64B2EE2D5232402AE82A6A7220D953 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes a bug in unused code for estimating the ratio of input to output of individual steps in cross-currency payments.
 
@@ -1265,9 +1302,9 @@ This amendment has no known impact on transaction processing.
 | Amendment    | fixReducedOffersV1 |
 |:-------------|:-------------------|
 | Amendment ID | 27CD95EE8E1E5A537FF2F89B6CEB7C622E78E9374EBD7DCBEDFAE21CD6F16E0A |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Adjusts rounding to prevent order books from being blocked by reduced offers whose exchange rate is affected by rounding of the remaining amounts.
 
@@ -1320,9 +1357,9 @@ This amendment has no effect unless either [NonFungibleTokensV1][] or [NonFungib
 | Amendment    | fixRmSmallIncreasedQOffers |
 |:-------------|:---------------------------|
 | Amendment ID | B6B3EEDC0267AB50491FDC450A398AF30DBCD977CECED8BEF2499CAB5DAC19E2 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 This amendment fixes an issue where certain Offers, when almost completely consumed, have a much lower exchange rate than when they were first placed. This occurs when the remaining amounts of one or both assets are so small that they cannot be rounded to a similar ratio as when the Offer was placed.
 
@@ -1337,9 +1374,9 @@ With this amendment, payments and trades can remove these types of Offers the sa
 | Amendment    | fixSTAmountCanonicalize |
 |:-------------|:------------------------|
 | Amendment ID | 452F5906C46D46F407883344BFDD90E672B672C5E9943DB4891E3A34FEEEB9DB |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes an edge case in [deserializing](../docs/references/protocol/binary-format.md) Amount-type fields. Without this amendment, in some rare cases the operation could result in otherwise valid serialized amounts overflowing during deserialization. With this amendment, the XRP Ledger detects error conditions more quickly and eliminates the problematic corner cases.
 
@@ -1350,9 +1387,9 @@ Fixes an edge case in [deserializing](../docs/references/protocol/binary-format.
 | Amendment    | fixTakerDryOfferRemoval |
 |:-------------|:------------------------|
 | Amendment ID | 2CD5286D8D687E98B41102BDD797198E81EA41DF7BD104E6561FEB104EFF2561 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Fixes a bug in [auto-bridging](../docs/concepts/tokens/decentralized-exchange/autobridging.md) that can leave a dry offer in the XRP Ledger. A dry offer is an offer that, if crossed, cannot yield any funds.
 
@@ -1382,9 +1419,9 @@ This amendment ensures that when escrowed MPTs are unlocked, the issuer's locked
 | Amendment    | fixTrustLinesToSelf |
 |:-------------|:--------------------|
 | Amendment ID | F1ED6B4A411D8B872E65B9DCB4C8B100375B0DD3D62D07192E011D6D7F339013 |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 This amendment removes two trust lines from an account to itself that were created due to an old bug (both on 2013-05-07). When the amendment becomes enabled, it deletes trust lines with the IDs `2F8F21EFCAFD7ACFB07D5BB04F0D2E18587820C7611305BB674A64EAB0FA71E1` and `326035D5C0560A9DA8636545DD5A1B0DFCFF63E68D491B5522B767BB00564B1A` if they exist. After doing so, the amendment does nothing else.
 
@@ -1429,9 +1466,9 @@ This amendment restores the intended rounding behavior. It has no effect unless 
 | Amendment    | Flow |
 |:-------------|:-----|
 | Amendment ID | 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment supersedes the [FlowV2](https://xrpl.org/blog/2016/flowv2-vetoed.html) amendment.
 
@@ -1461,9 +1498,9 @@ Streamlines the offer crossing logic in the XRP Ledger's decentralized exchange.
 | Amendment    | FlowSortStrands |
 |:-------------|:----------------|
 | Amendment ID | AF8DF7465C338AE64B1E937D6C8DA138C0D63AD5134A68792BBBE1F63356C422 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Improves the payment engine's calculations for finding the most cost-efficient way to execute a cross-currency transaction.
 
@@ -1489,9 +1526,9 @@ This is a previous version of the [Flow](#flow) amendment. It was [rejected due 
 | Amendment    | HardenedValidations |
 |:-------------|:--------------------|
 | Amendment ID | 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Allows validators to include a new optional field in their validations to attest to the hash of the latest ledger that the validator considers to be fully validated. The consensus process can use this information to increase the robustness of consensus.
 
@@ -1502,9 +1539,9 @@ Allows validators to include a new optional field in their validations to attest
 | Amendment    | ImmediateOfferKilled |
 |:-------------|:---------------------|
 | Amendment ID | 75A7E01C505DD5A179DFE3E000A9B6F1EDDEB55A12F95579A23E15B15DC8BE5A |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes OfferCreate transactions so that if an Offer uses `tfImmediateOrCancel` and transaction processing kills the Offer without moving any funds, the transaction uses the result code `tecKILLED` instead of `tesSUCCESS`. If the Offer exchanges any amount of funds, even a small amount, the transaction still uses `tesSUCCESS`. There are no other changes to the processing of the transaction (for example, in terms of whether it cleans up expired and unfunded Offers that were encountered in the ledger during transaction processing).
 
@@ -1621,9 +1658,9 @@ An address with a SignerList can disable the master key even if a regular key is
 | Amendment    | MultiSignReserve |
 |:-------------|:-----------------|
 | Amendment ID | 586480873651E106F1D6339B0C4A8945BA705A777F3F4524626FF1FC07EFE41D |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Reduces the [owner reserve](../docs/concepts/accounts/reserves.md#owner-reserves) counted against your XRP Ledger account when it owns a [multi-signing](../docs/concepts/accounts/multi-signing.md) SignerList.
 
@@ -1638,9 +1675,9 @@ With this amendment enabled, the owner reserve for a new SignerList is 5 XRP, re
 | Amendment    | NegativeUNL |
 |:-------------|:------------|
 | Amendment ID | B4E4F5D2D6FB84DF7399960A732309C9FD530EAE5941838160042833625A6076 |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Implements a "Negative UNL" system, where the network can track which validators are temporarily offline and disregard those validators for quorum calculations. This can improve the ability of the network to make progress during periods of network instability.
 
@@ -1704,9 +1741,9 @@ It also modifies the [AccountSet transaction][] type to allow you to set the `NF
 | Amendment    | NonFungibleTokensV1_1 |
 |:-------------|:----------------------|
 | Amendment ID | 32A122F1352A4C7B3A6D790362CC34749C5E57FCE896377BFDC6CCD14F6CD627 |
-| Status       | Enabled |
+| Status       | Retired |
 | Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | Yes |
 
 Adds native support for [non-fungible tokens](../docs/concepts/tokens/nfts/index.md), including fixes to several issues that were discovered after [NonFungibleTokensV1][].
 
@@ -1823,9 +1860,9 @@ This amendment creates a new ledger entry type, `PriceOracle`, and new transacti
 | Amendment    | RequireFullyCanonicalSig |
 |:-------------|:-------------------------|
 | Amendment ID | 00C1FC4A53E60AB02C864641002B3172F38677E29C26C5406685179B37E1EDAC |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 Changes the signature requirements for the XRP Ledger protocol so that non-fully-canonical signatures are no longer valid in any case. This protects against [transaction malleability](../docs/concepts/transactions/finality-of-results/transaction-malleability.md) on _all_ transactions, instead of only transactions with the [`tfFullyCanonicalSig` flag](../docs/references/protocol/transactions/common-fields.md#global-flags) enabled.
 
@@ -1946,9 +1983,9 @@ This amendment was replaced by the [Escrow](../docs/references/protocol/ledger-d
 | Amendment    | TicketBatch |
 |:-------------|:------------|
 | Amendment ID | 955DF3FA5891195A9DAEFA1DDC6BB244B545DDE1BAA84CBB25D5F12A8DA68A0C |
-| Status       | Enabled |
-| Default Vote (Latest stable release) | Yes |
-| Pre-amendment functionality retired? | No |
+| Status       | Retired |
+| Default Vote (Latest stable release) | No |
+| Pre-amendment functionality retired? | Yes |
 
 This amendment adds [Tickets](../docs/concepts/accounts/tickets.md) as a way of sending transactions out of the typical sequence number order.
 


### PR DESCRIPTION
Reflects the amendment retirements in rippled 3.2.0: 
- Renamed "Obsolete Amendments" → "Obsolete and Retired Amendments" with a new intro. 
- Added 35 retired amendments. 
- Classified 4 amendments as `Removed in v3.2.0` instead of Retired. 
- Parallelized the status badges (`Retired in <v>` / `Removed in <v>`) and re-sorted by version.
- Fixed `CheckCashMakesTrustLine` introduced version (v1.6.0 → v1.8.1).

Did not update corresponding JA and ES files. 