### PR TITLE
Update release notes script

### DIFF
--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -15,11 +15,14 @@ Requires: gh CLI (authenticated)
 
 import argparse
 import base64
+import hashlib
 import json
 import os
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from datetime import date, datetime
 
 
@@ -427,6 +430,20 @@ def is_amendment(files):
     return any("features.macro" in f for f in files)
 
 
+def compute_sha256(url):
+    """Stream a package and return its SHA-256 hex digest. Returns "TODO" if the download fails."""
+    print(f"  Computing SHA-256 for {url} ...")
+    digest = hashlib.sha256()
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp:
+            for chunk in iter(lambda: resp.read(1 << 16), b""):
+                digest.update(chunk)
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"  Warning: could not download {url} ({e}). Leaving SHA-256 as TODO.", file=sys.stderr)
+        return "TODO"
+    return digest.hexdigest()
+
+
 # --- Formatting ---
 
 def format_commit_entry(sha, title, body="", files=None):
@@ -465,7 +482,7 @@ def format_uncategorized_entry(pr_number, title, labels, body, files=None, link_
     return "\n".join(parts)
 
 
-def generate_markdown(version, release_date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit, to_ref):
+def generate_markdown(version, release_date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit, to_ref, rpm_url, rpm_sha, deb_url, deb_sha):
     """Generate the full markdown release notes."""
     year = release_date.split("-")[0]
     parts = []
@@ -499,8 +516,8 @@ On supported platforms, see the [instructions on installing or updating `xrpld`]
 
 | Package | SHA-256 |
 |:--------|:--------|
-| [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/xrpld-{version}-1.el9.x86_64.rpm) | `TODO` |
-| [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/xrpld_{version}-1_amd64.deb) | `TODO` |
+| [RPM for Red Hat / CentOS (x86-64)]({rpm_url}) | `{rpm_sha}` |
+| [DEB for Ubuntu / Debian (x86-64)]({deb_url}) | `{deb_sha}` |
 
 For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/{to_ref}/BUILD.md). The most recent commit in the git log should be the change setting the version:
 
@@ -776,8 +793,15 @@ def main():
             authors.add(f"@{login}")
     authors |= contributors_without_login
 
+    # Compute release packages SHA-256 checksums.
+    rpm_url = f"https://repos.ripple.com/repos/rippled-rpm/stable/xrpld-{version}-1.el9.x86_64.rpm"
+    deb_url = f"https://repos.ripple.com/repos/rippled-deb/pool/stable/xrpld_{version}-1_amd64.deb"
+    print("Computing package checksums...")
+    rpm_sha = compute_sha256(rpm_url)
+    deb_sha = compute_sha256(deb_url)
+
     # Generate markdown
-    markdown = generate_markdown(version, args.date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit, args.to_ref)
+    markdown = generate_markdown(version, args.date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit, args.to_ref, rpm_url, rpm_sha, deb_url, deb_sha)
 
     # Write output
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -1,5 +1,5 @@
 """
-Generate rippled release notes from GitHub commit history.
+Generate xrpld release notes from GitHub commit history.
 
 Usage (from repo root):
     python3 tools/generate-release-notes.py --from release-3.0 --to release-3.1 [--date 2026-03-24] [--output path/to/file.md]
@@ -8,7 +8,7 @@ Arguments:
     --from      (required) Base ref — must match exact tag or branch to compare from.
     --to        (required) Target ref — must match exact tag or branch to compare to.
     --date      (optional) Release date in YYYY-MM-DD format. Defaults to today.
-    --output    (optional) Output file path. Defaults to blog/<year>/rippled-<version>.md.
+    --output    (optional) Output file path. Defaults to blog/<year>/xrpld-<version>.md.
 
 Requires: gh CLI (authenticated)
 """
