### PR TITLE
Amendment component fixes

### DIFF
--- a/@theme/components/Amendments.tsx
+++ b/@theme/components/Amendments.tsx
@@ -14,46 +14,96 @@ type Amendment = {
   date?: string
   id: string
   eta?: string
-  deprecated?: boolean
+  deprecated: boolean
 }
 
 type AmendmentsResponse = {
   amendments: Amendment[]
 }
 
-type AmendmentsCachePayload = {
+type AmendmentsCache = {
   timestamp: number
-  amendments: Amendment[]
+  vote: Amendment[]
+  info: Amendment[]
 }
 
 // API data caching
-const amendmentsEndpoint = 'https://vhs.prod.ripplex.io/v1/network/amendments/vote/main/'
+const amendmentsVoteEndpoint = 'https://vhs.prod.ripplex.io/v1/network/amendments/vote/main/'
 const amendmentsInfoEndpoint = 'https://vhs.prod.ripplex.io/v1/network/amendments/info/main/'
 const amendmentsCacheKey = 'xrpl.amendments.mainnet.cache'
 const amendmentsTTL = 15 * 60 * 1000 // 15 minutes in milliseconds
 
-function readAmendmentsCache(): Amendment[] | null {
+function readCache(): AmendmentsCache | null {
   if (typeof window === 'undefined') return null
   try {
     const raw = window.localStorage.getItem(amendmentsCacheKey)
     if (!raw) return null
-    const parsed: AmendmentsCachePayload = JSON.parse(raw)
-    if (!parsed || !Array.isArray(parsed.amendments)) return null
+    const parsed: AmendmentsCache = JSON.parse(raw)
+    if (!parsed || !Array.isArray(parsed.vote) || !Array.isArray(parsed.info)) return null
     const fresh = Date.now() - parsed.timestamp < amendmentsTTL
-    return fresh ? parsed.amendments : null
+    return fresh ? parsed : null
   } catch {
     return null
   }
 }
 
-function writeAmendmentsCache(amendments: Amendment[]) {
+function writeCache(cache: AmendmentsCache) {
   if (typeof window === 'undefined') return
   try {
-    const payload: AmendmentsCachePayload = { timestamp: Date.now(), amendments }
-    window.localStorage.setItem(amendmentsCacheKey, JSON.stringify(payload))
+    window.localStorage.setItem(amendmentsCacheKey, JSON.stringify(cache))
   } catch {
     // Ignore quota or serialization errors
   }
+}
+
+// Fetch a single amendments endpoint (vote or info).
+async function fetchAmendmentList(endpoint: string): Promise<Amendment[]> {
+  const response = await fetch(endpoint)
+  if (!response.ok) {
+    throw new Error(`HTTP error ${response.status} from ${endpoint}`)
+  }
+  const data: AmendmentsResponse = await response.json()
+  return data.amendments
+}
+
+// Deduplicated fetching for the amendment data; concurrent callers share the same promise.
+let inFlight: Promise<AmendmentsCache> | null = null
+
+// Cache-first: return the fresh combined cache, or fetch both endpoints in parallel,
+// stamp them with a single timestamp, and store them under one cache key.
+function getAmendmentsCache(): Promise<AmendmentsCache> {
+  const cached = readCache()
+  if (cached) return Promise.resolve(cached)
+  if (inFlight) return inFlight
+  const request = (async () => {
+    const [vote, info] = await Promise.all([
+      fetchAmendmentList(amendmentsVoteEndpoint),
+      fetchAmendmentList(amendmentsInfoEndpoint),
+    ])
+    const cache: AmendmentsCache = { timestamp: Date.now(), vote, info }
+    writeCache(cache)
+    return cache
+  })()
+  inFlight = request
+  // Release the slot once settled so a later cold load can refresh.
+  const release = () => { if (inFlight === request) inFlight = null }
+  request.then(release, release)
+  return request
+}
+
+// Vote list for the amendments table (the caller filters out obsolete amendments).
+function getAmendments(): Promise<Amendment[]> {
+  return getAmendmentsCache().then(cache => cache.vote)
+}
+
+// Look up a single amendment for a disclaimer: the vote list first, then the info
+// list for obsolete/never-enabled amendments.
+async function findAmendment(name: string): Promise<Amendment> {
+  const { vote, info } = await getAmendmentsCache()
+  const found = vote.find(a => a.name === name) ?? info.find(a => a.name === name)
+  if (found) return found
+
+  throw new Error(`Couldn't find ${name} amendment in status tables.`)
 }
 
 // Obsolete amendments (deprecated and never enabled, e.g. Batch) are documented
@@ -171,35 +221,18 @@ export function AmendmentsTable() {
   const estimatedHeight = `${expectedTableHeight()}px`
 
   React.useEffect(() => {
-    const fetchAmendments = async () => {
-      try {
-        setLoading(true)
-        // 1. Try cache first
-        const cached = readAmendmentsCache()
-
-        if (cached) {
-          setAmendments(sortAmendments(cached.filter(a => !isObsolete(a))))
-          return // Use current cache (fresh)
-        }
-        // 2. Fetch new data if cache is stale
-        const response = await fetch(amendmentsEndpoint)
-        
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`)
-        }
-
-        const data: AmendmentsResponse = await response.json()
-        writeAmendmentsCache(data.amendments)
-
-        setAmendments(sortAmendments(data.amendments.filter(a => !isObsolete(a))))
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch amendments')
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchAmendments()
+    let cancelled = false
+    getAmendments()
+      .then(list => {
+        if (!cancelled) setAmendments(sortAmendments(list.filter(a => !isObsolete(a))))
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to fetch amendments')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
   }, [])
 
   // Fancy schmancy loading icon
@@ -334,61 +367,20 @@ export function AmendmentDisclaimer(props: {
   const link = () => <Link to={`/resources/known-amendments#${props.name.toLowerCase()}`}>{props.name}{ props.compact ? "" : " amendment"}</Link>
 
   React.useEffect(() => {
-    const loadAmendment = async () => {
-      try {
-        setLoading(true)
-        // 1. Try cache first
-        const cached = readAmendmentsCache()
-
-        if (cached) {
-          const found = cached.find(a => a.name === props.name)
-            if (found) {
-              setStatus(found)
-              return // amendment successfully found in cache
-            }
-        }
-        // 2. New API request for stale/missing cache. 
-        // Also catches edge case of new amendment appearing
-        // on mainnet within cache TTL window.
-        const response = await fetch(amendmentsEndpoint)
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! Status: ${response.status}`)
-        }
-
-        const data: AmendmentsResponse = await response.json()
-        writeAmendmentsCache(data.amendments)
-
-        const found = data.amendments.find(a => a.name === props.name)
-        
-        // 3. If not found in live data, try the info endpoint.
-        if (!found) {
-          
-          const infoResponse = await fetch(amendmentsInfoEndpoint)
-          
-          if (!infoResponse.ok) {
-            throw new Error(`HTTP error from info endpoint! Status: ${infoResponse.status}`)
-          }
-          
-          const infoData: AmendmentsResponse = await infoResponse.json()
-          const foundInInfo = infoData.amendments.find(a => a.name === props.name)
-          
-          if (!foundInInfo) {
-            throw new Error(`Couldn't find ${props.name} amendment in status tables.`)
-          }
-          
-          setStatus(foundInInfo)
-          return
-        }
-
-        setStatus(found)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch amendments')
-      } finally {
-        setLoading(false)
-      }
-    };
-    loadAmendment()
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    findAmendment(props.name)
+      .then(found => {
+        if (!cancelled) setStatus(found)
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to fetch amendments')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
   }, [props.name])
 
   if (loading) {

--- a/@theme/components/Amendments.tsx
+++ b/@theme/components/Amendments.tsx
@@ -5,6 +5,7 @@ import type { Node } from '@markdoc/markdoc'
 import { Link } from '@redocly/theme/components/Link/Link'
 import { useThemeHooks } from '@redocly/theme/core/hooks'
 import amendmentsSnapshot from '../data/amendments-snapshot.json'
+import obsoleteAmendments from '../data/obsolete-amendments.json'
 
 type Amendment = {
   name: string
@@ -15,6 +16,13 @@ type Amendment = {
   id: string
   eta?: string
   deprecated: boolean
+}
+type ObsoleteAmendment = {
+  id: string,
+  name: string,
+  rippled_version: string,
+  status: string
+  href?: string
 }
 
 type AmendmentsResponse = {
@@ -97,33 +105,25 @@ function getAmendments(): Promise<Amendment[]> {
 }
 
 // Look up a single amendment for a disclaimer: the vote list first, then the info
-// list for obsolete/never-enabled amendments.
-async function findAmendment(name: string): Promise<Amendment> {
+// list, then the hard-coded list of obsolete amendments.
+async function findAmendment(name: string): Promise<Amendment|ObsoleteAmendment> {
   const { vote, info } = await getAmendmentsCache()
   const found = vote.find(a => a.name === name) ?? info.find(a => a.name === name)
   if (found) return found
+  const obsolete = isObsolete(name)
+  if (obsolete) return obsolete
 
   throw new Error(`Couldn't find ${name} amendment in status tables.`)
 }
 
-// Obsolete amendments (deprecated and never enabled, e.g. Batch) are documented
-// in the "Obsolete and Retired Amendments" section, not the live Mainnet Status
-// table, so filter them out here. Deprecated amendments that are enabled keep
-// their functionality and remain in the table as Enabled.
-// OBSOLETE_AMENDMENT_NAMES is a manually maintained override.
-
-const OBSOLETE_AMENDMENT_NAMES = new Set<string>([
-  'CryptoConditionsSuite',
-  'fixNFTokenDirV1',
-  'fixNFTokenNegOffer',
-  'NonFungibleTokensV1',
-])
-
-function isObsolete(amendment: Amendment): boolean {
-  return (
-    OBSOLETE_AMENDMENT_NAMES.has(amendment.name) ||
-    (Boolean(amendment.deprecated) && !amendment.tx_hash)
-  )
+// Amendments ultimately become either obsolete (removed & never enabled)
+// or retired (enabled & unconditionalized). A "deprecated" status in the
+// VHS data can refer to either one, depending on if it has a tx_hash indicating
+// that it was enabled on Mainnet.
+// But since VHS data does not include everything, we rely on a manually
+// maintained list of obsolete amendments with status info.
+function isObsolete(amendment_name: string): ObsoleteAmendment|undefined {
+  return obsoleteAmendments.find( (a: ObsoleteAmendment) => a.name == amendment_name )
 }
 
 // Sort amendments table by status, then chronologically, then alphabetically
@@ -158,10 +158,17 @@ function sortAmendments(list: Amendment[]): Amendment[] {
 }
 
 // Get amendment status from snapshot data.
-function amendmentStatusForLlms(a: Amendment): string {
+function amendmentStatusForLlms(a: Amendment|ObsoleteAmendment): string {
+  const obsolete = isObsolete(a.name)
   if (a.tx_hash) {
     const date = a.date ? new Date(a.date).toISOString().split('T')[0] : ''
     return date ? `Enabled: ${date}` : 'Enabled'
+  }
+  if (obsolete) {
+    // Note: update to use translate() when Redocly supports it in renderForLlms
+    // const obsLabel = translate("amendment.status.obsolete", "Obsolete")
+    const obsLabel = "Obsolete"
+    return `${obsLabel}: ${obsolete.status}`
   }
   if (a.eta) return `Expected: ${new Date(a.eta).toISOString().split('T')[0]}`
   if (a.consensus) return `Open for Voting: ${a.consensus}`
@@ -181,7 +188,7 @@ export function amendmentsTableForLlms(): string {
     return `Note: Amendment status table is missing or malformed. For live status, visit https://xrpl.org/resources/known-amendments in a browser.\n`
   }
 
-  const rows = sortAmendments(amendments.filter(a => !isObsolete(a)))
+  const rows = sortAmendments(amendments.filter(a => !isObsolete(a.name)))
 
   const lines = [
     `Note: The amendment status table is a snapshot from ${asOf}. For live status, visit https://xrpl.org/resources/known-amendments in a browser.`,
@@ -203,7 +210,7 @@ export function amendmentsTableForLlms(): string {
 // have loaded.
 function expectedTableHeight() {
   const numAmendmentsCached = amendmentsSnapshot.amendments.filter(
-    a => !isObsolete(a)).length
+    a => !isObsolete(a.name)).length
   const rowHeight = 39 // pixel height per row, including border, based on CSS
   const headerHeight = 38 // pixel height of table header
   const wrapperMargin = 41 // extra margin added by the md-table-wrapper element
@@ -224,7 +231,7 @@ export function AmendmentsTable() {
     let cancelled = false
     getAmendments()
       .then(list => {
-        if (!cancelled) setAmendments(sortAmendments(list.filter(a => !isObsolete(a))))
+        if (!cancelled) setAmendments(sortAmendments(list.filter(a => !isObsolete(a.name))))
       })
       .catch(err => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to fetch amendments')
@@ -290,7 +297,51 @@ export function AmendmentsTable() {
   )
 }
 
-function AmendmentBadge(props: { amendment: Amendment }) {
+export function ObsoleteAmendmentsTable() {
+  const { useTranslate } = useThemeHooks()
+  const { translate } = useTranslate()
+
+  return (
+    <div className="md-table-wrapper">
+      <table className="md">
+        <thead>
+          <tr>
+            <th align="left" data-label="Name">{translate("amendment.table.name", "Name")}</th>
+            <th align="left" data-label="Introduced">{translate("amendment.table.introduced", "Introduced")}</th>
+            <th align="left" data-label="Status">{translate("amendment.table.status", "Status")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {obsoleteAmendments.map((amendment) => (
+            <tr key={amendment.id}>
+              <td align="left">
+                <Link to={`#${amendment.name.toLowerCase()}`}>{amendment.name}</Link>
+              </td>
+              <td align="left">{amendment.rippled_version}</td>
+              <td align="left">
+                <AmendmentBadge amendment={amendment} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function obsoleteAmendmentsTableForLlms() {
+  const lines = [
+    '| Name | Introduced | Status |',
+    '|:-----|:-----------|:-------|',
+    ...obsoleteAmendments.map(
+      a => `| [${a.name}](#${a.name.toLowerCase()}) | ${a.rippled_version} | ${amendmentStatusForLlms(a)} |`,
+    ),
+    '',
+  ]
+  return lines.join('\n')
+}
+
+function AmendmentBadge(props: { amendment: Amendment|ObsoleteAmendment}) {
   const [status, setStatus] = React.useState<string>('Loading...')
   const [href, setHref] = React.useState<string | undefined>(undefined)
   const [color, setColor] = React.useState<string>('blue')
@@ -300,8 +351,9 @@ function AmendmentBadge(props: { amendment: Amendment }) {
   const enabledLabel = translate("amendment.status.enabled", "Enabled")
   const votingLabel = translate("amendment.status.openForVoting", "Open for Voting")
   const etaLabel = translate("amendment.status.eta", "Expected")
-  const inactiveLabel = translate("amendment.status.inactive", "Inactive")
-  const inactiveButton = translate("amendment.status.inactiveButton", "Get details")
+  const unknownLabel = translate("amendment.status.unknown", "Unknown")
+  const unknownButton = translate("amendment.status.unknownButton", "Get details")
+  const obsLabel = translate("amendment.status.obsolete", "Obsolete")
 
   React.useEffect(() => {
     const amendment = props.amendment
@@ -312,27 +364,29 @@ function AmendmentBadge(props: { amendment: Amendment }) {
       setStatus(`${enabledLabel}: ${enabledDate}`)
       setColor('green')
       setHref(`https://livenet.xrpl.org/transactions/${amendment.tx_hash}`)
-    } 
-    // Check if expected activation is provided (has eta field)
-    else if (amendment.eta) {
+    } else if (isObsolete(amendment.name)) {
+      const obsAmendment = isObsolete(amendment.name)
+      setStatus(`${obsLabel}: ${obsAmendment.status}`)
+      setColor('red')
+      setHref(obsAmendment.href)
+    } else if (amendment.eta) {
+      // Expected activation is provided (has eta field)
       let etaDate = new Date(amendment.eta).toISOString().split('T')[0]
       setStatus(`${etaLabel}: ${etaDate}`)
       setColor('blue')
       setHref(undefined)
-    }
-    // Check if amendment is currently being voted on (has consensus field)
-    else if (amendment.consensus) {
+    } else if (amendment.consensus) {
+      // Amendment is currently being voted on (has consensus field)
       setStatus(`${votingLabel}: ${amendment.consensus}`)
       setColor('80d0e0')
       setHref(undefined)
-    }
-    // Fallback: amendment is inactive
-    else {
-      setStatus(`${inactiveLabel}: ${inactiveButton}`)
+    } else {
+      // Fallback: status is unknown
+      setStatus(`${unknownLabel}: ${unknownButton}`)
       setColor('lightgrey')
       setHref(`/resources/known-amendments#${amendment.name.toLowerCase()}`)
     }
-  }, [props.amendment, enabledLabel, etaLabel, votingLabel, inactiveLabel])
+  }, [props.amendment, enabledLabel, obsLabel, etaLabel, votingLabel, unknownLabel])
   
   // Split the status at the colon to create two-color badge
   const parts = status.split(':')
@@ -497,7 +551,10 @@ export function amendmentDisclaimerForLlms(node: Node): string {
   // const { translate } = useTranslate()
   const translate = (key:string, s:string) => s; // Shim version of translate
 
-  let amendment : Amendment | any = amendmentsSnapshot.amendments.find( (a) => a.name === name )
+  let amendment : Amendment | ObsoleteAmendment | any = (
+    isObsolete(name) ||
+    amendmentsSnapshot.amendments.find( (a) => a.name === name )
+  )
   let status = "Status Unknown"
   if (!amendment) {  
     status = translate("amendment.status.inactive", "Inactive")
@@ -522,8 +579,8 @@ export function amendmentDisclaimerForLlms(node: Node): string {
       text1 = translate("component.amendment-status.updated.1", "Updated by the ")
       text2 = translate("component.amendment-status.updated.2", ".")
     } else {
-      text1 = translate("component.amendment-status.requires.1", "Requires the ")
-      text2 = translate("component.amendment-status.requires.2", ".")
+      text1 = translate("component.amendment-status.updates.1", "The ")
+      text2 = translate("component.amendment-status.updates.2", " updates this.")
     }
   } else {
     if (amendment.date) {

--- a/@theme/components/Amendments.tsx
+++ b/@theme/components/Amendments.tsx
@@ -107,11 +107,11 @@ function getAmendments(): Promise<Amendment[]> {
 // Look up a single amendment for a disclaimer: the vote list first, then the info
 // list, then the hard-coded list of obsolete amendments.
 async function findAmendment(name: string): Promise<Amendment|ObsoleteAmendment> {
+  const obsolete = isObsolete(name)
+  if (obsolete) return obsolete
   const { vote, info } = await getAmendmentsCache()
   const found = vote.find(a => a.name === name) ?? info.find(a => a.name === name)
   if (found) return found
-  const obsolete = isObsolete(name)
-  if (obsolete) return obsolete
 
   throw new Error(`Couldn't find ${name} amendment in status tables.`)
 }

--- a/@theme/components/Amendments.tsx
+++ b/@theme/components/Amendments.tsx
@@ -1,6 +1,7 @@
 // Components related to XRPL Amendment previews and statuses
 
 import * as React from 'react'
+import type { Node } from '@markdoc/markdoc'
 import { Link } from '@redocly/theme/components/Link/Link'
 import { useThemeHooks } from '@redocly/theme/core/hooks'
 import amendmentsSnapshot from '../data/amendments-snapshot.json'
@@ -146,6 +147,19 @@ export function amendmentsTableForLlms(): string {
   return lines.join('\n')
 }
 
+// Calculate expected height of amendment table so there's little to no
+// page-height jump when the actual table loads in. This ensures that anchor
+// links go to the correct scroll position even before the amendment statuses
+// have loaded.
+function expectedTableHeight() {
+  const numAmendmentsCached = amendmentsSnapshot.amendments.filter(
+    a => !isObsolete(a)).length
+  const rowHeight = 39 // pixel height per row, including border, based on CSS
+  const headerHeight = 38 // pixel height of table header
+  const wrapperMargin = 41 // extra margin added by the md-table-wrapper element
+  return (numAmendmentsCached * rowHeight) + headerHeight + wrapperMargin
+}
+
 // Generate amendments table with live mainnet data
 export function AmendmentsTable() {
   const [amendments, setAmendments] = React.useState<Amendment[]>([])
@@ -153,6 +167,8 @@ export function AmendmentsTable() {
   const [error, setError] = React.useState<string | null>(null)
   const { useTranslate } = useThemeHooks()
   const { translate } = useTranslate()
+
+  const estimatedHeight = `${expectedTableHeight()}px`
 
   React.useEffect(() => {
     const fetchAmendments = async () => {
@@ -189,7 +205,13 @@ export function AmendmentsTable() {
   // Fancy schmancy loading icon
   if (loading) {
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', padding: '2rem' }}>
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-start',
+        alignItems: 'center',
+        padding: '2rem',
+        height: estimatedHeight }}>
         <div className="spinner-border text-primary" role="status">
           <span className="sr-only">{translate("amendment.loading", "Loading amendments...")}</span>
         </div>
@@ -300,6 +322,7 @@ function AmendmentBadge(props: { amendment: Amendment }) {
 export function AmendmentDisclaimer(props: {
   name: string,
   compact: boolean,
+  statusOnly: boolean,
   mode: string
 }) {
   const [amendmentStatus, setStatus] = React.useState<Amendment | null>(null)
@@ -369,6 +392,12 @@ export function AmendmentDisclaimer(props: {
   }, [props.name])
 
   if (loading) {
+    if (props.statusOnly) {
+      return <>
+        {translate("amendment.loading_status", "Loading...")}
+      </>
+    }
+
     return (
       <p><em>
       {translate("component.amendment-status.requires.1", "Requires the ")}{link()}{translate("component.amendment-status.requires.2", ".")}
@@ -381,6 +410,12 @@ export function AmendmentDisclaimer(props: {
   }
   
   if (error) {
+    if (props.statusOnly) {
+      return <>
+        {translate("amendment.error_status", "Error loading amendment status")}: {error}
+      </>
+    }
+
     return (
       <p><em>
       {translate("component.amendment-status.requires.1", "Requires the ")}{link()}{translate("component.amendment-status.requires.2", ".")}
@@ -389,6 +424,12 @@ export function AmendmentDisclaimer(props: {
         <strong>{translate("amendment.error_status", "Error loading amendment status")}:</strong> {error}
       </span>
       </em></p>
+    )
+  }
+
+  if (props.statusOnly) {
+    return(
+      <AmendmentBadge amendment={amendmentStatus} />
     )
   }
 
@@ -447,6 +488,61 @@ export function AmendmentDisclaimer(props: {
       }
     )</em></p>
   )
+}
+
+export function amendmentDisclaimerForLlms(node: Node): string {
+  const {
+    name,
+    compact,
+    statusOnly,
+    mode } = node.attributes
+  // Note: useThemeHooks() does not work here because it's not a React
+  // function component body. However, we would like to use translation.
+  // For now, shim translate with a placeholder function that does nothing
+  // but matches the syntax of the real translate function, in preparation for
+  // when we can actually use it.
+  // const { useTranslate } = useThemeHooks()
+  // const { translate } = useTranslate()
+  const translate = (key:string, s:string) => s; // Shim version of translate
+
+  let amendment : Amendment | any = amendmentsSnapshot.amendments.find( (a) => a.name === name )
+  let status = "Status Unknown"
+  if (!amendment) {  
+    status = translate("amendment.status.inactive", "Inactive")
+    amendment = {
+      name: name
+    }
+  } else {
+    status = amendmentStatusForLlms(amendment)
+  }
+  if (statusOnly) {
+    return status
+  }
+  const link = `/resources/known-amendments#${name.toLowerCase()}`
+
+  if (compact) {
+    return `[${name}](${link}) (${status})`
+  }
+
+  let text1, text2
+  if (mode === "updated") {
+    if (amendment.date) {
+      text1 = translate("component.amendment-status.updated.1", "Updated by the ")
+      text2 = translate("component.amendment-status.updated.2", ".")
+    } else {
+      text1 = translate("component.amendment-status.requires.1", "Requires the ")
+      text2 = translate("component.amendment-status.requires.2", ".")
+    }
+  } else {
+    if (amendment.date) {
+      text1 = translate("component.amendment-status.added.1", "Added by the ")
+      text2 = translate("component.amendment-status.added.2", ".")
+    } else {
+      text1 = translate("component.amendment-status.requires.1", "Requires the ")
+      text2 = translate("component.amendment-status.requires.2", ".")
+    }
+  }
+  return `_${text1}[${name} amendment](${link})${text2} (${status})_`
 }
 
 function shieldsIoEscape(s: string) {

--- a/@theme/data/obsolete-amendments.json
+++ b/@theme/data/obsolete-amendments.json
@@ -1,0 +1,82 @@
+[
+    {
+        "id": "267624F8F744C4A4F1B5821A7D54410BCEBABE987F0172EE89E5FC4B6EDBC18A",
+        "name": "fixBatchInnerSigs",
+        "rippled_version": "3.1.0",
+        "status": "Removed in 3.1.1",
+        "href": "https://xrpl.org/blog/2026/rippled-3.1.1"
+    },
+    {
+        "id": "894646DD5284E97DECFE6674A6D6152686791C4A95F8C132CCA9BAF9E5812FB6",
+        "name": "Batch",
+        "rippled_version": "2.5.0",
+        "status": "Removed in 3.1.1",
+        "href": "https://xrpl.org/blog/2026/rippled-3.1.1"
+    },
+    {
+        "id": "AE6AB9028EEB7299EBB03C7CBCC3F2A4F5FBE00EA28B8223AA3118A0B436C1C5",
+        "name": "PermissionDelegation",
+        "rippled_version": "2.5.0",
+        "status": "Removed in 2.6.1",
+        "href": "https://xrpl.org/blog/2026/rippled-2.6.1"
+    },
+    {
+        "id": "36799EA497B1369B170805C078AEFE6188345F9B3E324C21E9CA3FF574E3C3D6",
+        "name": "fixNFTokenNegOffer",
+        "rippled_version": "1.9.2",
+        "status": "To Be Removed"
+    },
+    {
+        "id": "0285B7E5E08E1A8E4C15636F0591D87F73CB6A7B6452A932AD72BBC8E5D1CBE3",
+        "name": "fixNFTokenDirV1",
+        "rippled_version": "1.9.1",
+        "status": "To Be Removed"
+    },
+    {
+        "id": "3C43D9A973AA4443EF3FC38E42DD306160FBFFDAB901CD8BAA15D09F2597EB87",
+        "name": "NonFungibleTokensV1",
+        "rippled_version": "1.9.0",
+        "status": "To Be Removed"
+    },
+    {
+        "id": "86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90",
+        "name": "CryptoConditionsSuite",
+        "rippled_version": "0.60.0",
+        "status": "To Be Removed"
+    },
+    {
+        "id": "9178256A980A86CF3D70D0260A7DA6402AAFE43632FDBCB88037978404188871",
+        "name": "OwnerPaysFee",
+        "rippled_version": "0.33.0",
+        "status": "Removed in 0.80.0",
+        "href": "https://xrpl.org/blog/2017/rippled-0.80.0"
+    },
+    {
+        "id": "C6970A8B603D8778783B61C0D445C23D1633CCFAEF0D43E7DBCD1521D34BD7C3",
+        "name": "SHAMapV2",
+        "rippled_version": "0.32.1",
+        "status": "Removed in 1.4.0",
+        "href": "https://xrpl.org/blog/2019/rippled-1.4.0.html"
+    },
+    {
+        "id": "C1B8D934087225F509BEB5A8EC24447854713EE447D277F69545ABFA0E0FD490",
+        "name": "Tickets",
+        "rippled_version": "0.30.1",
+        "status": "Removed in 0.90.0",
+        "href": "https://xrpl.org/blog/2018/rippled-0.90.0.html"
+    },
+    {
+        "id": "DA1BD556B42D85EA9C84066D028D355B52416734D3283F85E216EA5DA6DB7E13",
+        "name": "SusPay",
+        "rippled_version": "0.31.0",
+        "status": "Removed in 0.60.0",
+        "href": "https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features"
+    },
+    {
+        "id": "5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26",
+        "name": "FlowV2",
+        "rippled_version": "0.32.1",
+        "status": "Removed in 0.33.0",
+        "href": "https://xrpl.org/blog/2016/flowv2-vetoed.html"
+    }
+]

--- a/@theme/data/obsolete-amendments.json
+++ b/@theme/data/obsolete-amendments.json
@@ -1,5 +1,33 @@
 [
     {
+        "id": "36799EA497B1369B170805C078AEFE6188345F9B3E324C21E9CA3FF574E3C3D6",
+        "name": "fixNFTokenNegOffer",
+        "rippled_version": "1.9.2",
+        "status": "Removed in 3.2.0",
+        "href": "https://github.com/XRPLF/rippled/pull/5971"
+    },
+    {
+        "id": "0285B7E5E08E1A8E4C15636F0591D87F73CB6A7B6452A932AD72BBC8E5D1CBE3",
+        "name": "fixNFTokenDirV1",
+        "rippled_version": "1.9.1",
+        "status": "Removed in 3.2.0",
+        "href": "https://github.com/XRPLF/rippled/pull/5971"
+    },
+    {
+        "id": "3C43D9A973AA4443EF3FC38E42DD306160FBFFDAB901CD8BAA15D09F2597EB87",
+        "name": "NonFungibleTokensV1",
+        "rippled_version": "1.9.0",
+        "status": "Removed in 3.2.0",
+        "href": "https://github.com/XRPLF/rippled/pull/5971"
+    },
+    {
+        "id": "86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90",
+        "name": "CryptoConditionsSuite",
+        "rippled_version": "0.60.0",
+        "status": "Removed in 3.2.0",
+        "href": "https://github.com/XRPLF/rippled/pull/6036"
+    },
+    {
         "id": "267624F8F744C4A4F1B5821A7D54410BCEBABE987F0172EE89E5FC4B6EDBC18A",
         "name": "fixBatchInnerSigs",
         "rippled_version": "3.1.0",
@@ -18,38 +46,7 @@
         "name": "PermissionDelegation",
         "rippled_version": "2.5.0",
         "status": "Removed in 2.6.1",
-        "href": "https://xrpl.org/blog/2026/rippled-2.6.1"
-    },
-    {
-        "id": "36799EA497B1369B170805C078AEFE6188345F9B3E324C21E9CA3FF574E3C3D6",
-        "name": "fixNFTokenNegOffer",
-        "rippled_version": "1.9.2",
-        "status": "To Be Removed"
-    },
-    {
-        "id": "0285B7E5E08E1A8E4C15636F0591D87F73CB6A7B6452A932AD72BBC8E5D1CBE3",
-        "name": "fixNFTokenDirV1",
-        "rippled_version": "1.9.1",
-        "status": "To Be Removed"
-    },
-    {
-        "id": "3C43D9A973AA4443EF3FC38E42DD306160FBFFDAB901CD8BAA15D09F2597EB87",
-        "name": "NonFungibleTokensV1",
-        "rippled_version": "1.9.0",
-        "status": "To Be Removed"
-    },
-    {
-        "id": "86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90",
-        "name": "CryptoConditionsSuite",
-        "rippled_version": "0.60.0",
-        "status": "To Be Removed"
-    },
-    {
-        "id": "9178256A980A86CF3D70D0260A7DA6402AAFE43632FDBCB88037978404188871",
-        "name": "OwnerPaysFee",
-        "rippled_version": "0.33.0",
-        "status": "Removed in 0.80.0",
-        "href": "https://xrpl.org/blog/2017/rippled-0.80.0"
+        "href": "https://xrpl.org/blog/2025/rippled-2.6.1"
     },
     {
         "id": "C6970A8B603D8778783B61C0D445C23D1633CCFAEF0D43E7DBCD1521D34BD7C3",
@@ -64,6 +61,13 @@
         "rippled_version": "0.30.1",
         "status": "Removed in 0.90.0",
         "href": "https://xrpl.org/blog/2018/rippled-0.90.0.html"
+    },
+    {
+        "id": "9178256A980A86CF3D70D0260A7DA6402AAFE43632FDBCB88037978404188871",
+        "name": "OwnerPaysFee",
+        "rippled_version": "0.33.0",
+        "status": "Removed in 0.80.0",
+        "href": "https://xrpl.org/blog/2017/rippled-0.80.0"
     },
     {
         "id": "DA1BD556B42D85EA9C84066D028D355B52416734D3283F85E216EA5DA6DB7E13",

--- a/@theme/markdoc/components.tsx
+++ b/@theme/markdoc/components.tsx
@@ -1,6 +1,6 @@
 export { default as XRPLoader } from '../components/XRPLoader'
 export { XRPLCard, CardGrid } from '../components/XRPLCard'
-export { AmendmentsTable, AmendmentDisclaimer, Badge } from '../components/Amendments'
+export { AmendmentsTable, ObsoleteAmendmentsTable, AmendmentDisclaimer, Badge } from '../components/Amendments'
 export { Tabs } from '../components/SyncedTabs'
 export { default as ChildPages } from '../components/ChildPages'
 export { default as NotEnabled } from '../components/NotEnabled'

--- a/@theme/markdoc/schema.ts
+++ b/@theme/markdoc/schema.ts
@@ -2,7 +2,7 @@ import { Schema, Tag } from '@markdoc/markdoc';
 import type { MarkdocTagSchema } from '@redocly/theme/markdoc/tags/types';
 import { sourceLinkForLlms } from '../components/SourceLink';
 import { ResposiveGraphicForLlms } from '../components/ResponsiveGraphic'
-import { amendmentsTableForLlms, amendmentDisclaimerForLlms } from '../components/Amendments';
+import { amendmentsTableForLlms, amendmentDisclaimerForLlms, obsoleteAmendmentsTableForLlms } from '../components/Amendments';
 
 export const childPages: Schema & { tagName: string } = {
   tagName: 'child-pages',
@@ -247,6 +247,13 @@ export const amendmentsTable: MarkdocTagSchema & { tagName: string } = {
   render: 'AmendmentsTable',
   selfClosing: true,
   renderForLlms: amendmentsTableForLlms,
+}
+
+export const obsoleteAmendmentsTable: MarkdocTagSchema & { tagName: string } = {
+  tagName: 'obsolete-amendments-table',
+  render: 'ObsoleteAmendmentsTable',
+  selfClosing: true,
+  renderForLlms: obsoleteAmendmentsTableForLlms,
 }
 
 export const amendmentDisclaimer: MarkdocTagSchema &  { tagName: string } = {

--- a/@theme/markdoc/schema.ts
+++ b/@theme/markdoc/schema.ts
@@ -2,7 +2,7 @@ import { Schema, Tag } from '@markdoc/markdoc';
 import type { MarkdocTagSchema } from '@redocly/theme/markdoc/tags/types';
 import { sourceLinkForLlms } from '../components/SourceLink';
 import { ResposiveGraphicForLlms } from '../components/ResponsiveGraphic'
-import { amendmentsTableForLlms } from '../components/Amendments';
+import { amendmentsTableForLlms, amendmentDisclaimerForLlms } from '../components/Amendments';
 
 export const childPages: Schema & { tagName: string } = {
   tagName: 'child-pages',
@@ -249,7 +249,7 @@ export const amendmentsTable: MarkdocTagSchema & { tagName: string } = {
   renderForLlms: amendmentsTableForLlms,
 }
 
-export const amendmentDisclaimer: Schema &  { tagName: string } = {
+export const amendmentDisclaimer: MarkdocTagSchema &  { tagName: string } = {
   tagName: 'amendment-disclaimer',
   attributes: {
     name: {
@@ -261,6 +261,11 @@ export const amendmentDisclaimer: Schema &  { tagName: string } = {
       required: false,
       default: false
     },
+    statusOnly: {
+      type: 'Boolean',
+      required: false,
+      default: false
+    },
     mode: {
       type: 'String',
       required: false,
@@ -268,6 +273,7 @@ export const amendmentDisclaimer: Schema &  { tagName: string } = {
     }
   },
   render: 'AmendmentDisclaimer',
+  renderForLlms: amendmentDisclaimerForLlms,
   selfClosing: true
 }
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -115,7 +115,7 @@ This amendment was disabled in v3.1.1 due to a bug. It will be replaced by `Batc
 |:-------------|:------------------------|
 | Amendment ID | 98DECF327BF79997AEC178323AD51A830E457BFC6D454DAF3E46E5EC42DC619F |
 | Status       | {% amendment-disclaimer name="CheckCashMakesTrustLine" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Adjusts the [CheckCash transaction][] so that cashing a [Check](../docs/concepts/payment-types/checks.md) for an issued token automatically creates a [trust line](../docs/concepts/tokens/fungible-tokens/index.md) to hold the token. The new behavior is similar to how the [OfferCreate transaction][] behaves when users buy tokens in the decentralized exchange: the automatic trust line has a limit value of 0. This removes the setup step of setting up a trust line before receiving a token via a Check. (Checks that send XRP are unaffected.)
@@ -132,7 +132,7 @@ This amendment does not change the fact that you cannot force anyone to hold tok
 |:-------------|:-------|
 | Amendment ID | 157D2D480E006395B76F948E3E07A45A05FE10230D88A7993C71F97AE4B1F2D1 |
 | Status       | {% amendment-disclaimer name="Checks" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Introduces "Checks" to the XRP Ledger. Checks work similarly to personal paper checks. The sender signs a transaction to create a Check for a specific maximum amount and destination. Later, the destination can cash the Check to receive up to the specified amount. The actual movement of money only occurs when the Check is cashed, so cashing the Check may fail depending on the sender's current balance and the available liquidity. If cashing the Check fails, the Check object remains in the ledger so it may be successfully cashed later.
@@ -218,7 +218,7 @@ For more details, see [XLS-96: Confidential Transfers](https://opensource.ripple
 |:-------------|:-----------------|
 | Amendment ID | 1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146 |
 | Status       | {% amendment-disclaimer name="CryptoConditions" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Although this amendment is enabled, it has no effect unless the [SusPay](#suspay) amendment is also enabled. The SusPay amendment was replaced by the [Escrow](#escrow) amendment, so the CryptoConditions amendment has no effect.
@@ -231,8 +231,8 @@ Although this amendment is enabled, it has no effect unless the [SusPay](#suspay
 |:-------------|:----------------------|
 | Amendment ID | 86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90 |
 | Status       | {% amendment-disclaimer name="CryptoConditionsSuite" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | Yes |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This amendment was intended to add support for several types of crypto-conditions from the official [crypto-conditions specification](https://tools.ietf.org/html/draft-thomas-crypto-conditions-03) for use in [EscrowCreate][] and [EscrowFinish][] transactions.
 
@@ -266,7 +266,7 @@ This amendment enables issuers to deep freeze trustlines from interacting with p
 |:-------------|:------------------|
 | Amendment ID | 30CD365592B8EE40489BA01AE2F7555CAC9C983145871DC82A42A31CF5BAE7D9 |
 | Status       | {% amendment-disclaimer name="DeletableAccounts" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Makes it possible to delete [accounts](../docs/concepts/accounts/index.md).
@@ -283,7 +283,7 @@ With this amendment, new accounts start with their `Sequence` numbers equal to t
 |:-------------|:------------|
 | Amendment ID | F64E1EABBE79D55B3BB82020516CEC2C582A98A6BFE20FBE9BB6A0D233418064 |
 | Status       | {% amendment-disclaimer name="DepositAuth" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Adds a new account flag, `DepositAuth`, which lets an account strictly reject any incoming money from transactions sent by other accounts. Businesses can use this flag to comply with strict regulations that require due diligence before receiving money from any source.
@@ -302,7 +302,7 @@ Also fixes a bug in the EscrowCreate and PaymentChannelCreate transactions where
 |:-------------|:---------------|
 | Amendment ID | 3CBC5C4E630A1B82380295CDA84B32B49DD066602E74E39B85EF64137FA65194 |
 | Status       | {% amendment-disclaimer name="DepositPreauth" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Provides users of [deposit authorization](../docs/concepts/accounts/depositauth.md) with a way to preauthorize specific senders so those senders are allowed to send payments directly.
@@ -343,7 +343,7 @@ Adds several new transaction result codes.
 |:-------------|:-----------------|
 | Amendment ID | 47C3002ABA31628447E8E9A8B315FAA935CE30183F9A9B86845E469CA2CDC3DF |
 | Status       | {% amendment-disclaimer name="DisallowIncoming" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Provides options to categorically block incoming Checks, Payment Channels, NFTokenOffers, and trust lines from reaching your account. When an account has these options enabled, other accounts cannot create those types of objects with the account as the destination.
@@ -398,7 +398,7 @@ For more details, see [XLS-94: Dynamic MPTs](https://opensource.ripple.com/docs/
 |:-------------|:------------------|
 | Amendment ID | DC9CA96AEA1DCF83E527D1AFC916EFAF5D27388ECA4060A88817C1238CAEE0BF |
 | Status       | {% amendment-disclaimer name="EnforceInvariants" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Adds sanity checks to transaction processing to ensure that certain conditions are always met. This provides an extra, independent layer of protection against bugs in transaction processing that could otherwise cause exploits and vulnerabilities in the XRP Ledger. Future versions of `rippled` may add more invariants without additional amendments.
@@ -421,7 +421,7 @@ Examples of invariant checks:
 |:-------------|:-------|
 | Amendment ID | 07D43DCE529B15A10827E5E04943B496762F9A88E3268269D69C44BE49E21104 |
 | Status       | {% amendment-disclaimer name="Escrow" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Replaces the [SusPay](#suspay) and [CryptoConditions](#cryptoconditions) amendments.
@@ -436,7 +436,7 @@ Provides "suspended payments" for XRP for escrow within the XRP Ledger, includin
 |:-------------|:-------------------|
 | Amendment ID | B2A4DB846F0891BF2C76AB2F2ACC8F5B4EC64437135C6E56F3F859DE5FFD5856 |
 | Status       | {% amendment-disclaimer name="ExpandedSignerList" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 This amendment expands the maximum signer list size and allows each signer to have optional data associated with it. The additional data can be used to identify the signer, which may be useful for smart contracts, or for identifying who controls a key in a large organization: for example, you could store an IPv6 address or the identifier of a Hardware Security Module (HSM).
@@ -453,7 +453,7 @@ With this amendment, the maximum [SignerList object][] size is 32 entries. Addit
 |:-------------|:--------------|
 | Amendment ID | 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE |
 | Status       | {% amendment-disclaimer name="FeeEscalation" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes the way the [transaction cost](../docs/concepts/transactions/transaction-cost.md) applies to proposed transactions. Modifies the consensus process to prioritize transactions that pay a higher transaction cost. <!-- STYLE_OVERRIDE: prioritize -->
@@ -476,7 +476,7 @@ A transaction remains in the queue until one of the following happens:
 |:-------------|:--------|
 | Amendment ID | B4D44CC3111ADD964E846FC57760C8B50FFCD5A82C86A72756F6B058DDDF96AD |
 | Status       | {% amendment-disclaimer name="fix1201" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Correctly implements a limit on [transfer fees](../docs/concepts/tokens/fungible-tokens/transfer-fees.md) to a 100% fee, represented by a maximum `TransferRate` value of `2000000000`. (A 100% fee in this case means you must send 2 units of the token for every 1 unit you want to deliver.) Without the amendment, the effective limit is a `TransferRate` value of 2<sup>32</sup>-1, for approximately a 329% fee.
@@ -491,7 +491,7 @@ With this amendment enabled, an [AccountSet][] transaction that attempts to set 
 |:-------------|:--------|
 | Amendment ID | E2E6F2866106419B88C50045ACE96368558C345566AC8F2BDF5A5B5587F0E6FA |
 | Status       | {% amendment-disclaimer name="fix1368" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a minor bug in transaction processing that causes some payments to fail when they should be valid. Specifically, during payment processing, some payment steps that are expected to produce a certain amount of currency may produce a microscopically different amount, due to a loss of precision related to floating-point number representation. When this occurs, those payments fail because they cannot deliver the exact amount intended. The fix1368 amendment corrects transaction processing so payments can no longer fail in this manner.
@@ -504,7 +504,7 @@ Fixes a minor bug in transaction processing that causes some payments to fail wh
 |:-------------|:--------|
 | Amendment ID | 42EEA5E28A97824821D4EF97081FE36A54E9593C6E4F20CBAE098C69D2E072DC |
 | Status       | {% amendment-disclaimer name="fix1373" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a minor bug in transaction processing that causes failures when trying to prepare certain [payment paths](../docs/concepts/tokens/fungible-tokens/paths.md) for processing. As a result, payments could not use certain paths that should have been valid but were invalidly prepared. Without this amendment, those payments are forced to use less-preferable paths or may even fail.
@@ -519,7 +519,7 @@ The fix1373 amendment corrects the issue so that the paths are properly prepared
 |:-------------|:--------|
 | Amendment ID | 6C92211186613F9647A89DFFBAB8F94C99D4C7E956D495270789128569177DA1 |
 | Status       | {% amendment-disclaimer name="fix1512" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a bug in transaction processing that causes some invalid [PaymentChannelClaim][] transactions to fail with the wrong error code. Without this amendment, the transactions have a `tec`-class result code despite not being included in a ledger.
@@ -534,7 +534,7 @@ With this amendment, the transactions fail with a more appropriate result code, 
 |:-------------|:--------|
 | Amendment ID | 67A34F2CF55BFC0F93AACD5B281413176FEE195269FA6D95219A2DF738671172 |
 | Status       | {% amendment-disclaimer name="fix1513" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a bug that resulted in transaction processing not using new `STAmountCalcSwitchovers` code when the `FeeEscalation` amendment is enabled.
@@ -549,7 +549,7 @@ With this amendment, the new `STAmountCalcSwitchovers` code applies, which may c
 |:-------------|:--------|
 | Amendment ID | 5D08145F0A4983F23AFFFF514E83FAD355C5ABFBB6CAB76FB5BC8519FF5F33BE |
 | Status       | {% amendment-disclaimer name="fix1515" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes how Payment transactions consume offers to remove a minor difference in how payment processing and offer processing consume liquidity. (Also affects how OfferCreate transactions are processed if [FlowCross][] is enabled.)
@@ -568,7 +568,7 @@ In both cases, transaction processing can still complete by using liquidity from
 |:-------------|:--------|
 | Amendment ID | B9E739B8296B4A1BB29BE990B17D66E21B62A300A909F25AC55C22D6C72E1F9D |
 | Status       | {% amendment-disclaimer name="fix1523" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Adds tracking by destination account to [escrows](../docs/concepts/payment-types/escrow.md). Without this amendment, pending escrows are only tracked by sender. This amendment makes it possible to look up pending escrows by the destination address using the [account_objects method][], excluding any pending escrows that were created before this amendment became enabled. This amendment also makes [EscrowCreate transactions][] appear in the destination's transaction history, as viewed with the [account_tx method][].
@@ -583,7 +583,7 @@ With this amendment, new escrows are added to the [owner directories](../docs/re
 |:-------------|:--------|
 | Amendment ID | 1D3463A5891F9E589C5AE839FFAC4A917CE96197098A1EF22304E1BC5B98A454 |
 | Status       | {% amendment-disclaimer name="fix1528" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a bug where validators could build consensus ledgers with different timestamps, potentially delaying the process of declaring validated ledgers. The circumstances for this to occur require precise timing, so this bug is unlikely to happen outside of controlled test conditions.
@@ -598,7 +598,7 @@ This amendment changes how validators negotiate the close time of the consensus 
 |:-------------|:--------|
 | Amendment ID | CA7C02118BA27599528543DFE77BA6838D1B0F43B447D4D7F53523CE6A0E9AC2 |
 | Status       | {% amendment-disclaimer name="fix1543" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Enforces reserved flag ranges on some transaction types that did not correctly enforce them already. Transactions of the affected types are now considered invalid if they enable undefined or unknown flags, or flags from the reserved range. (Transactions unaffected by this change already correctly enforce the same rules.)
@@ -618,7 +618,7 @@ The affected transaction types are:
 |:-------------|:--------|
 | Amendment ID | 7117E2EC2DBF119CA55181D69819F1999ECEE1A0225A7FD2B9ED47940968479C |
 | Status       | {% amendment-disclaimer name="fix1571" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes Escrow to fix the following issues:
@@ -634,7 +634,7 @@ Changes Escrow to fix the following issues:
 |:-------------|:--------|
 | Amendment ID | FBD513F1B893AC765B78F250E6FFA6A11B573209D1842ADC787C850696741288 |
 | Status       | {% amendment-disclaimer name="fix1578" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes the result codes returned by two transaction types:
@@ -650,7 +650,7 @@ Changes the result codes returned by two transaction types:
 |:-------------|:--------|
 | Amendment ID | 58BE9B5968C4DA7C59BA900961828B113E5490699B21877DEF9A31E9D0FE5D5F |
 | Status       | {% amendment-disclaimer name="fix1623" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Adds delivered amount to metadata for CheckCash transactions cashed for a flexible amount. (Has no effect unless the [Checks](#checks) amendment is enabled.)
@@ -667,7 +667,7 @@ The fix1623 amendment has no effect on [CheckCash transactions][] for a fixed am
 |:-------------|:--------|
 | Amendment ID | 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E |
 | Status       | {% amendment-disclaimer name="fix1781" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a bug where certain XRP endpoints were not checked when detecting circular paths.
@@ -684,7 +684,7 @@ With this amendment, those payments fail with the [`temBAD_PATH_LOOP` result cod
 |:-------------|:--------|
 | Amendment ID | 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 |
 | Status       | {% amendment-disclaimer name="fixAmendmentMajorityCalc" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a bug that could cause an amendment to achieve a majority and later activate with support of slightly less than 80% of trusted validators due to rounding semantics.
@@ -1077,7 +1077,7 @@ This amendment adds missing `DeliveredAmount` and `delivered_amount` metadata fi
 
 This amendment fixes an off-by-one error that occurred in some corner cases when determining which `NFTokenPage` a `NFToken` object belongs on. It also adjusts the constraints of `NFTokenPage` invariant checks, so that certain error cases fail with a suitable error code such as `tecNO_SUITABLE_TOKEN_PAGE` instead of failing with a `tecINVARIANT_FAILED` error code.
 
-This amendment has no effect unless the [NonFungibleTokensV1][] amendment is enabled. This amendment is obsolete because its effects are included as part of [NonFungibleTokensV1_1][].
+This amendment is obsolete because its effects are included as part of [NonFungibleTokensV1_1][].
 
 
 ### fixNFTokenNegOffer
@@ -1087,12 +1087,12 @@ This amendment has no effect unless the [NonFungibleTokensV1][] amendment is ena
 |:-------------|:-------------------|
 | Amendment ID | 36799EA497B1369B170805C078AEFE6188345F9B3E324C21E9CA3FF574E3C3D6 |
 | Status       | {% amendment-disclaimer name="fixNFTokenNegOffer" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This amendment fixes a bug in the [NonFungibleTokensV1][] amendment code where NFTs could be traded for negative amounts of money. Without this fix, users could place and accept an offer to buy or sell a `NFToken` for a negative amount of money, which resulted in the person "buying" the NFT also receiving money from the "seller". With this amendment, NFT offers for negative amounts are considered invalid.
 
-This amendment has no effect unless the [NonFungibleTokensV1][] amendment is enabled. This amendment is obsolete because its effects are included as part of [NonFungibleTokensV1_1][].
+This amendment is obsolete because its effects are included as part of [NonFungibleTokensV1_1][].
 
 
 ### fixNFTokenPageLinks
@@ -1119,7 +1119,7 @@ Without this amendment, it is possible in specific circumstances to delete the l
 |:-------------|:--------|
 | Amendment ID | AE35ABDEFBDE520372B31C957020B34A7A4A9DC3115A69803A44016477C84D6E |
 | Status       | {% amendment-disclaimer name="fixNFTokenRemint" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Amendment `fixNFTokenRemint` would change the way NFT sequence numbers are constructed to prevent a situation where the same NFT could be minted more than once with the same sequence number, creating a possible collision scenario. This amendment would change the construction of NFT sequence numbers to:
@@ -1145,7 +1145,7 @@ This is a **breaking change** for projects & tools relying on their own locally 
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-This amendment adds a check to the `NFTokenAcceptOffer` transactor to see if the `OwnerCount` changes. If it does, it makes an additional check that the reserve requirement is met for the updated owner count.
+This amendment adds a check to the [NFTokenAcceptOffer transaction][] to see if the buyer's number of objects owned in the ledger changes. Without this amendment, an account could accept an NFT offer even if they did not meet the reserve requirement after doing so. With this amendment, accepting the offer fails if their reserve is below the necessary amount.
 
 
 ### fixNonFungibleTokensV1_2
@@ -1155,38 +1155,17 @@ This amendment adds a check to the `NFTokenAcceptOffer` transactor to see if the
 |:-------------|:--------|
 | Amendment ID | 73761231F7F3D94EC3D8C63D91BDD0D89045C6F71B917D1925C01253515A6669 |
 | Status       | {% amendment-disclaimer name="fixNonFungibleTokensV1_2" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
-Amendment `fixNonFungibleTokensV1_2` is a combination of bug fixes that have been individually merged into feature/nft-fixes through the pull request process.
+This amendment combines several bug fixes to NFTs:
 
-**Fix Unburnable NFT**
-
-Currently, an NFT cannot be burned when it has over 500 offers. To remove this restriction, this change deletes exactly 500 offers upon burning the NFT, leaving any remaining offers untouched. This addresses a concern where the issuer account cannot burn an NFT that has enabled the `lsfBurnable` flag, due to the exceeding number of offers.
-
-See [PR 4346](https://github.com/XRPLF/rippled/pull/4346).
-
-**Fix 3 Issues Around NFToken Offer Acceptance**
-
-Issue 1: Resolve situation where an account is unable to broker a deal due to an erroneous insufficient funds condition.
-
-Issue 2: Resolve situation where a buyer has insufficient funds to cover a transfer fee on the account.
-
-Issue 3: Enable currency issuers to buy and sell NFTs using their own currency.
-
-See [PR 4380](https://github.com/XRPLF/rippled/pull/4380).
-
-**Prevent Brokered Sale of NFToken to Owner (fix #4374)**
-
-This fix prevents a broker from selling an NFT to the account that already owns the token.
-
-See [Issue 4374](https://github.com/XRPLF/rippled/issues/4374).
-
-**Only allow the destination to settle an NFT offer through brokerage (fix #4373)**
-
-If you set a destination on an NFT offer, only that destination can settle through brokerage (fix #4373).
-
-See [Issue 4373](https://github.com/XRPLF/rippled/issues/4373).
+- **Fix Unburnable NFT:** Without this amendment, an NFT cannot be burned when it has over 500 offers. With this amendment, an attempt to burn the NFT deletes up to 500 offers at a time, leaving any remaining offers "orphaned" in the ledger.
+- **Fix erroneous insufficient funds when brokering:** Without this amendment, an account is unable to broker a deal due to an erroneous insufficient funds condition if the broker does not hold at least the purchase price of the NFT. With this amendment, the deal can succeed because only the buyer, not the broker, needs to hold the purchase amount.
+- **Fix transfer fee not accounted for in purchase:** Without this amendment, if a buyer pays for an NFT using a trust line token with a transfer fee, but the buyer has insufficient funds to cover the transfer fee, their balance of a trust line token can go negative by the amount of the transfer fee in violation of the token issuer's limit. With this amendment, the buyer must hold enough to pay the purchase price _and_ the transfer fee.
+- **Allow issuers to buy and sell NFTs for their own tokens:** Without this amendment, issuers could not use their own trust line tokens to buy and sell NFTs. With this amendment, issuers can buy and sell NFTs using their own trust line tokens.
+- **Prevent brokered sale to owner:** Without this amendment, if an account has existing offers to buy and sell an NFT that they already own, another account can broker a "trade" where the owner sells it to themself, and the broker claims part of the spread between the offers. With this amendment, such a trade cannot be brokered.
+- **Only allow destination to broker NFT offers:** Without this amendment, when an NFT offer specifies a specific destination account, and that offer is matched, anyone can use brokered mode to complete the trade to the specified destination. With this amendment, an NFT offer with a destination specified can only be completed in brokered mode if the broker is specified as the destination.
 
 
 ### fixPayChanCancelAfter
@@ -1328,7 +1307,7 @@ This amendment has no effect unless either [NonFungibleTokensV1][] or [NonFungib
 |:-------------|:--------|
 | Amendment ID | B6B3EEDC0267AB50491FDC450A398AF30DBCD977CECED8BEF2499CAB5DAC19E2 |
 | Status       | {% amendment-disclaimer name="fixRmSmallIncreasedQOffers" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 This amendment fixes an issue where certain Offers, when almost completely consumed, have a much lower exchange rate than when they were first placed. This occurs when the remaining amounts of one or both assets are so small that they cannot be rounded to a similar ratio as when the Offer was placed.
@@ -1345,7 +1324,7 @@ With this amendment, payments and trades can remove these types of Offers the sa
 |:-------------|:--------|
 | Amendment ID | 452F5906C46D46F407883344BFDD90E672B672C5E9943DB4891E3A34FEEEB9DB |
 | Status       | {% amendment-disclaimer name="fixSTAmountCanonicalize" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes an edge case in [deserializing](../docs/references/protocol/binary-format.md) Amount-type fields. Without this amendment, in some rare cases the operation could result in otherwise valid serialized amounts overflowing during deserialization. With this amendment, the XRP Ledger detects error conditions more quickly and eliminates the problematic corner cases.
@@ -1358,7 +1337,7 @@ Fixes an edge case in [deserializing](../docs/references/protocol/binary-format.
 |:-------------|:--------|
 | Amendment ID | 2CD5286D8D687E98B41102BDD797198E81EA41DF7BD104E6561FEB104EFF2561 |
 | Status       | {% amendment-disclaimer name="fixTakerDryOfferRemoval" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Fixes a bug in [auto-bridging](../docs/concepts/tokens/decentralized-exchange/autobridging.md) that can leave a dry offer in the XRP Ledger. A dry offer is an offer that, if crossed, cannot yield any funds.
@@ -1390,7 +1369,7 @@ This amendment ensures that when escrowed MPTs are unlocked, the issuer's locked
 |:-------------|:--------|
 | Amendment ID | F1ED6B4A411D8B872E65B9DCB4C8B100375B0DD3D62D07192E011D6D7F339013 |
 | Status       | {% amendment-disclaimer name="fixTrustLinesToSelf" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 This amendment removes two trust lines from an account to itself that were created due to an old bug (both on 2013-05-07). When the amendment becomes enabled, it deletes trust lines with the IDs `2F8F21EFCAFD7ACFB07D5BB04F0D2E18587820C7611305BB674A64EAB0FA71E1` and `326035D5C0560A9DA8636545DD5A1B0DFCFF63E68D491B5522B767BB00564B1A` if they exist. After doing so, the amendment does nothing else.
@@ -1437,7 +1416,7 @@ This amendment restores the intended rounding behavior. It has no effect unless 
 |:-------------|:--------|
 | Amendment ID | 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 |
 | Status       | {% amendment-disclaimer name="Flow" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Replaces the payment processing engine with a more robust and efficient rewrite called the Flow engine. The new version of the payment processing engine is intended to follow the same rules as the old one, but occasionally produces different results due to floating point rounding. This Amendment supersedes the [FlowV2](https://xrpl.org/blog/2016/flowv2-vetoed.html) amendment.
@@ -1452,7 +1431,7 @@ The Flow Engine also makes it easier to improve and expand the payment engine wi
 |:-------------|:--------|
 | Amendment ID | 3012E8230864E95A58C60FD61430D7E1B4D3353195F2981DC12B0C7C0950FFAC |
 | Status       | {% amendment-disclaimer name="FlowCross" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Streamlines the offer crossing logic in the XRP Ledger's decentralized exchange. Uses the updated code from the [Flow](#flow) amendment to power offer crossing, so [OfferCreate transactions][] and [Payment transactions][] share more code. This has subtle differences in how offers are processed:
@@ -1469,7 +1448,7 @@ Streamlines the offer crossing logic in the XRP Ledger's decentralized exchange.
 |:-------------|:--------|
 | Amendment ID | AF8DF7465C338AE64B1E937D6C8DA138C0D63AD5134A68792BBBE1F63356C422 |
 | Status       | {% amendment-disclaimer name="FlowSortStrands" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Improves the payment engine's calculations for finding the most cost-efficient way to execute a cross-currency transaction.
@@ -1497,7 +1476,7 @@ This is a previous version of the [Flow](#flow) amendment. It was [rejected due 
 |:-------------|:--------|
 | Amendment ID | 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 |
 | Status       | {% amendment-disclaimer name="HardenedValidations" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Allows validators to include a new optional field in their validations to attest to the hash of the latest ledger that the validator considers to be fully validated. The consensus process can use this information to increase the robustness of consensus.
@@ -1510,7 +1489,7 @@ Allows validators to include a new optional field in their validations to attest
 |:-------------|:--------|
 | Amendment ID | 75A7E01C505DD5A179DFE3E000A9B6F1EDDEB55A12F95579A23E15B15DC8BE5A |
 | Status       | {% amendment-disclaimer name="ImmediateOfferKilled" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes OfferCreate transactions so that if an Offer uses `tfImmediateOrCancel` and transaction processing kills the Offer without moving any funds, the transaction uses the result code `tecKILLED` instead of `tesSUCCESS`. If the Offer exchanges any amount of funds, even a small amount, the transaction still uses `tesSUCCESS`. There are no other changes to the processing of the transaction (for example, in terms of whether it cleans up expired and unfunded Offers that were encountered in the ledger during transaction processing).
@@ -1602,7 +1581,7 @@ For more details, see [XLS-82: MPT DEX Integration](https://opensource.ripple.co
 |:-------------|:--------|
 | Amendment ID | 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 |
 | Status       | {% amendment-disclaimer name="MultiSign" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Introduces [multi-signing](../docs/concepts/accounts/multi-signing.md) as a way to authorize transactions. Creates the [`SignerList` ledger object type](../docs/references/protocol/ledger-data/ledger-entry-types/signerlist.md) and the [`SignerListSet` transaction type](../docs/references/protocol/transactions/types/signerlistset.md). Adds the optional `Signers` field to all transaction types. Modifies some transaction result codes.
@@ -1629,7 +1608,7 @@ An address with a SignerList can disable the master key even if a regular key is
 |:-------------|:--------|
 | Amendment ID | 586480873651E106F1D6339B0C4A8945BA705A777F3F4524626FF1FC07EFE41D |
 | Status       | {% amendment-disclaimer name="MultiSignReserve" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Reduces the [owner reserve](../docs/concepts/accounts/reserves.md#owner-reserves) counted against your XRP Ledger account when it owns a [multi-signing](../docs/concepts/accounts/multi-signing.md) SignerList.
@@ -1646,7 +1625,7 @@ With this amendment enabled, the owner reserve for a new SignerList is 5 XRP, re
 |:-------------|:--------|
 | Amendment ID | B4E4F5D2D6FB84DF7399960A732309C9FD530EAE5941838160042833625A6076 |
 | Status       | {% amendment-disclaimer name="NegativeUNL" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Implements a "Negative UNL" system, where the network can track which validators are temporarily offline and disregard those validators for quorum calculations. This can improve the ability of the network to make progress during periods of network instability.
@@ -1681,13 +1660,11 @@ Without this amendment, you must separately send an [NFTokenCreateOffer transact
 | Amendment ID | 3C43D9A973AA4443EF3FC38E42DD306160FBFFDAB901CD8BAA15D09F2597EB87 |
 | Status       | {% amendment-disclaimer name="NonFungibleTokensV1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | N/A |
-| Pre-amendment functionality retired? | N/A |
+| Pre-amendment functionality retired? | Yes |
 
 Adds native support for [non-fungible tokens](../docs/concepts/tokens/nfts/index.md). Standards Draft: [XLS-20d](https://github.com/XRPLF/XRPL-Standards/discussions/46). <!-- SPELLING_IGNORE: xls, 20d -->
 
-{% admonition type="danger" name="Warning" %}
-There are several known issues with this amendment including one that can cause `tecINVARIANT_FAILED` errors to appear in the ledger. It has been replaced by the [NonFungibleTokensV1_1 amendment][].
-{% /admonition %}
+This amendment was replaced by the [NonFungibleTokensV1_1 amendment][].
 
 This amendment adds 5 new transaction types:
 
@@ -1714,7 +1691,7 @@ It also modifies the [AccountSet transaction][] type to allow you to set the `NF
 |:-------------|:--------|
 | Amendment ID | 32A122F1352A4C7B3A6D790362CC34749C5E57FCE896377BFDC6CCD14F6CD627 |
 | Status       | {% amendment-disclaimer name="NonFungibleTokensV1_1" statusOnly=true /%} |
-| Default Vote (Latest stable release) | No |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Adds native support for [non-fungible tokens](../docs/concepts/tokens/nfts/index.md), including fixes to several issues that were discovered after [NonFungibleTokensV1][].
@@ -1758,7 +1735,7 @@ An incomplete version of this amendment was introduced in v0.33.0 and removed in
 |:-------------|:--------|
 | Amendment ID | 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 |
 | Status       | {% amendment-disclaimer name="PayChan" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Creates "Payment Channels" for XRP. Payment channels are a tool for facilitating repeated, unidirectional payments or temporary credit between two parties. This feature is expected to be useful for the [Interledger Protocol](https://interledger.org/). One party creates a Payment Channel and sets aside some XRP in that channel for a predetermined expiration. Then, through off-ledger secure communications, the sender can send "Claim" messages to the receiver. The receiver can redeem the Claim messages before the expiration, or choose not to in case the payment is not needed. The receiver can verify Claims individually without actually distributing them to the network and waiting for the consensus process to redeem them, then redeem the combined content of many small Claims later, as long as it is within the expiration.
@@ -1837,7 +1814,7 @@ This amendment creates a new ledger entry type, `PriceOracle`, and new transacti
 |:-------------|:--------|
 | Amendment ID | 00C1FC4A53E60AB02C864641002B3172F38677E29C26C5406685179B37E1EDAC |
 | Status       | {% amendment-disclaimer name="RequireFullyCanonicalSig" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes the signature requirements for the XRP Ledger protocol so that non-fully-canonical signatures are no longer valid in any case. This protects against [transaction malleability](../docs/concepts/transactions/finality-of-results/transaction-malleability.md) on _all_ transactions, instead of only transactions with the [`tfFullyCanonicalSig` flag](../docs/references/protocol/transactions/common-fields.md#global-flags) enabled.
@@ -1917,7 +1894,7 @@ For more details, see [XLS-100: Smart Escrows](https://opensource.ripple.com/doc
 |:-------------|:--------|
 | Amendment ID | CC5ABAE4F3EC92E94A59B1908C2BE82D2228B6485C00AFF8F22DF930D89C194E |
 | Status       | {% amendment-disclaimer name="SortedDirectories" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Sorts the entries in [DirectoryNode ledger objects](../docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md) and fixes a bug that occasionally caused pages of owner directories not to be deleted when they should have been.
@@ -1962,7 +1939,7 @@ This amendment was replaced by the [Escrow](../docs/references/protocol/ledger-d
 |:-------------|:--------|
 | Amendment ID | 955DF3FA5891195A9DAEFA1DDC6BB244B545DDE1BAA84CBB25D5F12A8DA68A0C |
 | Status       | {% amendment-disclaimer name="TicketBatch" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 This amendment adds [Tickets](../docs/concepts/accounts/tickets.md) as a way of sending transactions out of the typical sequence number order.
@@ -1990,7 +1967,7 @@ This amendment was replaced by the [TicketBatch][] amendment.
 |:-------------|:--------|
 | Amendment ID | 532651B4FD58DF8922A49BA101AB3E996E5BFBF95A913B3E392504863E63B164 |
 | Status       | {% amendment-disclaimer name="TickSize" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Changes the way [Offers](../docs/concepts/tokens/decentralized-exchange/offers.md#lifecycle-of-an-offer) are ranked in order books, so that currency issuers can configure how many significant digits are taken into account when ranking Offers by exchange rate. With this amendment, the exchange rates of Offers are rounded to the configured number of significant digits, so that more Offers have the same exact exchange rate. The intent of this change is to require a meaningful improvement in price to outrank a previous Offer. If used by major issuers, this should reduce the incentive to spam the ledger with Offers that are only a tiny fraction of a percentage point better than existing offers. It may also increase the efficiency of order book storage in the ledger, because Offers can be grouped into fewer exchange rates.
@@ -2033,7 +2010,7 @@ Specification: [XLS-85](https://xls.xrpl.org/xls/XLS-0085-token-escrow.html)
 |:-------------|:--------|
 | Amendment ID | 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC |
 | Status       | {% amendment-disclaimer name="TrustSetAuth" statusOnly=true /%} |
-| Default Vote (Latest stable release) | Yes |
+| Default Vote (Latest stable release) | N/A |
 | Pre-amendment functionality retired? | Yes |
 
 Allows pre-authorization of accounting relationships (zero-balance trust lines) when using [Authorized Trust Lines](../docs/concepts/tokens/fungible-tokens/authorized-trust-lines.md).

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -26,7 +26,7 @@ The following is a list of [amendments](../docs/concepts/networks-and-servers/am
 | [ConfidentialTransfer][]          | {% badge %}In Development: TBD{% /badge %} | [XLS-96 Confidential Transfers](https://opensource.ripple.com/docs/xls-96-confidential-transfers) |
 | [MPTokensV2][]                    | {% badge %}In Development: TBD{% /badge %} | [XLS-82 MPT DEX Integration](https://opensource.ripple.com/docs/xls-82-mpt-dex) |
 | [Sponsor][]                       | {% badge %}In Development: TBD{% /badge %} | [XLS-68 Sponsored Fees and Reserves](https://opensource.ripple.com/docs/xls-68-sponsored-fees-and-reserves) |
-| [SmartEscrow][]                 | {% badge %}In Development: TBD{% /badge %} | [XLS-100 Smart Escrows](https://opensource.ripple.com/docs/xls-100-smart-escrows) |
+| [SmartEscrow][]                   | {% badge %}In Development: TBD{% /badge %} | [XLS-100 Smart Escrows](https://opensource.ripple.com/docs/xls-100-smart-escrows) |
 
 {% admonition type="success" name="Tip" %}
 This list is updated manually. If you're working on an amendment and have a private network to test the changes, you can edit this page to add your in-development amendment to this list. For more information on contributing to the XRP Ledger, see [Contribute Code to the XRP Ledger](contribute-code/index.md).
@@ -37,21 +37,7 @@ This list is updated manually. If you're working on an amendment and have a priv
 
 The following is a list of known [amendments](../docs/concepts/networks-and-servers/amendments.md) that have been removed in a previous version of the core server, or are obsolete and have been marked for removal.
 
-| Name                              | Introduced | Status                        |
-|:----------------------------------|:-----------|:------------------------------|
-| [fixBatchInnerSigs]               | v3.1.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.1.1" %}Obsolete: Removed in v3.1.1{% /badge %} |
-| [Batch]                           | v2.5.0     | {% badge href="https://xrpl.org/blog/2026/rippled-3.1.1" %}Obsolete: Removed in v3.1.1{% /badge %} |
-| [PermissionDelegation]            | v2.5.0     | {% badge href="https://xrpl.org/blog/2025/rippled-2.6.1" %}Obsolete: Removed in v2.6.1{% /badge %} |
-| [fixNFTokenNegOffer][]            | v1.9.2     | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [fixNFTokenDirV1][]               | v1.9.1     | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [NonFungibleTokensV1][]           | v1.9.0     | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [CryptoConditionsSuite][]         | v0.60.0    | {% badge %}Obsolete: To Be Removed{% /badge %} |
-| [OwnerPaysFee][]                  | v0.33.0    | {% badge href="https://xrpl.org/blog/2017/rippled-0.80.0" %}Obsolete: Removed in v0.80.0{% /badge %} |
-| [SHAMapV2][]                      | v0.32.1    | {% badge href="https://xrpl.org/blog/2019/rippled-1.4.0.html" %}Obsolete: Removed in v1.4.0{% /badge %} |
-| [Tickets][]                       | v0.30.1    | {% badge href="https://xrpl.org/blog/2018/rippled-0.90.0.html" %}Obsolete: Removed in v0.90.0{% /badge %} |
-| [SusPay][]                        | v0.31.0    | {% badge href="https://xrpl.org/blog/2017/ticksize-voting.html#upcoming-features" %}Obsolete: Removed in v0.60.0{% /badge %} |
-| [FlowV2][]                        | v0.32.1    | {% badge href="https://xrpl.org/blog/2016/flowv2-vetoed.html" %}Obsolete: Removed in v0.33.0{% /badge %} |
-
+{% obsolete-amendments-table /%}
 
 ## Details about Known Amendments
 
@@ -244,7 +230,7 @@ Although this amendment is enabled, it has no effect unless the [SusPay](#suspay
 | Amendment    | CryptoConditionsSuite |
 |:-------------|:----------------------|
 | Amendment ID | 86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90 |
-| Status       | {% amendment-disclaimer name="CryptoConditionsSuite" statusOnly=true /%} |
+| Status       | {% badge %}Obsolete: To Be Removed{% /badge %} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -786,14 +772,14 @@ Adds several fixes to Automated Market Maker code, specifically:
 | Amendment    | fixBatchInnerSigs |
 |:-------------|:----------------|
 | Amendment ID | 267624F8F744C4A4F1B5821A7D54410BCEBABE987F0172EE89E5FC4B6EDBC18A |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="fixBatchInnerSigs" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This amendment fixes an issue where inner transactions of a `Batch` transaction would be flagged as having valid signatures. Since inner transactions aren't signed directly, they should never have valid signatures.
 
 {% admonition type="danger" name="Warning" %}
-This amendment was disabled in v3.1.1 due to a bug. It will be replaced by `BatchV1_1` in a future release.
+This amendment was disabled in v3.1.1 due to a bug in `Batch`. The `BatchV1_1` amendment in a future release will include this fix.
 {% /admonition %}
 
 
@@ -1085,9 +1071,9 @@ This amendment adds missing `DeliveredAmount` and `delivered_amount` metadata fi
 | Amendment    | fixNFTokenDirV1 |
 |:-------------|:----------------|
 | Amendment ID | 0285B7E5E08E1A8E4C15636F0591D87F73CB6A7B6452A932AD72BBC8E5D1CBE3 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="fixNFTokenDirV1" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This amendment fixes an off-by-one error that occurred in some corner cases when determining which `NFTokenPage` a `NFToken` object belongs on. It also adjusts the constraints of `NFTokenPage` invariant checks, so that certain error cases fail with a suitable error code such as `tecNO_SUITABLE_TOKEN_PAGE` instead of failing with a `tecINVARIANT_FAILED` error code.
 
@@ -1100,7 +1086,7 @@ This amendment has no effect unless the [NonFungibleTokensV1][] amendment is ena
 | Amendment    | fixNFTokenNegOffer |
 |:-------------|:-------------------|
 | Amendment ID | 36799EA497B1369B170805C078AEFE6188345F9B3E324C21E9CA3FF574E3C3D6 |
-| Status       | Obsolete |
+| Status       | {% amendment-disclaimer name="fixNFTokenNegOffer" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1497,9 +1483,9 @@ Without this change, the engine simulates a payment through each possible path t
 | Amendment    | FlowV2 |
 |:-------------|:-------|
 | Amendment ID | 5CC22CFF2864B020BD79E0E1F048F63EF3594F95E650E43B3F837EF1DF5F4B26 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="FlowV2" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This is a previous version of the [Flow](#flow) amendment. It was [rejected due to a bug](https://xrpl.org/blog/2016/flowv2-vetoed.html) and removed in version 0.33.0.
 
@@ -1693,9 +1679,9 @@ Without this amendment, you must separately send an [NFTokenCreateOffer transact
 | Amendment    | NonFungibleTokensV1 |
 |:-------------|:--------------------|
 | Amendment ID | 3C43D9A973AA4443EF3FC38E42DD306160FBFFDAB901CD8BAA15D09F2597EB87 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="NonFungibleTokensV1" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 Adds native support for [non-fungible tokens](../docs/concepts/tokens/nfts/index.md). Standards Draft: [XLS-20d](https://github.com/XRPLF/XRPL-Standards/discussions/46). <!-- SPELLING_IGNORE: xls, 20d -->
 
@@ -1752,9 +1738,9 @@ The [fixRemoveNFTokenAutoTrustLine][] fixes an known issue with this amendment. 
 | Amendment    | OwnerPaysFee |
 |:-------------|:-------------|
 | Amendment ID | 9178256A980A86CF3D70D0260A7DA6402AAFE43632FDBCB88037978404188871 |
-| Status       | Obsolete |
+| Status       | {% amendment-disclaimer name="OwnerPaysFee" statusOnly=true /%} |
 | Default Vote (Latest stable release) | N/A |
-| Pre-amendment functionality retired? | No |
+| Pre-amendment functionality retired? | N/A |
 
 Fixes an inconsistency in the way [transfer fees](../docs/concepts/tokens/fungible-tokens/transfer-fees.md) are calculated between [OfferCreate](../docs/references/protocol/transactions/types/offercreate.md) and [Payment](../docs/references/protocol/transactions/types/payment.md) transaction types. Without this amendment, the holder of the token pays the transfer fee if an offer is executed in offer placement, but the initial sender of a transaction pays the transfer fees for offers that are executed as part of payment processing. With this amendment, the holder of the token always pays the transfer fee, regardless of whether the offer is executed as part of a Payment or an OfferCreate transaction. Offer processing outside of payments is unaffected.
 
@@ -1788,9 +1774,9 @@ For more information, see the [Payment Channels Tutorial](../docs/tutorials/paym
 | Amendment    | PermissionDelegation |
 |:-------------|:---------------------|
 | Amendment ID | AE6AB9028EEB7299EBB03C7CBCC3F2A4F5FBE00EA28B8223AA3118A0B436C1C5 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="PermissionDelegation" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 Allows accounts to delegate some permissions to other accounts. Specification: [XLS-75](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0075-permission-delegation).
 
@@ -1869,13 +1855,13 @@ For more information, see [`rippled` issue #3042](https://github.com/XRPLF/rippl
 | Amendment    | SHAMapV2 |
 |:-------------|:---------|
 | Amendment ID | C6970A8B603D8778783B61C0D445C23D1633CCFAEF0D43E7DBCD1521D34BD7C3 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="SHAMapV2" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
-Changes the hash tree structure that `rippled` uses to represent a ledger. The new structure is more compact and efficient than the previous version. This affects how ledger hashes are calculated, but has no other user-facing consequences.
+Changes the hash tree structure used to represent a ledger. The new structure is more compact and efficient than the previous version. This affects how ledger hashes are calculated, but has no other user-facing consequences.
 
-When this amendment is activated, the XRP Ledger will undergo a brief scheduled unavailability while the network calculates the changes to the hash tree structure. <!-- STYLE_OVERRIDE: will -->
+Activating this amendment would have required the XRP Ledger to undergo scheduled unavailability while the network calculated the changes to the hash tree structure. This amendment was removed because the efficiency gains were judged to be not worth the downtime.
 
 
 ### SingleAssetVault
@@ -1962,9 +1948,9 @@ For more details, see [XLS-68: Sponsored Fees and Reserves](https://opensource.r
 | Amendment    | SusPay |
 |:-------------|:-------|
 | Amendment ID | DA1BD556B42D85EA9C84066D028D355B52416734D3283F85E216EA5DA6DB7E13 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="SusPay" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This amendment was replaced by the [Escrow](../docs/references/protocol/ledger-data/ledger-entry-types/escrow.md) amendment.
 
@@ -1990,9 +1976,9 @@ Standards Draft: [XLS-13d](https://github.com/XRPLF/XRPL-Standards/issues/16). <
 | Amendment    | Tickets |
 |:-------------|:--------|
 | Amendment ID | C1B8D934087225F509BEB5A8EC24447854713EE447D277F69545ABFA0E0FD490 |
-| Status       | Obsolete |
-| Default Vote (Latest stable release) | No |
-| Pre-amendment functionality retired? | No |
+| Status       | {% amendment-disclaimer name="Tickets" statusOnly=true /%} |
+| Default Vote (Latest stable release) | N/A |
+| Pre-amendment functionality retired? | N/A |
 
 This amendment was replaced by the [TicketBatch][] amendment.
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -230,7 +230,7 @@ Although this amendment is enabled, it has no effect unless the [SusPay](#suspay
 | Amendment    | CryptoConditionsSuite |
 |:-------------|:----------------------|
 | Amendment ID | 86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90 |
-| Status       | {% badge %}Obsolete: To Be Removed{% /badge %} |
+| Status       | {% amendment-disclaimer name="CryptoConditionsSuite" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -61,7 +61,7 @@ The following is a list of known [amendments](../docs/concepts/networks-and-serv
 | Amendment    | AMM |
 |:-------------|:----|
 | Amendment ID | 8CC0774A3BF66D1D22E76BBDA8E8A232E6B6313834301B3B23E8601196AE6455 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="AMM" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -92,7 +92,7 @@ Adds several new transaction result codes.
 | Amendment    | AMMClawback |
 |:-------------|:------------|
 | Amendment ID | 726F944886BCDF7433203787E93DD9AA87FAB74DFE3AF4785BA03BEFC97ADA1F |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="AMMClawback" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -111,7 +111,7 @@ For details, see the [XLS-73: AMMClawback specification](https://github.com/XRPL
 | Amendment    | Batch |
 |:-------------|:------|
 | Amendment ID | 894646DD5284E97DECFE6674A6D6152686791C4A95F8C132CCA9BAF9E5812FB6 |
-| Status       | Obsolete |
+| Status       | {% amendment-disclaimer name="Batch" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -128,7 +128,7 @@ This amendment was disabled in v3.1.1 due to a bug. It will be replaced by `Batc
 | Amendment    | CheckCashMakesTrustLine |
 |:-------------|:------------------------|
 | Amendment ID | 98DECF327BF79997AEC178323AD51A830E457BFC6D454DAF3E46E5EC42DC619F |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="CheckCashMakesTrustLine" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -145,7 +145,7 @@ This amendment does not change the fact that you cannot force anyone to hold tok
 | Amendment    | Checks |
 |:-------------|:-------|
 | Amendment ID | 157D2D480E006395B76F948E3E07A45A05FE10230D88A7993C71F97AE4B1F2D1 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="Checks" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -162,7 +162,7 @@ Introduces three new transaction types: CheckCreate, CheckCancel, and CheckCash,
 | Amendment    | Clawback |
 |:-------------|:---------|
 | Amendment ID | 56B241D7A43D40354D02A9DC4C8DF5C7A1F930D92A9035C4E12291B3CA3E1C2B |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="Clawback" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -179,7 +179,7 @@ See [Clawback](../docs/concepts/tokens/fungible-tokens/clawing-back-tokens.md) f
 | Amendment    | Credentials |
 |:-------------|:------------|
 | Amendment ID | 1CB67D082CF7D9102412D34258CEDB400E659352D3B207348889297A6D90F5EF |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="Credentials" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -231,7 +231,7 @@ For more details, see [XLS-96: Confidential Transfers](https://opensource.ripple
 | Amendment    | CryptoConditions |
 |:-------------|:-----------------|
 | Amendment ID | 1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="CryptoConditions" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -244,7 +244,7 @@ Although this amendment is enabled, it has no effect unless the [SusPay](#suspay
 | Amendment    | CryptoConditionsSuite |
 |:-------------|:----------------------|
 | Amendment ID | 86E83A7D2ECE3AD5FA87AB2195AE015C950469ABF0B72EAACED318F74886AE90 |
-| Status       | Obsolete |
+| Status       | {% amendment-disclaimer name="CryptoConditionsSuite" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -259,7 +259,7 @@ However, the amendment was added to `rippled` v0.60.0 before implementation was 
 | Amendment    | DeepFreeze |
 |:-------------|:-----------|
 | Amendment ID | DAF3A6EB04FA5DC51E8E4F23E9B7022B693EFA636F23F22664746C77B5786B23 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DeepFreeze" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -279,7 +279,7 @@ This amendment enables issuers to deep freeze trustlines from interacting with p
 | Amendment    | DeletableAccounts |
 |:-------------|:------------------|
 | Amendment ID | 30CD365592B8EE40489BA01AE2F7555CAC9C983145871DC82A42A31CF5BAE7D9 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DeletableAccounts" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -296,7 +296,7 @@ With this amendment, new accounts start with their `Sequence` numbers equal to t
 | Amendment    | DepositAuth |
 |:-------------|:------------|
 | Amendment ID | F64E1EABBE79D55B3BB82020516CEC2C582A98A6BFE20FBE9BB6A0D233418064 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DepositAuth" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -315,7 +315,7 @@ Also fixes a bug in the EscrowCreate and PaymentChannelCreate transactions where
 | Amendment    | DepositPreauth |
 |:-------------|:---------------|
 | Amendment ID | 3CBC5C4E630A1B82380295CDA84B32B49DD066602E74E39B85EF64137FA65194 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DepositPreauth" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -334,7 +334,7 @@ Also changes the OfferCreate transaction to return `tecEXPIRED` when trying to c
 | Amendment    | DID |
 |:-------------|:----|
 | Amendment ID | DB432C3A09D9D5DFC7859F39AE5FF767ABC59AED0A9FB441E83B814D8946C109 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DID" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -356,7 +356,7 @@ Adds several new transaction result codes.
 | Amendment    | DisallowIncoming |
 |:-------------|:-----------------|
 | Amendment ID | 47C3002ABA31628447E8E9A8B315FAA935CE30183F9A9B86845E469CA2CDC3DF |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DisallowIncoming" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -380,7 +380,7 @@ Without this amendment, any account can create these objects with any object as 
 | Amendment    | DynamicNFT |
 |:-------------|:-----------|
 | Amendment ID | C1CE18F2A268E6A849C27B3DE485006771B4C01B2FCEC4F18356FE92ECD6BB74 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="DynamicNFT" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -411,7 +411,7 @@ For more details, see [XLS-94: Dynamic MPTs](https://opensource.ripple.com/docs/
 | Amendment    | EnforceInvariants |
 |:-------------|:------------------|
 | Amendment ID | DC9CA96AEA1DCF83E527D1AFC916EFAF5D27388ECA4060A88817C1238CAEE0BF |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="EnforceInvariants" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -434,7 +434,7 @@ Examples of invariant checks:
 | Amendment    | Escrow |
 |:-------------|:-------|
 | Amendment ID | 07D43DCE529B15A10827E5E04943B496762F9A88E3268269D69C44BE49E21104 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="Escrow" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -449,7 +449,7 @@ Provides "suspended payments" for XRP for escrow within the XRP Ledger, includin
 | Amendment    | ExpandedSignerList |
 |:-------------|:-------------------|
 | Amendment ID | B2A4DB846F0891BF2C76AB2F2ACC8F5B4EC64437135C6E56F3F859DE5FFD5856 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="ExpandedSignerList" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -466,7 +466,7 @@ With this amendment, the maximum [SignerList object][] size is 32 entries. Addit
 | Amendment    | FeeEscalation |
 |:-------------|:--------------|
 | Amendment ID | 42426C4D4F1009EE67080A9B7965B44656D7714D104A72F9B4369F97ABF044EE |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="FeeEscalation" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -489,7 +489,7 @@ A transaction remains in the queue until one of the following happens:
 | Amendment    | fix1201 |
 |:-------------|:--------|
 | Amendment ID | B4D44CC3111ADD964E846FC57760C8B50FFCD5A82C86A72756F6B058DDDF96AD |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1201" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -504,7 +504,7 @@ With this amendment enabled, an [AccountSet][] transaction that attempts to set 
 | Amendment    | fix1368 |
 |:-------------|:--------|
 | Amendment ID | E2E6F2866106419B88C50045ACE96368558C345566AC8F2BDF5A5B5587F0E6FA |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1368" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -517,7 +517,7 @@ Fixes a minor bug in transaction processing that causes some payments to fail wh
 | Amendment    | fix1373 |
 |:-------------|:--------|
 | Amendment ID | 42EEA5E28A97824821D4EF97081FE36A54E9593C6E4F20CBAE098C69D2E072DC |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1373" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -532,7 +532,7 @@ The fix1373 amendment corrects the issue so that the paths are properly prepared
 | Amendment    | fix1512 |
 |:-------------|:--------|
 | Amendment ID | 6C92211186613F9647A89DFFBAB8F94C99D4C7E956D495270789128569177DA1 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1512" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -547,7 +547,7 @@ With this amendment, the transactions fail with a more appropriate result code, 
 | Amendment    | fix1513 |
 |:-------------|:--------|
 | Amendment ID | 67A34F2CF55BFC0F93AACD5B281413176FEE195269FA6D95219A2DF738671172 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1513" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -562,7 +562,7 @@ With this amendment, the new `STAmountCalcSwitchovers` code applies, which may c
 | Amendment    | fix1515 |
 |:-------------|:--------|
 | Amendment ID | 5D08145F0A4983F23AFFFF514E83FAD355C5ABFBB6CAB76FB5BC8519FF5F33BE |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1515" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -581,7 +581,7 @@ In both cases, transaction processing can still complete by using liquidity from
 | Amendment    | fix1523 |
 |:-------------|:--------|
 | Amendment ID | B9E739B8296B4A1BB29BE990B17D66E21B62A300A909F25AC55C22D6C72E1F9D |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1523" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -596,7 +596,7 @@ With this amendment, new escrows are added to the [owner directories](../docs/re
 | Amendment    | fix1528 |
 |:-------------|:--------|
 | Amendment ID | 1D3463A5891F9E589C5AE839FFAC4A917CE96197098A1EF22304E1BC5B98A454 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1528" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -611,7 +611,7 @@ This amendment changes how validators negotiate the close time of the consensus 
 | Amendment    | fix1543 |
 |:-------------|:--------|
 | Amendment ID | CA7C02118BA27599528543DFE77BA6838D1B0F43B447D4D7F53523CE6A0E9AC2 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1543" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -631,7 +631,7 @@ The affected transaction types are:
 | Amendment    | fix1571 |
 |:-------------|:--------|
 | Amendment ID | 7117E2EC2DBF119CA55181D69819F1999ECEE1A0225A7FD2B9ED47940968479C |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1571" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -647,7 +647,7 @@ Changes Escrow to fix the following issues:
 | Amendment    | fix1578 |
 |:-------------|:--------|
 | Amendment ID | FBD513F1B893AC765B78F250E6FFA6A11B573209D1842ADC787C850696741288 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1578" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -663,7 +663,7 @@ Changes the result codes returned by two transaction types:
 | Amendment    | fix1623 |
 |:-------------|:--------|
 | Amendment ID | 58BE9B5968C4DA7C59BA900961828B113E5490699B21877DEF9A31E9D0FE5D5F |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1623" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -680,7 +680,7 @@ The fix1623 amendment has no effect on [CheckCash transactions][] for a fixed am
 | Amendment    | fix1781 |
 |:-------------|:--------|
 | Amendment ID | 25BA44241B3BD880770BFA4DA21C7180576831855368CBEC6A3154FDE4A7676E |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fix1781" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -695,9 +695,9 @@ With this amendment, those payments fail with the [`temBAD_PATH_LOOP` result cod
 [fixAmendmentMajorityCalc]: #fixamendmentmajoritycalc
 
 | Amendment    | fixAmendmentMajorityCalc |
-|:-------------|:-------------------------|
+|:-------------|:--------|
 | Amendment ID | 4F46DF03559967AC60F2EB272FEFE3928A7594A45FF774B87A7E540DB0F8F068 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixAmendmentMajorityCalc" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -710,9 +710,9 @@ Without this amendment, the minimum threshold for amendment activation is any va
 [fixAMMClawbackRounding]: #fixammclawbackrounding
 
 | Amendment    | fixAMMClawbackRounding |
-|:-------------|:-------------------------|
+|:-------------|:--------|
 | Amendment ID | 5E9586DB3D765B4C5794658FB6BB385071E9838DF4016027E6E26820C8526724 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixAMMClawbackRounding" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -723,9 +723,9 @@ Fixes an accounting error that can occur when performing an `AMMClawback` transa
 [fixAMMOverflowOffer]: #fixammoverflowoffer
 
 | Amendment    | fixAMMOverflowOffer |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | 12523DF04B553A0B1AD74F42DDB741DE8DC06A03FC089A0EF197E2A87F1D8107 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixAMMOverflowOffer" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | No |
 
@@ -736,9 +736,9 @@ This amendment fixes the improper handling of large synthetic AMM offers in the 
 [fixAMMv1_1]: #fixammv1_1
 
 | Amendment    | fixAMMv1_1 |
-|:-------------|:-----------|
+|:-------------|:--------|
 | Amendment ID | 35291ADD2D79EB6991343BDA0912269C817D0F094B02226C1C14AD2858962ED4 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixAMMv1_1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -749,9 +749,9 @@ Fixes AMM offer rounding and low quality order book offers from blocking the AMM
 [fixAMMv1_2]: #fixammv1_2
 
 | Amendment    | fixAMMv1_2 |
-|:-------------|:-----------|
+|:-------------|:--------|
 | Amendment ID | 1E7ED950F2F13C4F8E2A54103B74D57D5D298FFDBD005936164EE9E6484C438C |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixAMMv1_2" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -765,9 +765,9 @@ Fixes two bugs in Automated Market Maker (AMM) transaction processing:
 [fixAMMv1_3]: #fixammv1_3
 
 | Amendment    | fixAMMv1_3 |
-|:-------------|:-----------|
+|:-------------|:--------|
 | Amendment ID | 7CA70A7674A26FA517412858659EBC7EDEEF7D2D608824464E6FDEFD06854E14 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixAMMv1_3" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -801,9 +801,9 @@ This amendment was disabled in v3.1.1 due to a bug. It will be replaced by `Batc
 [fixCheckThreading]: #fixcheckthreading
 
 | Amendment    | fixCheckThreading |
-|:-------------|:------------------|
+|:-------------|:--------|
 | Amendment ID | 8F81B066ED20DAECA20DF57187767685EEF3980B228E0667A650BAF24426D3B4 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixCheckThreading" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -818,7 +818,7 @@ Without this amendment, Checks transactions ([CheckCreate][], [CheckCash][], and
 | Amendment    | fixCleanup3_1_3 |
 |:-------------|:----------------|
 | Amendment ID | 303ACB16CF8DBD3B5C34F131A9D19A7DE01AE05F480A8A682B869D1B4AAC8CFC |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixCleanup3_1_3" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | No  |
 
@@ -838,7 +838,7 @@ This amendment is a collection of fixes for NFTs, Permissioned Domains, Vaults, 
 | Amendment    | fixCleanup3_2_0 |
 |:-------------|:----------------|
 | Amendment ID | 21B8D2F76F68E11E9C077A43BBBC394136E9987E99DDB73966DD68419467E431 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixCleanup3_2_0" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -855,9 +855,9 @@ This amendment is a collection of fixes for Single Asset Vaults, the Lending Pro
 [fixDirectoryLimit]: #fixdirectorylimit
 
 | Amendment    | fixdirectorylimit |
-|:-------------|:----------------------|
+|:-------------|:--------|
 | Amendment ID | 41765F664A8D67FF03DDB1C1A893DE6273690BA340A6C2B07C8D29D0DD013D3A |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixDirectoryLimit" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -868,9 +868,9 @@ This amendment removes the directory page limit. Object reserve requirements pro
 [fixDisallowIncomingV1]: #fixdisallowincomingv1
 
 | Amendment    | fixDisallowIncomingV1 |
-|:-------------|:----------------------|
+|:-------------|:--------|
 | Amendment ID | 15D61F0C6DB6A2F86BCF96F1E2444FEC54E705923339EC175BD3E517C8B3FF91 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixDisallowIncomingV1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -892,9 +892,9 @@ This amendment has no effect unless the [DisallowIncoming][] amendment is enable
 [fixEmptyDID]: #fixemptydid
 
 | Amendment    | fixEmptyDID |
-|:-------------|:------------|
+|:-------------|:--------|
 | Amendment ID | 755C971C29971C9F20C6F080F2ED96F87884E40AD19554A5EBECDCEC8A1F77FE |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixEmptyDID" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -911,9 +911,9 @@ This amendment has no effect unless the [DID][] amendment is enabled.
 [fixEnforceNFTokenTrustline]: #fixenforcenftokentrustline
 
 | Amendment    | fixEnforceNFTokenTrustline |
-|:-------------|:---------------------------|
+|:-------------|:--------|
 | Amendment ID | 763C37B352BE8C7A04E810F8E462644C45AFEAD624BF3894A08E5C917CF9FF39 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixEnforceNFTokenTrustline" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -927,9 +927,9 @@ Fixes two bugs relating to the handling of NFT transfer fees and trust lines:
 [fixEnforceNFTokenTrustlineV2]: #fixenforcenftokentrustlinev2
 
 | Amendment    | fixEnforceNFTokenTrustlineV2 |
-|:-------------|:-----------------------------|
+|:-------------|:--------|
 | Amendment ID | B32752F7DCC41FB86534118FC4EEC8F56E7BD0A7DB60FD73F93F257233C08E3A |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixEnforceNFTokenTrustlineV2" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -945,9 +945,9 @@ Without this amendment, NFT transfer fees could be paid to an NFT issuer circumv
 [fixFillOrKill]: #fixfillorkill
 
 | Amendment    | fixFillOrKill |
-|:-------------|:--------------|
+|:-------------|:--------|
 | Amendment ID | 3318EA0CF0755AF15DAC19F2B5C5BCBFF4B78BDD57609ACCAABE2C41309B051A |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixFillOrKill" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -962,9 +962,9 @@ This amendment has no effect unless the [FlowCross][] amendment is enabled.
 [fixFrozenLPTokenTransfer]: #fixfrozenlptokentransfer
 
 | Amendment    | fixFrozenLPTokenTransfer |
-|:-------------|:-------------------------|
+|:-------------|:--------|
 | Amendment ID | 83FD6594FF83C1D105BD2B41D7E242D86ECB4A8220BD9AF4DA35CB0F69E39B2A |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixFrozenLPTokenTransfer" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -980,9 +980,9 @@ With this amendment enabled, if an LP token is associated with a liquidity pool 
 [fixIncludeKeyletFields]: #fixincludekeyletfields
 
 | Amendment    | fixIncludeKeyletFields |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | 6143A27B71F7DAF9330ECA7C5EC3D54C8083A4FDEF7016737EEC06AB61E82EE0 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixIncludeKeyletFields" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1000,9 +1000,9 @@ The presence of a `Sequence` field on Escrow ledger entries is especially useful
 [fixInnerObjTemplate]: #fixinnerobjtemplate
 
 | Amendment    | fixInnerObjTemplate |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | C393B3AEEBF575E475F0C60D5E4241B2070CC4D0EB6C4846B1A07508FAEFC485 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixInnerObjTemplate" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1015,9 +1015,9 @@ Currently, the inner object template isn't set upon object creation. If the obje
 [fixInnerObjTemplate2]: #fixinnerobjtemplate2
 
 | Amendment    | fixInnerObjTemplate2 |
-|:-------------|:---------------------|
+|:-------------|:--------|
 | Amendment ID | 9196110C23EA879B4229E51C286180C7D02166DA712559F634372F5264D0EC59 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixInnerObjTemplate2" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1040,9 +1040,9 @@ It is believed that this change does not affect transaction processing, but it i
 [fixInvalidTxFlags]: #fixinvalidtxflags
 
 | Amendment    | fixInvalidTxFlags |
-|:-------------|:------------------|
+|:-------------|:--------|
 | Amendment ID | 8EC4304A06AF03BE953EA6EDA494864F6F3F30AA002BABA35869FBB8C6AE5D52 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixInvalidTxFlags" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1053,9 +1053,9 @@ Adds flag checks for `CredentialCreate`, `CredentialAccept`, `CredentialDelete`,
 [fixMasterKeyAsRegularKey]: #fixmasterkeyasregularkey
 
 | Amendment    | fixMasterKeyAsRegularKey |
-|:-------------|:-------------------------|
+|:-------------|:--------|
 | Amendment ID | C4483A1896170C66C098DEA5B0E024309C60DC960DE5F01CD7AF986AA3D9AD37 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixMasterKeyAsRegularKey" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1070,9 +1070,9 @@ With this amendment enabled, a SetRegularKey transaction cannot set the regular 
 [fixMPTDeliveredAmount]: #fixmptdeliveredamount
 
 | Amendment    | fixMPTDeliveredAmount |
-|:-------------|:----------------|
+|:-------------|:--------|
 | Amendment ID | AB8D932A5F338903FE5BCBD80B611FFED70839ABA3170E9CE01D947C0EDEDCF2 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixMPTDeliveredAmount" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1113,9 +1113,9 @@ This amendment has no effect unless the [NonFungibleTokensV1][] amendment is ena
 [fixNFTokenPageLinks]: #fixnftokenpagelinks
 
 | Amendment    | fixNFTokenPageLinks |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | C7981B764EC4439123A86CC7CCBA436E9B3FF73B3F10A0AE51882E404522FC41 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixNFTokenPageLinks" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1130,9 +1130,9 @@ Without this amendment, it is possible in specific circumstances to delete the l
 [fixNFTokenRemint]: #fixnftokenremint
 
 | Amendment    | fixNFTokenRemint |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | AE35ABDEFBDE520372B31C957020B34A7A4A9DC3115A69803A44016477C84D6E |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixNFTokenRemint" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1144,16 +1144,18 @@ Amendment `fixNFTokenRemint` would change the way NFT sequence numbers are const
 
 The amendment also introduces a new account deletion restriction. An account can only be deleted if `FirstNFTSequence` + `MintedNFTokens` + 256 is less than the current ledger sequence (256 was chosen as a heuristic restriction for account deletion and already exists in the account deletion constraint). Without this restriction, an NFT could still be re-minted under certain conditions.
 
-{% admonition type="danger" name="Warning" %}This is a **breaking change** for projects & tools relying on their own locally computed NFTokenID for minted tokens. If you have code to calculate NFTokenIDs, you must update it to match the new fomula. For an example of how to do so with backwards compatibility, see this [well known reference implementation in JavaScript](https://gist.github.com/N3TC4T/a20fb528931ed009ebdd708be4938748?permalink_comment_id=4738760#gistcomment-4738760).{% /admonition %}
+{% admonition type="danger" name="Warning" %}
+This is a **breaking change** for projects & tools relying on their own locally computed NFTokenID for minted tokens. If you have code to calculate NFTokenIDs, you must update it to match the new fomula. For an example of how to do so with backwards compatibility, see this [well known reference implementation in JavaScript](https://gist.github.com/N3TC4T/a20fb528931ed009ebdd708be4938748?permalink_comment_id=4738760#gistcomment-4738760).
+{% /admonition %}
 
 
 ### fixNFTokenReserve
 [fixNFTokenReserve]: #fixnftokenreserve
 
 | Amendment    | fixNFTokenReserve |
-|:-------------|:------------------|
+|:-------------|:--------|
 | Amendment ID | 03BDC0099C4E14163ADA272C1B6F6FABB448CC3E51F522F978041E4B57D9158C |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixNFTokenReserve" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1164,9 +1166,9 @@ This amendment adds a check to the `NFTokenAcceptOffer` transactor to see if the
 [fixNonFungibleTokensV1_2]: #fixnonfungibletokensv1_2
 
 | Amendment    | fixNonFungibleTokensV1_2 |
-|:-------------|:-------------------------|
+|:-------------|:--------|
 | Amendment ID | 73761231F7F3D94EC3D8C63D91BDD0D89045C6F71B917D1925C01253515A6669 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixNonFungibleTokensV1_2" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1205,9 +1207,9 @@ See [Issue 4373](https://github.com/XRPLF/rippled/issues/4373).
 [fixPayChanCancelAfter]: #fixpaychancancelafter
 
 | Amendment    | fixPayChanCancelAfter |
-|:-------------|:----------------------|
+|:-------------|:--------|
 | Amendment ID | D3456A862DC07E382827981CA02E21946E641877F19B8889031CC57FDCAC83E2 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixPayChanCancelAfter" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1220,9 +1222,9 @@ Without this amendment, transactions can create a payment channel whose `CancelA
 [fixPayChanRecipientOwnerDir]: #fixpaychanrecipientownerdir
 
 | Amendment    | fixPayChanRecipientOwnerDir |
-|:-------------|:----------------------------|
+|:-------------|:--------|
 | Amendment ID | 621A0B264970359869E3C0363A899909AAB7A887C8B73519E4ECF952D33258A8 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixPayChanRecipientOwnerDir" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1235,9 +1237,9 @@ This change prevents accounts from being deleted if they are the recipient for o
 [fixPreviousTxnID]: #fixprevioustxnid
 
 | Amendment    | fixPreviousTxnID |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | 7BB62DC13EC72B775091E9C71BF8CF97E122647693B50C5E87A80DFD6FCFAC50 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixPreviousTxnID" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1252,9 +1254,9 @@ Without this amendment, some types of ledger entries don't have those fields, wh
 [fixPriceOracleOrder]: #fixpriceoracleorder
 
 | Amendment    | fixPriceOracleOrder |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | FF2D1E13CF6D22427111B967BD504917F63A900CECD320D6FD3AC9FA90344631 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixPriceOracleOrder" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1267,9 +1269,9 @@ This amendment ensures asset pairs follow a canonical order at all times, so you
 [fixQualityUpperBound]: #fixqualityupperbound
 
 | Amendment    | fixQualityUpperBound |
-|:-------------|:---------------------|
+|:-------------|:--------|
 | Amendment ID | 89308AF3B8B10B7192C4E613E1D2E4D9BA64B2EE2D5232402AE82A6A7220D953 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixQualityUpperBound" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1282,9 +1284,9 @@ This amendment has no known impact on transaction processing.
 [fixReducedOffersV1]: #fixreducedoffersv1
 
 | Amendment    | fixReducedOffersV1 |
-|:-------------|:-------------------|
+|:-------------|:--------|
 | Amendment ID | 27CD95EE8E1E5A537FF2F89B6CEB7C622E78E9374EBD7DCBEDFAE21CD6F16E0A |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixReducedOffersV1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1305,9 +1307,9 @@ Without this amendment, an offer with very small amounts remaining can have a a 
 [fixReducedOffersV2]: #fixreducedoffersv2
 
 | Amendment    | fixReducedOffersV2 |
-|:-------------|:-------------------|
+|:-------------|:--------|
 | Amendment ID | 31E0DA76FB8FB527CADCDF0E61CB9C94120966328EFA9DCA202135BAF319C0BA |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixReducedOffersV2" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1318,9 +1320,9 @@ This amendment adjusts rounding in an additional case that can cause an order bo
 [fixRemoveNFTokenAutoTrustLine]: #fixremovenftokenautotrustline
 
 | Amendment    | fixRemoveNFTokenAutoTrustLine |
-|:-------------|:------------------------------|
+|:-------------|:--------|
 | Amendment ID | DF8B4536989BDACE3F934F29423848B9F1D76D09BE6A1FCFE7E7F06AA26ABEAD |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixRemoveNFTokenAutoTrustLine" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | No |
 
@@ -1337,9 +1339,9 @@ This amendment has no effect unless either [NonFungibleTokensV1][] or [NonFungib
 [fixRmSmallIncreasedQOffers]: #fixrmsmallincreasedqoffers
 
 | Amendment    | fixRmSmallIncreasedQOffers |
-|:-------------|:---------------------------|
+|:-------------|:--------|
 | Amendment ID | B6B3EEDC0267AB50491FDC450A398AF30DBCD977CECED8BEF2499CAB5DAC19E2 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixRmSmallIncreasedQOffers" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1354,9 +1356,9 @@ With this amendment, payments and trades can remove these types of Offers the sa
 [fixSTAmountCanonicalize]: #fixstamountcanonicalize
 
 | Amendment    | fixSTAmountCanonicalize |
-|:-------------|:------------------------|
+|:-------------|:--------|
 | Amendment ID | 452F5906C46D46F407883344BFDD90E672B672C5E9943DB4891E3A34FEEEB9DB |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixSTAmountCanonicalize" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1367,9 +1369,9 @@ Fixes an edge case in [deserializing](../docs/references/protocol/binary-format.
 [fixTakerDryOfferRemoval]: #fixtakerdryofferremoval
 
 | Amendment    | fixTakerDryOfferRemoval |
-|:-------------|:------------------------|
+|:-------------|:--------|
 | Amendment ID | 2CD5286D8D687E98B41102BDD797198E81EA41DF7BD104E6561FEB104EFF2561 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixTakerDryOfferRemoval" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1384,9 +1386,9 @@ With this amendment enabled, the XRP Ledger removes these dry offers when they'r
 [fixTokenEscrowV1]: #fixtokenescrowv1
 
 | Amendment    | fixTokenEscrowV1 |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | 32B8614321F7E070419115ABEAB1742EA20F3E3AF34432B5E2F474F8083260DC |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixTokenEscrowV1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1399,9 +1401,9 @@ This amendment ensures that when escrowed MPTs are unlocked, the issuer's locked
 [fixTrustLinesToSelf]: #fixtrustlinestoself
 
 | Amendment    | fixTrustLinesToSelf |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | F1ED6B4A411D8B872E65B9DCB4C8B100375B0DD3D62D07192E011D6D7F339013 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixTrustLinesToSelf" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1414,9 +1416,9 @@ On test networks that do not have these trust lines, the amendment has no effect
 [fixUniversalNumber]: #fixuniversalnumber
 
 | Amendment    | fixUniversalNumber |
-|:-------------|:-------------------|
+|:-------------|:--------|
 | Amendment ID | 2E2FB9CF8A44EB80F4694D38AADAE9B8B7ADAFD2F092E10068E61C98C4F092B0 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="fixUniversalNumber" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1429,9 +1431,9 @@ Without this amendment, the code continues to use separate calculations for `STA
 [fixXChainRewardRounding]: #fixxchainrewardrounding
 
 | Amendment    | fixXChainRewardRounding |
-|:-------------|:------------------------|
+|:-------------|:--------|
 | Amendment ID | 2BF037D90E1B676B17592A8AF55E88DB465398B4B597AE46EECEE1399AB05699 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="fixXChainRewardRounding" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1446,9 +1448,9 @@ This amendment restores the intended rounding behavior. It has no effect unless 
 [Flow]: #flow
 
 | Amendment    | Flow |
-|:-------------|:-----|
+|:-------------|:--------|
 | Amendment ID | 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="Flow" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1461,9 +1463,9 @@ The Flow Engine also makes it easier to improve and expand the payment engine wi
 [FlowCross]: #flowcross
 
 | Amendment    | FlowCross |
-|:-------------|:----------|
+|:-------------|:--------|
 | Amendment ID | 3012E8230864E95A58C60FD61430D7E1B4D3353195F2981DC12B0C7C0950FFAC |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="FlowCross" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1478,9 +1480,9 @@ Streamlines the offer crossing logic in the XRP Ledger's decentralized exchange.
 [FlowSortStrands]: #flowsortstrands
 
 | Amendment    | FlowSortStrands |
-|:-------------|:----------------|
+|:-------------|:--------|
 | Amendment ID | AF8DF7465C338AE64B1E937D6C8DA138C0D63AD5134A68792BBBE1F63356C422 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="FlowSortStrands" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1506,9 +1508,9 @@ This is a previous version of the [Flow](#flow) amendment. It was [rejected due 
 [HardenedValidations]: #hardenedvalidations
 
 | Amendment    | HardenedValidations |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | 1F4AFA8FA1BC8827AD4C0F682C03A8B671DCDF6B5C4DE36D44243A684103EF88 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="HardenedValidations" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1519,9 +1521,9 @@ Allows validators to include a new optional field in their validations to attest
 [ImmediateOfferKilled]: #immediateofferkilled
 
 | Amendment    | ImmediateOfferKilled |
-|:-------------|:---------------------|
+|:-------------|:--------|
 | Amendment ID | 75A7E01C505DD5A179DFE3E000A9B6F1EDDEB55A12F95579A23E15B15DC8BE5A |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="ImmediateOfferKilled" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1549,9 +1551,9 @@ This amendment adds several new invariants to protect the ledger against bugs in
 [LendingProtocol]: #lendingprotocol
 
 | Amendment    | LendingProtocol |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | 565B90CA1AB2B9D42208ED10884188C64F9E19083DECB9634AAF06EB03299509 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="LendingProtocol" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1564,9 +1566,9 @@ Specification: [XLS-66](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-
 [MPTokensV1]: #mptokensv1
 
 | Amendment    | MPTokensV1 |
-|:-------------|:-----------|
+|:-------------|:--------|
 | Amendment ID | 950AE2EA4654E47F04AA8739C0B214E242097E802FD372D24047A89AB1F5EC38 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="MPTokensV1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1611,9 +1613,9 @@ For more details, see [XLS-82: MPT DEX Integration](https://opensource.ripple.co
 [MultiSign]: #multisign
 
 | Amendment    | MultiSign |
-|:-------------|:----------|
+|:-------------|:--------|
 | Amendment ID | 4C97EBA926031A7CF7D7B36FDE3ED66DDA5421192D63DE53FFB46E43B9DC8373 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="MultiSign" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1638,9 +1640,9 @@ An address with a SignerList can disable the master key even if a regular key is
 [MultiSignReserve]: #multisignreserve
 
 | Amendment    | MultiSignReserve |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | 586480873651E106F1D6339B0C4A8945BA705A777F3F4524626FF1FC07EFE41D |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="MultiSignReserve" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1655,9 +1657,9 @@ With this amendment enabled, the owner reserve for a new SignerList is 5 XRP, re
 [NegativeUNL]: #negativeunl
 
 | Amendment    | NegativeUNL |
-|:-------------|:------------|
+|:-------------|:--------|
 | Amendment ID | B4E4F5D2D6FB84DF7399960A732309C9FD530EAE5941838160042833625A6076 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="NegativeUNL" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1668,9 +1670,9 @@ Implements a "Negative UNL" system, where the network can track which validators
 [NFTokenMintOffer]: #nftokenmintoffer
 
 | Amendment    | NFTokenMintOffer |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | EE3CF852F0506782D05E65D49E5DCC3D16D50898CD1B646BAE274863401CC3CE |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="NFTokenMintOffer" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1697,7 +1699,9 @@ Without this amendment, you must separately send an [NFTokenCreateOffer transact
 
 Adds native support for [non-fungible tokens](../docs/concepts/tokens/nfts/index.md). Standards Draft: [XLS-20d](https://github.com/XRPLF/XRPL-Standards/discussions/46). <!-- SPELLING_IGNORE: xls, 20d -->
 
-{% admonition type="danger" name="Warning" %}There are several known issues with this amendment including one that can cause `tecINVARIANT_FAILED` errors to appear in the ledger. It has been replaced by the [NonFungibleTokensV1_1 amendment][].{% /admonition %}
+{% admonition type="danger" name="Warning" %}
+There are several known issues with this amendment including one that can cause `tecINVARIANT_FAILED` errors to appear in the ledger. It has been replaced by the [NonFungibleTokensV1_1 amendment][].
+{% /admonition %}
 
 This amendment adds 5 new transaction types:
 
@@ -1721,9 +1725,9 @@ It also modifies the [AccountSet transaction][] type to allow you to set the `NF
 [NonFungibleTokensV1_1]: #nonfungibletokensv1_1
 
 | Amendment    | NonFungibleTokensV1_1 |
-|:-------------|:----------------------|
+|:-------------|:--------|
 | Amendment ID | 32A122F1352A4C7B3A6D790362CC34749C5E57FCE896377BFDC6CCD14F6CD627 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="NonFungibleTokensV1_1" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1737,7 +1741,9 @@ This amendment combines the effects of the following amendments, rendering the i
 
 It has no other effects.
 
-{% admonition type="warning" name="Caution" %}The [fixRemoveNFTokenAutoTrustLine][] fixes an known issue with this amendment. When creating a new test network, you should make sure that these amendments should be enabled together or the fix amendment is enabled first.{% /admonition %}
+{% admonition type="warning" name="Caution" %}
+The [fixRemoveNFTokenAutoTrustLine][] fixes an known issue with this amendment. When creating a new test network, you should make sure that these amendments should be enabled together or the fix amendment is enabled first.
+{% /admonition %}
 
 
 ### OwnerPaysFee
@@ -1754,7 +1760,9 @@ Fixes an inconsistency in the way [transfer fees](../docs/concepts/tokens/fungib
 
 This Amendment requires the [Flow Amendment](#flow) to be enabled.
 
-{% admonition type="info" name="Note" %}An incomplete version of this amendment was introduced in v0.33.0 and removed in v0.80.0. (It was never enabled.){% /admonition %}
+{% admonition type="info" name="Note" %}
+An incomplete version of this amendment was introduced in v0.33.0 and removed in v0.80.0. (It was never enabled.)
+{% /admonition %}
 
 
 ### PayChan
@@ -1763,7 +1771,7 @@ This Amendment requires the [Flow Amendment](#flow) to be enabled.
 | Amendment    | PayChan |
 |:-------------|:--------|
 | Amendment ID | 08DE7D96082187F6E6578530258C77FAABABE4C20474BDB82F04B021F1A68647 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="PayChan" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1795,9 +1803,9 @@ This amendment was disabled in v2.6.1 due to a bug. It will be replaced by `Perm
 [PermissionedDEX]: #permissioneddex
 
 | Amendment    | PermissionedDEX |
-|:-------------|:----------------|
+|:-------------|:--------|
 | Amendment ID | 677E401A423E3708363A36BA8B3A7D019D21AC5ABD00387BDBEA6BDE4C91247E |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="PermissionedDEX" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1810,9 +1818,9 @@ Specification: [XLS-81](https://github.com/XRPLF/XRPL-Standards/pull/281)
 [PermissionedDomains]: #permissioneddomains
 
 | Amendment    | PermissionedDomains |
-|:-------------|:--------------------|
+|:-------------|:--------|
 | Amendment ID | A730EB18A9D4BB52502C898589558B4CCEB4BE10044500EE5581137A2E80E849 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="PermissionedDomains" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1825,9 +1833,9 @@ This amendment creates a new ledger entry type, `PermissionedDomain`, and new tr
 [PriceOracle]: #priceoracle
 
 | Amendment    | PriceOracle |
-|:-------------|:------------|
+|:-------------|:--------|
 | Amendment ID | 96FD2F293A519AE1DB6F8BED23E4AD9119342DA7CB6BAFD00953D16C54205D8B |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="PriceOracle" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1840,9 +1848,9 @@ This amendment creates a new ledger entry type, `PriceOracle`, and new transacti
 [RequireFullyCanonicalSig]: #requirefullycanonicalsig
 
 | Amendment    | RequireFullyCanonicalSig |
-|:-------------|:-------------------------|
+|:-------------|:--------|
 | Amendment ID | 00C1FC4A53E60AB02C864641002B3172F38677E29C26C5406685179B37E1EDAC |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="RequireFullyCanonicalSig" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1874,9 +1882,9 @@ When this amendment is activated, the XRP Ledger will undergo a brief scheduled 
 [SingleAssetVault]: #singleassetvault
 
 | Amendment    | SingleAssetVault |
-|:-------------|:-----------------|
+|:-------------|:--------|
 | Amendment ID | 81BD2619B6B3C8625AC5D0BC01DE17F06C3F0AB95C7C87C93715B87A4FD240D8 |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="SingleAssetVault" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -1920,15 +1928,17 @@ For more details, see [XLS-100: Smart Escrows](https://opensource.ripple.com/doc
 [SortedDirectories]: #sorteddirectories
 
 | Amendment    | SortedDirectories |
-|:-------------|:------------------|
+|:-------------|:--------|
 | Amendment ID | CC5ABAE4F3EC92E94A59B1908C2BE82D2228B6485C00AFF8F22DF930D89C194E |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="SortedDirectories" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
 Sorts the entries in [DirectoryNode ledger objects](../docs/references/protocol/ledger-data/ledger-entry-types/directorynode.md) and fixes a bug that occasionally caused pages of owner directories not to be deleted when they should have been.
 
-{% admonition type="danger" name="Warning" %}Older versions of `rippled` that do not know about this amendment may crash when they find a DirectoryNode sorted by the new rules. To avoid this problem, [upgrade](../docs/infrastructure/installation/index.md) to `rippled` version 0.80.0 or later.{% /admonition %}
+{% admonition type="danger" name="Warning" %}
+Older versions of `rippled` that do not know about this amendment may crash when they find a DirectoryNode sorted by the new rules. To avoid this problem, [upgrade](../docs/infrastructure/installation/index.md) to `rippled` version 0.80.0 or later.
+{% /admonition %}
 
 
 ### Sponsor
@@ -1963,9 +1973,9 @@ This amendment was replaced by the [Escrow](../docs/references/protocol/ledger-d
 [TicketBatch]: #ticketbatch
 
 | Amendment    | TicketBatch |
-|:-------------|:------------|
+|:-------------|:--------|
 | Amendment ID | 955DF3FA5891195A9DAEFA1DDC6BB244B545DDE1BAA84CBB25D5F12A8DA68A0C |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="TicketBatch" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -1991,9 +2001,9 @@ This amendment was replaced by the [TicketBatch][] amendment.
 [TickSize]: #ticksize
 
 | Amendment    | TickSize |
-|:-------------|:---------|
+|:-------------|:--------|
 | Amendment ID | 532651B4FD58DF8922A49BA101AB3E996E5BFBF95A913B3E392504863E63B164 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="TickSize" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -2006,9 +2016,9 @@ Introduces a `TickSize` field to accounts, which can be set with the [AccountSet
 [TokenEscrow]: #tokenescrow
 
 | Amendment    | TokenEscrow |
-|:-------------|:------------|
+|:-------------|:--------|
 | Amendment ID | 138B968F25822EFBF54C00F97031221C47B1EAB8321D93C7C2AEAF85F04EC5DF |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="TokenEscrow" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -2034,9 +2044,9 @@ Specification: [XLS-85](https://xls.xrpl.org/xls/XLS-0085-token-escrow.html)
 [TrustSetAuth]: #trustsetauth
 
 | Amendment    | TrustSetAuth |
-|:-------------|:-------------|
+|:-------------|:--------|
 | Amendment ID | 6781F8368C4771B83E8B821D88F580202BCB4228075297B19E4FDC5233F1EFDC |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="TrustSetAuth" statusOnly=true /%} |
 | Default Vote (Latest stable release) | Yes |
 | Pre-amendment functionality retired? | Yes |
 
@@ -2049,9 +2059,9 @@ With this amendment enabled, a `TrustSet` transaction with [`tfSetfAuth` enabled
 [XChainBridge]: #xchainbridge
 
 | Amendment    | XChainBridge |
-|:-------------|:-------------|
+|:-------------|:--------|
 | Amendment ID | C98D98EE9616ACD36E81FDEB8D41D349BF5F1B41DD64A0ABC1FE9AA5EA267E9C |
-| Status       | Open for Voting |
+| Status       | {% amendment-disclaimer name="XChainBridge" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
@@ -2084,7 +2094,7 @@ Adds several new transaction result codes.
 | Amendment    | XRPFees |
 |:-------------|:--------|
 | Amendment ID | 93E516234E35E08CA689FA33A6D38E103881F8DCB53023F728C307AA89D515A7 |
-| Status       | Enabled |
+| Status       | {% amendment-disclaimer name="XRPFees" statusOnly=true /%} |
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 


### PR DESCRIPTION
- Pre-calculate height of amendment status table and set the loader element to that size so that the page doesn't jump significantly when the table properly loads in. Fixes #3539.
- Add a status-only mode to `{% amendment-disclaimer ... /%}` so that it can be used in the individual amendments' info tables on the Known Amendments page. Note, this does not work for amendments that are not in the VHS data, namely In Development and Obsolete amendments, so those tables still need to manually specify their status.
    - This fixes a couple cases where the individual amendment table is not up-to-date with the actual status of the amendment  (like it says "Open for Voting" even though the amendment has been enabled already).
    - Note, we are _close_ to being able to replace these detail tables entirely with a Markdoc tag that handles them automatically. The two limitations that are stopping us from going there yet are: (a) We don't have data for "In Development" amendments this way, and (b) VHS doesn't have "default vote" data.
- Add a `renderForLlms` function for `{% amendment-disclaimer ... /%}` so that the component renders properly in the Markdown-for-LLMs view. Note, it currently does not support translation. (That appears to be a Redocly limitation, which I've asked them about.)
- Extend the manually-curated list of obsolete amendments into a more thorough JSON file, and use it with a new Markdoc tag to populate the Obsolete Amendments table much in the same way as the main Amendments table (except it doesn't have to rely on live data from VHS).