### PR TITLE
Add link to XRPL EVM doc site

### DIFF
--- a/@l10n/ja/docs/concepts/xrpl-sidechains/index.md
+++ b/@l10n/ja/docs/concepts/xrpl-sidechains/index.md
@@ -16,7 +16,7 @@ _（[XChainBridge Amendment][] {% not-enabled /%} が必要です）_
 サイドチェーンは、XRP Ledgerのプロトコルを特定のユースケースやプロジェクトのニーズに合わせてカスタマイズし、独自のブロックチェーンとして運用することができます。いくつかの例を紹介します。
 
 * スマートコントラクト層の追加: [Xahau](https://xahau.network/)をご覧ください。
-* イーサリアム仮想マシン(EVM)互換性の追加: [EVMサイドチェーン](https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/)をご覧ください。
+* イーサリアム仮想マシン(EVM)互換性の追加: [XRPL EVM](https://docs.xrplevm.org/pages/users/introduction/what-is-the-xrplevm)および[ブリッジのオプション](https://docs.xrplevm.org/pages/bridge)をご覧ください。
 * 独自のアルゴリズムによるステーブルコインの構築。
 * メインネットの[分散型取引所](../tokens/decentralized-exchange/index.md)で資産を取引できる、パーミッションあり、またはほぼパーミッションレス、中央集権型、または大部分が分散されている台帳の構築。
 

--- a/docs/concepts/xrpl-sidechains/index.md
+++ b/docs/concepts/xrpl-sidechains/index.md
@@ -12,7 +12,7 @@ A sidechain is an independent ledger with its own consensus algorithm, transacti
 Sidechains can customize the XRP Ledger protocol to the needs of a specific use case or project and run it as its own blockchain. Some examples include:
 
 * Adding a smart contract layer. See: [Xahau](https://xahau.network/)
-* Adding Ethereum Virtual Machine (EVM) compatibility. See: [EVM Sidechain](https://opensource.ripple.com/docs/evm-sidechain/intro-to-evm-sidechain/).
+* Adding Ethereum Virtual Machine (EVM) compatibility. See: [XRPL EVM](https://docs.xrplevm.org/pages/users/introduction/what-is-the-xrplevm), including its [bridge options](https://docs.xrplevm.org/pages/bridge).
 * Building your own algorithmic stable coin with customised ledger types and transaction rules.
 * Building permissioned or nearly permissionless, centralized or largely decentralized ledgers whose assets can be traded on the Mainnet [decentralized exchange](../tokens/decentralized-exchange/index.md).
 


### PR DESCRIPTION
Add link to the XRPL EVM doc site to replace this existing wiki page: https://github.com/XRPLF/rippled/wiki/XRPL-EVM