@@ -465,7 +465,7 @@ def format_uncategorized_entry(pr_number, title, labels, body, files=None, link_
     return "\n".join(parts)
 
 
-def generate_markdown(version, release_date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit):
+def generate_markdown(version, release_date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit, to_ref):
     """Generate the full markdown release notes."""
     year = release_date.split("-")[0]
     parts = []
@@ -476,16 +476,16 @@ date: "{release_date}"
 template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing XRP Ledger version {version}
-    description: rippled version {version} is now available.
+    description: xrpld version {version} is now available.
 labels:
-    - rippled Release Notes
+    - xrpld Release Notes
 markdown:
     editPage:
         hide: true
 ---
 # Introducing XRP Ledger version {version}
 
-Version {version} of `rippled`, the reference server implementation of the XRP Ledger protocol, is now available.
+Version {version} of `xrpld`, the reference server implementation of the XRP Ledger protocol, is now available.
 
 
 ## Action Required
@@ -495,14 +495,14 @@ If you run an XRP Ledger server, upgrade to version {version} as soon as possibl
 
 ## Install / Upgrade
 
-On supported platforms, see the [instructions on installing or updating `rippled`](../../docs/infrastructure/installation/index.md).
+On supported platforms, see the [instructions on installing or updating `xrpld`](../../docs/infrastructure/installation/index.md).
 
 | Package | SHA-256 |
 |:--------|:--------|
-| [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/rippled-{version}-1.el9.x86_64.rpm) | `TODO` |
-| [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/rippled_{version}-1_amd64.deb) | `TODO` |
+| [RPM for Red Hat / CentOS (x86-64)](https://repos.ripple.com/repos/rippled-rpm/stable/xrpld-{version}-1.el9.x86_64.rpm) | `TODO` |
+| [DEB for Ubuntu / Debian (x86-64)](https://repos.ripple.com/repos/rippled-deb/pool/stable/xrpld_{version}-1_amd64.deb) | `TODO` |
 
-For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/master/BUILD.md). The most recent commit in the git log should be the change setting the version:
+For other platforms, please [build from source](https://github.com/XRPLF/rippled/blob/{to_ref}/BUILD.md). The most recent commit in the git log should be the change setting the version:
 
 ```text
 {version_commit}
@@ -549,16 +549,16 @@ For other platforms, please [build from source](https://github.com/XRPLF/rippled
     for author in sorted(authors):
         parts.append(f"- {author}")
 
-    parts.append("""
+    parts.append(f"""
 
 ## Bug Bounties and Responsible Disclosures
 
-We welcome reviews of the `rippled` code and urge researchers to responsibly disclose any issues they may find.
+We welcome reviews of the `xrpld` code and urge researchers to responsibly disclose any issues they may find.
 
 For more information, see:
 
 - [Ripple's Bug Bounty Program](https://ripple.com/legal/bug-bounty/)
-- [`rippled` Security Policy](https://github.com/XRPLF/rippled/blob/develop/SECURITY.md)
+- [`xrpld` Security Policy](https://github.com/XRPLF/rippled/blob/{to_ref}/SECURITY.md)
 """)
 
     # Unsorted entries with full context (after all published sections)
@@ -572,11 +572,11 @@ For more information, see:
 # --- Main ---
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate rippled release notes")
+    parser = argparse.ArgumentParser(description="Generate xrpld release notes")
     parser.add_argument("--from", dest="from_ref", required=True, help="Base ref (tag or branch)")
     parser.add_argument("--to", dest="to_ref", required=True, help="Target ref (tag or branch)")
     parser.add_argument("--date", help="Release date (YYYY-MM-DD). Defaults to today.")
-    parser.add_argument("--output", help="Output file path (default: blog/<year>/rippled-<version>.md)")
+    parser.add_argument("--output", help="Output file path (default: blog/<year>/xrpld-<version>.md)")
     args = parser.parse_args()
 
     args.date = args.date or date.today().isoformat()
@@ -595,7 +595,7 @@ def main():
     if args.output:
         output_path = args.output if os.path.isabs(args.output) else os.path.join(REPO_ROOT, args.output)
     else:
-        output_path = os.path.join(REPO_ROOT, "blog", year, f"rippled-{version}.md")
+        output_path = os.path.join(REPO_ROOT, "blog", year, f"xrpld-{version}.md")
 
     print(f"Fetching commits: {args.from_ref}...{args.to_ref}")
     commits = fetch_commits(args.from_ref, args.to_ref)
@@ -777,7 +777,7 @@ def main():
     authors |= contributors_without_login
 
     # Generate markdown
-    markdown = generate_markdown(version, args.date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit)
+    markdown = generate_markdown(version, args.date, amendment_diff, amendment_unchanged, amendment_entries, entries, authors, version_commit, args.to_ref)
 
     # Write output
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -212,16 +212,27 @@ def fetch_commits(from_ref, to_ref):
 def parse_features_macro(text):
     """Parse features.macro into {amendment_name: status_string} dict."""
     results = {}
+    # Anchor to line start (re.MULTILINE) so commented-out example lines like
+    # "// XRPL_FEATURE(Example, ...)" in the docs block aren't parsed as real amendments.
     for match in re.finditer(
-        r'XRPL_(FEATURE|FIX)\s*\(\s*(\w+)\s*,\s*Supported::(\w+)\s*,\s*VoteBehavior::(\w+)', text):
+        r'^XRPL_(FEATURE|FIX)\s*\(\s*(\w+)\s*,\s*Supported::(\w+)\s*,\s*VoteBehavior::(\w+)', text, re.MULTILINE):
         macro_type, name, supported, vote = match.groups()
         key = f"fix{name}" if macro_type == "FIX" else name
         results[key] = f"{supported}, {vote}"
-    for match in re.finditer(r'XRPL_RETIRE(?:_(FEATURE|FIX))?\s*\(\s*(\w+)\s*\)', text):
+    for match in re.finditer(r'^XRPL_RETIRE(?:_(FEATURE|FIX))?\s*\(\s*(\w+)\s*\)', text, re.MULTILINE):
         macro_type, name = match.groups()
         key = f"fix{name}" if macro_type == "FIX" else name
         results[key] = "retired"
     return results
+
+
+def is_supported_yes(status):
+    """True if a parsed status string is Supported::Yes (case-insensitive).
+
+    The macro uses `Supported::Yes` (capital Y); matching case-insensitively
+    keeps this robust to capitalization changes in features.macro.
+    """
+    return status.lower().startswith("yes")
 
 
 def fetch_amendment_diff(from_ref, to_ref):
@@ -244,22 +255,22 @@ def fetch_amendment_diff(from_ref, to_ref):
     changes = {}
     for name, to_status in to_amendments.items():
         if name not in from_amendments:
-            # New amendment — include only if Supported::yes
-            changes[name] = to_status.startswith("yes")
+            # New amendment — include only if Supported::Yes
+            changes[name] = is_supported_yes(to_status)
         elif from_amendments[name] != to_status:
             # Include if either old or new status involves yes (voting-ready)
             from_status = from_amendments[name]
-            changes[name] = from_status.startswith("yes") or to_status.startswith("yes")
+            changes[name] = is_supported_yes(from_status) or is_supported_yes(to_status)
 
-    # Removed amendments — include only if they were Supported::yes
+    # Removed amendments — include only if they were Supported::Yes
     for name in from_amendments:
         if name not in to_amendments:
-            changes[name] = from_amendments[name].startswith("yes")
+            changes[name] = is_supported_yes(from_amendments[name])
 
     # Unchanged amendments to also exclude (unreleased work)
     unchanged = sorted(
         name for name, to_status in to_amendments.items()
-        if name not in changes and to_status != "retired" and not to_status.startswith("yes")
+        if name not in changes and to_status != "retired" and not is_supported_yes(to_status)
     )
 
     return changes, unchanged

--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -218,7 +218,7 @@ def parse_features_macro(text):
         r'^XRPL_(FEATURE|FIX)\s*\(\s*(\w+)\s*,\s*Supported::(\w+)\s*,\s*VoteBehavior::(\w+)', text, re.MULTILINE):
         macro_type, name, supported, vote = match.groups()
         key = f"fix{name}" if macro_type == "FIX" else name
-        results[key] = f"{supported}, {vote}"
+        results[key] = f"{supported}, {vote}".lower()
     for match in re.finditer(r'^XRPL_RETIRE(?:_(FEATURE|FIX))?\s*\(\s*(\w+)\s*\)', text, re.MULTILINE):
         macro_type, name = match.groups()
         key = f"fix{name}" if macro_type == "FIX" else name


### PR DESCRIPTION
This PR updates the `generate-release-notes.py` script:

1. Streams and calculates SHA 256 checksum from `xrpld` packages. Falls back to `TODO` if download fails.
2. Fixes a case-sensitivity matching issue when creating the Amendments key for an AI to sort.