### PR TITLE
Clarify that --silent suppresses console logging for the entire run, not just startup

### DIFF
--- a/docs/infrastructure/commandline-usage.md
+++ b/docs/infrastructure/commandline-usage.md
@@ -40,7 +40,7 @@ The following generic options affect the amount of information written to standa
 | Option      | Short Version | Description                                    |
 |:------------|:--------------|:-----------------------------------------------|
 | `--debug`   |               | **DEPRECATED** Enables trace-level debugging (alias for `--verbose`). Use the [log_level method][] instead. |
-| `--silent`  |               | Don't write logs to standard out and standard error during startup. Recommended when starting `xrpld` as a systemd unit to reduce redundant logging. |
+| `--silent`  |               | Don't write logs to standard out and standard error. This suppresses console logging for the entire run of the process, not only during startup. (The startup banner is still printed before this flag takes effect.) Recommended when starting `xrpld` as a systemd unit to reduce redundant logging. When running under a process supervisor or in a container that captures logs from standard output/error, see the note in [Diagnosing Problems](troubleshooting/diagnosing-problems.md#check-the-server-log). |
 | `--verbose` | `-v`          | **DEPRECATED** Enables trace-level debugging. Use the [log_level method][] instead. |
 
 

--- a/docs/infrastructure/troubleshooting/diagnosing-problems.md
+++ b/docs/infrastructure/troubleshooting/diagnosing-problems.md
@@ -118,11 +118,20 @@ This generally indicates one of several problems:
 
 [By default,](https://github.com/XRPLF/rippled/blob/master/cfg/xrpld-example.cfg#L1139-L1142) `rippled` writes the server's debug log to the file `/var/log/xrpld/debug.log`. The location of the debug log can differ based on your server's config file. If you start the `xrpld` service directly (instead of using `systemctl` or `service` to start it), it also prints log messages to the console by default.
 
-The default config file sets the log level to severity "warning" for all categories of log messages by internally using the [log_level method][] during startup. You can control the verbosity of the debug log [using the `--silent` commandline option during startup](../commandline-usage.md#verbosity-options) and with the [log_level method][] while the server is running. (See the `[rpc_startup]` stanza of the config file for settings.)
+The default config file sets the log level to severity "warning" for all categories of log messages by internally using the [log_level method][] during startup. You can control the verbosity of the debug log [using the `--silent` commandline option](../commandline-usage.md#verbosity-options) and with the [log_level method][] while the server is running. (See the `[rpc_startup]` stanza of the config file for settings.)
 
 It is normal for an `xrpld` the server to print many warning-level (`WRN`) messages during startup and a few warning-level messages from time to time later on. You can **safely ignore** most warnings in the first 5 to 15 minutes of server startup.
 
 For a more thorough explanation of various types of log messages, see [Understanding Log Messages](understanding-log-messages.md).
+
+{% admonition type="info" name="Logging in containers and process supervisors" %}
+`xrpld` writes ongoing operational logs to two places: the file named in the `[debug_logfile]` config stanza (if set) and the console (standard error). The `--silent` option suppresses the console output for the **entire run**, not only during startup, so under a process supervisor or in a container, `xrpld --silent` emits only the early startup banner to standard output/error and drops all later operational logs from any stdout-based capture (such as a container log driver).
+
+To surface ongoing logs to a container log driver or supervisor, do one of the following:
+
+- Run `xrpld` in the foreground (for example, as PID 1) **without** `--silent`, so its native standard-error output is captured by the container's log stream.
+- Set `[debug_logfile]` to `/dev/stdout` (or `/proc/1/fd/1`, which is more portable across base images). The file log sink keeps writing even when `--silent` is set, because it is gated only on whether a log file is configured.
+{% /admonition %}
 
 
 ## See Also


### PR DESCRIPTION
## Summary

The `--silent` option for `xrpld` (formerly `rippled`) is currently documented as suppressing standard-output/standard-error logging "during startup." In practice the flag suppresses console logging for the **entire run** of the process — only the pre-`--silent` startup banner is still printed. This is easy to trip over when running `xrpld` under a process supervisor or in a container, where the operator expects ongoing logs on the container log driver but sees only the startup banner.

This PR:

1. Corrects the `--silent` description in the Verbosity Options table on the Commandline Usage page to say it suppresses console logging for the whole run, not only startup.
2. Adds a short note to the "Check the server log" section of Diagnosing Problems explaining how to surface logs in a container/supervisor: either run `xrpld` in the foreground without `--silent`, or set `[debug_logfile]` to `/dev/stdout` (the file sink keeps flowing even with `--silent`).

## Why

`xrpld` has a single console log sink (standard error). `--silent` disables that sink for the lifetime of the process, so any stdout/stderr-based log capture (e.g. a container log driver) receives nothing after the banner. The file sink configured by `[debug_logfile]` is independent of `--silent`, so pointing it at `/dev/stdout` restores log visibility.

## Test Plan

Documentation-only change. Verified the cross-page anchor (`#check-the-server-log`) resolves to the existing heading on the Diagnosing Problems page, and that the `{% admonition %}` syntax matches existing usage in both edited files.