### PR TITLE
Migration guide v2

### DIFF
--- a/docs/infrastructure/installation/migrate-to-xrpld.md
+++ b/docs/infrastructure/installation/migrate-to-xrpld.md
@@ -33,16 +33,74 @@ These steps assume a typical Debian/Ubuntu `rippled` install with:
 
 Run these steps on each host you are migrating and adjust the paths to match your environment.
 
-### 1. Stop and remove rippled
+### 1. Back up, then stop and remove rippled
 
-Back up your config and data files (for example, `wallet.db`). Then stop the service and remove the package:
+{% admonition type="warning" name="Back up first - or risk losing your config and data" %}
+The next step removes the `rippled` package. While `apt-get remove` is *designed* to leave your config and data in place, a single slip - `purge` instead of `remove`, a wrong path, a failed disk, or an interrupted migration - can permanently destroy your configuration, your node identity, and your validator keys, with no way to recover them. Copy the files below to a location **off this host** before you run anything in this step.
+{% /admonition %}
+
+Back up the following files. In a default install they live here:
+
+**Configuration and identity** (cannot be regenerated - losing these loses your settings and, for validators, your on-ledger identity):
+
+- `/opt/ripple/etc/rippled.cfg` - main server config, including your `[validator_token]` on validators.
+- `/opt/ripple/etc/validators.txt` - your trusted validator list (UNL). Skip if your `[validators]` section lives inside `rippled.cfg`.
+- `/var/lib/rippled/db/wallet.db` - your node's persistent identity (node keypair) and peer reservations.
+- `validator-keys.json` (validators only) - your validator master keys, stored wherever you generated them with `validator-keys-tool` (often kept offline). Without this file you can never renew or rotate your validator token.
+
+**Ledger data** (large, but re-syncable from the network - back up only to skip a long re-sync):
+
+- `/var/lib/rippled/db/nudb/` - the NuDB node store, the bulk of your ledger data.
+- `/var/lib/rippled/db/*.db` - the SQLite databases, such as `transaction.db` and `ledger.db`.
+- `/var/lib/rippled/db/` - the whole data directory covers all of the above in one step.
+
+**Logs** (optional):
+
+- `/var/log/rippled/debug.log`
+
+{% admonition type="info" name="Find your own paths" %}
+The locations above are the defaults. Your real paths are whatever `[database_path]`, `[node_db]`, and `[debug_logfile]` point to in your `rippled.cfg`. If you customized them, back up those locations instead.
+{% /admonition %}
+
+Copy the config and identity files into a backup directory:
+
+```sh
+sudo mkdir -p /root/rippled-backup
+sudo cp /opt/ripple/etc/rippled.cfg     /root/rippled-backup/
+sudo cp /opt/ripple/etc/validators.txt  /root/rippled-backup/   # if present
+sudo cp /var/lib/rippled/db/wallet.db   /root/rippled-backup/
+```
+
+Then copy that directory **off the host**, so a disk failure or a botched migration can't take your backup down with it. For example, pull it to your own machine over SSH:
+
+```sh
+# Replace user@your-node with your SSH login and host
+scp -r user@your-node:/root/rippled-backup ./rippled-backup
+```
+
+{% admonition type="info" name="Optional: full-history and large-history nodes" %}
+This is optional. In Step 5 you keep your existing data by moving the directory into the new location, so the ledger store is preserved in place - not re-downloaded - and a separate snapshot usually isn't needed.
+
+That said, moving data directories is the riskiest part of the migration. If you have the disk space and any doubt, take a snapshot first as a safety net - it's cheap insurance. Stop the node so the copy is consistent:
+
+```sh
+sudo systemctl stop rippled
+sudo tar -czf /root/rippled-data-$(hostname).tar.gz -C /var/lib rippled
+```
+
+Validators and small-history nodes (a day or so) can skip this either way - they re-sync from the network in minutes.
+{% /admonition %}
+
+Once your backups are safely off the host, stop the service and remove the package:
 
 ```sh
 sudo systemctl stop rippled
 sudo apt-get remove -y rippled
 ```
 
-{% admonition type="info" name="Note" %}`apt-get remove` leaves the config files and your data directory in place.{% /admonition %}
+{% admonition type="info" name="Note" %}
+`apt-get remove` leaves the config files and your data directory in place. (By contrast, `apt-get purge` would delete the config - which is exactly why you back up first.)
+{% /admonition %}
 
 ### 2. Install xrpld
 
