### PR TITLE
Clarify pagination: request a specific ledger version across pages

### DIFF
--- a/docs/references/http-websocket-apis/api-conventions/markers-and-pagination.md
+++ b/docs/references/http-websocket-apis/api-conventions/markers-and-pagination.md
@@ -10,6 +10,8 @@ Some methods return more data than can efficiently fit into one response. When t
 
 The format of the `marker` field is intentionally undefined. Each server can define a `marker` field as desired, so it may take the form of a string, a nested object, or another type. Different servers, and different methods provided by the same server, can have different `marker` definitions. Each `marker` is ephemeral, and may not work as expected after 10 minutes.
 
+When a query's results span multiple pages, request a specific [ledger version](../../../concepts/ledgers/open-closed-validated-ledgers.md) instead of a shorthand such as `current` or `validated`. A shorthand can resolve to a different ledger version on each call, because the network validates a new ledger every few seconds, so paging with one can return inconsistent or incomplete results. As the examples below show, make the first request with the shorthand, save the `ledger_index` from the response, then pass that exact `ledger_index` value (along with the `marker`) in each of the following requests.
+
 {% tabs %}
 
 {% tab label="Python" %}


### PR DESCRIPTION
Adds prose to the Markers and Pagination page explaining that paginated queries should request a specific ledger version instead of a shorthand like validated, so results stay consistent across pages. Closes #1755