### PR TITLE
Add simulate method limitation for Batch transactions

### DIFF
--- a/docs/concepts/transactions/batch-transactions.md
+++ b/docs/concepts/transactions/batch-transactions.md
@@ -172,7 +172,7 @@ Inner transactions cannot be broadcast (and won't be accepted if they happen to 
 
 ## Limitations
 
-`Batch` transactions are incompatible with the [simulate method][]. `simulate` operates locally as a dry run and does not interact with the peer protocol. Therefore, the transaction is neither applied nor broadcast over the network.
+`Batch` transactions are incompatible with the [simulate method][]. Since `simulate` operates as a dry run for a single transaction only, it cannot simulate the effect of adding inner transactions to the consensus set.
 
 ## Integration Considerations
 

--- a/docs/concepts/transactions/batch-transactions.md
+++ b/docs/concepts/transactions/batch-transactions.md
@@ -165,9 +165,14 @@ If Alice provides a fully autofilled and signed transaction to Bob, Bob can subm
 If Alice just signs her part of the Batch transaction, Bob can modify his transaction to only provide 1 USD instead, thereby getting his 1000 XRP at a much cheaper rate. Therefore, the entire Batch transaction (and all its inner transactions) must be signed by all parties.
 
 ### Inner Transaction Safety
+
 An inner batch transaction is a special case. It doesn't include a signature or a fee (since those are both included in the outer transaction). Therefore, they must be handled carefully to ensure that someone can't somehow directly submit an inner `Batch` transaction without it being included in an outer transaction.
 
 Inner transactions cannot be broadcast (and won't be accepted if they happen to be broadcast, for example, from a malicious node). They must be generated from the `Batch` outer transaction instead. Inner transactions cannot be directly submitted via the submit RPC.
+
+## Limitations
+
+`Batch` transactions are incompatible with the [simulate method][]. `simulate` operates locally as a dry run and does not interact with the peer protocol. Therefore, the transaction is neither applied nor broadcast over the network.
 
 ## Integration Considerations
 
@@ -205,3 +210,5 @@ Explorers and indexers that display `Batch` transactions should:
 - Display the relationship between outer `Batch` transactions and their inner transactions using the `ParentBatchID` field in the inner transaction metadata.
 - Show inner transactions in context with their outer `Batch` transaction, rather than as standalone transactions.
 - Consider grouping inner transactions with their outer transaction in transaction lists for clarity.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/references/http-websocket-apis/public-api-methods/transaction-methods/simulate.md
+++ b/docs/references/http-websocket-apis/public-api-methods/transaction-methods/simulate.md
@@ -190,6 +190,7 @@ The response follows the [standard format][], with a successful result containin
 ## Possible Errors
 
 * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
+* `notImpl` - The transaction type is not supported by the `simulate` method (for example, `Batch` transactions).
 * `transactionSigned` - The transaction was signed. The simulated transaction must be unsigned.
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
As part of issue #[3667](https://github.com/XRPLF/xrpl-dev-portal/issues/3667), migrates [Batch and Simulate](https://github.com/XRPLF/rippled/wiki/Batch-and-Simulate) wiki content to XRPL.org: 
- Added a limitations section to [Batch Transactions](https://xrpl.org/docs/concepts/transactions/batch-transactions)
- Added new possible error to [simulate](https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/transaction-methods/simulate)