### PR TITLE
Bump redocly to v 0.134.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.133.1",
+        "@redocly/realm": "0.134.0",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -238,19 +238,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -275,21 +262,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
-      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.5",
-        "@babel/parser": "^7.23.5",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -498,6 +486,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -749,6 +738,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
       "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -795,6 +785,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -943,12 +934,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
@@ -1454,6 +1439,16 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1611,6 +1606,7 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.3.tgz",
       "integrity": "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.3",
         "@libsql/hrana-client": "^0.10.0",
@@ -1776,6 +1772,7 @@
       "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.5.2.tgz",
       "integrity": "sha512-clrqWpJ3+S8PXigRE+zBIs6LVZYXaJ7JTDFq1CcCWc4xpoB2kz+9qRUQQ4vXtLUjQ8ige1BGdMruV6gM/2gloA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.7.0"
       },
@@ -1846,6 +1843,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2411,20 +2409,20 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.10.0.tgz",
-      "integrity": "sha512-om6A20yP316rBgjuaFDVW6ZMVoFkoAAdq5p85YxjpyeOxbLqTgjv3h467J5RlzPbaC2vBJTFy2smjBPXtaSS3g==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.11.0.tgz",
+      "integrity": "sha512-GF5xjLlGLSohq2qZh/cAYCxOkxZJ29EAC50kCYJ67/v5aEauGY9td4JxWzxJowvVhxHAigUs5n4Igk3Qz1a43Q==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.48.1",
-        "@redocly/openapi-docs": "3.21.0",
-        "@redocly/redoc-opentelemetry": "0.1.0",
-        "@redocly/theme": "0.65.0",
+        "@redocly/config": "0.49.0",
+        "@redocly/openapi-docs": "3.22.0",
+        "@redocly/redoc-opentelemetry": "0.2.0",
+        "@redocly/theme": "0.66.0",
         "jotai": "^2.11.1",
         "openapi-sampler": "^1.7.2",
         "react-router-dom": "^6.30.3",
-        "styled-components": "5.3.11",
+        "styled-components": "^6.4.2",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
@@ -2432,53 +2430,54 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.1.tgz",
-      "integrity": "sha512-vq8GM3e0KiglqkwE5Lb9XayrmZY4dHCs21BsvV92yAZN68f1N9cZUuwY1SwnztPbH06dn9uLzubBl/JNfImqfA==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.49.0.tgz",
+      "integrity": "sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.10.0.tgz",
-      "integrity": "sha512-5GnOCb2eSzkkoPl41684ZEIyO0SeRDHSQBHoUZHmhvpZjOTwM4heN/8bJtymzGbnXbFJe6hsym34BEq5PRbBVA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.11.0.tgz",
+      "integrity": "sha512-cRBq9odUhKtKo+lZuYVF+EREr8m0K5mwbRF2zkZQbrHwBxtIr2TP/gl8m3geqt0faKf1rxIidUHzOG7Axb9WPA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.48.1",
-        "@redocly/openapi-docs": "3.21.0",
-        "@redocly/redoc-opentelemetry": "0.1.0",
+        "@redocly/config": "0.49.0",
+        "@redocly/openapi-docs": "3.22.0",
+        "@redocly/redoc-opentelemetry": "0.2.0",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
         "web-vitals": "3.3.1"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.65.0",
+        "@redocly/theme": "0.66.0",
         "graphql": "16.12.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.3",
-        "styled-components": "^5.3.11"
+        "styled-components": "^5.3.11 || ^6.0.0"
       }
     },
     "node_modules/@redocly/hookstate-core": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@redocly/hookstate-core/-/hookstate-core-4.2.3.tgz",
