### PR TITLE
Update first-loss capital info

### DIFF
--- a/docs/concepts/tokens/lending-protocol.md
+++ b/docs/concepts/tokens/lending-protocol.md
@@ -46,9 +46,11 @@ The lifecycle of a loan is as follows:
 
 #### First-Loss Capital
 
-First-Loss Capital is an optional mechanism to mitigate the risks associated with lending. To protect investors' assets, a loan broker can deposit assets as first-loss capital, which acts as a buffer in the event of loan defaults. The first-loss capital is placed into the vault to cover a percentage of losses from missed payments.
+First-loss capital is an optional mechanism to mitigate the risks associated with lending. To protect investors' assets, a loan broker can deposit the same asset as first-loss capital in a separate loan broker pseudo-account. First-loss capital acts as a buffer in the event of loan defaults, moving assets from the pseudo-account to the single asset vault to cover losses from missed payments.
 
-Three parameters control the First-Loss Capital:
+First-loss capital doesn't eliminate credit risk, but it does incentivize loan brokers to underwrite and manage loans more carefully since their own capital is at risk first.
+
+Three parameters control the first-loss capital:
 
 - `CoverAvailable`: The total amount of cover deposited by the lending protocol owner.
 - `CoverRateMinimum`: The percentage of debt that must be covered by `CoverAvailable`.
@@ -57,7 +59,7 @@ Three parameters control the First-Loss Capital:
 Whenever the available cover falls below the minimum required:
 
 - The loan broker can't issue new loans.
-- The loan broker can't receive fees. All fees are added to the First-Loss Capital to cover the deficit.
+- The loan broker can't receive fees. All fees are added to the first-loss capital to cover the deficit.
 
 Below is an example of how first-loss capital is used to cover a loan default:
 
@@ -132,7 +134,7 @@ If the loan broker discovers a borrower can't make an upcoming payment, impairme
 
 #### Clawback
 
-Issuers (trust line token or MPT, not XRP) can claw back funds from First-Loss Capital. To ensure there is always a minimum amount of capital available to protect depositors, issuers can't claw back the entire available amount. Instead, they can claw back up to a minimum amount of First-Loss Capital that the loan broker must maintain for the lending protocol; the minimum amount is calculated as `LoanBroker.DebtTotal * LoanBroker.CoverRateMinimum`.
+Issuers (trust line token or MPT, not XRP) can claw back funds from first-loss capital. To ensure there is always a minimum amount of capital available to protect depositors, issuers can't claw back the entire available amount. Instead, they can claw back up to a minimum amount of first-loss capital that the loan broker must maintain for the lending protocol; the minimum amount is calculated as `LoanBroker.DebtTotal * LoanBroker.CoverRateMinimum`.
 
 #### Freeze
 

--- a/docs/references/protocol/ledger-data/ledger-entry-types/loanbroker.md
+++ b/docs/references/protocol/ledger-data/ledger-entry-types/loanbroker.md
@@ -41,8 +41,8 @@ The lending protocol uses the pseudo-account of the associated `Vault` entry to 
   "DebtTotal": 50000,
   "DebtMaximum": 100000,
   "CoverAvailable": 10000,
-  "CoverRateMinimum": 1000,
-  "CoverRateLiquidation": 500
+  "CoverRateMinimum": 10000,
+  "CoverRateLiquidation": 5000
 }
 ```
 
@@ -69,7 +69,7 @@ In addition to the [common ledger entry fields][], {% code-page-name /%} entries
 | `DebtMaximum`         | String    | Number        | No        | The maximum amount the protocol can owe the vault. The default value of `0` means there is no limit to the debt. |
 | `CoverAvailable`      | String    | Number        | Yes       | The total amount of first-loss capital deposited into the lending protocol. |
 | `CoverRateMinimum`    | Number    | UInt32        | Yes       | The 1/10th basis point of the `DebtTotal` that the first-loss capital must cover. Valid values are 0 to 100000 (inclusive), representing 0% to 100%. |
-| `CoverRateLiquidation`| Number    | UInt12        | Yes       | The 1/10th basis point of minimum required first-loss capital that is moved to an asset vault to cover a loan default. Valid values are 0 to 100000 (inclusive), representing 0% to 100%. |
+| `CoverRateLiquidation`| Number    | UInt32        | Yes       | The 1/10th basis point of minimum required first-loss capital that is moved to an asset vault to cover a loan default. Valid values are 0 to 100000 (inclusive), representing 0% to 100%. |
 
 
 ## {% $frontmatter.seo.title %} Flags

--- a/docs/references/protocol/transactions/types/loanbrokerset.md
+++ b/docs/references/protocol/transactions/types/loanbrokerset.md
@@ -32,8 +32,8 @@ Only the owner of the associated vault can initiate this transaction.
   "Data": "5468697320697320617262697472617279206D657461646174612061626F757420746865206C6F616E62726F6B65722E",
   "ManagementFeeRate": 100,
   "DebtMaximum": 100000,
-  "CoverRateMinimum": 1000,
-  "CoverRateLiquidation": 500
+  "CoverRateMinimum": 10000,
+  "CoverRateLiquidation": 5000
 }
 ```
 


### PR DESCRIPTION
Adds a couple lines to clarify first-loss capital mechanics. Also fixes an incorrect data type in reference pages and improves the sample values to more realistic ones.