### PR TITLE
Bump Redocly to Realm v0.135.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.22.2",
         "@lezer/highlight": "^1.2.0",
-        "@redocly/realm": "0.135.0",
+        "@redocly/realm": "0.135.2",
         "@uiw/codemirror-themes": "4.21.21",
         "@uiw/react-codemirror": "^4.21.21",
         "@xrplf/isomorphic": "^1.0.0-beta.1",
@@ -1517,9 +1517,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
-      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.5.tgz",
+      "integrity": "sha512-PrlQ8glBdWS5UOqgnFCmPxAJbhuOhb0WoDnSAXiNQPjivlDujhuUQ1K/fxyk2vFoq4VTBgFtFZOc8sOpiYjz5g==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -2216,14 +2216,14 @@
       }
     },
     "node_modules/@redocly/asyncapi-docs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.12.0.tgz",
-      "integrity": "sha512-gnpaatjlNhxDTFCO4OmQjrbMa1KVFcxP9AuyDZFalAFSIEDwcdK+CVUzWTnphmLXXB9p+N8bzUDoYeDPhO6MxA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@redocly/asyncapi-docs/-/asyncapi-docs-1.12.1.tgz",
+      "integrity": "sha512-PhQKEDuUlXn74ALootngAm9F5IZ4AwhhgLOK8/bgwxkE0tJd70Cy59PuTBM9W13v7jnQQwMA2XT34ROWUQW6OA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@markdoc/markdoc": "0.5.2",
         "@redocly/config": "0.50.1",
-        "@redocly/openapi-docs": "3.23.0",
+        "@redocly/openapi-docs": "3.23.1",
         "@redocly/redoc-opentelemetry": "0.2.2",
         "@redocly/theme": "0.67.0",
         "jotai": "^2.11.1",
@@ -2246,13 +2246,13 @@
       }
     },
     "node_modules/@redocly/graphql-docs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.0.tgz",
-      "integrity": "sha512-E1+suS+e47dlrGhvIIiDitwREtk92lblgXPONi1WnM502de8ifMTDcjcuKB277ENy873qFCjFvWYuk+5SVBbpQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-1.12.1.tgz",
+      "integrity": "sha512-h0PT5sdhI+yOZl3vaH8Qk+YrqFw8tKPsW9wFVDkGUCyRjoaVHRpGiMuhrSmL1JIo78UIgffOtReQA58/eVrI9g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.50.1",
-        "@redocly/openapi-docs": "3.23.0",
+        "@redocly/openapi-docs": "3.23.1",
         "@redocly/redoc-opentelemetry": "0.2.2",
         "deepmerge": "^4.2.2",
         "marked": "^4.0.15",
@@ -2321,9 +2321,9 @@
       }
     },
     "node_modules/@redocly/mock-server": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.9.0.tgz",
-      "integrity": "sha512-Ut1dRfq+g2PcJJHGf5DVFEjyJhAb8x0APnaTfiTEcuZUbm2vWjLeQ6PhrnFhtTVN/FIBS2bj0uIm5THcI7Yl5Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.9.1.tgz",
+      "integrity": "sha512-8EaTzA8qgrsBpC1OovHcAvEWjNuPreCIwM2YiTXoQAEr87D9TAwFgfrr94CWbhwIy4nvPIdtMl9Z6CB45dg3tQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/ajv": "8.18.0",
@@ -2331,7 +2331,7 @@
         "ajv": "8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-xml-parser": "5.7.3",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "openapi-sampler": "^1.7.2",
         "punycode": "2.3.0",
         "swagger2openapi": "^7.0.8",
@@ -2422,9 +2422,9 @@
       }
     },
     "node_modules/@redocly/openapi-docs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.23.0.tgz",
-      "integrity": "sha512-6JJ0we9lvXqqvg5Kqkn8wo6O1LK3/UOsbCKqp54vGecpRkORXS4ZU/2C7FRVNEtggIV6av9tY2iWN6/DybnkHA==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.23.1.tgz",
+      "integrity": "sha512-rzAkYiFlPdie/SWt8bpEnUtQnJNkV8SCnUJJCXpdnMcnN3YXflJXDyjx58ZlcnwmciZyJtcSDnwvsG8l+79SXw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2432,9 +2432,9 @@
         "@redocly/config": "0.50.1",
         "@redocly/openapi-core": "2.37.0",
         "@redocly/redoc-opentelemetry": "0.2.2",
-        "@redocly/replay": "0.26.0",
+        "@redocly/replay": "0.26.1",
         "deepmerge": "^4.2.2",
-        "dompurify": "3.4.11",
+        "dompurify": "3.4.12",
         "fast-deep-equal": "^3.1.3",
         "fast-xml-parser": "5.7.3",
         "jotai": "^2.12.5",
@@ -2475,20 +2475,20 @@
       }
     },
     "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.20.0.tgz",