-      "integrity": "sha512-1S/E5S1mhFj5WG9ob6hv5CXKf99x4QY8TdknWZ4ByH+9emmqIfaKrPFVUSMl2Pbu5hp74rHffK0p8v74rGC65A==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@redocly/hookstate-core/-/hookstate-core-4.2.4.tgz",
+      "integrity": "sha512-N+0DkPva4oJXPocDqW8GSRcbKP6J9243lj3jpC34d/kJQgW6k83eudyJFzeq2MFZ5GplbTMm27CF+rng3ReS5Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@redocly/hookstate-devtools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@redocly/hookstate-devtools/-/hookstate-devtools-4.2.0.tgz",
-      "integrity": "sha512-83u/kqVD5v0m99okmHiNT/d7uGmIIxx4TOrX9IhwfPP7Oc9gk7rCicOlkDZx5nomVVaE7380Ivku624aX6YWUw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@redocly/hookstate-devtools/-/hookstate-devtools-4.2.1.tgz",
+      "integrity": "sha512-YA9WNRug0TNQjxoS4krH8vliCZvy6XkN4ULBWSr2YQwUciHUUx6gMMwGC42gKNzq1d3A/zzC2Z98t+st9eeDPQ==",
       "license": "MIT",
       "dependencies": {
-        "redux": "4.2.0",
-        "redux-devtools-extension": "2.13.9"
+        "@redux-devtools/extension": "3.3.0",
+        "redux": "4.2.0"
       },
       "peerDependencies": {
         "@redocly/hookstate-core": "^4.0.0"
@@ -2516,13 +2515,13 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.7.0.tgz",
-      "integrity": "sha512-gr9e1aq5iKy+AN3F+NwFC4cbi15XCdL1HTpfZudV9jg2OqTPRMZd1RNvFQvKUF0UZq+TLLpR88KmD+ufiVAX0w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.8.0.tgz",
+      "integrity": "sha512-Tb3R+Xlpvpinr+A18TOYOkdTqstmE+yvBKEO4jZF1XTsgztaobxKv5RkMT4Wg0enlyUYh9D+mmilaaLIMRniAg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
-        "@redocly/openapi-core": "2.30.5",
+        "@redocly/openapi-core": "2.31.6",
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
@@ -2551,13 +2550,13 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.5.tgz",
-      "integrity": "sha512-ikljMaow1wX3GoRvLiJvqOq8H3f6XsuMBZqCGmeY0+UPmlnVhrvW8m/gC1vkKcGNvYINUrgi/Z6dBtzQ7854wA==",
+      "version": "2.31.6",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.31.6.tgz",
+      "integrity": "sha512-h+zh6UQ4e5oRspUZUaNl1XRXwMf0ENHbGLKIDFAjhV6JACpqUrcBxkPKHY/uCXGdJSCzxVP3twCrnOWB0iMVuw==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
-        "@redocly/config": "^0.48.1",
+        "@redocly/config": "^0.49.0",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -2607,16 +2606,17 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.21.0.tgz",
-      "integrity": "sha512-ZcEklWqBP4suNksTLHDE9b7ttH1e+I+1UgtBEZjQ50Ly4QBVYGV11TosYiYCBQTddc8RZVlYaOKQc05boA4cgQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.22.0.tgz",
+      "integrity": "sha512-aFTTobAsIDm3aZgABKPuLIS+2xiONCvrhWkt/EsTJ4RDS99lBOnOCjvmH55tNwuO96macJ6qYWQUHyrY6MgVAg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
+        "@babel/core": "7.29.7",
         "@markdoc/markdoc": "0.5.2",
-        "@redocly/config": "0.48.1",
-        "@redocly/openapi-core": "2.30.5",
-        "@redocly/redoc-opentelemetry": "0.1.0",
-        "@redocly/replay": "0.24.0",
+        "@redocly/config": "0.49.0",
+        "@redocly/openapi-core": "2.31.6",
+        "@redocly/redoc-opentelemetry": "0.2.0",
+        "@redocly/replay": "0.25.0",
         "deepmerge": "^4.2.2",
         "dompurify": "3.4.0",
         "fast-deep-equal": "^3.1.3",
@@ -2628,7 +2628,7 @@
         "react-router-dom": "^6.30.3",
         "slugify": "^1.4.7",
         "stringify-object": "^3.3.0",
-        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
+        "styled-components": "^6.4.2",
         "swagger2openapi": "^7.0.8",
         "url-template": "^2.0.8",
         "util": "~0.12.5",
@@ -2639,44 +2639,45 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@redocly/theme": ">=0.65.0-next.0",
+        "@redocly/theme": ">=0.66.0-next.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0"
       }
     },
     "node_modules/@redocly/portal-legacy-ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.16.0.tgz",
-      "integrity": "sha512-yMYXV8b6bYVYE5Y8y3GevAK7PAnxqYxgCtyLoiDSE6wmFqsF2ajBdyt3e2KvMKvJLjMPG23kXjmCgEeOvx6slA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-legacy-ui/-/portal-legacy-ui-0.17.0.tgz",
+      "integrity": "sha512-vq/NnPrYEMXOI6sCIsSqrua8ogejlYOEhAjsxQ5MGawGkvn7/T8CTEkj1F+r+IuNlGSUcMQXaeJIYV8iHN+6cg==",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "highlight-words-core": "^1.2.2",
         "react": "^19.2.4",
         "react-router-dom": "^6.30.3",
