### PR TITLE
docs: update OS support documentation with glibc requirement

### DIFF
--- a/docs/infrastructure/installation/install-xrpld-on-rhel.md
+++ b/docs/infrastructure/installation/install-xrpld-on-rhel.md
@@ -8,7 +8,15 @@ labels:
 
 This page describes the recommended instructions for installing the latest stable version of `xrpld` on **Red Hat Enterprise Linux**, using a binary that has been compiled and published by Ripple as an `rpm` package.
 
-Currently, **Red Hat Enterprise Linux (RHEL) 9.6 is supported on x86_64 processors**. You may also be able to adapt these instructions to similar Linux distributions including CentOS or Rocky Linux, but other configurations are not officially supported.
+The following distributions are officially supported and recommended (x86_64):
+
+| Distribution | Versions |
+|---|---|
+| Rocky Linux | 9 |
+| AlmaLinux | 9 |
+| Fedora | 42 |
+
+You may also be able to adapt these instructions to Red Hat Enterprise Linux 9 or other compatible RPM-based distributions, but those configurations are not officially recommended.
 
 ## Prerequisites
 

--- a/docs/infrastructure/installation/install-xrpld-on-rhel.md
+++ b/docs/infrastructure/installation/install-xrpld-on-rhel.md
@@ -8,15 +8,13 @@ labels:
 
 This page describes the recommended instructions for installing the latest stable version of `xrpld` on **Red Hat Enterprise Linux**, using a binary that has been compiled and published by Ripple as an `rpm` package.
 
-The following distributions are officially supported and recommended (x86_64):
+These packages require glibc 2.31 or later. The following distributions meet this requirement on x86_64:
 
-| Distribution | Versions |
-|---|---|
-| Rocky Linux | 9 |
-| AlmaLinux | 9 |
-| Fedora | 42 |
+- Rocky Linux 9 or later
+- AlmaLinux 9 or later
+- Fedora 38 or later
 
-You may also be able to adapt these instructions to Red Hat Enterprise Linux 9 or other compatible RPM-based distributions, but those configurations are not officially recommended.
+Other RPM-based distributions with glibc >= 2.31, including Red Hat Enterprise Linux 9, may also work but are not officially recommended.
 
 ## Prerequisites
 

--- a/docs/infrastructure/installation/install-xrpld-on-rhel.md
+++ b/docs/infrastructure/installation/install-xrpld-on-rhel.md
@@ -12,9 +12,8 @@ These packages require glibc 2.31 or later. The following distributions meet thi
 
 - Rocky Linux 9 or later
 - AlmaLinux 9 or later
-- Fedora 38 or later
 
-Other RPM-based distributions with glibc >= 2.31, including Red Hat Enterprise Linux 9, may also work but are not officially recommended.
+Other RPM-based distributions with glibc >= 2.31, including Fedora and Red Hat Enterprise Linux 9, may also work but are not officially recommended.
 
 ## Prerequisites
 

--- a/docs/infrastructure/installation/install-xrpld-on-rhel.md
+++ b/docs/infrastructure/installation/install-xrpld-on-rhel.md
@@ -13,7 +13,7 @@ These packages require glibc 2.31 or later. The following distributions meet thi
 - Rocky Linux 9 or later
 - AlmaLinux 9 or later
 
-Other RPM-based distributions with glibc >= 2.31, including Fedora and Red Hat Enterprise Linux 9, may also work but are not officially recommended.
+Other RPM-based distributions with glibc >= 2.31, including Red Hat Enterprise Linux 9, may also work but are not officially recommended.
 
 ## Prerequisites
 

--- a/docs/infrastructure/installation/install-xrpld-on-rhel.md
+++ b/docs/infrastructure/installation/install-xrpld-on-rhel.md
@@ -10,10 +10,11 @@ This page describes the recommended instructions for installing the latest stabl
 
 These packages require glibc 2.31 or later. The following distributions meet this requirement on x86_64:
 
+- Red Hat Enterprise Linux 9 or later
 - Rocky Linux 9 or later
 - AlmaLinux 9 or later
 
-Other RPM-based distributions with glibc >= 2.31, including Red Hat Enterprise Linux 9, may also work but are not officially recommended.
+Other RPM-based distributions with glibc >= 2.31 may also work but are not officially recommended.
 
 ## Prerequisites
 

--- a/docs/infrastructure/installation/install-xrpld-on-ubuntu.md
+++ b/docs/infrastructure/installation/install-xrpld-on-ubuntu.md
@@ -10,7 +10,14 @@ labels:
 
 This page describes the recommended instructions for installing the latest stable version of `xrpld` on **Ubuntu Linux**, using a binary that has been compiled and published by Ripple as a `deb` package.
 
