### PR TITLE
Improve discoverability of Lending Protocol and Single Asset Vault examples

### DIFF
--- a/docs/concepts/tokens/lending-protocol.md
+++ b/docs/concepts/tokens/lending-protocol.md
@@ -203,6 +203,7 @@ In scenarios where excess payment amounts are "ignored", the transaction succeed
 
 - **Concepts:**
     - [Single Asset Vaults](./single-asset-vaults.md)
+    - [Pseudo-Accounts](../accounts/pseudo-accounts.md)
 - **Tutorials:**
     - [Claw Back First-Loss Capital](../../tutorials/defi/lending/use-the-lending-protocol/claw-back-cover.md)
     - [Create a Loan](../../tutorials/defi/lending/use-the-lending-protocol/create-a-loan.md)

--- a/docs/concepts/tokens/lending-protocol.md
+++ b/docs/concepts/tokens/lending-protocol.md
@@ -199,4 +199,28 @@ Based on the timing and transaction flags, the lending protocol processes the pa
 In scenarios where excess payment amounts are "ignored", the transaction succeeds, but the borrower is only charged on the expected amount.
 {% /admonition %}
 
+## See Also
+
+- **Concepts:**
+    - [Single Asset Vaults](./single-asset-vaults.md)
+- **Tutorials:**
+    - [Claw Back First-Loss Capital](../../tutorials/defi/lending/use-the-lending-protocol/claw-back-cover.md)
+    - [Create a Loan](../../tutorials/defi/lending/use-the-lending-protocol/create-a-loan.md)
+    - [Create a Loan Broker](../../tutorials/defi/lending/use-the-lending-protocol/create-a-loan-broker.md)
+    - [Deposit and Withdraw First-Loss Capital](../../tutorials/defi/lending/use-the-lending-protocol/deposit-and-withdraw-cover.md)
+    - [Manage a Loan](../../tutorials/defi/lending/use-the-lending-protocol/manage-a-loan.md)
+    - [Pay Off a Loan](../../tutorials/defi/lending/use-the-lending-protocol/pay-off-a-loan.md)
+- **References:**
+    - [Loan entry](../../references/protocol/ledger-data/ledger-entry-types/loan.md)
+    - [LoanBroker entry](../../references/protocol/ledger-data/ledger-entry-types/loanbroker.md)
+    - [LoanBrokerCoverClawback transaction](../../references/protocol/transactions/types/loanbrokercoverclawback.md)
+    - [LoanBrokerCoverDeposit transaction](../../references/protocol/transactions/types/loanbrokercoverdeposit.md)
+    - [LoanBrokerCoverWithdraw transaction](../../references/protocol/transactions/types/loanbrokercoverwithdraw.md)
+    - [LoanBrokerDelete transaction](../../references/protocol/transactions/types/loanbrokerdelete.md)
+    - [LoanBrokerSet transaction](../../references/protocol/transactions/types/loanbrokerset.md)
+    - [LoanDelete transaction](../../references/protocol/transactions/types/loandelete.md)
+    - [LoanManage transaction](../../references/protocol/transactions/types/loanmanage.md)
+    - [LoanPay transaction](../../references/protocol/transactions/types/loanpay.md)
+    - [LoanSet transaction](../../references/protocol/transactions/types/loanset.md)
+
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/concepts/tokens/single-asset-vaults.md
+++ b/docs/concepts/tokens/single-asset-vaults.md
@@ -232,20 +232,25 @@ Depending on the connected on-chain protocol, vaults can be applied to various u
 
 The only supported use cases right now are _asset management_ and [_lending markets_](./lending-protocol.md).
 
-{% raw-partial file="/docs/_snippets/common-links.md" /%}
-
 ## See Also
 
 - **Concepts:**
-    - [Credentials](../../concepts/decentralized-storage/credentials.md) - Define access requirements for private vaults.
-    - [Permissioned Domains](../tokens/decentralized-exchange/permissioned-domains.md) - Control access to private vaults.
-    - [Pseudo-Accounts](../accounts/pseudo-accounts.md) - Special accounts that hold assets on behalf of on-chain protocols.
+    - [Credentials](../../concepts/decentralized-storage/credentials.md)
+    - [Lending Protocol](./lending-protocol.md)
+    - [Permissioned Domains](../tokens/decentralized-exchange/permissioned-domains.md)
+    - [Pseudo-Accounts](../accounts/pseudo-accounts.md)
+- **Tutorials:**
+    - [Create a Single Asset Vault](../../tutorials/defi/lending/use-single-asset-vaults/create-a-single-asset-vault.md)
+    - [Deposit into a Vault](../../tutorials/defi/lending/use-single-asset-vaults/deposit-into-a-vault.md)
+    - [Withdraw from a Vault](../../tutorials/defi/lending/use-single-asset-vaults/withdraw-from-a-vault.md)
 - **References:**
-    - [Vault entry][] - Data structure on the ledger that records vault information.
-    - [VaultClawback transaction][] - Allow asset issuers to recover assets from the vault.
-    - [VaultCreate transaction][] - Create a new vault for aggregating assets.
-    - [VaultDelete transaction][] - Delete an existing vault entry.
-    - [VaultDeposit transaction][] - Add assets to a vault in exchange for shares.
-    - [VaultSet transaction][] - Update the configuration of an existing vault.
-    - [VaultWithdraw transaction][] - Redeem liquidity from a vault.
-    - [vault_info method][] - Retrieve information about a vault and its shares.
+    - [Vault entry][]
+    - [VaultClawback transaction][]
+    - [VaultCreate transaction][]
+    - [VaultDelete transaction][]
+    - [VaultDeposit transaction][]
+    - [VaultSet transaction][]
+    - [VaultWithdraw transaction][]
+    - [vault_info method][]
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/tutorials/sections.config.ts
+++ b/docs/tutorials/sections.config.ts
@@ -102,8 +102,7 @@ export const sectionConfig: Record<string, {
           title: "Lending Protocol & SAV Reference App",
           description: "A Next.js lending platform template with dashboards for brokers, depositors, and borrowers.",
           author: { name: "Max", url: "https://github.com/krkmu" },
-          // TODO: This has been changed to a private repo for now, update to public repo when available.
-          // github: "https://github.com/RippleDevRel/xls-lending-sav-DAP",
+          github: "https://github.com/ripple/xrpl-reference-app-lending-sav",
           url: "https://lending.xls-demo.com/",
         }
       ],


### PR DESCRIPTION
This change adds the following:

- Tutorial and reference links to the Lending Protocol and Single Asset Vault concept pages. [VODF-193](https://ripplelabs.atlassian.net/browse/VODF-193)
- GitHub link for the Lending Protocol & SAV Reference App on the Tutorials landing page.