### PR TITLE
Updated credits list

### DIFF
--- a/blog/2026/xrpld-3.3.0.md
+++ b/blog/2026/xrpld-3.3.0.md
@@ -259,7 +259,6 @@ The following RippleX teams and GitHub users contributed to this release:
 - RippleX Docs
 - RippleX Product
 - @Kassaking7
-- @TimothyBanks
 - @dangell7
 - @marek-foss-neti
 - @solunolab


### PR DESCRIPTION
Incorrectly excluded a contributor from RippleX engineering. Remove that attribution in this PR. 