@@ -60,31 +118,45 @@ sudo yum install xrpld
 
 This installs the `xrpld` binary at `/usr/bin/xrpld`, creates the `xrpld` user and group, and installs a default mainnet config at `/etc/xrpld/xrpld.cfg`. The `xrpld` service starts automatically.
 
-### 3. Migrate the binary config
-
-Your existing `rippled.cfg` already contains your tuning, validators, and peers. Copy it to the new location:
+Stop it before going further. The auto-started service is running on the default config and syncing into a fresh `/var/lib/xrpld/`. Stop it so nothing is writing to those directories while you restore your config and move your data into place:
 
 ```sh
-sudo cp /opt/ripple/etc/rippled.cfg /etc/xrpld/xrpld.cfg
+sudo systemctl stop xrpld
 ```
+
+### 3. Migrate the binary config
+
+Restore the config you backed up in Step 1 - it already holds your tuning, validators, and peers - into the new `xrpld` location:
+
+```sh
+sudo cp /root/rippled-backup/rippled.cfg /etc/xrpld/xrpld.cfg
+```
+
+{% admonition type="info" name="Note" %}
+Because `apt-get remove` leaves the original in place, `sudo cp /opt/ripple/etc/rippled.cfg /etc/xrpld/xrpld.cfg` also works. Restoring from `/root/rippled-backup` just keeps the migration self-contained and independent of the old files surviving.
+{% /admonition %}
 
 ### 4. Migrate the validators config
 
-If you keep a separate `validators.txt`, replace the package-shipped copy with yours:
+If you keep a separate `validators.txt`, restore it from your backup over the package-shipped copy:
 
 ```sh
-sudo cp /opt/ripple/etc/validators.txt /etc/xrpld/validators.txt
+sudo cp /root/rippled-backup/validators.txt /etc/xrpld/validators.txt
 ```
 
-{% admonition type="info" name="Note" %}Some operators do not have a separate `validators.txt` file and instead have the `[validators]` and `[validator_xxx]` sections embedded within the `xrpld.cfg` file. In that case, delete the generic config file instead.{% /admonition %}
+{% admonition type="info" name="Note" %}
+Some operators do not have a separate `validators.txt` file and instead keep the `[validators]` and `[validator_xxx]` sections embedded within `xrpld.cfg`. In that case, delete the generic config file instead.
+{% /admonition %}
 
 ### 5. Migrate the data directories
 
-Follow the scenario that matches your setup.
+Two scenarios, depending on whether you need to keep your ledger data. Pick the one that matches your node.
 
-#### Connect to the XRPL only
+#### Re-sync from the network (validators and small-history nodes)
 
-Update the following paths in `/etc/xrpld/xrpld.cfg`. These are the same values that appear in the default config.
+For validators and nodes that keep only a small window of history (a day or so). Re-syncing from peers takes only minutes, so there's no need to carry the old data across - just point `xrpld` at the new default paths and let it rebuild.
+
+Set the following paths in `/etc/xrpld/xrpld.cfg` (these match the default config):
 
 ```
 [node_db]
@@ -102,17 +174,27 @@ path=/var/lib/xrpld/db/nudb
 /var/log/xrpld/debug.log
 ```
 
-#### Keep your existing data
+#### Keep your existing data (full-history and large-history nodes)
 
-If your data is stored in `/var/lib/rippled/` and your logs in `/var/log/rippled/`, apply the path updates above. Once complete, move the directories to `/var/lib/xrpld/` and `/var/log/xrpld/`, respectively:
+For full-history and large-history nodes, where re-downloading the ledger store from peers would take hours or days. You preserve what's already on disk instead of rebuilding it.
+
+If your data is stored in `/var/lib/rippled/` and your logs in `/var/log/rippled/`, apply the path updates above. The new install already created empty `/var/lib/xrpld/` and `/var/log/xrpld/` directories. Rather than deleting them, move them aside so the names are free, then move your existing directories into their place:
 
 ```sh
+# Park the empty default dirs - nothing is destroyed, fully reversible
+sudo mv /var/lib/xrpld /var/lib/xrpld.default
+sudo mv /var/log/xrpld /var/log/xrpld.default
+
 sudo mv /var/lib/rippled /var/lib/xrpld
 sudo chown -R xrpld:xrpld /var/lib/xrpld
 
 sudo mv /var/log/rippled /var/log/xrpld
 sudo chown -R xrpld:xrpld /var/log/xrpld
 ```
