### PR TITLE
Clio release 2.8.0 blog post

### DIFF
--- a/blog/2026/clio-2.8.0.md
+++ b/blog/2026/clio-2.8.0.md
@@ -1,0 +1,247 @@
+---
+category: 2026
+date: "2026-08-20"
+template: '../../@theme/templates/blogpost'
+seo:
+    title: Introducing Clio version 2.8.0
+    description: Version 2.8.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds support for the Lending Protocol and Confidential Transfers, new features, and bug fixes.
+labels:
+    - Clio Release Notes
+markdown:
+    editPage:
+        hide: true
+---
+# Introducing Clio version 2.8.0
+
+Version 2.8.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds support for several new amendments alongside bug fixes and build improvements.
+
+## Amendment Support
+
+The following amendments have been introduced since Clio 2.7.1 and have transaction or ledger model changes. Clio 2.8.0 is built with `libxrpl` 3.3.0, which supports all of them:
+
+- [BatchV1_1](https://xrpl.org/resources/known-amendments#batchv1_1)
+- [ConfidentialTransfer](https://xrpl.org/resources/known-amendments#confidentialtransfer)
+- [DynamicMPT](https://xrpl.org/resources/known-amendments#dynamicmpt)
+- [PermissionDelegationV1_1](https://xrpl.org/resources/known-amendments#permissiondelegationv1_1)
+- [Sponsor](https://xrpl.org/resources/known-amendments#sponsor)
+- [fixCleanup3_3_0](https://xrpl.org/resources/known-amendments#fixcleanup3_3_0)
+
+If any of these amendments are enabled and you have not upgraded Clio to 2.8.0 or newer, the ETL will be amendment blocked and new ledgers will not be processed.
+
+To check the current voting status of these amendments on Mainnet, see the [XRPL Amendments Dashboard](https://livenet.xrpl.org/amendments).
+
+## Install / Upgrade
+
+| Package  |
+| :------- |
+| [Clio Server Linux Release (GCC)](https://github.com/XRPLF/clio/releases/download/2.8.0/clio_server_Linux_Release_gcc.zip) |
+| [Clio Server Linux Debian Release (amd64)](https://github.com/XRPLF/clio/releases/download/2.8.0/clio_2.8.0_amd64.deb) |
+| [Clio Server macOS Release (Apple Clang 21)](https://github.com/XRPLF/clio/releases/download/2.8.0/clio_server_macOS_Release_apple-clang.zip) |
+
+For other platforms, please [build from source](https://github.com/XRPLF/clio/releases/tag/2.8.0). The most recent commit in the git log should be:
+
+```text
+Author: Ayaz Salikhov <mathbunnyru@users.noreply.github.com>
+Date:   Thu Aug 20 14:59:46 2026 +0000
+
+    chore: Merge develop into release/2.8.0 (#3186)
+```
+
+## What's Changed
+
+See the [Full Changelog on GitHub](https://github.com/XRPLF/clio/compare/2.7.1...2.8.0).
+
+### Features
+
+- Added support for the Lending Protocol. ([#2945](https://github.com/XRPLF/clio/pull/2945))
+- Added support for Confidential Transfer fields. ([#3152](https://github.com/XRPLF/clio/pull/3152))
+- Added the ability to filter transactions by `mpt_issuance_id`. ([#3153](https://github.com/XRPLF/clio/pull/3153))
+- Updated the MPToken ETL to support all transaction types. ([#3102](https://github.com/XRPLF/clio/pull/3102))
+- Added storage and backend for `mpt_issuance_history`. ([#3091](https://github.com/XRPLF/clio/pull/3091))
+- Added ETL indexing for `mpt_issuance_history`. ([#3104](https://github.com/XRPLF/clio/pull/3104))
+- Added the `mptoken_issuance_history` RPC, which was later reverted in this release. ([#3141](https://github.com/XRPLF/clio/pull/3141))
+- Added cluster communication to choose the writer node. ([#2830](https://github.com/XRPLF/clio/pull/2830))
+- Added the ability to recover from the fallback writer state. ([#3000](https://github.com/XRPLF/clio/pull/3000))
+- Added a limit on cache loading in a cluster. ([#2985](https://github.com/XRPLF/clio/pull/2985))
+- Added optional log rotation. ([#3016](https://github.com/XRPLF/clio/pull/3016))
+- Added metrics for the age of the requested ledger. ([#2947](https://github.com/XRPLF/clio/pull/2947))
+
+### Bug Fixes
+
+- Fixed an issue where `feature` could not query amendments that were deleted from `libxrpl`. ([#3011](https://github.com/XRPLF/clio/pull/3011))
+- Fixed an issue where a forwarded stream ignored the specified `api_version`. ([#3010](https://github.com/XRPLF/clio/pull/3010))
+- Fixed an issue where `Loan` and `LoanBroker` objects were not filterable in `account_objects` and `ledger_data`. ([#3124](https://github.com/XRPLF/clio/pull/3124))
+- Fixed an issue where MPToken `UInt64` amounts were not serialized as base-10 strings. ([#3139](https://github.com/XRPLF/clio/pull/3139))
+- Fixed an issue where the proxy IP address was not resolved before a request was processed. ([#3006](https://github.com/XRPLF/clio/pull/3006))
+- Fixed an issue where the client IP address was resolved only once per connection, so it was incorrect when a proxy reused a TCP connection. ([#3043](https://github.com/XRPLF/clio/pull/3043))
+- Fixed an issue where the SSL context was recreated for each connection instead of being shared. ([#3137](https://github.com/XRPLF/clio/pull/3137))
+- Fixed an issue where responses to admin requests were cached. ([#3058](https://github.com/XRPLF/clio/pull/3058))
+- Fixed an issue where responses were cached using only the method as the key, so a request with parameters could receive a response generated for different parameters. ([#3113](https://github.com/XRPLF/clio/pull/3113))
+- Fixed an issue where buffers were not flushed before the cache file was renamed. ([#2927](https://github.com/XRPLF/clio/pull/2927))
+- Fixed an issue where Clio could not start without a cache file. ([#2976](https://github.com/XRPLF/clio/pull/2976))
+- Fixed an issue where an amendment block could occur during the initial ledger load and cache load. ([#3149](https://github.com/XRPLF/clio/pull/3149))
+- Added a retry for transient database errors. ([#3167](https://github.com/XRPLF/clio/pull/3167))
+- Improved validation of the `issuer` field in requests. ([#3184](https://github.com/XRPLF/clio/pull/3184))
+- Used `credentialTypeValidator` for credential type fields in `ledger_entry`. ([#3185](https://github.com/XRPLF/clio/pull/3185))
+- Removed `RpcEntryNotFound` from `ClioError`. ([#2661](https://github.com/XRPLF/clio/pull/2661))
+- Removed `clio_etl` from the RPC CMake configuration. ([#3166](https://github.com/XRPLF/clio/pull/3166))
+- Added a `pragma once` checker. ([#3111](https://github.com/XRPLF/clio/pull/3111))
+
+### Performance
+
+- Used `string_view` in `AccountInfo`. ([#2951](https://github.com/XRPLF/clio/pull/2951))
+
+### Refactor
+
+- Used error codes in `make_address()` calls instead of exceptions. ([#3044](https://github.com/XRPLF/clio/pull/3044))
+- Renamed static constants. ([#3073](https://github.com/XRPLF/clio/pull/3073))
+
+### Documentation
+
+- Added a section about faster cache loading. ([#2932](https://github.com/XRPLF/clio/pull/2932))
+
+### Styling
+
+- Adopted `cmake-format` from `xrpld`. ([#2938](https://github.com/XRPLF/clio/pull/2938))
+- Switched from `cmake-format` to `gersemi`. ([#2980](https://github.com/XRPLF/clio/pull/2980))
+- Applied custom CMake definitions. ([#2983](https://github.com/XRPLF/clio/pull/2983))
+- Set the `clang-format` line width to 100. ([#2953](https://github.com/XRPLF/clio/pull/2953))
+- Fixed lint comments affected by the style changes. ([#2963](https://github.com/XRPLF/clio/pull/2963))
+- Removed `readability-identifier-naming` where it was not needed. ([#2962](https://github.com/XRPLF/clio/pull/2962))
+- Applied more `clang-tidy` identifier renaming. ([#3076](https://github.com/XRPLF/clio/pull/3076))
+- Unified the style for `not expectedNext.has_value()`. ([#2979](https://github.com/XRPLF/clio/pull/2979))
+- Unified the style for `not expectedLgrInfo.has_value()`. ([#2977](https://github.com/XRPLF/clio/pull/2977))
+- Unified the style for all Doxygen comments. ([#3142](https://github.com/XRPLF/clio/pull/3142))
+- Ran `shfmt` on workflows and actions. ([#3085](https://github.com/XRPLF/clio/pull/3085))
+- Updated pre-commit hooks. ([#2939](https://github.com/XRPLF/clio/pull/2939), [#2968](https://github.com/XRPLF/clio/pull/2968), [#3022](https://github.com/XRPLF/clio/pull/3022), [#3057](https://github.com/XRPLF/clio/pull/3057), [#3087](https://github.com/XRPLF/clio/pull/3087), [#3130](https://github.com/XRPLF/clio/pull/3130), [#3164](https://github.com/XRPLF/clio/pull/3164))
+
+### Testing
+
+- Stopped hardcoding `apiVersion` where possible. ([#3017](https://github.com/XRPLF/clio/pull/3017))
+- Fixed integration tests. ([#3072](https://github.com/XRPLF/clio/pull/3072))
+- Deleted duplicate `etlng` tests. ([#2920](https://github.com/XRPLF/clio/pull/2920))
+- Pinned the ScyllaDB Docker image version to fix integration tests. ([#3126](https://github.com/XRPLF/clio/pull/3126))
+
+### Build
+
+- Compiled all dependencies with C++23. ([#3129](https://github.com/XRPLF/clio/pull/3129))
+- Stopped reusing binaries between different C++ versions. ([#3131](https://github.com/XRPLF/clio/pull/3131))
+- Switched to Apple Clang 21 and removed the `SourceLocation` stub. ([#3123](https://github.com/XRPLF/clio/pull/3123))
+- Linked `libatomic` statically on Linux `aarch64`. ([#3120](https://github.com/XRPLF/clio/pull/3120))
+- Switched to the new XRPLF Conan remote. ([#3118](https://github.com/XRPLF/clio/pull/3118))
+
+### Miscellaneous Tasks
+
+- Updated `libxrpl` to version 3.1.3. ([#3070](https://github.com/XRPLF/clio/pull/3070))
+- Updated `libxrpl` to version 3.2.0. ([#3114](https://github.com/XRPLF/clio/pull/3114))
+- Switched to `libxrpl` 3.3.0-rc1. ([#3144](https://github.com/XRPLF/clio/pull/3144))
+- Updated `libxrpl` to 3.3.0-rc1-custom. ([#3160](https://github.com/XRPLF/clio/pull/3160))
+- Updated `libxrpl` to version 3.3.0. ([#3170](https://github.com/XRPLF/clio/pull/3170))
+- Enabled debug symbols. ([#2967](https://github.com/XRPLF/clio/pull/2967))
+- Enabled TSAN without ignoring errors. ([#2828](https://github.com/XRPLF/clio/pull/2828))
+- Updated CI to build the image with LLVM tools 21. ([#3049](https://github.com/XRPLF/clio/pull/3049))
+- Updated CI to upload the `clang-tidy` git diff. ([#3050](https://github.com/XRPLF/clio/pull/3050))
+- Switched to LLVM tools 21. ([#3051](https://github.com/XRPLF/clio/pull/3051))
+- Fixed `clang-tidy` 21 issues. ([#3052](https://github.com/XRPLF/clio/pull/3052))
+- Enabled more `clang-tidy` checks. ([#3054](https://github.com/XRPLF/clio/pull/3054))
+- Fixed `clang-tidy` issues. ([#3061](https://github.com/XRPLF/clio/pull/3061))
+- Updated `clang-tidy` with the new checks from version 22. ([#3119](https://github.com/XRPLF/clio/pull/3119))
+- Fixed the issues that followed the `clang-tidy` 22 update. ([#3108](https://github.com/XRPLF/clio/pull/3108))
+- Added `clang-tidy` rules for lower_case namespaces. ([#3165](https://github.com/XRPLF/clio/pull/3165))
+- Updated CI to run `clang-tidy` on individual files in pull requests. ([#3067](https://github.com/XRPLF/clio/pull/3067))
+- Updated CI to print tidy errors. ([#3068](https://github.com/XRPLF/clio/pull/3068))
+- Updated CI to use Nix-based images for all workflows except pre-commit. ([#3098](https://github.com/XRPLF/clio/pull/3098))
+- Updated CI to use an in-house image for pre-commit. ([#3147](https://github.com/XRPLF/clio/pull/3147))
+- Updated the hashes of `XRPLF/actions`. ([#2944](https://github.com/XRPLF/clio/pull/2944))
+- Updated `XRPLF/actions`. ([#2996](https://github.com/XRPLF/clio/pull/2996), [#3023](https://github.com/XRPLF/clio/pull/3023), [#3148](https://github.com/XRPLF/clio/pull/3148))
+- Adopted `check-pr-title` from `XRPLF/actions`. ([#2984](https://github.com/XRPLF/clio/pull/2984))
+- Adopted `print-env` from `XRPLF/actions`. ([#3053](https://github.com/XRPLF/clio/pull/3053))
+- Renamed `print-env` to `print-build-env`. ([#3056](https://github.com/XRPLF/clio/pull/3056))
+- Adopted `XRPLF/create-issue`. ([#3066](https://github.com/XRPLF/clio/pull/3066))
+- Fixed how workflows behave in forks. ([#3074](https://github.com/XRPLF/clio/pull/3074))
+- Restricted `actions/configure-pages` to the main repository. ([#3075](https://github.com/XRPLF/clio/pull/3075))
+- Restricted DockerHub pushes to the main repository. ([#3084](https://github.com/XRPLF/clio/pull/3084))
+- Fixed the docs workflow and enabled building it on pull requests. ([#3109](https://github.com/XRPLF/clio/pull/3109))
+- Rewrote the `verify-commits` script. ([#3086](https://github.com/XRPLF/clio/pull/3086))
+- Added a body for the nightly issue. ([#3125](https://github.com/XRPLF/clio/pull/3125))
+- Added CODEOWNERS for CI-related changes. ([#3145](https://github.com/XRPLF/clio/pull/3145))
+- Updated CI to run `colima delete` on macOS. ([#2915](https://github.com/XRPLF/clio/pull/2915))
+- Updated `cleanup-workspace` to delete the old `.conan2` directory on macOS. ([#2964](https://github.com/XRPLF/clio/pull/2964))
+- Removed copyright headers from all source files. ([#2975](https://github.com/XRPLF/clio/pull/2975))
+- Removed the remaining copyright headers from the code. ([#3012](https://github.com/XRPLF/clio/pull/3012))
+- Removed the explicit `accountNotFound` message. ([#2978](https://github.com/XRPLF/clio/pull/2978))
+- Moved `sharedPtrBackend`. ([#2974](https://github.com/XRPLF/clio/pull/2974))
+- Stopped including forward-declaration headers. ([#3117](https://github.com/XRPLF/clio/pull/3117))
+- Fixed compilation due to the use of `std::ranges::mismatch`. ([#2960](https://github.com/XRPLF/clio/pull/2960))
+- Fixed a linker warning in the benchmark. ([#2918](https://github.com/XRPLF/clio/pull/2918))
+- Added `.zed` to `.gitignore`. ([#2919](https://github.com/XRPLF/clio/pull/2919))
+- Added more AI tool folders to `.gitignore`. ([#3038](https://github.com/XRPLF/clio/pull/3038))
+- Removed remaining `cmake-format` mentions. ([#2986](https://github.com/XRPLF/clio/pull/2986))
+- Reverted the `mptoken_issuance_history` RPC, so the method is not available in this release. ([#3183](https://github.com/XRPLF/clio/pull/3183))
+- [DEPENDABOT] bump actions/cache from 5.0.1 to 5.0.2. ([#2925](https://github.com/XRPLF/clio/pull/2925))
+- [DEPENDABOT] bump actions/checkout from 6.0.1 to 6.0.2. ([#2933](https://github.com/XRPLF/clio/pull/2933))
+- [DEPENDABOT] bump peter-evans/create-pull-request from 8.0.0 to 8.1.0. ([#2934](https://github.com/XRPLF/clio/pull/2934))
+- [DEPENDABOT] bump docker/login-action from 3.6.0 to 3.7.0. ([#2940](https://github.com/XRPLF/clio/pull/2940))
+- [DEPENDABOT] bump actions/cache from 5.0.2 to 5.0.3. ([#2941](https://github.com/XRPLF/clio/pull/2941))
+- [DEPENDABOT] bump docker/login-action from 3.6.0 to 3.7.0 in /.github/actions/build-docker-image. ([#2942](https://github.com/XRPLF/clio/pull/2942))
+- [DEPENDABOT] bump actions/upload-artifact from 6.0.0 to 7.0.0. ([#2969](https://github.com/XRPLF/clio/pull/2969))
+- [DEPENDABOT] bump actions/download-artifact from 7.0.0 to 8.0.0. ([#2970](https://github.com/XRPLF/clio/pull/2970))
+- [DEPENDABOT] bump actions/upload-artifact from 6.0.0 to 7.0.0 in /.github/actions/code-coverage. ([#2971](https://github.com/XRPLF/clio/pull/2971))
+- [DEPENDABOT] bump docker/setup-buildx-action from 3.12.0 to 4.0.0. ([#2987](https://github.com/XRPLF/clio/pull/2987))
+- [DEPENDABOT] bump docker/login-action from 3.7.0 to 4.0.0. ([#2988](https://github.com/XRPLF/clio/pull/2988))
+- [DEPENDABOT] bump crazy-max/ghaction-import-gpg from 6.3.0 to 7.0.0. ([#2989](https://github.com/XRPLF/clio/pull/2989))
+- [DEPENDABOT] bump tj-actions/changed-files from 47.0.1 to 47.0.5. ([#2990](https://github.com/XRPLF/clio/pull/2990))
+- [DEPENDABOT] bump docker/setup-qemu-action from 3.7.0 to 4.0.0 in /.github/actions/build-docker-image. ([#2991](https://github.com/XRPLF/clio/pull/2991))
+- [DEPENDABOT] bump docker/metadata-action from 5.10.0 to 6.0.0 in /.github/actions/build-docker-image. ([#2992](https://github.com/XRPLF/clio/pull/2992))
+- [DEPENDABOT] bump docker/login-action from 3.7.0 to 4.0.0 in /.github/actions/build-docker-image. ([#2993](https://github.com/XRPLF/clio/pull/2993))
+- [DEPENDABOT] bump docker/build-push-action from 6.18.0 to 7.0.0 in /.github/actions/build-docker-image. ([#2994](https://github.com/XRPLF/clio/pull/2994))
+- [DEPENDABOT] bump docker/setup-buildx-action from 3.12.0 to 4.0.0 in /.github/actions/build-docker-image. ([#2995](https://github.com/XRPLF/clio/pull/2995))
+- [DEPENDABOT] bump actions/download-artifact from 8.0.0 to 8.0.1. ([#3001](https://github.com/XRPLF/clio/pull/3001))
+- [DEPENDABOT] bump codecov/codecov-action from 5.5.2 to 5.5.3. ([#3008](https://github.com/XRPLF/clio/pull/3008))
+- [DEPENDABOT] bump actions/cache from 5.0.3 to 5.0.4. ([#3009](https://github.com/XRPLF/clio/pull/3009))
+- [DEPENDABOT] bump codecov/codecov-action from 5.5.3 to 6.0.0. ([#3018](https://github.com/XRPLF/clio/pull/3018))
+- [DEPENDABOT] bump actions/configure-pages from 5.0.0 to 6.0.0. ([#3019](https://github.com/XRPLF/clio/pull/3019))
+- [DEPENDABOT] bump actions/deploy-pages from 4.0.5 to 5.0.0. ([#3020](https://github.com/XRPLF/clio/pull/3020))
+- [DEPENDABOT] bump docker/login-action from 4.0.0 to 4.1.0. ([#3024](https://github.com/XRPLF/clio/pull/3024))
+- [DEPENDABOT] bump docker/login-action from 4.0.0 to 4.1.0 in /.github/actions/build-docker-image. ([#3025](https://github.com/XRPLF/clio/pull/3025))
+- [DEPENDABOT] bump actions/upload-artifact from 7.0.0 to 7.0.1. ([#3031](https://github.com/XRPLF/clio/pull/3031))
+- [DEPENDABOT] bump actions/upload-pages-artifact from 4.0.0 to 5.0.0. ([#3032](https://github.com/XRPLF/clio/pull/3032))
+- [DEPENDABOT] bump peter-evans/create-pull-request from 8.1.0 to 8.1.1. ([#3033](https://github.com/XRPLF/clio/pull/3033))
+- [DEPENDABOT] bump docker/build-push-action from 7.0.0 to 7.1.0 in /.github/actions/build-docker-image. ([#3034](https://github.com/XRPLF/clio/pull/3034))
+- [DEPENDABOT] bump actions/upload-artifact from 7.0.0 to 7.0.1 in /.github/actions/code-coverage. ([#3035](https://github.com/XRPLF/clio/pull/3035))
+- [DEPENDABOT] bump actions/cache from 5.0.4 to 5.0.5. ([#3039](https://github.com/XRPLF/clio/pull/3039))
+- [DEPENDABOT] bump tj-actions/changed-files from 47.0.5 to 47.0.6. ([#3040](https://github.com/XRPLF/clio/pull/3040))
+- [DEPENDABOT] bump docker/login-action from 4.1.0 to 4.2.0. ([#3077](https://github.com/XRPLF/clio/pull/3077))
+- [DEPENDABOT] bump docker/setup-buildx-action from 4.0.0 to 4.1.0. ([#3078](https://github.com/XRPLF/clio/pull/3078))
+- [DEPENDABOT] bump codecov/codecov-action from 6.0.0 to 6.0.1. ([#3079](https://github.com/XRPLF/clio/pull/3079))
+- [DEPENDABOT] bump docker/setup-buildx-action from 4.0.0 to 4.1.0 in /.github/actions/build-docker-image. ([#3080](https://github.com/XRPLF/clio/pull/3080))
+- [DEPENDABOT] bump docker/metadata-action from 6.0.0 to 6.1.0 in /.github/actions/build-docker-image. ([#3081](https://github.com/XRPLF/clio/pull/3081))
+- [DEPENDABOT] bump docker/login-action from 4.1.0 to 4.2.0 in /.github/actions/build-docker-image. ([#3082](https://github.com/XRPLF/clio/pull/3082))
+- [DEPENDABOT] bump docker/build-push-action from 7.1.0 to 7.2.0 in /.github/actions/build-docker-image. ([#3083](https://github.com/XRPLF/clio/pull/3083))
+- [DEPENDABOT] bump docker/setup-qemu-action from 4.0.0 to 4.1.0 in /.github/actions/build-docker-image. ([#3088](https://github.com/XRPLF/clio/pull/3088))
+- [DEPENDABOT] bump codecov/codecov-action from 6.0.1 to 7.0.0. ([#3096](https://github.com/XRPLF/clio/pull/3096))
+- [DEPENDABOT] bump actions/checkout from 6.0.2 to 6.0.3. ([#3097](https://github.com/XRPLF/clio/pull/3097))
+- [DEPENDABOT] bump actions/checkout from 6.0.3 to 7.0.0. ([#3112](https://github.com/XRPLF/clio/pull/3112))
+- [DEPENDABOT] bump actions/cache/save from 5.0.5 to 6.1.0. ([#3121](https://github.com/XRPLF/clio/pull/3121))
+- [DEPENDABOT] bump actions/cache/restore from 5.0.5 to 6.1.0. ([#3122](https://github.com/XRPLF/clio/pull/3122))
+- [DEPENDABOT] bump docker/setup-buildx-action from 4.1.0 to 4.2.0 in /.github/actions/build-docker-image. ([#3132](https://github.com/XRPLF/clio/pull/3132))
+- [DEPENDABOT] bump docker/build-push-action from 7.2.0 to 7.3.0 in /.github/actions/build-docker-image. ([#3133](https://github.com/XRPLF/clio/pull/3133))
+- [DEPENDABOT] bump docker/login-action from 4.2.0 to 4.4.0 in /.github/actions/build-docker-image. ([#3134](https://github.com/XRPLF/clio/pull/3134))
+- [DEPENDABOT] bump docker/metadata-action from 6.1.0 to 6.2.0 in /.github/actions/build-docker-image. ([#3135](https://github.com/XRPLF/clio/pull/3135))
+- [DEPENDABOT] bump docker/setup-qemu-action from 4.1.0 to 4.2.0 in /.github/actions/build-docker-image. ([#3136](https://github.com/XRPLF/clio/pull/3136))
+- [DEPENDABOT] bump actions/checkout from 7.0.0 to 7.0.1. ([#3146](https://github.com/XRPLF/clio/pull/3146))
+- [DEPENDABOT] bump docker/login-action from 4.4.0 to 4.5.1 in /.github/actions/build-docker-image. ([#3155](https://github.com/XRPLF/clio/pull/3155))
+- [DEPENDABOT] bump docker/login-action from 4.5.1 to 4.6.0 in /.github/actions/build-docker-image. ([#3163](https://github.com/XRPLF/clio/pull/3163))
+
+## Credits
+
+The following RippleX teams and GitHub users contributed to this release:
+
+- RippleX Engineering
+- RippleX Docs
+- [@BryanJ1ang](https://github.com/BryanJ1ang)
+- [@emreariyurek](https://github.com/emreariyurek)
+
+## Feedback
+
+To report an issue or propose a new idea, please [open an issue](https://github.com/XRPLF/clio/issues).

--- a/blog/2026/clio-2.8.0.md
+++ b/blog/2026/clio-2.8.0.md
@@ -4,7 +4,7 @@ date: "2026-08-20"
 template: '../../@theme/templates/blogpost'
 seo:
     title: Introducing Clio version 2.8.0
-    description: Version 2.8.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds support for the Lending Protocol and Confidential Transfers, new features, and bug fixes.
+    description: Version 2.8.0 of Clio, an XRP Ledger API server optimized for HTTP and WebSocket API calls, is now available. This release adds support for several new amendments alongside bug fixes and build improvements.
 labels:
     - Clio Release Notes
 markdown:

--- a/blog/sidebars.yaml
+++ b/blog/sidebars.yaml
@@ -10,6 +10,7 @@
     - group: '2026'
       expanded: false
       items:
+        - page: 2026/clio-2.8.0.md
         - page: 2026/vulnerabilitydisclosurereport-bug-jul2026.md
         - page: 2026/xrpld-3.3.0.md
         - page: 2026/xrpld-3.2.1.md


### PR DESCRIPTION
Adds release notes for Clio 2.8.0

Preview here: https://xrpl-dev-portal--e82b2e.preview.redocly.app/blog/2026/clio-2.8.0