-        "styled-components": "^4.1.1 || ^5.3.11",
+        "styled-components": "^4.1.1 || ^5.3.11 || ^6.0.0",
         "styled-system": "^5.1.5"
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.18.0.tgz",
-      "integrity": "sha512-zrsgUyQuCWxhRvpJmEzvOuVcMyTueAu0pg8mpaB9ugCiKnz5+/+/bcaA5JVeXPQ26kWDD0hzP5RVcOq3udG/uw==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.19.0.tgz",
+      "integrity": "sha512-DO6+4jdPWgvzQW5GmhSdMcMJCx/7UHV7FqUBMrkTj2FL+qhsFuugQqK0wJ3gzMPpOt2rUnDIR8oqASqYe/hd4g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@redocly/config": "0.48.1",
-        "@redocly/mock-server": "0.7.0",
-        "@redocly/openapi-docs": "3.21.0"
+        "@redocly/config": "0.49.0",
+        "@redocly/mock-server": "0.8.0",
+        "@redocly/openapi-docs": "3.22.0"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.133.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.133.1.tgz",
-      "integrity": "sha512-uj1o+AT0+uGhYfF9K57cHgNT5WMIeSbSbsuv0xUHse0bX8YWn3p+y9GUdVsfd/3KNHtb2vAEtmjipRAPeT0sfQ==",
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.134.0.tgz",
+      "integrity": "sha512-tKO0ZR+iOaPyyrBoesjL/jRb4zQIfyOyp8R/9jLmxpMY5NPEIoxaiD2bKXWHmXdlqgqgNM5m3Ree3pvvjghRvw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@babel/core": "7.23.5",
+        "@babel/core": "7.29.7",
         "@dr.pogodin/react-helmet": "3.0.2",
+        "@emotion/is-prop-valid": "^1.3.1",
         "@libsql/client": "0.17.3",
         "@markdoc/markdoc": "0.5.2",
         "@opentelemetry/api": "1.9.0",
@@ -2690,16 +2691,16 @@
         "@opentelemetry/sdk-trace-web": "2.6.1",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/asyncapi-docs": "1.10.0",
-        "@redocly/config": "0.48.1",
-        "@redocly/graphql-docs": "1.10.0",
+        "@redocly/asyncapi-docs": "1.11.0",
+        "@redocly/config": "0.49.0",
+        "@redocly/graphql-docs": "1.11.0",
         "@redocly/mcp-typescript-sdk": "1.18.1",
-        "@redocly/openapi-core": "2.30.5",
-        "@redocly/openapi-docs": "3.21.0",
-        "@redocly/portal-legacy-ui": "0.16.0",
-        "@redocly/portal-plugin-mock-server": "0.18.0",
-        "@redocly/realm-asyncapi-sdk": "0.11.1",
-        "@redocly/theme": "0.65.0",
+        "@redocly/openapi-core": "2.31.6",
+        "@redocly/openapi-docs": "3.22.0",
+        "@redocly/portal-legacy-ui": "0.17.0",
+        "@redocly/portal-plugin-mock-server": "0.19.0",
+        "@redocly/realm-asyncapi-sdk": "0.12.0",
+        "@redocly/theme": "0.66.0",
         "@shikijs/transformers": "3.21.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-table": "8.21.3",
@@ -2722,7 +2723,7 @@
         "flexsearch": "0.7.43",
         "graphql": "16.12.0",
         "gray-matter": "4.0.3",
-        "hono": "4.12.18",
+        "hono": "4.12.23",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
@@ -2748,7 +2749,7 @@
         "simple-git": "3.36.0",
         "sitemap": "7.1.1",
         "stream-http": "3.2.0",
-        "styled-components": "5.3.11",
+        "styled-components": "^6.4.2",
         "tty-browserify": "0.0.1",
         "typesense": "2.1.0",
         "ulid": "^2.3.0",
@@ -2773,21 +2774,24 @@
       }
     },
     "node_modules/@redocly/realm-asyncapi-sdk": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.11.1.tgz",
-      "integrity": "sha512-PpTAZP4WpyKRN0p8OVKBiOKNTeDVkkCx1PkGOsFmBb9Ogxka8t3Ymxfxp7pWKeXhcss80zPJjKZBk7zdSrD2OQ==",
-      "license": "SEE LICENSE IN LICENSE"
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@redocly/realm-asyncapi-sdk/-/realm-asyncapi-sdk-0.12.0.tgz",
+      "integrity": "sha512-JQiSi3lPYsGLJ5EXd1gEo/2XkCnXN/JWnST9ZKKJwLSu4tmHynFb8P3P5HfJXUS3zLox5N3uqms9YgrarYv5fA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "safe-stable-stringify": "2.5.0"
+      }
     },
     "node_modules/@redocly/redoc-opentelemetry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@redocly/redoc-opentelemetry/-/redoc-opentelemetry-0.1.0.tgz",
