### PR TITLE
Document delegate destination node field (rippled #6681)

### DIFF
--- a/docs/references/protocol/ledger-data/ledger-entry-types/delegate.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/delegate.md
@@ -44,7 +44,8 @@ In addition to the [common fields](../common-fields.md), {% code-page-name /%} e
 | `Account`           | String - [Address][] | AccountID         | Yes       | The account delegating permissions to another, also called the _delegating account_. |
 | `Authorize`         | String - [Address][] | AccountID         | Yes       | The account receiving permissions, also called the _delegate_. |
 | `Permissions`       | Array                | Array             | Yes       | A list of permissions granted, with at least 1 and at most 10 items. Each item in the list is a [Permission Object](#permission-objects). |
-| `OwnerNode`         | String - Hexadecimal | UInt64            | Yes       | A hint indicating which page of the delegating account's owner directory links to this object, in case the directory consists of multiple pages. 
+| `OwnerNode`         | String - Hexadecimal | UInt64            | Yes       | A hint indicating which page of the delegating account's owner directory links to this object, in case the directory consists of multiple pages. |
+| `DestinationNode`   | String - Hexadecimal | UInt64            | No        | A hint indicating which page of the delegate's owner directory links to this object, in case the directory consists of multiple pages. |
 | `PreviousTxnID`     | String - Hexadecimal | UInt256           | Yes       | The identifying hash of the transaction that most recently modified this object. |
 | `PreviousTxnLgrSeq` | Number               | UInt32            | Yes       |The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this object. |
 
@@ -64,7 +65,7 @@ There are no flags defined for {% code-page-name /%} entries.
 
 {% code-page-name /%} entries count as one item towards the owner reserve of the delegating account, as long as the entry is in the ledger, regardless of how many permissions are delegating. Removing all permissions deletes the entry and frees up the reserve.
 
-{% code-page-name /%} entries are not deletion blockers. If the owner (delegating) account is deleted, all such ledger entries are deleted along with them. However, the `Authorize`
+{% code-page-name /%} entries are not deletion blockers. If the owner (delegating) account is deleted, all such ledger entries are deleted along with them. Deleting the `Authorize` (delegate) account removes the entry as well, freeing the delegating account's reserve.
 
 ## See Also
 


### PR DESCRIPTION
Updates the `Delegate` ledger entry reference as part of 3.2.0 (https://github.com/XRPLF/rippled/pull/6681):
- Add the new optional `DestinationNode` field to the fields table.
- Complete an unfinished sentence in the Reserve section that previously cut off mid-word.
- Close a missing trailing `|` on the `OwnerNode` table row.