-      "integrity": "sha512-lBO6mtdbzQp3vgVJy49xNzlzEyFVtjQ+2TinGPG0fhzCaQZbhe5lkvm4bBmF5RaKTteU/xOARJYKBsAC9Snlmw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.20.1.tgz",
+      "integrity": "sha512-EQ6gFeiKxhBKA+L42avJhCiw5jwt1Uzb+ihSDOk9XmGge+Gj/KXhDiKQphPpm6NewOQRQxUUxRNQacoWd7CzyQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.50.1",
-        "@redocly/mock-server": "0.9.0",
-        "@redocly/openapi-docs": "3.23.0"
+        "@redocly/mock-server": "0.9.1",
+        "@redocly/openapi-docs": "3.23.1"
       }
     },
     "node_modules/@redocly/realm": {
-      "version": "0.135.0",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.135.0.tgz",
-      "integrity": "sha512-jTrMioNTVMhJp30qZLok3XjDWiVVN1tqOIMy0iRpEy7R2faqf6qGR+vYjhS51fb9dSg4BYMrXifsflk/eGqYcQ==",
+      "version": "0.135.2",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.135.2.tgz",
+      "integrity": "sha512-TmgFq80Ay+jsgpyzJFRu3j4utDVin/MzCW5vj72dy6+Pt9eFXZAb5Tx1KjIcmi3YXp6RyKlCqdN33t2zE7h6OQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.29.7",
@@ -2509,14 +2509,14 @@
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/ajv": "8.18.0",
-        "@redocly/asyncapi-docs": "1.12.0",
+        "@redocly/asyncapi-docs": "1.12.1",
         "@redocly/config": "0.50.1",
-        "@redocly/graphql-docs": "1.12.0",
+        "@redocly/graphql-docs": "1.12.1",
         "@redocly/mcp-typescript-sdk": "1.18.1",
         "@redocly/openapi-core": "2.37.0",
-        "@redocly/openapi-docs": "3.23.0",
+        "@redocly/openapi-docs": "3.23.1",
         "@redocly/portal-legacy-ui": "0.18.0",
-        "@redocly/portal-plugin-mock-server": "0.20.0",
+        "@redocly/portal-plugin-mock-server": "0.20.1",
         "@redocly/realm-asyncapi-sdk": "0.13.0",
         "@redocly/theme": "0.67.0",
         "@shikijs/transformers": "3.21.0",
@@ -2540,11 +2540,11 @@
         "fflate": "0.7.4",
         "flexsearch": "0.7.43",
         "graphql": "16.12.0",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "htmlparser2": "8.0.2",
         "i18next": "22.4.15",
         "is-glob": "4.0.3",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "lru-cache": "11.1.0",
         "minimatch": "10.2.4",
         "mri": "1.2.0",
@@ -2607,9 +2607,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/replay": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.0.tgz",
-      "integrity": "sha512-FX91J/zq4YyRiSLIxUfeE0DeCV+tIDstwG9PNHa9sejH05sic0A0zBAmCauBtxXpdvtdabC/ifGxjA54qGpgIg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.26.1.tgz",
+      "integrity": "sha512-IGxLsfRuHtWCO6C0Mag9yt0hi1N4gWX7NpdgfXCk4wdUYSM0bd8ZUgVhijP5O5Om1K8hpF96D33cluC+5E/7qQ==",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.1",
         "@ai-sdk/google": "3.0.1",
@@ -2654,7 +2654,7 @@
         "drizzle-orm": "^0.45.0",
         "fast-xml-parser": "5.7.3",
         "idb": "^8.0.2",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "json-pointer": "^0.6.2",
         "json-schema-typed": "^8.0.1",
         "marked": "^4.0.15",
@@ -4001,9 +4001,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4338,15 +4338,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5058,9 +5058,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5435,9 +5435,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5893,9 +5893,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6294,9 +6294,9 @@
       "peer": true
     },
     "node_modules/js-base64": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.1.tgz",
-      "integrity": "sha512-U73qptcvf/HIOauFOmqT3a0mDUp0MYlfd15oqoe9kqZt5XhiXVb+HG09sLvI9PQ9tZIBFS4nlErai8zbWazP0g==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-levenshtein": {
@@ -6315,9 +6315,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -8505,9 +8505,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
-      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.5.0.tgz",
+      "integrity": "sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.22.2",
     "@lezer/highlight": "^1.2.0",
-    "@redocly/realm": "0.135.0",
+    "@redocly/realm": "0.135.2",
     "@uiw/codemirror-themes": "4.21.21",
     "@uiw/react-codemirror": "^4.21.21",
     "@xrplf/isomorphic": "^1.0.0-beta.1",


### PR DESCRIPTION
This minor release fixes some security issues in the `hono` dependency and improves performance of `llms.txt`. Tested it using the recently-added checklist and found no incompatibilities.