### PR TITLE
Fix the [peer_private] verification step for validators

### DIFF
--- a/docs/infrastructure/configuration/server-modes/run-xrpld-as-a-validator.md
+++ b/docs/infrastructure/configuration/server-modes/run-xrpld-as-a-validator.md
@@ -192,7 +192,9 @@ _**To connect your validator to the XRP Ledger network using proxies:**_
     $ sudo systemctl restart xrpld.service
     ```
 
-6. Use the [Peer Crawler](../../../references/http-websocket-apis/peer-port-methods/peer-crawler.md) endpoint on one of your stock `xrpld` servers. The response should not include your validator. This verifies that your validator's `[peer_private]` configuration is working. One of the effects of enabling `[peer_private]` on your validator is that your validator's peers do not include it in their Peer Crawler results.
+6. Use the [peers method][] on your validator to confirm that `[peer_private]` is working. The `peers` array should contain _only_ the stock `xrpld` servers you configured: no inbound connections, and no `address` outside the `[ips_fixed]` stanza. If other peers appear, double-check your config file and restart the validator.
+
+    {% admonition type="info" name="Note" %}The [Peer Crawler](../../../references/http-websocket-apis/peer-port-methods/peer-crawler.md) does not confirm this setting. A server's `ip` and `port` are omitted from crawler results if it is configured **as a validator _or_ as a private peer**, so your validator's address is suppressed whether or not `[peer_private]` is set.{% /admonition %}
 
     ```
     $ curl --insecure https://STOCK_SERVER_IP_ADDRESS_HERE:51235/crawl | python3 -m json.tool
@@ -307,6 +309,7 @@ For information about how to revoke a master key pair you generated for your val
 - **References:**
     - [Validator Keys Tool Guide](https://github.com/ripple/validator-keys-tool/blob/master/doc/validator-keys-tool-guide.md)
     - [consensus_info method][]
+    - [peers method][]
     - [validator_list_sites method][]
     - [validators method][]
 


### PR DESCRIPTION
Step 6 of "Connect using proxies" says to check the Peer Crawler, and that an
absent validator "verifies that your validator's `[peer_private]` configuration is
working."

That check returns the same result either way, so it can't confirm the setting.
The peer-crawler reference on this site already explains why — `ip` and `port` are:

> Omitted if the peer is configured as a validator or a private peer

Validator status alone suppresses the address, so the crawler output is identical
whether `[peer_private]` is `1`, `0`, or absent.

This swaps in the check the sibling page already uses
(`peering/configure-a-private-server.md`, step 6): the `peers` method, confirming
no inbound connections and no `address` outside `[ips_fixed]` — which is what
`[peer_private]` actually changes for a validator. The crawler behaviour stays as
a note so it isn't surprising, and `peers method` is added to See Also.

Happy to adjust the wording if you'd rather keep the crawler step and just
re-scope what it claims to prove.