-Currently, **Ubuntu 22.04 and Ubuntu 24.04 on x86_64 processors** have received the highest level of support and testing. Packages are also available for **Debian Linux 12 Bookworm**. You may be able to adapt these instructions to other Linux distributions that also use the `apt` package manager, but other configurations are not officially supported.
+The following distributions are officially supported and recommended (x86_64):
+
+| Distribution | Versions |
+|---|---|
+| Ubuntu | 22.04 (Jammy), 24.04 (Noble), 26.04 (Resolute) |
+| Debian | 12 (Bookworm), 13 (Trixie) |
+
+You may be able to adapt these instructions to other `apt`-based distributions, but those configurations are not officially recommended.
 
 
 ## Prerequisites
@@ -66,8 +73,8 @@ Before you install `xrpld`, you must meet the [System Requirements](system-requi
 
     The above example is appropriate for **Ubuntu 24.04 Noble Numbat**. For other operating systems, replace the word `noble` with one of the following:
 
-    - `bullseye` for **Debian 11 Bullseye**
     - `bookworm` for **Debian 12 Bookworm**
+    - `trixie` for **Debian 13 Trixie**
     - `jammy` for **Ubuntu 22.04 Jammy Jellyfish**
     - `noble` for **Ubuntu 24.04 Noble Numbat**
     - `resolute` for **Ubuntu 26.04 Resolute Raccoon**

--- a/docs/infrastructure/installation/install-xrpld-on-ubuntu.md
+++ b/docs/infrastructure/installation/install-xrpld-on-ubuntu.md
@@ -10,14 +10,12 @@ labels:
 
 This page describes the recommended instructions for installing the latest stable version of `xrpld` on **Ubuntu Linux**, using a binary that has been compiled and published by Ripple as a `deb` package.
 
-The following distributions are officially supported and recommended (x86_64):
+These packages require glibc 2.31 or later. The following distributions meet this requirement on x86_64:
 
-| Distribution | Versions |
-|---|---|
-| Ubuntu | 22.04 (Jammy), 24.04 (Noble), 26.04 (Resolute) |
-| Debian | 12 (Bookworm), 13 (Trixie) |
+- Ubuntu 20.04 (Focal) or later
+- Debian 11 (Bullseye) or later
 
-You may be able to adapt these instructions to other `apt`-based distributions, but those configurations are not officially recommended.
+Other `apt`-based distributions with glibc >= 2.31 may also work but are not officially recommended.
 
 
 ## Prerequisites
@@ -73,11 +71,13 @@ Before you install `xrpld`, you must meet the [System Requirements](system-requi
 
     The above example is appropriate for **Ubuntu 24.04 Noble Numbat**. For other operating systems, replace the word `noble` with one of the following:
 
-    - `bookworm` for **Debian 12 Bookworm**
-    - `trixie` for **Debian 13 Trixie**
+    - `focal` for **Ubuntu 20.04 Focal Fossa**
     - `jammy` for **Ubuntu 22.04 Jammy Jellyfish**
     - `noble` for **Ubuntu 24.04 Noble Numbat**
     - `resolute` for **Ubuntu 26.04 Resolute Raccoon**
+    - `bullseye` for **Debian 11 Bullseye**
+    - `bookworm` for **Debian 12 Bookworm**
+    - `trixie` for **Debian 13 Trixie**
 
     If you want access to development or pre-release versions of `xrpld`, use one of the following instead of `stable`:
 

--- a/docs/infrastructure/installation/system-requirements.md
+++ b/docs/infrastructure/installation/system-requirements.md
@@ -12,15 +12,7 @@ The following system requirements apply to both the core XRP Ledger server, `xrp
 
 For reliable performance in production environments, it is recommended to run a server on bare metal with the following characteristics or better:
 
-- Operating System: One of the following supported Linux distributions:
-
-    | Distribution | Versions |
-    |---|---|
-    | Ubuntu | 22.04 (Jammy), 24.04 (Noble), 26.04 (Resolute) |
-    | Debian | 12 (Bookworm), 13 (Trixie) |
-    | Rocky Linux | 9 |
-    | AlmaLinux | 9 |
-    | Fedora | 42 |
+- Operating System: A supported Linux distribution. See [Install on Ubuntu or Debian](install-xrpld-on-ubuntu.md) or [Install on RHEL](install-xrpld-on-rhel.md) for the full list of recommended versions.
 - CPU: 3+ GHz 64-bit x86_64 processor with 8+ cores.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
 - RAM: 64 GB.
@@ -34,7 +26,7 @@ For a validator in AWS, consider `z1d.2xlarge` with an extra 1 TB disk for loggi
 
 For testing purposes, you can run an XRP Ledger server on commodity hardware with the following minimum requirements:
 
-- Operating System: macOS, Windows (64-bit), or a supported Linux distribution (see recommended specs above).
+- Operating System: Linux (see recommended specs above), or macOS/Windows (64-bit) for development only.
 - CPU: 64-bit x86_64, 4+ cores.
     - For development purposes, it is also possible to compile `rippled` for some Apple Silicon or ARM processors. See the {% source-link name="Build instructions" path="BUILD.md" /%} for guidance. However, architectures other than x86_64 are not officially supported and are not recommended for production.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.

--- a/docs/infrastructure/installation/system-requirements.md
+++ b/docs/infrastructure/installation/system-requirements.md
@@ -12,7 +12,14 @@ The following system requirements apply to both the core XRP Ledger server, `xrp
 
 For reliable performance in production environments, it is recommended to run a server on bare metal with the following characteristics or better:
 
-- Operating System: Ubuntu (LTS), Red Hat Enterprise Linux (latest release), or a compatible Linux distribution.
+- Operating System: One of the following supported Linux distributions:
+
+    | Distribution | Versions |
+    |---|---|
+    | Ubuntu | 22.04 (Jammy), 24.04 (Noble), 26.04 (Resolute) |
+    | Debian | 12 (Bookworm), 13 (Trixie) |
+    | Red Hat Enterprise Linux / Rocky Linux / AlmaLinux | 9 |
+    | Fedora | 42 |
 - CPU: 3+ GHz 64-bit x86_64 processor with 8+ cores.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.
 - RAM: 64 GB.
@@ -26,7 +33,7 @@ For a validator in AWS, consider `z1d.2xlarge` with an extra 1 TB disk for loggi
 
 For testing purposes, you can run an XRP Ledger server on commodity hardware with the following minimum requirements:
 
-- Operating System: macOS, Windows (64-bit), or most Linux distributions (Red Hat, Ubuntu, and Debian supported).
+- Operating System: macOS, Windows (64-bit), or a supported Linux distribution (see recommended specs above).
 - CPU: 64-bit x86_64, 4+ cores.
     - For development purposes, it is also possible to compile `rippled` for some Apple Silicon or ARM processors. See the {% source-link name="Build instructions" path="BUILD.md" /%} for guidance. However, architectures other than x86_64 are not officially supported and are not recommended for production.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.

--- a/docs/infrastructure/installation/system-requirements.md
+++ b/docs/infrastructure/installation/system-requirements.md
@@ -18,7 +18,8 @@ For reliable performance in production environments, it is recommended to run a 
     |---|---|
     | Ubuntu | 22.04 (Jammy), 24.04 (Noble), 26.04 (Resolute) |
     | Debian | 12 (Bookworm), 13 (Trixie) |
-    | Red Hat Enterprise Linux / Rocky Linux / AlmaLinux | 9 |
+    | Rocky Linux | 9 |
+    | AlmaLinux | 9 |
     | Fedora | 42 |
 - CPU: 3+ GHz 64-bit x86_64 processor with 8+ cores.
 - Disk: SSD / NVMe (10,000 IOPS sustained - not burst or peak - or better). Minimum 50 GB for the database partition. Do not use Amazon Elastic Block Store (AWS EBS) because its latency is too high to sync reliably.


### PR DESCRIPTION
## Summary

- Replaces vague OS descriptions in system-requirements.md with links to the install pages
- Updates install pages to use minimum glibc requirement (>= 2.31) instead of a hardcoded version table, so the doc stays accurate as new distro versions are released
- Lists minimum supported versions per distro family

## Changes

**system-requirements.md**: replaced hardcoded OS list with links to install pages

**install-xrpld-on-ubuntu.md**:
- Ubuntu 20.04 (Focal) or later
- Debian 11 (Bullseye) or later
- Added `focal`, `trixie` codenames to apt sources list

**install-xrpld-on-rhel.md**:
- Red Hat Enterprise Linux 9 or later
- Rocky Linux 9 or later
- AlmaLinux 9 or later

## Test plan

- [ ] Verify rendered pages look correct on the docs site
- [ ] Confirm codenames in apt sources list match the repo at repos.ripple.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)