### PR TITLE
Add RHEL commands and clarify full-history re-sync time

### DIFF
--- a/docs/infrastructure/installation/migrate-to-xrpld.md
+++ b/docs/infrastructure/installation/migrate-to-xrpld.md
@@ -119,8 +119,8 @@ For RHEL-based distros:
 sudo yum remove -y rippled
 ```
 
-{% admonition type="info" name="remove keeps your config" %}
-`apt-get remove` (and `yum remove`) leaves your config and data in place. `apt-get purge` would delete the config, which is why you back up first.
+{% admonition type="info" name="rely on your backup, not on remove" %}
+On Debian-based distros, `apt-get remove` leaves your config and data in place (only `apt-get purge` deletes the config). Other package managers, including `yum`/`dnf`, may handle config and data differently, so don't count on removal to preserve them - the backup you took above is what guarantees you can restore your config, node identity, and keys.
 {% /admonition %}
 
 ### 3. Install xrpld

--- a/docs/infrastructure/installation/migrate-to-xrpld.md
+++ b/docs/infrastructure/installation/migrate-to-xrpld.md
@@ -23,6 +23,14 @@ Before you migrate:
     sudo apt-get upgrade
     ```
 
+    On RHEL-based systems, run:
+
+    ```sh
+    sudo yum update
+    ```
+
+    On RHEL 8 and 9, `dnf` and `yum` are interchangeable - use whichever you prefer.
+
 
 ## Migration Steps
 
@@ -93,15 +101,26 @@ Validators and small-history nodes (a day or so) can skip this either way - they
 
 ### 2. Stop and remove rippled
 
-Once your backups are safely off the host, stop the service and remove the package:
+Once your backups are safely off the host, stop the service:
 
 ```sh
 sudo systemctl stop rippled
+```
+
+Then remove the package. For Debian-based distros:
+
+```sh
 sudo apt-get remove -y rippled
 ```
 
+For RHEL-based distros:
+
+```sh
+sudo yum remove -y rippled
+```
+
 {% admonition type="info" name="remove keeps your config" %}
-`apt-get remove` leaves your config and data in place. `apt-get purge` would delete the config, which is why you back up first.
+`apt-get remove` (and `yum remove`) leaves your config and data in place. `apt-get purge` would delete the config, which is why you back up first.
 {% /admonition %}
 
 ### 3. Install xrpld
@@ -115,7 +134,7 @@ sudo apt-get install -y xrpld
 For RHEL-based distros, run:
 
 ```sh
-sudo yum install xrpld
+sudo yum install -y xrpld
 ```
 
 This installs the `xrpld` binary at `/usr/bin/xrpld`, creates the `xrpld` user and group, and installs a default mainnet config at `/etc/xrpld/xrpld.cfg`. The `xrpld` service starts automatically.

--- a/docs/infrastructure/installation/migrate-to-xrpld.md
+++ b/docs/infrastructure/installation/migrate-to-xrpld.md
@@ -201,7 +201,7 @@ path=/var/lib/xrpld/db/nudb
 
 #### Keep existing data on full-history nodes
 
-For full-history and large-history nodes, where re-downloading the ledger store from peers would take hours or days. The simplest and safest option is to leave your data where it is and hand ownership to the new `xrpld` user. The config you restored in Step 4 already points at `/var/lib/rippled` and `/var/log/rippled`, so no paths need to change:
+For full-history and large-history nodes, where re-downloading the ledger store from peers can take many months to years - a full-history backfill is impractical to rebuild from scratch. The simplest and safest option is to leave your data where it is and hand ownership to the new `xrpld` user. The config you restored in Step 4 already points at `/var/lib/rippled` and `/var/log/rippled`, so no paths need to change:
 
 ```sh
 sudo chown -R xrpld:xrpld /var/lib/rippled


### PR DESCRIPTION
Adds the missing RHEL / `yum` equivalents so the migration steps are not Debian-only, and corrects the full-history re-sync estimate.

- **Prerequisites:** adds `sudo yum update`, and a note that `dnf` and `yum` are interchangeable on RHEL 8 and 9.
- **Step 2 (Stop and remove rippled):** shows the removal for both Debian (`apt-get remove`) and RHEL (`yum remove`); the remove-vs-purge note now mentions `yum remove` too.
- **Step 3 (Install xrpld):** adds `-y` to the RHEL install for parity with the Debian command.
- **Step 6 (Keep existing data):** corrects the re-sync time for full-history nodes - rebuilding the full ledger store from the network can take many months to years, not "hours or days", which is the whole reason to keep the data in place.

No other steps change. The xrpld RPM ships no SELinux policy, so no SELinux step is required.
