### PR TITLE
Update Partial Payments Readme

### DIFF
--- a/_code-samples/partial-payment/README.md
+++ b/_code-samples/partial-payment/README.md
@@ -1,12 +1,5 @@
 # Send Partial Payments
 
-Send partial payments with money amount less than the amount specified on 2 conditions:
+Send a partial payment, which delivers less than the amount specified. Partial payments are useful for deducting fees and exchange rates from the amount delivered instead of adding them to the amount sent, but they can also lead to exploits if an integration incorrectly assumes a successful payment delivered the whole amount.
 
-- Sender has less money than the aamount specified in the payment Tx.
-- Sender has the tfPartialPayment flag activated.
-
-Other ways to specify flags are by using Hex code and decimal code.
-eg. For partial payment(tfPartialPayment)
-decimal ->131072, hex -> 0x00020000
-
-For more context, see [Partial Payments](https://xrpl.org/partial-payments.html)
+For more context, see [Partial Payments](https://xrpl.org/docs/concepts/payment-types/partial-payments)


### PR DESCRIPTION
The Code Samples page cuts off the introduction after the first paragraph, which leaves a hanging colon. Additionally, the original description is not quite accurate since a partial payment can deliver less in other conditions (like high exchange rates).

| Before | After |
|---|---|
| <img width="534" height="478" alt="Sceenshot showing cut-off description in code sample card" src="https://github.com/user-attachments/assets/71cdc612-4891-4721-975b-5e4b6459c095" /> | <img width="520" height="470" alt="Screenshot of same card with lengthier description" src="https://github.com/user-attachments/assets/6c3110b4-7c90-48e1-a83a-86c8c1b9238d" /> |