-      "integrity": "sha512-S1glrpuxEBBz31nJ/t/uEyMBRRT2KPesdFH8IMKBoDa/r5hrN67QoHBP6M4EW8hZJrQoSP6ppZUbag1FfueLrA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redocly/redoc-opentelemetry/-/redoc-opentelemetry-0.2.0.tgz",
+      "integrity": "sha512-ngyCr0yqq7H3STwRDAWWYQgDXe/6oc6rVyCkAdiBMuVn+ZlUUgThmLYAm+Jx+Rqair716oKp+2sB6lz6miK11g==",
       "license": "MIT"
     },
     "node_modules/@redocly/replay": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.24.0.tgz",
-      "integrity": "sha512-FWJUbHWKoNdU61co6Q4nH9S2X7qU6R/NOgfvHC0TjGSMfy4eQ4g/SpwD4iwck3UFOyAkPkFOopaDpx/+tAPiQQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.25.0.tgz",
+      "integrity": "sha512-EiTgOkRjkW9fF48xabE/07+dFExz/EV6/3wE4LOsKJzPBmt19qPsfMZnEPCRCpucxAxXhzXMEMZnvxo8VUwZSA==",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.1",
         "@ai-sdk/google": "3.0.1",
@@ -2814,10 +2818,10 @@
         "@lezer/highlight": "^1.1.6",
         "@noble/hashes": "^1.8.0",
         "@opentelemetry/api": "1.9.0",
-        "@redocly/hookstate-core": "4.2.3",
-        "@redocly/hookstate-devtools": "^4.2.0",
-        "@redocly/openapi-core": "2.30.5",
-        "@redocly/respect-core": "2.30.5",
+        "@redocly/hookstate-core": "^4.2.4",
+        "@redocly/hookstate-devtools": "^4.2.1",
+        "@redocly/openapi-core": "2.31.6",
+        "@redocly/respect-core": "2.31.6",
         "@redocly/vscode-json-languageservice": "^3.4.9",
         "@tauri-apps/api": "2.4.1",
         "@tauri-apps/plugin-dialog": "2.0.0-rc.1",
@@ -2843,27 +2847,28 @@
         "shellwords": "^1.1.1",
         "ulid": "^2.3.0",
         "usehooks-ts": "^3.1.1",
+        "yaml": "^2.0.0",
         "zod": "^3.25.76"
       },
       "peerDependencies": {
-        "@redocly/theme": "0.65.0",
+        "@redocly/theme": "0.66.0",
         "@tanstack/react-query": "5.62.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.3",
-        "styled-components": "^5.3.11"
+        "styled-components": "^6.4.2"
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.30.5",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.30.5.tgz",
-      "integrity": "sha512-8rmMr5/8CCIFU5fghxSQ+SZC+W4ewM15w4U+ZH36MVSjdROLrwiPjC+lfe6VxdaJunbmRACzent2HTLLgw4+BQ==",
+      "version": "2.31.6",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.31.6.tgz",
+      "integrity": "sha512-xLsbP+jRVTaYKMnx44nx4p9UqVGjZGqyq6bsYlQQWeLem83OrU4EPE7vKKIdWTuwtQkEQ1ousEuenW7lqeqFnA==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.1",
-        "@redocly/openapi-core": "2.30.5",
+        "@redocly/openapi-core": "2.31.6",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "better-ajv-errors": "^2.0.3",
         "colorette": "^2.0.20",
@@ -2907,12 +2912,14 @@
       }
     },
     "node_modules/@redocly/theme": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.65.0.tgz",
-      "integrity": "sha512-G/5L33gFAG8v85lx8cbT0uplhCS4idvfEgOuhEPx/HEZiWu50tuoN1KtWVYinVQDzm0fNdapFPk+MsY4xqV44w==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.66.0.tgz",
+      "integrity": "sha512-0UYQYpG/HZLXKZiJPbOlyVavrQGUUac3Ke5Dx+gl2KRpW96tJKFOcX+cAmjw4F7mq+WMyF+GL0trlOXFrcgnKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@redocly/config": "0.48.1",
+        "@emotion/is-prop-valid": "^1.3.1",
+        "@redocly/config": "0.49.0",
         "@tanstack/react-query": "5.62.3",
         "@tanstack/react-virtual": "3.13.0",
         "@xyflow/react": "^12.8.2",
