### PR TITLE
Clarify ManagementFeeRate and fix valid values

### DIFF
--- a/docs/references/protocol/ledger-data/ledger-entry-types/loanbroker.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/loanbroker.md
@@ -63,7 +63,7 @@ In addition to the [common ledger entry fields][], {% code-page-name /%} entries
 | `Account`             | String    | AccountID     | Yes       | The address of the `LoanBroker` pseudo-account. |
 | `Owner`               | String    | AccountID     | Yes       | The account address of the vault owner. |
 | `Data`                | String    | Blob          | No        | Arbitrary metadata about the vault. Limited to 256 bytes. |
-| `ManagementFeeRate`   | Number    | UInt16        | No        | The fee charged by the lending protocol, in units of 1/10th basis points. Valid values are 0 to 100000 (inclusive), representing 0% to 100%. |
+| `ManagementFeeRate`   | Number    | UInt16        | No        | The fee charged by the lending protocol on any loan interest, in units of 1/10th basis points. Valid values are 0 to 10000 (inclusive), representing 0% to 10%. |
 | `OwnerCount`          | Number    | UInt32        | Yes       | The number of active loans issued by the LoanBroker. |
 | `DebtTotal`           | String    | Number        | Yes       | The total asset amount the protocol owes the vault, including interest. |
 | `DebtMaximum`         | String    | Number        | No        | The maximum amount the protocol can owe the vault. The default value of `0` means there is no limit to the debt. |

--- a/docs/references/protocol/transactions/types/loanbrokerset.md
+++ b/docs/references/protocol/transactions/types/loanbrokerset.md
@@ -46,7 +46,7 @@ In addition to the [common fields][], {% code-page-name /%} transactions use the
 | `VaultID`              | String    | Hash256       | Yes       | The ID of the vault that the lending protocol will use to access liquidity. |
 | `LoanBrokerID`         | String    | Hash256       | No        | The loan broker ID that the transaction is modifying. |
 | `Data`                 | String    | Blob          | No        | Arbitrary metadata in hex format--limited to 256 bytes. |
-| `ManagementFeeRate`    | Number    | UInt16        | No        | The 1/10th basis point fee charged by the lending protocol owner. Valid values range from `0` to `10000` (inclusive), representing 0% to 10%. |
+| `ManagementFeeRate`    | Number    | UInt16        | No        | The 1/10th basis point fee charged by the lending protocol owner against any loan interest. Valid values range from `0` to `10000` (inclusive), representing 0% to 10%. |
 | `DebtMaximum`          | String    | Number        | No        | The maximum amount the protocol can owe the vault. The default value of `0` means there is no limit to the debt. Must be a positive value. |
 | `CoverRateMinimum`     | Number    | UInt32        | No        | The 1/10th basis point `DebtTotal` that the first-loss capital must cover. Valid values range from `0` to `100000` (inclusive), representing 0% to 100%. |
 | `CoverRateLiquidation` | Number    | UInt32        | No        | The 1/10th basis point of minimum required first-loss capital that is moved to an asset vault to cover a loan default. Valid values range from `0` to `100000` (inclusive), representing 0% to 100%. |


### PR DESCRIPTION
- Clarifies that the management fee is a % charge on interest generated from loans.
- Fixed an incorrect value range in `LoanBroker` entry.