### PR TITLE
Add OpenChainBench latency benchmarks to public-servers page

### DIFF
--- a/docs/tutorials/public-servers.md
+++ b/docs/tutorials/public-servers.md
@@ -24,6 +24,12 @@ If you don't [run your own `xrpld` server](../infrastructure/installation/index.
 | [QuickNode](https://www.quicknode.com/chains/xrpl) | Testnet/Mainnet | N/A | QuickNode provides hosted XRPL RPC mainnet and testnet under their free and paid plans, granting flexible and reliable access to the network.
 
 
+## Benchmarks
+
+| Tool | Notes |
+|:-----|:------|
+| [OpenChainBench](https://openchainbench.com/benchmarks/xrp-rpc) | Live latency benchmarks for XRPL public servers. Tracks p50/p90/p99 for Ripple (s1.ripple.com), XRPL Labs (xrplcluster.com) and PublicNode, measured every 60 seconds from US-East, EU-West and Singapore. |
+
 ## Test Networks
 
 | Operator  | [Network][] | JSON-RPC URL | WebSocket URL | Notes                |


### PR DESCRIPTION
Adds a **Benchmarks** section at the bottom of the Public Servers page, before the Test Networks section.

**What it does:** [OpenChainBench](https://openchainbench.com/benchmarks/xrp-rpc) probes the public XRPL servers listed on this page (Ripple s1, XRPL Labs/xrplcluster.com, PublicNode) every 60 seconds from US-East, EU-West and Singapore, publishing live p50/p90/p99 latency data.

**Why it fits here:** This page is the reference for XRPL public server endpoints. Developers choosing between servers naturally also want to know which one responds fastest from their region. The Benchmarks section is a direct extension of the server listing — same audience, same decision context.

Open source: https://github.com/ChainBench/OpenChainBench