### PR TITLE
Add plain linking

### DIFF
--- a/@theme/components/SourceLink.tsx
+++ b/@theme/components/SourceLink.tsx
@@ -1,4 +1,7 @@
-// Create a link to xrpld source code. Release branch is defined in .env
+// Create a link to xrpld source code.
+// URL built from base repo + PUBLIC_XRPLD_RELEASE in .env + given path.
+// - Default (no `name`): a [Source] link with `source-link` class styling.
+// - With `name`: same URL, but `name` link text and no class styling.
 
 import type { Node } from '@markdoc/markdoc'
 import { Link } from '@redocly/theme/components/Link/Link'
@@ -11,18 +14,26 @@ function buildSourceHref(path: string, release: string): string {
   return `${XRPLD_REPO}/${treeblob}/${release}/${cleanPath}`
 }
 
-// sourceLinkForLlms for LLM .md export
-// SourceLink for rendered page link
+// Markdown link output for LLM export.
 export function sourceLinkForLlms(node: Node): string {
   const release = process.env.PUBLIC_XRPLD_RELEASE || ''
-  return `[Source](${buildSourceHref(node.attributes.path, release)})`
+  const href = buildSourceHref(node.attributes.path, release)
+  const { name } = node.attributes
+  return name ? `[${name}](${href})` : `[Source](${href})`
 }
 
 export default function SourceLink(props: {
   path: string
   xrpld_release: string
+  name?: string
 }) {
   const href = buildSourceHref(props.path, props.xrpld_release)
 
+  // Custom link text, no source-link styling.
+  if (props.name) {
+    return <Link to={href}>{props.name}</Link>
+  }
+
+  // [Source] link with right-aligned styling.
   return <Link to={href} className="source-link">[Source]</Link>
 }

--- a/@theme/markdoc/schema.ts
+++ b/@theme/markdoc/schema.ts
@@ -42,6 +42,10 @@ export const sourceLink: MarkdocTagSchema & { tagName: string } = {
         type: 'String',
         required: true,
       },
+      name: {
+        type: 'String',
+        required: false,
+      },
     },
     transform(node, config) {
         const attributes = node.transformAttributes(config);

--- a/resources/contribute-documentation/markdoc-tags.md
+++ b/resources/contribute-documentation/markdoc-tags.md
@@ -212,18 +212,27 @@ Demonstration:
 
 ### Source Link
 
-Link to an `xrpld` source code file. The link is built using a `path` parameter and `PUBLIC_XRPLD_RELEASE` variable in this repository's `.env` file.
+Link to an `xrpld` source code file. The link is built using a `path` parameter and `PUBLIC_XRPLD_RELEASE` variable in this repository's `.env` file. If an optional `name` parameter is provided, the link is styled differently.
 
-Example usage:
+Example usage _without_ `name`:
 
 <pre><code>
 {% source-link path="src/xrpld/app/tx/detail/DeleteAccount.cpp" /%}
 </code></pre>
 
-
-Demonstration: 
+Demonstration:
 
 {% source-link path="src/xrpld/app/tx/detail/DeleteAccount.cpp" /%}
+
+Example usage _with_ `name`:
+
+<pre><code>
+{% source-link name="AccountDelete" path="src/xrpld/app/tx/detail/DeleteAccount.cpp" /%}
+</code></pre>
+
+Demonstration:
+
+This is a plain link to the {% source-link name="AccountDelete" path="src/xrpld/app/tx/detail/DeleteAccount.cpp" /%} source code.
 
 
 ### Try It


### PR DESCRIPTION
This PR adds to the `source-link` component. Now, if you provide an optional `name` parameter, it renders as a clickable `name` link without special formatting. All other functionality remains the same (mainly the LLM .md export).