+
+{% admonition type="info" name="Nothing is deleted here" %}
+The `.default` directories hold the fresh, empty directories - not your data - so this is fully reversible. Once the server is verified healthy in Step 7, you can remove them with `sudo rm -rf /var/lib/xrpld.default /var/log/xrpld.default`.
+{% /admonition %}
 
 If your data or logs are in a non-default location, you only need to update ownership:
 
@@ -121,11 +203,13 @@ sudo chown -R xrpld:xrpld [path to your data directory]
 sudo chown -R xrpld:xrpld [path to your log directory]
 ```
 
-### 6. Start xrpld
+### 6. Restart xrpld
+
+You stopped `xrpld` in Step 2 to migrate safely. Bring it up now so it loads your migrated config and the new data and log paths. `restart` is the safe command to use - it starts the service whether it is currently stopped or already running:
 
 ```sh
 sudo systemctl daemon-reload
-sudo systemctl start --now xrpld
+sudo systemctl restart xrpld
 ```
 
 ### 7. Verify the server

--- a/docs/infrastructure/installation/migrate-to-xrpld.md
+++ b/docs/infrastructure/installation/migrate-to-xrpld.md
@@ -33,10 +33,10 @@ These steps assume a typical Debian/Ubuntu `rippled` install with:
 
 Run these steps on each host you are migrating and adjust the paths to match your environment.
 
-### 1. Back up, then stop and remove rippled
+### 1. Back up
 
 {% admonition type="warning" name="Back up first - or risk losing your config and data" %}
-The next step removes the `rippled` package. While `apt-get remove` is *designed* to leave your config and data in place, a single slip - `purge` instead of `remove`, a wrong path, a failed disk, or an interrupted migration - can permanently destroy your configuration, your node identity, and your validator keys, with no way to recover them. Copy the files below to a location **off this host** before you run anything in this step.
+`apt-get remove` is *designed* to leave your config and data in place, but one wrong flag or path - `purge` instead of `remove`, a failed disk, an interrupted run - can irreversibly destroy your config, node identity, and validator keys. Copy the files below to a location **off this host** before you continue.
 {% /admonition %}
 
 Back up the following files. In a default install they live here:
@@ -71,7 +71,7 @@ sudo cp /opt/ripple/etc/validators.txt  /root/rippled-backup/   # if present
 sudo cp /var/lib/rippled/db/wallet.db   /root/rippled-backup/
 ```
 
-Then copy that directory **off the host**, so a disk failure or a botched migration can't take your backup down with it. For example, pull it to your own machine over SSH:
+Then copy that directory **off the host**, so a disk failure or a failed migration does not also destroy your backup. For example, pull it to your own machine over SSH:
 
 ```sh
 # Replace user@your-node with your SSH login and host
@@ -79,9 +79,9 @@ scp -r user@your-node:/root/rippled-backup ./rippled-backup
 ```
 
 {% admonition type="info" name="Optional: full-history and large-history nodes" %}
-This is optional. In Step 5 you keep your existing data by moving the directory into the new location, so the ledger store is preserved in place - not re-downloaded - and a separate snapshot usually isn't needed.
+This is optional. In Step 6, full-history nodes keep their existing data in place, so the ledger store is preserved - not re-downloaded - and a separate snapshot usually isn't needed.
 
-That said, moving data directories is the riskiest part of the migration. If you have the disk space and any doubt, take a snapshot first as a safety net - it's cheap insurance. Stop the node so the copy is consistent:
+Still, if you have the disk space and any doubt, take a snapshot first as a safety net. Stop the node so the copy is consistent:
 
 ```sh
 sudo systemctl stop rippled
@@ -91,6 +91,8 @@ sudo tar -czf /root/rippled-data-$(hostname).tar.gz -C /var/lib rippled
 Validators and small-history nodes (a day or so) can skip this either way - they re-sync from the network in minutes.
 {% /admonition %}
 
+### 2. Stop and remove rippled
+
 Once your backups are safely off the host, stop the service and remove the package:
 
 ```sh
