### PR TITLE
Configure several public hubs on a private server, not one

### DIFF
--- a/docs/infrastructure/configuration/peering/configure-a-private-server.md
+++ b/docs/infrastructure/configuration/peering/configure-a-private-server.md
@@ -50,7 +50,12 @@ To set up a specific server as a private peer, complete the following steps:
     ```
     [ips_fixed]
     r.ripple.com 51235
+    sahyadri.isrdc.in 51235
+    hubs.xrpkuwait.com 51235
+    hub.xrpl-commons.org 51235
     ```
+
+    {% admonition type="warning" name="Caution" %}Configure several hubs, run by different operators. `[peer_private]` disables peer discovery, so `[ips_fixed]` is not a starting point your server can build on -- it is the complete set of peers your server will ever have. If every hub listed here becomes unreachable at the same time, the server cannot find a replacement on its own and stays disconnected until an operator intervenes. See [Pros and Cons of Peering Configurations](../../../concepts/networks-and-servers/peer-protocol.md#pros-and-cons-of-peering-configurations).{% /admonition %}
 
     If your server connects using **proxies**, the IP addresses and ports should match the configurations of the `xrpld` servers you are using as proxies. For each of those servers, the port number should match the `protocol = peer` port in that server's config file (usually 51235). For example, your configuration might look like this:
 


### PR DESCRIPTION
The public-hub example in step 3 pins a single hub.

Because `[peer_private]` disables peer discovery, `[ips_fixed]` isn't a starting
point the server grows from — it's the complete set of peers it will ever have.
With one entry, that hub is a single point of failure for the server's whole
network connection, and if it becomes unreachable the server can't find a
replacement on its own.

This is also inconsistent with guidance elsewhere on the site: the peer-protocol
page already advises "use more public hubs; the more the better" for this exact
configuration, and the validator tutorial's public-hub example lists four. This
uses that same list so the two pages agree, plus a short caution making the
no-discovery mechanism explicit at the point of use.

(Context, not a claim about frequency: we run a mainnet validator in this
configuration and lost network connectivity when the hubs we relied on became
unreachable together. Recovering needed an operator.)
