### PR TITLE
Clarify ledger index/index naming confusion

### DIFF
--- a/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
+++ b/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry.md
@@ -1729,11 +1729,11 @@ The response follows the [standard format][], with a successful result containin
 
 | Field          | Type             | Description                              |
 |:---------------|:-----------------|:-----------------------------------------|
-| `index`        | String           | The unique ID of this [ledger entry](../../../protocol/ledger-data/ledger-entry-types/index.md). |
+| `index`        | String           | The [ledger entry ID][] of this [ledger entry](../../../protocol/ledger-data/ledger-entry-types/index.md). |
 | `ledger_index` | Unsigned Integer | The [ledger index][] of the ledger that was used when retrieving this data. |
 | `node`         | Object           | _(Omitted if `"binary": true` specified.)_ Object containing the data of this ledger entry, according to the [ledger format][]. |
-| `node_binary`  | String           | _(Omitted unless `"binary":true` specified)_ The [binary representation](../../../protocol/binary-format.md) of the ledger object, as hexadecimal. |
-| `deleted_ledger_index` | String   | _(Clio server only, returned if `include_deleted` parameter is set.)_ The [ledger index][] where the ledger entry object was deleted. |
+| `node_binary`  | String           | _(Omitted unless `"binary":true` specified)_ The [binary representation](../../../protocol/binary-format.md) of the ledger entry, as hexadecimal. |
+| `deleted_ledger_index` | String   | _(Clio server only, returned if `include_deleted` parameter is set.)_ The [ledger index][] where the ledger entry was deleted. |
 
 An example of a successful response:
 

--- a/docs/references/protocol/ledger-data/common-fields.md
+++ b/docs/references/protocol/ledger-data/common-fields.md
@@ -23,7 +23,7 @@ Every entry in a [ledger](../../../concepts/ledgers/index.md)'s state data has t
 
 Each ledger entry has a unique ID. The ID is derived by hashing important contents of the entry, along with a _namespace identifier_ which is a 16 bit value. The [ledger entry type](ledger-entry-types/index.md) determines the namespace identifier to use and which contents to include in the hash. This ensures every ID is unique. The hash function is [SHA-512Half][].
 
-Generally, a ledger entry's ID is returned as the `index` field in JSON, at the same level as the object's contents. In [transaction metadata](../transactions/metadata.md), the ledger object's ID in JSON is `LedgerIndex`.
+Generally, a ledger entry's ID is returned as the `index` field in JSON, at the same level as the object's contents. In [transaction metadata](../transactions/metadata.md), the ledger entry's ID in JSON is `LedgerIndex`.
 
 Offer directories have special IDs, where part of the hash is replaced with the exchange rate of Offers in that directory.
 


### PR DESCRIPTION
- Adjust language to clarify ledger index/index confusion address on this wiki page: https://github.com/XRPLF/rippled/wiki/Recommended-Terminology-Changes#ledgerentryid
- Changed a few random instances of ledger object -> ledger entry