@@ -98,11 +100,11 @@ sudo systemctl stop rippled
 sudo apt-get remove -y rippled
 ```
 
-{% admonition type="info" name="Note" %}
-`apt-get remove` leaves the config files and your data directory in place. (By contrast, `apt-get purge` would delete the config - which is exactly why you back up first.)
+{% admonition type="info" name="remove keeps your config" %}
+`apt-get remove` leaves your config and data in place. `apt-get purge` would delete the config, which is why you back up first.
 {% /admonition %}
 
-### 2. Install xrpld
+### 3. Install xrpld
 
 For Debian-based distros, run:
 
@@ -118,25 +120,25 @@ sudo yum install xrpld
 
 This installs the `xrpld` binary at `/usr/bin/xrpld`, creates the `xrpld` user and group, and installs a default mainnet config at `/etc/xrpld/xrpld.cfg`. The `xrpld` service starts automatically.
 
-Stop it before going further. The auto-started service is running on the default config and syncing into a fresh `/var/lib/xrpld/`. Stop it so nothing is writing to those directories while you restore your config and move your data into place:
+**Important: stop the auto-started service before continuing.** It is running on the default config and writing into a fresh `/var/lib/xrpld/`. Stop it so nothing changes those directories while you restore your config:
 
 ```sh
 sudo systemctl stop xrpld
 ```
 
-### 3. Migrate the binary config
+### 4. Migrate the binary config
 
-Restore the config you backed up in Step 1 - it already holds your tuning, validators, and peers - into the new `xrpld` location:
+Restore the config you backed up in Step 1 into the new `xrpld` location. It already holds your tuning, validators, and peers:
 
 ```sh
 sudo cp /root/rippled-backup/rippled.cfg /etc/xrpld/xrpld.cfg
 ```
 
-{% admonition type="info" name="Note" %}
-Because `apt-get remove` leaves the original in place, `sudo cp /opt/ripple/etc/rippled.cfg /etc/xrpld/xrpld.cfg` also works. Restoring from `/root/rippled-backup` just keeps the migration self-contained and independent of the old files surviving.
+{% admonition type="info" name="The original also works" %}
+Because `apt-get remove` leaves the original in place, `sudo cp /opt/ripple/etc/rippled.cfg /etc/xrpld/xrpld.cfg` also works. Restoring from `/root/rippled-backup` keeps the migration self-contained and independent of the old files surviving.
 {% /admonition %}
 
-### 4. Migrate the validators config
+### 5. Migrate the validators config
 
 If you keep a separate `validators.txt`, restore it from your backup over the package-shipped copy:
 
@@ -144,19 +146,23 @@ If you keep a separate `validators.txt`, restore it from your backup over the pa
 sudo cp /root/rippled-backup/validators.txt /etc/xrpld/validators.txt
 ```
 
-{% admonition type="info" name="Note" %}
-Some operators do not have a separate `validators.txt` file and instead keep the `[validators]` and `[validator_xxx]` sections embedded within `xrpld.cfg`. In that case, delete the generic config file instead.
+{% admonition type="info" name="No separate validators.txt?" %}
+Some operators keep the `[validators]` and `[validator_token]` sections inside `xrpld.cfg` instead of a separate file. In that case there is nothing to restore here - remove the package-shipped list so it cannot override your embedded section:
+
+```sh
+sudo rm /etc/xrpld/validators.txt
+```
 {% /admonition %}
 
-### 5. Migrate the data directories
+### 6. Migrate the data directories
 
-Two scenarios, depending on whether you need to keep your ledger data. Pick the one that matches your node.
+There are two scenarios, depending on whether you need to keep your ledger data. Pick the one that matches your node.
 
-#### Re-sync from the network (validators and small-history nodes)
+#### Re-sync small-history nodes and validators from the network
 
-For validators and nodes that keep only a small window of history (a day or so). Re-syncing from peers takes only minutes, so there's no need to carry the old data across - just point `xrpld` at the new default paths and let it rebuild.
+For validators and nodes that keep only a small window of history (a day or so). Re-syncing from peers takes only minutes, so there is no need to carry the old data across - point `xrpld` at the new default paths so it rebuilds from the network.
 
-Set the following paths in `/etc/xrpld/xrpld.cfg` (these match the default config):
+Set these paths in `/etc/xrpld/xrpld.cfg` (they match the default config):
 
 ```
 [node_db]
@@ -174,45 +180,31 @@ path=/var/lib/xrpld/db/nudb
 /var/log/xrpld/debug.log
 ```
 
-#### Keep your existing data (full-history and large-history nodes)
+#### Keep existing data on full-history nodes
 
