### PR TITLE
Fix stale amendment refs and add Sponsorship

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -211,7 +211,7 @@
 [PaymentChannelFund transactions]: /docs/references/protocol/transactions/types/paymentchannelfund.md
 [PaymentChannelFund]: /docs/references/protocol/transactions/types/paymentchannelfund.md
 [Payment]: /docs/references/protocol/transactions/types/payment.md
-[PermissionDelegation amendment]: /resources/known-amendments.md#permissiondelegation
+[PermissionDelegation amendment]: /resources/known-amendments.md#permissiondelegationv1_1
 [PermissionedDEX amendment]: /resources/known-amendments.md#permissioneddex
 [Permissioned DEXes]: /docs/concepts/tokens/decentralized-exchange/permissioned-dexes.md
 [PermissionedDomain entry]: /docs/references/protocol/ledger-data/ledger-entry-types/permissioneddomain.md

--- a/docs/concepts/accounts/blackholed-accounts.md
+++ b/docs/concepts/accounts/blackholed-accounts.md
@@ -20,7 +20,7 @@ To be considered blackholed, an account must meet all of the following condition
 - The master key is disabled.
 - The regular key is set to a known [blackhole address](addresses.md#special-addresses).
 - The account has no [signer list](multi-signing.md).
-- The account has no [delegates](permission-delegation.md). {% amendment-disclaimer name="PermissionDelegation" /%}
+- The account has no [delegates](permission-delegation.md). {% amendment-disclaimer name="PermissionDelegationV1_1" /%}
 
 ## Checking Whether an Account Is Blackholed
 

--- a/docs/references/http-websocket-apis/api-conventions/ledger-entry-short-names.md
+++ b/docs/references/http-websocket-apis/api-conventions/ledger-entry-short-names.md
@@ -12,7 +12,7 @@ The "Ownable" column indicates whether the ledger entry type can appear in owner
 | `Bridge`             | `bridge`              | Yes     | {% amendment-disclaimer name="XChainBridge" compact=true /%} |
 | `Check`              | `check`               | Yes     | {% amendment-disclaimer name="Checks" compact=true /%} |
 | `Credential`         | `credential`          | Yes     | {% amendment-disclaimer name="Credentials" compact=true /%} |
-| `Delegate`           | `delegate`            | Yes     | {% amendment-disclaimer name="PermissionDelegation" compact=true /%} |
+| `Delegate`           | `delegate`            | Yes     | {% amendment-disclaimer name="PermissionDelegationV1_1" compact=true /%} |
 | `DepositPreauth`     | `deposit_preauth`     | Yes     | {% amendment-disclaimer name="DepositPreauth" compact=true /%} |
 | `DID`                | `did`                 | Yes     | {% amendment-disclaimer name="DID" compact=true /%} |
 | `DirectoryNode`      | `directory`           | No      | |
@@ -30,6 +30,7 @@ The "Ownable" column indicates whether the ledger entry type can appear in owner
 | `PermissionedDomain` | `permissioned_domain` | Yes     | {% amendment-disclaimer name="PermissionedDomains" compact=true /%} |
 | `RippleState`        | `state`               | Yes     | |
 | `SignerList`         | `signer_list`         | Yes     | |
+| `Sponsorship`        | `sponsorship`         | Yes     | {% amendment-disclaimer name="Sponsor" compact=true /%} |
 | `Ticket`             | `ticket`              | Yes     | {% amendment-disclaimer name="TicketBatch" compact=true /%} |
 | `XChainOwnedClaimID` | `xchain_owned_claim_id` | Yes   | {% amendment-disclaimer name="XChainBridge" compact=true /%} |
 | `XChainOwnedCreate`<wbr>`AccountClaimID` | `xchain_owned_`<wbr>`create_account_claim_id` | Yes | {% amendment-disclaimer name="XChainBridge" compact=true /%} |

--- a/docs/references/protocol/ledger-data/ledger-entry-types/delegate.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/delegate.md
@@ -11,7 +11,7 @@ status: not_enabled
 
 A `Delegate` ledger entry stores a set of permissions that an account has delegated to another account. You create a `Delegate` entry by sending a [DelegateSet transaction][].
 
-{% amendment-disclaimer name="PermissionDelegation" /%}
+{% amendment-disclaimer name="PermissionDelegationV1_1" /%}
 
 ## Example {% $frontmatter.seo.title %} JSON
 
@@ -63,7 +63,7 @@ There are no flags defined for {% code-page-name /%} entries.
 
 ## {% $frontmatter.seo.title %} Reserve
 
-{% code-page-name /%} entries count as one item towards the owner reserve of the delegating account, as long as the entry is in the ledger, regardless of how many permissions are delegating. Removing all permissions deletes the entry and frees up the reserve.
+{% code-page-name /%} entries count as one item towards the owner reserve of the delegating account, as long as the entry is in the ledger, regardless of how many permissions are delegated. Removing all permissions deletes the entry and frees up the reserve.
 
 {% code-page-name /%} entries are not deletion blockers. If the owner (delegating) account is deleted, all such ledger entries are deleted along with them. Deleting the `Authorize` (delegate) account removes the entry as well, freeing the delegating account's reserve.
 

--- a/docs/references/protocol/transactions/common-fields.md
+++ b/docs/references/protocol/transactions/common-fields.md
@@ -15,7 +15,7 @@ Every transaction has the same set of common fields, plus additional fields base
 | `Fee`                | String - Number      | Amount            | Yes; [auto-fillable][] | Integer amount of XRP, in drops, to be destroyed as a cost for sending this transaction. Some transaction types have different minimum requirements. See [Transaction Cost][] for details. |
 | `Sequence`           | Number               | UInt32            | Yes; [auto-fillable][] | The [sequence number](../data-types/basic-data-types.md#account-sequence) of the account sending the transaction. A transaction is only valid if the `Sequence` number is exactly 1 greater than the previous transaction from the same account. The special case `0` means the transaction is using a [Ticket](../../../concepts/accounts/tickets.md) instead {% amendment-disclaimer name="TicketBatch" /%}. |
 | [`AccountTxnID`](#accounttxnid) | String - [Hash][] | UInt256   | No        | Hash value identifying another transaction. If provided, this transaction is only valid if the sending account's previously-sent transaction matches the provided hash. |
-| [`Delegate`](#delegate) | String - [Address][] | AccountID      | No        | A delegate account that is sending the transaction on behalf of the `Account`. {% amendment-disclaimer name="PermissionDelegation" /%} |
+| [`Delegate`](#delegate) | String - [Address][] | AccountID      | No        | A delegate account that is sending the transaction on behalf of the `Account`. {% amendment-disclaimer name="PermissionDelegationV1_1" /%} |
 | [`Flags`](#flags-field) | Number            | UInt32            | No        | Set of bit-flags for this transaction. |
 | `LastLedgerSequence` | Number               | UInt32            | No; [auto-fillable][] | Highest ledger index this transaction can appear in. Specifying this field places a strict upper limit on how long the transaction can wait to be validated or rejected. See [Reliable Transaction Submission](../../../concepts/transactions/reliable-transaction-submission.md) for more details. |
 | [`Memos`](#memos-field) | Array of Objects  | Array             | No        | Additional arbitrary information attached to this transaction. |
@@ -70,7 +70,7 @@ If the `Delegate` field is provided, this transaction is being sent by a differe
 
 Sending a transaction this way is only possible if the delegating account has granted the appropriate transaction permissions to the delegate account. For more information, see [Permission Delegation](/docs/concepts/accounts/permission-delegation.md).
 
-{% amendment-disclaimer name="PermissionDelegation" /%}
+{% amendment-disclaimer name="PermissionDelegationV1_1" /%}
 
 ## Flags Field
 


### PR DESCRIPTION
- Add the `Sponsorship` ledger entry to the short names table.
- Update five `PermissionDelegation` amendment disclaimers to `PermissionDelegationV1_1`. 
- Repoint the [PermissionDelegation amendment] link definition to the V1_1 entry.
- Fix weird wording in Delegate. 