@@ -2955,6 +2962,19 @@
         "vscode-languageserver-textdocument": "^1.0.0-next.4",
         "vscode-languageserver-types": "^3.15.0-next.6",
         "vscode-uri": "^2.1.1"
+      }
+    },
+    "node_modules/@redux-devtools/extension": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.3.0.tgz",
+      "integrity": "sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "immutable": "^4.3.4"
+      },
+      "peerDependencies": {
+        "redux": "^3.1.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3105,7 +3125,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
       "integrity": "sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3115,7 +3134,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.1.5.tgz",
       "integrity": "sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3125,7 +3143,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.1.2.tgz",
       "integrity": "sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3135,7 +3152,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.1.2.tgz",
       "integrity": "sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1"
       }
@@ -3144,15 +3160,13 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
       "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@styled-system/flexbox": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.1.2.tgz",
       "integrity": "sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3162,7 +3176,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.1.2.tgz",
       "integrity": "sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3172,7 +3185,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.1.2.tgz",
       "integrity": "sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3182,7 +3194,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.1.2.tgz",
       "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3192,7 +3203,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.1.2.tgz",
       "integrity": "sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3202,7 +3212,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
       "integrity": "sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3212,7 +3221,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.1.2.tgz",
       "integrity": "sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2"
       }
@@ -3222,7 +3230,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.5.tgz",
       "integrity": "sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@styled-system/core": "^5.1.2",
         "@styled-system/css": "^5.1.5"
@@ -3243,6 +3250,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.3.tgz",
       "integrity": "sha512-y2zDNKuhgiuMgsKkqd4AcsLIBiCfEO8U11AdrtAUihmLbRNztPrlcZqx2lH1GacZsx+y1qRRbCcJLYTtF1vKsw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.62.3"
       },
@@ -3488,6 +3496,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3745,24 +3754,34 @@
       }
     },
     "node_modules/@xyflow/react": {
-      "version": "12.10.2",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
-      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
       "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.76",
+        "@xyflow/system": "0.0.77",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
       "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
         "react": ">=17",
         "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.76",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
-      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -3781,6 +3800,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3874,6 +3894,7 @@
       "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3953,6 +3974,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -4040,9 +4073,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4156,6 +4189,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4257,9 +4291,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4494,6 +4528,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4530,7 +4573,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -4589,6 +4633,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4999,9 +5044,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.364",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
-      "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+      "version": "1.5.370",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz",
+      "integrity": "sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5556,6 +5601,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -5716,9 +5762,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5847,6 +5893,12 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -6073,6 +6125,7 @@
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.0.tgz",
       "integrity": "sha512-b5GAqgmXmXzB4WPaTH26ppk9Sl7AA9WSQX7yfdM+gJ1rFROiWcVbi97gFuN/yVCojOcbcvop2sfLL+fjxW0JVg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -6744,9 +6797,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6790,6 +6843,15 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/oas-linter/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
@@ -6807,6 +6869,15 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/oas-schema-walker": {
@@ -6835,6 +6906,15 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-assign": {
@@ -7207,17 +7287,12 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-util/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
     "node_modules/react": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7396,6 +7471,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7447,11 +7523,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "license": "MIT",
-      "peer": true
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-resizable-panels": {
       "version": "3.0.6",
@@ -7483,6 +7558,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
       "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.3",
         "react-router": "6.30.4"
@@ -7640,18 +7716,9 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
-      }
-    },
-    "node_modules/redux-devtools-extension": {
-      "version": "2.13.9",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
-      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
-      "deprecated": "Package moved to @redux-devtools/extension.",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^3.1.0 || ^4.0.0"
       }
     },
     "node_modules/reftools": {
@@ -7819,6 +7886,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7915,12 +7991,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
     },
     "node_modules/shellwords": {
       "version": "1.1.1",
@@ -8194,16 +8264,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -8212,61 +8285,47 @@
       "license": "MIT"
     },
     "node_modules/styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
+      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 16"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
+        "react-native": ">= 0.68.0"
       },
-      "engines": {
-        "node": ">=4"
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
@@ -8365,6 +8424,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/swr": {
@@ -8797,9 +8865,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
@@ -8855,9 +8923,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -9021,12 +9089,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yaml-ast-parser": {
@@ -9076,6 +9150,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9084,7 +9159,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zustand": {
       "version": "4.5.7",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.133.1",
+    "@redocly/realm": "0.134.0",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",


### PR DESCRIPTION
Bumping to 0.134.0. I spot checked a handful of pages, including:

- [x] Language Picker
- [x] Light/Dark Mode
- [x] Websocket Tool
- [x] Interactive Tutorials

I also noticed the [Source] code link formatting is now fixed.