### PR TITLE
chore: upgrade Osano CMP to new account (SXt7r81ogd)

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -147,7 +147,7 @@ feedback:
     rightScaleLabel: Very helpful
 scripts:
   head:
-    - src: https://cmp.osano.com/AzyjT6TIZMlgyLyy8/f11f7772-8ed5-4b73-bd17-c0814edcc440/osano.js
+    - src: https://cmp.osano.com/SXt7r81ogd/bbc71a55-7b77-492e-94d7-b9eaa94e8bb2/osano.js
     - src: ./static/js/xrpl-2.11.0.min.js
     - src: ./static/vendor/jquery-3.7.1.min.js
     - src: ./static/vendor/bootstrap.min.js


### PR DESCRIPTION
Migrates the Osano CMP script to the new Foundation Osano account (SXt7r81ogd) per Rene's request.