### PR TITLE
Update the PHP samples to xrpl_php 2.x

### DIFF
--- a/_code-samples/get-started/php/base.php
+++ b/_code-samples/get-started/php/base.php
@@ -4,9 +4,9 @@
 require __DIR__ . '/vendor/autoload.php';
 
 // Imports
-use XRPL_PHP\Client\JsonRpcClient;
-use XRPL_PHP\Wallet\Wallet;
-use function XRPL_PHP\Sugar\fundWallet;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
+use function Hardcastle\XRPL_PHP\Sugar\fundWallet;
 
 // Create a client using the Testnet
 $client = new JsonRpcClient("https://s.altnet.rippletest.net:51234");

--- a/_code-samples/get-started/php/composer.json
+++ b/_code-samples/get-started/php/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "hardcastle/xrpl_php": "^0.8.5"
+    "hardcastle/xrpl_php": "^2.3"
   }
 }

--- a/_code-samples/get-started/php/get-account-info.php
+++ b/_code-samples/get-started/php/get-account-info.php
@@ -4,10 +4,10 @@
 require __DIR__ . '/vendor/autoload.php';
 
 // Imports
-use XRPL_PHP\Client\JsonRpcClient;
-use XRPL_PHP\Models\Account\AccountInfoRequest;
-use XRPL_PHP\Wallet\Wallet;
-use function XRPL_PHP\Sugar\fundWallet;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Models\Account\AccountInfoRequest;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
+use function Hardcastle\XRPL_PHP\Sugar\fundWallet;
 
 // Create a client using the Testnet
 $client = new JsonRpcClient("https://s.altnet.rippletest.net:51234");

--- a/_code-samples/send-xrp/php/composer.json
+++ b/_code-samples/send-xrp/php/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "hardcastle/xrpl_php": "^0.8.5"
+    "hardcastle/xrpl_php": "^2.3"
   }
 }

--- a/_code-samples/send-xrp/php/send-xrp.php
+++ b/_code-samples/send-xrp/php/send-xrp.php
@@ -4,15 +4,15 @@
 require __DIR__ . '/vendor/autoload.php';
 
 // Imports
-use XRPL_PHP\Client\JsonRpcClient;
-use XRPL_PHP\Models\Account\AccountInfoRequest;
-use XRPL_PHP\Wallet\Wallet;
-use function XRPL_PHP\Sugar\fundWallet;
-use function XRPL_PHP\Sugar\xrpToDrops;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Models\Account\AccountInfoRequest;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
+use function Hardcastle\XRPL_PHP\Sugar\fundWallet;
+use function Hardcastle\XRPL_PHP\Sugar\xrpToDrops;
 
 // Example credentials
 $wallet = Wallet::fromSeed("sEd7zwWAu7vXMCBkkzokJHEXiKw2B2s");
-print_r('Wallet Address: ' . $wallet->getAddress() .PHP_EOL); // rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH
+print_r('Wallet Address: ' . $wallet->getAddress() .PHP_EOL); // rUYHuEvNGemBkF9LpcStHcGUhf84fbnUcN
 
 // Create a client using the Testnet
 $client = new JsonRpcClient("https://s.altnet.rippletest.net:51234");

--- a/docs/tutorials/get-started/get-started-php.md
+++ b/docs/tutorials/get-started/get-started-php.md
@@ -31,7 +31,7 @@ In this tutorial, you'll learn:
 
 ## Requirements
 
