### PR TITLE
Show tree nav on mobile

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -380,6 +380,23 @@ button[role="tab"].active {
   line-height: var(--md-table-line-height);
 }
 
+@media screen and (max-width: 959.9px) {
+  [data-component-name="Layout/PageLayout"] {
+    flex-direction: column-reverse;
+  }
+  [data-component-name="Sidebar/Sidebar"] {
+    display: block;
+    position: static;
+    height: auto;
+  }
+  #content {
+    width: auto;
+  }
+  [data-component-name="Menu/MenuContainer"] {
+    overscroll-behavior: auto;
+  }
+}
+
 @media screen and (min-width: 990px) {
   [data-component-name="LanguagePicker/LanguagePicker"] {
     display: block;


### PR DESCRIPTION
Fix #3323 so that the tree nav (on pages that have it) displays following the main page content on mobile, instead of being completely gone.

This isn't necessarily the prettiest or _most_ usable solution, but it is a fairly small set of changes that makes the tree navigation usable _at all_ on mobile. With the big redesign of #3362 still pending, I didn't want to put in a lot of effort that would have to be thrown out.

| Before | After |
|---|---|
| <img width="200" height="437" alt="2026-07-07_123951_543983928" src="https://github.com/user-attachments/assets/84f88241-31d4-44fa-a8a7-5f66782dc287" /> | <img width="200" height="437" alt="2026-07-07_123853_691354136" src="https://github.com/user-attachments/assets/c905c14c-8f75-4f67-8cfd-6b0ae22dd50e" /> |
| Feedback widget and prev/next page buttons are followed by footer. | Feedback widget and prev/next page buttons are followed by tree nav, and footer is below that. |


