### PR TITLE
Add 3.3.0 transaction reference caveats

### DIFF
--- a/docs/references/protocol/transactions/types/ammcreate.md
+++ b/docs/references/protocol/transactions/types/ammcreate.md
@@ -56,7 +56,7 @@ Creates both an [AMM entry][] and a [special AccountRoot entry](../../ledger-dat
 | `Amount2`    | [Currency Amount][] | Amount            | Yes       | The second of the two assets to fund this AMM with. This must be a positive amount. |
 | `TradingFee` | Number              | UInt16            | Yes       | The fee to charge for trades against this AMM instance, in units of 1/100,000; a value of 1 is equivalent to 0.001%. The maximum value is `1000`, indicating a 1% fee. The minimum value is `0`. |
 
-One or both of `Amount` and `Amount2` can be [tokens](../../../../concepts/tokens/index.md); at most one of them can be [XRP](../../../../introduction/what-is-xrp.md). They cannot both have the same currency code and issuer. The tokens' issuers must have [Default Ripple](../../../../concepts/tokens/fungible-tokens/rippling.md#the-default-ripple-flag) enabled. The assets _cannot_ be LP tokens for another AMM.
+One or both of `Amount` and `Amount2` can be [tokens](../../../../concepts/tokens/index.md); at most one of them can be [XRP](../../../../introduction/what-is-xrp.md). They cannot both have the same currency code and issuer. The tokens' issuers must have [Default Ripple](../../../../concepts/tokens/fungible-tokens/rippling.md#the-default-ripple-flag) enabled. The assets _cannot_ be LP tokens for another AMM, and _cannot_ be the shares of a [Single Asset Vault](../../../../concepts/tokens/single-asset-vaults.md). Vault shares are issued by a [pseudo-account](../../../../concepts/accounts/pseudo-accounts.md) and can't be held by another one.
 
 ## Special Transaction Cost
 
@@ -76,6 +76,7 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecNO_LINE`        | The sender does not have a trust line for at least one of the deposit assets. |
 | `tecNO_PERMISSION`  | At least one of the deposit assets cannot be used in an AMM. |
 | `tecUNFUNDED_AMM`   | The sender does not hold enough of the assets specified in `Amount` and `Amount2` to fund the AMM. |
+| `tecWRONG_ASSET`    | At least one of `Amount` or `Amount2` is the shares of a [Single Asset Vault](../../../../concepts/tokens/single-asset-vaults.md), which cannot be used as an AMM pool asset. |
 | `terNO_RIPPLE`      | The issuer of at least one of the assets has not enabled the [Default Ripple flag](../../../../concepts/tokens/fungible-tokens/rippling.md#the-default-ripple-flag). |
 | `temAMM_BAD_TOKENS` | The values of `Amount` and `Amount2` are not valid: for example, both refer to the same token. |
 | `temBAD_FEE`        | The `TradingFee` value is invalid. It must be zero or a positive integer and cannot be over 1000. |

--- a/docs/references/protocol/transactions/types/ammcreate.md
+++ b/docs/references/protocol/transactions/types/ammcreate.md
@@ -76,7 +76,7 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | `tecNO_LINE`        | The sender does not have a trust line for at least one of the deposit assets. |
 | `tecNO_PERMISSION`  | At least one of the deposit assets cannot be used in an AMM. |
 | `tecUNFUNDED_AMM`   | The sender does not hold enough of the assets specified in `Amount` and `Amount2` to fund the AMM. |
-| `tecWRONG_ASSET`    | At least one of `Amount` or `Amount2` is the shares of a [Single Asset Vault](../../../../concepts/tokens/single-asset-vaults.md), which cannot be used as an AMM pool asset. |
+| `tecWRONG_ASSET`    | At least one of `Amount` or `Amount2` is the share token of a [Single Asset Vault](../../../../concepts/tokens/single-asset-vaults.md), which cannot be used as an AMM pool asset. |
 | `terNO_RIPPLE`      | The issuer of at least one of the assets has not enabled the [Default Ripple flag](../../../../concepts/tokens/fungible-tokens/rippling.md#the-default-ripple-flag). |
 | `temAMM_BAD_TOKENS` | The values of `Amount` and `Amount2` are not valid: for example, both refer to the same token. |
 | `temBAD_FEE`        | The `TradingFee` value is invalid. It must be zero or a positive integer and cannot be over 1000. |

--- a/docs/references/protocol/transactions/types/checkcancel.md
+++ b/docs/references/protocol/transactions/types/checkcancel.md
@@ -35,6 +35,7 @@ Cancels an unredeemed [check](../../../../concepts/payment-types/checks.md), rem
 
 ## Error Cases
 
+- If the `CheckID` is an all-zero value, the transaction fails with the result `temMALFORMED`. (Requires the `fixCleanup3_3_0` amendment. Before that amendment is enabled, the transaction instead passes preflight and fails during ledger lookup with `tecNO_ENTRY`.)
 - If the object identified by the `CheckID` does not exist or is not a Check, the transaction fails with the result `tecNO_ENTRY`.
 - If the Check is not expired and the sender of the CheckCancel transaction is not the source or destination of the Check, the transaction fails with the result `tecNO_PERMISSION`.
 

--- a/docs/references/protocol/transactions/types/checkcash.md
+++ b/docs/references/protocol/transactions/types/checkcash.md
@@ -43,6 +43,7 @@ The transaction ***must*** include either `Amount` or `DeliverMin`, but not both
 ## Error Cases
 
 - If the sender of the CheckCash transaction is not the `Destination` of the check, the transaction fails with the result code `tecNO_PERMISSION`.
+- If the `CheckID` is an all-zero value, the transaction fails with the result `temMALFORMED`. (Requires the `fixCleanup3_3_0` amendment. Before that amendment is enabled, the transaction instead passes preflight and fails during ledger lookup with `tecNO_ENTRY`.)
 - If the Check identified by the `CheckID` field does not exist, the transaction fails with the result `tecNO_ENTRY`.
 - If the Check identified by the `CheckID` field has already expired, the transaction fails with the result `tecEXPIRED`.
 - If the destination of the Check has the `RequireDest` flag enabled but the Check, as created, does not have a destination tag, the transaction fails with the result code `tecDST_TAG_NEEDED`.

--- a/docs/references/protocol/transactions/types/nftokencanceloffer.md
+++ b/docs/references/protocol/transactions/types/nftokencanceloffer.md
@@ -58,7 +58,7 @@ Besides errors that can occur for all transactions, {% $frontmatter.seo.title %}
 | Error Code         | Description                                             |
 |:-------------------|:--------------------------------------------------------|
 | `temDISABLED`      | The [NonFungibleTokensV1 amendment][] is not enabled. |
-| `temMALFORMED`     | The transaction was not validly formatted. For example, the `NFTokenOffers` array was empty or contained more than the maximum number of offers that can be canceled at one time. |
+| `temMALFORMED`     | The transaction was not validly formatted. For example, the `NFTokenOffers` array was empty, contained more than the maximum number of offers that can be canceled at one time, or contained an all-zero offer ID. |
 | `tecNO_PERMISSION` | At least one of the IDs in the `NFTokenOffers` field refers to an object that cannot be canceled. For example, the sender of this transaction is not the owner or `Destination` of the offer, or the object was not an `NFTokenOffer` type object. |
 
 ## See Also


### PR DESCRIPTION
Small transaction-reference updates in 3.3.0:

- **AMMCreate:** assets cannot be Single Asset Vault shares; added a `tecWRONG_ASSET` error case (#7666).
- **CheckCancel / CheckCash:** an all-zero `CheckID` is rejected with `temMALFORMED` under `fixCleanup3_3_0` (#7685).
- **NFTokenCancelOffer:** extended the `temMALFORMED` description to note an all-zero offer ID (#7391).
