### PR TITLE
Document key StatsD metrics on the Configure StatsD page

### DIFF
--- a/docs/infrastructure/configuration/configure-statsd.md
+++ b/docs/infrastructure/configuration/configure-statsd.md
@@ -60,7 +60,55 @@ To enable StatsD on your `xrpld` server, perform the following steps:
 
     You should periodically see messages indicating outbound traffic to the configured address and port of your `rippledmon` instance.
 
-For descriptions of each StatsD metric, see the [`rippledmon` repository](https://github.com/ripple/rippledmon).
+## Key Metrics to Monitor
+
+After you enable StatsD, the core server exports metrics about its own health and behavior. Each metric arrives as `<prefix>.<group>.<metric>`, where `prefix` is the value you set in the `[insight]` stanza and `group` is the server subsystem that reports it. For example, with `prefix=my_xrpld`, the validated ledger age arrives as `my_xrpld.LedgerMaster.Validated_Ledger_Age`.
+
+All of the metrics in this section are reported as StatsD gauges. Cumulative values are not reset between reports, so calculate rates in your collector. For the complete list of exported metrics, see the [`rippledmon` repository](https://github.com/ripple/rippledmon).
+
+### Ledger
+
+| Metric | Description |
+| --- | --- |
+| `LedgerMaster.Validated_Ledger_Age` | Age of the last validated ledger, in seconds. |
+| `LedgerMaster.Published_Ledger_Age` | Age of the last published ledger, in seconds. |
+
+{% admonition type="info" name="Note" %}
+Before the server records its first validated or published ledger, the corresponding metric reports `1209600` (two weeks) rather than an actual age. Exclude that value when setting alert thresholds.
+{% /admonition %}
+
+### Server State
+
+These metrics report how long the server has spent in each operational state and how many times it has entered each one. The core server tracks five accounting states: Disconnected, Connected, Syncing, Tracking, and Full. The [xrpld Server States](../../references/http-websocket-apis/api-conventions/xrpld-server-states.md) reference lists seven states, but `validating` and `proposing` aren't tracked separately here; time the server spends in those states is counted under `Full_duration`.
+
+| Metric | Description |
+| --- | --- |
+| `State_Accounting.Disconnected_duration` | Total time spent in the Disconnected state, in microseconds. |
+| `State_Accounting.Connected_duration` | Total time spent in the Connected state, in microseconds. |
+| `State_Accounting.Syncing_duration` | Total time spent in the Syncing state, in microseconds. |
+| `State_Accounting.Tracking_duration` | Total time spent in the Tracking state, in microseconds. |
+| `State_Accounting.Full_duration` | Total time spent in the Full state, in microseconds. |
+| `State_Accounting.Disconnected_transitions` | Number of times the server has entered the Disconnected state. |
+| `State_Accounting.Connected_transitions` | Number of times the server has entered the Connected state. |
+| `State_Accounting.Syncing_transitions` | Number of times the server has entered the Syncing state. |
+| `State_Accounting.Tracking_transitions` | Number of times the server has entered the Tracking state. |
+| `State_Accounting.Full_transitions` | Number of times the server has entered the Full state. |
+
+### Peers
+
+| Metric | Description |
+| --- | --- |
+| `Overlay.Peer_Disconnects` | Total number of peer connections that have closed since the server started. |
+| `Peer_Finder.Active_Inbound_Peers` | Number of active inbound peer slots (connections initiated by other servers). |
+| `Peer_Finder.Active_Outbound_Peers` | Number of active outbound peer slots (connections this server initiated). |
+
+### List All Exported Metrics
+
+```
+tcpdump -A -i lo udp port 8125
+```
+
+If your collector runs on a different machine, use that machine's network interface instead. Replace `lo` with the interface your StatsD traffic crosses, and `8125` with the port your collector listens on. When the collector runs on the same host as the server, that traffic stays on the loopback interface, which is `lo` on Linux and `lo0` on macOS. On Linux you can also pass `any` to capture on every interface. Each metric appears in the payload as `<prefix>.<group>.<metric>:<value>|<type>`.
 
 
 


### PR DESCRIPTION
Adds a 'Key Metrics to Monitor' section to the Configure StatsD page, documenting the key StatsD metrics the core server exports- Ledger, Server State, and Peers. Plus how to list all exported metrics. Previously the page only pointed to the `rippledmon` repository for metric descriptions.

Details:
- **Server State intro:** explains the core server tracks five accounting states (Disconnected, Connected, Syncing, Tracking, Full), while the [xrpld Server States](https://xrpl.org/docs/references/http-websocket-apis/api-conventions/xrpld-server-states) reference lists seven. `validating` and `proposing` aren't tracked separately, so that time is counted under `Full_duration`.
- **Ledger note:** both ledger-age metrics report `1209600` (two weeks) before the server records its first ledger. Excluded that value from alert thresholds.

