### PR TITLE
Fix overlapping Osano/AI buttons

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -397,7 +397,15 @@ button[role="tab"].active {
   }
 }
 
+:root {
+  --ai-assistant-button-bottom: 16px;
+  --ai-assistant-button-right: 71px; /* align w/ Osano cookie widget (mobile) */
+}
+
 @media screen and (min-width: 990px) {
+  :root {
+      --ai-assistant-button-right: 86px;
+  }
   [data-component-name="LanguagePicker/LanguagePicker"] {
     display: block;
   }


### PR DESCRIPTION
Move the "Ask AI" button to display to the left of the Osano cookie button instead of on top of it. The positioning is slightly different for mobile and desktop.

(This is a bit hard to test since the "Ask AI" button doesn't display in local dev mode, but it looks good on the preview build to me at least.)

Fixes #3624 (the remaining part of it).

| Before | After |
|---|---|
| <img width="301" height="655" alt="Screenshot showing overlapping Ask AI and Osano cookie buttons on mobile" src="https://github.com/user-attachments/assets/30d24e0e-bd0b-456d-b350-17e19d545945" /> | <img width="301" height="655" alt="Screenshot showing the Ask AI button to the left of the Osano cookie button" src="https://github.com/user-attachments/assets/0049fb0c-119c-4b04-9f82-0bd426c9c136" /> |