-For full-history and large-history nodes, where re-downloading the ledger store from peers would take hours or days. You preserve what's already on disk instead of rebuilding it.
-
-If your data is stored in `/var/lib/rippled/` and your logs in `/var/log/rippled/`, apply the path updates above. The new install already created empty `/var/lib/xrpld/` and `/var/log/xrpld/` directories. Rather than deleting them, move them aside so the names are free, then move your existing directories into their place:
+For full-history and large-history nodes, where re-downloading the ledger store from peers would take hours or days. The simplest and safest option is to leave your data where it is and hand ownership to the new `xrpld` user. The config you restored in Step 4 already points at `/var/lib/rippled` and `/var/log/rippled`, so no paths need to change:
 
 ```sh
-# Park the empty default dirs - nothing is destroyed, fully reversible
-sudo mv /var/lib/xrpld /var/lib/xrpld.default
-sudo mv /var/log/xrpld /var/log/xrpld.default
-
-sudo mv /var/lib/rippled /var/lib/xrpld
-sudo chown -R xrpld:xrpld /var/lib/xrpld
-
-sudo mv /var/log/rippled /var/log/xrpld
-sudo chown -R xrpld:xrpld /var/log/xrpld
+sudo chown -R xrpld:xrpld /var/lib/rippled
+sudo chown -R xrpld:xrpld /var/log/rippled
 ```
 
-{% admonition type="info" name="Nothing is deleted here" %}
-The `.default` directories hold the fresh, empty directories - not your data - so this is fully reversible. Once the server is verified healthy in Step 7, you can remove them with `sudo rm -rf /var/lib/xrpld.default /var/log/xrpld.default`.
+`xrpld` reads your existing data in place. The empty `/var/lib/xrpld/` the install created stays unused, and you can remove it whenever you like.
+
+{% admonition type="info" name="Prefer the /var/lib/xrpld naming?" %}
+Moving the data under the new path is optional and cosmetic - the service runs fine either way. If you do move it, update `[node_db]`, `[database_path]`, and `[debug_logfile]` in `/etc/xrpld/xrpld.cfg` to the `/var/lib/xrpld` values shown above, so the config matches where the data now lives. A config that points at the old path after the data has moved is the most common way to break the node on restart.
 {% /admonition %}
 
-If your data or logs are in a non-default location, you only need to update ownership:
+### 7. Restart xrpld
 
-```sh
-sudo chown -R xrpld:xrpld [path to your data directory]
-sudo chown -R xrpld:xrpld [path to your log directory]
-```
-
-### 6. Restart xrpld
-
-You stopped `xrpld` in Step 2 to migrate safely. Bring it up now so it loads your migrated config and the new data and log paths. `restart` is the safe command to use - it starts the service whether it is currently stopped or already running:
+You stopped `xrpld` in Step 3 to migrate safely. Bring it up now so it loads your restored config and reads your data with the right ownership:
 
 ```sh
 sudo systemctl daemon-reload
 sudo systemctl restart xrpld
 ```
 
-### 7. Verify the server
+### 8. Verify the server
 
 Query `server_info` on your server's admin port to check sync status. The port is `5005` by default; if yours differs, check `[port_rpc_admin_local]` in `/etc/xrpld/xrpld.cfg`. A re-sync usually completes within 20 minutes, depending on how long the service was stopped and your database size.
 


### PR DESCRIPTION
Updates the rippled → xrpld migration guide to make the backup and data steps safer and easier to follow. Same page format as before (admonitions, badge, links).

## What changed

**Step 1 - Back up first**
- Adds a clear checklist of which files to back up and where they live, grouped by how important they are: config and keys (can't be recovered), ledger data (can be re-synced), and logs (optional).
- Adds a warning to back up before removing the package, with commands to copy the important files and move them off the server.
- Makes the full ledger backup (`tar`) optional, since Step 5 keeps your data in place anyway - only worth doing if you're unsure.

**Step 2 - Install xrpld**
- Stops the service after install, so nothing is running while you migrate.

**Steps 3-4 - Restore config**
- Restores your config and validators file from the backup you made in Step 1.

**Step 5 - Move your data**
- Splits the two options by who they're for: re-sync from scratch (validators and small nodes), or keep your data (full and large-history nodes).
- Removes the risky delete step and uses a safe move instead - the default folders are renamed, not deleted, so it can be undone.

**Step 6 - Restart xrpld**
- Uses `restart` instead of `start`, so the service actually picks up your new config.

Nothing was removed from the Post-Migration or See Also sections.

copy created via my friend claude