### PR TITLE
Update AccountRoot Flags and other small edits

### DIFF
--- a/docs/references/protocol/ledger-data/ledger-entry-types/accountroot.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/accountroot.md
@@ -2,32 +2,32 @@
 seo:
     description: The settings, XRP balance, and other metadata for one account.
 labels:
-  - Accounts
-  - XRP
+    - Accounts
+    - XRP
 ---
 # AccountRoot
 [[Source]](https://github.com/XRPLF/rippled/blob/a5d238e7d4fa6ef2b539b759d58744d0a1c33c0c/include/xrpl/protocol/detail/ledger_entries.macro#L129-L153 "Source")
 
-An `AccountRoot` ledger entry type describes a single [account](../../../../concepts/accounts/index.md), its settings, and XRP balance. You can create a new account by sending a [Payment transaction][] with enough XRP to a mathematically-valid address.
+An `AccountRoot` ledger entry type describes a single [account](/docs/concepts/accounts/index.md), its settings, and XRP balance. You can create a new account by sending a [Payment transaction][] with enough XRP to a mathematically-valid address.
 
 ## Example {% $frontmatter.seo.title %} JSON
 
 ```json
 {
-    "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-    "AccountTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
-    "Balance": "148446663",
-    "Domain": "6D64756F31332E636F6D",
-    "EmailHash": "98B4375E1D753E5B91627516F6D70977",
-    "Flags": 8388608,
-    "LedgerEntryType": "AccountRoot",
-    "MessageKey": "0000000000000000000000070000000300",
-    "OwnerCount": 3,
-    "PreviousTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
-    "PreviousTxnLgrSeq": 14091160,
-    "Sequence": 336,
-    "TransferRate": 1004999999,
-    "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+  "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+  "AccountTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
+  "Balance": "148446663",
+  "Domain": "6D64756F31332E636F6D",
+  "EmailHash": "98B4375E1D753E5B91627516F6D70977",
+  "Flags": 8388608,
+  "LedgerEntryType": "AccountRoot",
+  "MessageKey": "0000000000000000000000070000000300",
+  "OwnerCount": 3,
+  "PreviousTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
+  "PreviousTxnLgrSeq": 14091160,
+  "Sequence": 336,
+  "TransferRate": 1004999999,
+  "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
 }
 ```
 
@@ -37,26 +37,26 @@ In addition to the [common fields](../common-fields.md), {% code-page-name /%} e
 
 | Field                         | JSON Type | [Internal Type][] | Required? | Description  |
 |:------------------------------|:----------|:------------------|:----------|:-------------|
-| `Account`                     | String    | AccountID         | Yes       | The identifying (classic) address of this [account](../../../../concepts/accounts/index.md). |
+| `Account`                     | String    | AccountID         | Yes       | The identifying [address](/docs/concepts/accounts/addresses.md) of this account. |
 | `AccountTxnID`                | String    | UInt256           | No        | The identifying hash of the transaction most recently sent by this account. This field must be enabled to use the [`AccountTxnID` transaction field](../../transactions/common-fields.md#accounttxnid). To enable it, send an [AccountSet transaction with the `asfAccountTxnID` flag enabled](../../transactions/types/accountset.md#accountset-flags). |
-| `AMMID`                       | String    | UInt256           | No        | {% amendment-disclaimer name="AMM" /%} The ledger entry ID of the corresponding AMM ledger entry. Set during account creation; cannot be modified. If present, indicates that this is a special AMM [pseudo-account](../../../../concepts/accounts/pseudo-accounts.md) AccountRoot; always omitted on non-AMM accounts. |
+| `AMMID`                       | String    | UInt256           | No        | If present, indicates that this is a special AMM [pseudo-account](/docs/concepts/accounts/pseudo-accounts.md) AccountRoot; always omitted on non-AMM accounts. Contains the ledger entry ID of the corresponding AMM ledger entry. Set during account creation; cannot be modified. {% amendment-disclaimer name="AMM" /%} |
 | `Balance`                     | String    | Amount            | No        | The account's current [XRP balance in drops][XRP, in drops], represented as a string. |
-| `BurnedNFTokens`              | Number    | UInt32            | No        | How many total of this account's issued [non-fungible tokens](../../../../concepts/tokens/nfts/index.md) have been burned. This number is always equal or less than `MintedNFTokens`. |
+| `BurnedNFTokens`              | Number    | UInt32            | No        | How many total of this account's issued [non-fungible tokens](/docs/concepts/tokens/nfts/index.md) have been burned. This number is always equal or less than `MintedNFTokens`. |
 | `Domain`                      | String    | Blob              | No        | A domain associated with this account. In JSON, this is the hexadecimal for the ASCII representation of the domain. [Cannot be more than 256 bytes in length.](https://github.com/XRPLF/rippled/blob/5b6e8b6f93b19c1e3f6a3467a25639031d9d9a53/include/xrpl/protocol/Protocol.h#L215) |
 | `EmailHash`                   | String    | UInt128           | No        | The md5 hash of an email address. Clients can use this to look up an avatar through services such as [Gravatar](https://en.gravatar.com/). |
-| `FirstNFTokenSequence`        | Number    | UInt32            | No        | The account's [Sequence Number][] at the time it minted its first [non-fungible-token](../../../../concepts/tokens/nfts/index.md). {% amendment-disclaimer name="fixNFTokenRemint" /%} |
+| `FirstNFTokenSequence`        | Number    | UInt32            | No        | The account's [Sequence Number][] at the time it minted its first [non-fungible-token](/docs/concepts/tokens/nfts/index.md). {% amendment-disclaimer name="fixNFTokenRemint" /%} |
 | `MessageKey`                  | String    | Blob              | No        | A public key that may be used to send encrypted messages to this account. In JSON, uses hexadecimal. Must be exactly 33 bytes, with the first byte indicating the key type: `0x02` or `0x03` for secp256k1 keys, `0xED` for Ed25519 keys. |
-| `MintedNFTokens`              | Number    | UInt32            | No        | How many total [non-fungible tokens](../../../../concepts/tokens/nfts/index.md) have been minted by and on behalf of this account. {% amendment-disclaimer name="NonFungibleTokensV1_1" /%} |
-| `NFTokenMinter`               | String    | AccountID         | No        | Another account that can mint [non-fungible tokens](../../../../concepts/tokens/nfts/index.md) on behalf of this account. {% amendment-disclaimer name="NonFungibleTokensV1_1" /%} |
+| `MintedNFTokens`              | Number    | UInt32            | No        | How many total [non-fungible tokens](/docs/concepts/tokens/nfts/index.md) have been minted by and on behalf of this account. {% amendment-disclaimer name="NonFungibleTokensV1_1" /%} |
+| `NFTokenMinter`               | String    | AccountID         | No        | Another account that can mint [non-fungible tokens](/docs/concepts/tokens/nfts/index.md) on behalf of this account. {% amendment-disclaimer name="NonFungibleTokensV1_1" /%} |
 | `OwnerCount`                  | Number    | UInt32            | Yes       | The number of objects this account owns in the ledger, which contributes to its owner reserve. |
 | `PreviousTxnID`               | String    | UInt256           | Yes       | The identifying hash of the transaction that most recently modified this object. |
-| `PreviousTxnLgrSeq`           | Number    | UInt32            | Yes       |The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this object. |
-| `RegularKey`                  | String    | AccountID         | No        | The address of a [key pair](../../../../concepts/accounts/cryptographic-keys.md) that can be used to sign transactions for this account instead of the master key. Use a [SetRegularKey transaction][] to change this value. |
+| `PreviousTxnLgrSeq`           | Number    | UInt32            | Yes       | The [index of the ledger][Ledger Index] that contains the transaction that most recently modified this object. |
+| `RegularKey`                  | String    | AccountID         | No        | The address of a [key pair](/docs/concepts/accounts/cryptographic-keys.md) that can be used to sign transactions for this account instead of the master key. Use a [SetRegularKey transaction][] to change this value. |
 | `Sequence`                    | Number    | UInt32            | Yes       | The [sequence number](../../data-types/basic-data-types.md#account-sequence) of the next valid transaction for this account. |
-| `TicketCount`                 | Number    | UInt32            | No        | How many [Tickets](../../../../concepts/accounts/tickets.md) this account owns in the ledger. This is updated automatically to ensure that the account stays within the hard limit of 250 Tickets at a time. This field is omitted if the account has zero Tickets. |
+| `TicketCount`                 | Number    | UInt32            | No        | How many [Tickets](/docs/concepts/accounts/tickets.md) this account owns in the ledger. This is updated automatically to ensure that the account stays within the hard limit of 250 Tickets at a time. This field is omitted if the account has zero Tickets. |
 | `TickSize`                    | Number    | UInt8             | No        | How many significant digits to use for exchange rates of Offers involving currencies issued by this address. Valid values are `3` to `15`, inclusive. |
-| `TransferRate`                | Number    | UInt32            | No        | A [transfer fee](../../../../concepts/tokens/fungible-tokens/transfer-fees.md) to charge other users for sending currency issued by this account to each other. |
-| `VaultID`                     | String    | UInt256           | No        | {% amendment-disclaimer name="SingleAssetVault" /%} The ID of the `Vault` entry associated with this account. Set during account creation; cannot be modified. If present, indicates that this is a special Vault [pseudo-account](../../../../concepts/accounts/pseudo-accounts.md) AccountRoot; always omitted on non-Vault accounts. |
+| `TransferRate`                | Number    | UInt32            | No        | A [transfer fee](/docs/concepts/tokens/fungible-tokens/transfer-fees.md) to charge other users for sending currency issued by this account to each other. |
+| `VaultID`                     | String    | UInt256           | No        | {% amendment-disclaimer name="SingleAssetVault" /%} The ID of the `Vault` entry associated with this account. Set during account creation; cannot be modified. If present, indicates that this is a special Vault [pseudo-account](/docs/concepts/accounts/pseudo-accounts.md) AccountRoot; always omitted on non-Vault accounts. |
 | `WalletLocator`               | String    | UInt256           | No        | An arbitrary 256-bit value that users can set. |
 | `WalletSize`                  | Number    | UInt32            | No        | Unused. (The code supports this field but there is no way to set it.) |
 
@@ -72,12 +72,12 @@ Automated Market Makers use an AccountRoot ledger entry (pseudo-account) to issu
 
 In addition, the following special rules apply to an AMM's AccountRoot entry:
 
-- It is not subject to the [reserve requirement](../../../../concepts/accounts/reserves.md). It can hold XRP only if XRP is one of the two assets in the AMM's pool.
+- It is not subject to the [reserve requirement](/docs/concepts/accounts/reserves.md). It can hold XRP only if XRP is one of the two assets in the AMM's pool.
 - It cannot be the destination of Checks, Escrows, or Payment Channels. Any transactions that would create such entries instead fail with the result code `tecNO_PERMISSION`.
 - Users cannot create trust lines to it for anything other than the AMM's LP Tokens. Transactions that would create such trust lines instead fail with result code `tecNO_PERMISSION`. (The AMM does have two trust lines to hold the tokens in its pool, or one trust line if the other asset in its pool is XRP.)
 - If the [Clawback amendment][] is also enabled, the issuer cannot clawback funds from an AMM.
 
-Other than those exceptions, these accounts are like ordinary accounts; the LP Tokens they issue behave like other [tokens](../../../../concepts/tokens/index.md) except that those tokens can also be used in AMM-related transactions. You can check an AMM's balances and the history of transactions that affected it the same way you would with a regular account.
+Other than those exceptions, these accounts are like ordinary accounts; the LP Tokens they issue behave like other [tokens](/docs/concepts/tokens/index.md) except that those tokens can also be used in AMM-related transactions. You can check an AMM's balances and the history of transactions that affected it the same way you would with a regular account.
 
 ## Special Vault AccountRoot (Pseudo-Account)
 
@@ -91,37 +91,60 @@ Vaults use an AccountRoot ledger entry (pseudo-account) to issue their shares an
 
 In addition, the following special rules apply to a Vault's AccountRoot entry:
 
-- The vault owner account must pay one [incremental owner reserve](../../../../concepts/accounts/reserves#base-reserve-and-owner-reserve) (currently {% $env.PUBLIC_OWNER_RESERVE %}) when creating the vault to cover the pseudo-account.
+- The vault owner account must pay one [incremental owner reserve](/docs/concepts/accounts/reserves#base-reserve-and-owner-reserve) (currently {% $env.PUBLIC_OWNER_RESERVE %}) when creating the vault to cover the pseudo-account.
 - The `Sequence` number is always `0` and never changes, preventing the pseudo-account from submitting transactions.
 - A pseudo-account is automatically deleted when the vault is deleted, and cannot exist independently of a Vault entry.
 
 ## AccountRoot Flags
 
-Many AccountRoot flags correspond to options you can change with an [AccountSet transaction][]. However, the bit values used in the ledger are different than the values used to enable or disable those flags in a transaction. Ledger flags have names that begin with **`lsf`**.
-
 AccountRoot objects can have the following flags combined in the `Flags` field:
 
-| Flag Name                         | Hex Value    | Decimal Value | Corresponding [AccountSet Flag](../../transactions/types/accountset.md#accountset-flags) | Description |
-|-----------------------------------|--------------|-------------------|-----------------------------------|----|
-| `lsfAllowTrustLineClawback`       | `0x80000000` | 2147483648        | `asfAllowTrustLineClawback`       | Enable [Clawback](../../../../concepts/tokens/fungible-tokens/clawing-back-tokens.md) for this account. {% amendment-disclaimer name="Clawback" /%} |
-| `lsfAllowTrustLineLocking`        | `0x40000000` | 1073741824        | `asfAllowTrustLineLocking`        | Enable [Escrow](../../../../concepts/payment-types/escrow.md) for Trust Line Tokens issued by this account. {% amendment-disclaimer name="TokenEscrow" /%} |
-| `lsfDefaultRipple`                | `0x00800000` | 8388608           | `asfDefaultRipple`                | Enable [rippling](../../../../concepts/tokens/fungible-tokens/rippling.md) on this addresses's trust lines by default. Required for issuing addresses; discouraged for others. |
-| `lsfDepositAuth`                  | `0x01000000` | 16777216          | `asfDepositAuth`                  | This account has [DepositAuth](../../../../concepts/accounts/depositauth.md) enabled, meaning it can only receive funds from transactions it sends, and from [preauthorized](../../../../concepts/accounts/depositauth.md#preauthorization) accounts. {% amendment-disclaimer name="DepositAuth" /%} |
-| `lsfDisableMaster`                | `0x00100000` | 1048576           | `asfDisableMaster`                | Disallows use of the master key to sign transactions for this account. |
-| `lsfDisallowIncomingCheck`        | `0x08000000` | 134217728         | `asfDisallowIncomingCheck`        | This account blocks incoming Checks. {% amendment-disclaimer name="DisallowIncoming" /%} |
-| `lsfDisallowIncomingNFTokenOffer` | `0x04000000` | 67108864          | `asfDisallowIncomingNFTokenOffer` | This account blocks incoming NFTokenOffers. {% amendment-disclaimer name="DisallowIncoming" /%} |
-| `lsfDisallowIncomingPayChan`      | `0x10000000` | 268435456         | `asfDisallowIncomingPayChan`      | This account blocks incoming Payment Channels. {% amendment-disclaimer name="DisallowIncoming" /%} |
-| `lsfDisallowIncomingTrustline`    | `0x20000000` | 536870912         | `asfDisallowIncomingTrustline`    | This account blocks incoming trust lines. {% amendment-disclaimer name="DisallowIncoming" /%} |
-| `lsfDisallowXRP`                  | `0x00080000` | 524288            | `asfDisallowXRP`                  | Client applications should not send XRP to this account. (Advisory; not enforced by the protocol.) |
-| `lsfGlobalFreeze`                 | `0x00400000` | 4194304           | `asfGlobalFreeze`                 | All assets issued by this account are frozen. |
-| `lsfNoFreeze`                     | `0x00200000` | 2097152           | `asfNoFreeze`                     | This account cannot freeze trust lines connected to it. Once enabled, cannot be disabled. |
-| `lsfPasswordSpent`                | `0x00010000` | 65536             | (None)                            | This account has used its free SetRegularKey transaction. |
-| `lsfRequireAuth`                  | `0x00040000` | 262144            | `asfRequireAuth`                  | This account must individually approve other users for those users to hold this account's tokens. |
-| `lsfRequireDestTag`               | `0x00020000` | 131072            | `asfRequireDest`                  | Requires incoming payments to specify a Destination Tag. |
+| Flag Name                         | Hex Value    | Decimal Value | Description |
+|-----------------------------------|--------------|---------------|-------------|
+| `lsfAllowTrustLineClawback`       | `0x80000000` | 2147483648    | This account has [Clawback](/docs/concepts/tokens/fungible-tokens/clawing-back-tokens.md) enabled. Once enabled, cannot be disabled. {% amendment-disclaimer name="Clawback" /%} |
+| `lsfAllowTrustLineLocking`        | `0x40000000` | 1073741824    | Trust line tokens issued by this account have [Escrow](/docs/concepts/payment-types/escrow.md) enabled. {% amendment-disclaimer name="TokenEscrow" /%} |
+| `lsfDefaultRipple`                | `0x00800000` | 8388608       | Enable [rippling](/docs/concepts/tokens/fungible-tokens/rippling.md) on this addresses's trust lines by default. Required for issuers of trust line tokens; discouraged otherwise. |
+| `lsfDepositAuth`                  | `0x01000000` | 16777216      | This account has [DepositAuth](/docs/concepts/accounts/depositauth.md) enabled, meaning it can only receive funds from transactions it sends, and from [preauthorized](/docs/concepts/accounts/depositauth.md#preauthorization) accounts. {% amendment-disclaimer name="DepositAuth" /%} |
+| `lsfDisableMaster`                | `0x00100000` | 1048576       | This account's [master key pair](/docs/concepts/accounts/cryptographic-keys.md) is disabled and cannot be used to sign transactions from this account. |
+| `lsfDisallowIncomingCheck`        | `0x08000000` | 134217728     | This account blocks incoming [checks](/docs/concepts/payment-types/checks.md). {% amendment-disclaimer name="DisallowIncoming" /%} |
+| `lsfDisallowIncomingNFTokenOffer` | `0x04000000` | 67108864      | This account blocks incoming [NFT offers](/docs/concepts/tokens/nfts/trading.md). {% amendment-disclaimer name="DisallowIncoming" /%} |
+| `lsfDisallowIncomingPayChan`      | `0x10000000` | 268435456     | This account blocks incoming [payment channels](/docs/concepts/payment-types/payment-channels.md). {% amendment-disclaimer name="DisallowIncoming" /%} |
+| `lsfDisallowIncomingTrustline`    | `0x20000000` | 536870912     | This account blocks incoming [trust lines](/docs/concepts/tokens/fungible-tokens/trust-line-tokens.md). {% amendment-disclaimer name="DisallowIncoming" /%} |
+| `lsfDisallowXRP`                  | `0x00080000` | 524288        | Client applications should not send XRP to this account. (Advisory; not enforced by the protocol.) |
+| `lsfGlobalFreeze`                 | `0x00400000` | 4194304       | Trust line tokens issued by this account are [frozen](/docs/concepts/tokens/fungible-tokens/freezes.md). |
+| `lsfNoFreeze`                     | `0x00200000` | 2097152       | This account cannot freeze trust lines connected to it. Once enabled, cannot be disabled. |
+| `lsfPasswordSpent`                | `0x00010000` | 65536         | This account has used its [free key reset transaction](/docs/concepts/transactions/transaction-cost#key-reset-transaction). |
+| `lsfRequireAuth`                  | `0x00040000` | 262144        | Trust line tokens issued by this account use [authorized trust lines](/docs/concepts/tokens/fungible-tokens/authorized-trust-lines.md) (allowlisting). |
+| `lsfRequireDestTag`               | `0x00020000` | 131072        | Payments to this account must specify a Destination Tag. Commonly used on exchanges and other shared accounts to require incoming payments to specify a customer or purpose to credit the payment towards. |
+
+### Correlation with AccountSet Flags
+
+Many AccountRoot flags correspond to options you can change with an [AccountSet transaction][]. However, the bit values used in the ledger entry are different than the values used to enable or disable those flags in a transaction. Ledger flags have names that begin with **`lsf`**.
+
+The following table shows the correlation between AccountRoot flags and the AccountSet flags that control them:
+
+| Flag Name                         | Corresponding [AccountSet Flag](../../transactions/types/accountset.md#accountset-flags) |
+|-----------------------------------|-----------------------------------|
+| `lsfAllowTrustLineClawback`       | `asfAllowTrustLineClawback`       |
+| `lsfAllowTrustLineLocking`        | `asfAllowTrustLineLocking`        |
+| `lsfDefaultRipple`                | `asfDefaultRipple`                |
+| `lsfDepositAuth`                  | `asfDepositAuth`                  |
+| `lsfDisableMaster`                | `asfDisableMaster`                |
+| `lsfDisallowIncomingCheck`        | `asfDisallowIncomingCheck`        |
+| `lsfDisallowIncomingNFTokenOffer` | `asfDisallowIncomingNFTokenOffer` |
+| `lsfDisallowIncomingPayChan`      | `asfDisallowIncomingPayChan`      |
+| `lsfDisallowIncomingTrustline`    | `asfDisallowIncomingTrustline`    |
+| `lsfDisallowXRP`                  | `asfDisallowXRP`                  |
+| `lsfGlobalFreeze`                 | `asfGlobalFreeze`                 |
+| `lsfNoFreeze`                     | `asfNoFreeze`                     |
+| `lsfPasswordSpent`                | (None)                            |
+| `lsfRequireAuth`                  | `asfRequireAuth`                  |
+| `lsfRequireDestTag`               | `asfRequireDest`                  |
+
 
 ## {% $frontmatter.seo.title %} Reserve
 
-The [reserve](../../../../concepts/accounts/reserves.md) for an AccountRoot entry is the base reserve, currently {% $env.PUBLIC_BASE_RESERVE %}, except in the case of a special AMM or Vault AccountRoot.
+The [reserve](/docs/concepts/accounts/reserves.md) for an AccountRoot entry is the base reserve, currently {% $env.PUBLIC_BASE_RESERVE %}, except in the case of a special AMM or Vault AccountRoot.
 
 This XRP cannot be sent to others but it can be burned as part of the [transaction cost][].
 
@@ -135,10 +158,10 @@ The ID of an AccountRoot entry is the [SHA-512Half][] of the following values, c
 ## See Also
 
 - **Concepts:**
-  - [Pseudo-Accounts](../../../../concepts/accounts/pseudo-accounts.md)
+    - [Pseudo-Accounts](/docs/concepts/accounts/pseudo-accounts.md)
 
 - **Transactions:**
-  - [AccountSet transaction][]
-  - [AccountDelete transaction][]
+    - [AccountSet transaction][]
+    - [AccountDelete transaction][]
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
- Split the AccountSet flag correlations out to a separate table so that both of them are more readable and less likely to spill off the side of the page.
- Update the descriptions for flags to match modern style guidelines and link the relevant concepts. Fixes #2796.
- Switch from relative links to absolute links in cases where this is more concise.
- Other minor formatting/style edits.