-* `XRPL_PHP` requires PHP 8.1 and the PHP extension [GMP](http://php.net/manual/en/book.gmp.php).
+* `XRPL_PHP` requires PHP 8.2 and the PHP extensions [bcmath](https://www.php.net/manual/en/book.bc.php) and [GMP](https://www.php.net/manual/en/book.gmp.php).
 * The PHP extension [BCMATH](https://www.php.net/manual/de/book.bc.php) is recommended for increased performance.
  
 ## Installation
@@ -65,7 +65,7 @@ To make queries and submit transactions, you need to connect to the XRP Ledger. 
 require __DIR__ . '/vendor/autoload.php';
 
 // Imports 
-use XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
 
 // Create a Client using the Testnet
 $client = new JsonRpcClient("https://s.altnet.rippletest.net:51234");
@@ -80,7 +80,7 @@ The sample code in the previous section shows you how to connect to the Testnet,
 * By [installing the core server](../../infrastructure/installation/index.md) (`xrpld`) and running a node yourself. The core server connects to the Mainnet by default, but you can [change the configuration to use Testnet or Devnet](../../infrastructure/configuration/connect-your-xrpld-to-the-xrp-test-net.md). [There are good reasons to run your own core server](../../concepts/networks-and-servers/index.md#reasons-to-run-your-own-server). If you run your own server, you can connect to it like so:
 
     ```
-    use XRPL_PHP\Client\JsonRpcClient;
+    use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
 
     const LOCAL_JSON_RPC_URL = "http://localhost:5005/";
     $client = new JsonRpcClient("LOCAL_JSON_RPC_URL");
@@ -91,7 +91,7 @@ The sample code in the previous section shows you how to connect to the Testnet,
 * By using one of the available [public servers][]:
 
     ```
-    use XRPL_PHP\Client\JsonRpcClient;
+    use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
 
     const MAINNET_JSON_RPC_URL = "https://s2.ripple.com:51234/";
     $client = new JsonRpcClient("MAINNET_JSON_RPC_URL");
@@ -110,7 +110,7 @@ To generate a new account, `PHP_XRPL` provides the static `generate()` method in
 require __DIR__ . '/vendor/autoload.php';
 
 // Imports 
-use XRPL_PHP\Wallet\Wallet;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
 
 // Create a new wallet
 $wallet = Wallet::generate();
@@ -168,7 +168,7 @@ php get-account-info.php
 You should see output similar to this example:
 
 ```console
-XRPL_PHP\Models\Account\AccountInfoResponse Object
+Hardcastle\XRPL_PHP\Models\Account\AccountInfoResponse Object
 (
     [id:protected] => 
     [result:protected] => Array

--- a/docs/tutorials/payments/send-xrp.md
+++ b/docs/tutorials/payments/send-xrp.md
@@ -417,7 +417,7 @@ System.out.println(generationResult.seed()); // Example: sp6JS7f14BuwFY8Mw6bTtLK
 
 {% tab label="PHP" %}
 ```php
-use XRPL_PHP\Wallet\Wallet;
+use Hardcastle\XRPL_PHP\Wallet\Wallet;
 
 $wallet = Wallet::generate();
 
@@ -472,7 +472,7 @@ XrplClient xrplClient = new XrplClient(rippledUrl);
 
 {% tab label="PHP" %}
 ```
-use XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
 
 $client = new JsonRpcClient("https://xrplcluster.com");
 ```
@@ -522,7 +522,7 @@ XrplClient xrplClient = new XrplClient(rippledUrl);
 
 {% tab label="PHP" %}
 ```php
-use XRPL_PHP\Client\JsonRpcClient;
+use Hardcastle\XRPL_PHP\Client\JsonRpcClient;
 
 $client = new JsonRpcClient("http://localhost:5005");
 ```


### PR DESCRIPTION
The XRPL_PHP library has been updated and the PHP code samples don't run with the newest version. 
They use the namespace `XRPL_PHP\`, but the library renamed it to `Hardcastle\XRPL_PHP\`

The samples' own `composer.json` pins `^0.8.5`, so they are internally
consistent — but [Get Started Using PHP][1] tells the reader:

```console
composer require hardcastle/xrpl_php
````

That is unpinned, so anyone following the tutorial today installs 2.3.0 and every sample fails immediately:

PHP Fatal error: Uncaught Error: Class "XRPL_PHP\Client\JsonRpcClient" not found

[1]: https://xrpl.org/docs/tutorials/get-started/get-started-php

## Changes

- Namespace corrected in the three samples and in the inline code blocks of
  both tutorials — 20 places. send-xrp.md pulls most of its code in via
  code-snippet, so only its three additional inline blocks needed touching.
- composer.json of both samples: ^0.8.5 → ^2.3. Pinning the tutorial
  to 0.8.5 instead would also have worked, but that release predates everything
  from 1.0.0 onwards.
- Requirements in get-started-php.md: the page says PHP 8.1. The library
  has required 8.2 since 1.0.0 and declares it as a constraint since 2.0.0, so
  8.1 can no longer install it. ext-bcmath was missing from the list as well —
  it is a direct requirement alongside GMP.
- A stale comment in send-xrp.php named an address that does not belong to
  the seed above it.

Nothing else in the samples needed changing: fundWallet(), autofill(),
sign() and submitAndWait() all behave the same in 2.x.

## Verification

All three samples were run against the Testnet with xrpl_php 2.3.0:

| Sample |  Result |
| get-started/php/base.php |  wallet created and funded | 
| get-started/php/get-account-info.php | account data returned | 
| send-xrp/php/send-xrp.php |  tesSUCCESS | 

The hardcoded example seed in send-xrp.php still has a funded Testnet account,
so that sample works as written.

## Note

I maintain hardcastle/xrpl_php, so
happy to keep these samples current as the library moves. If a newer version
ever breaks them again, feel free to ping me.