### PR TITLE
about page inline link changed from brand to neutral for gray background

### DIFF
--- a/about/index.page.tsx
+++ b/about/index.page.tsx
@@ -406,7 +406,7 @@ export default function XrplOverview() {
                   "about.index.tomorrow.ppart1",
                   "XRP Ledger’s innovation relies on the shared community experience of builders like you. If you’re ready to start your next big blockchain project, explore the XRPL now and consider applying for funding on your next"
                 )}`}
-                <XrplLink href="/community/developer-funding" intention="brand">
+                <XrplLink href="/community/developer-funding" intention="neutral">
                   {translate("about.index.tomorrow.ppart2", " blockchain project")}
                 </XrplLink>
                 {translate("about.index.tomorrow.ppart3", ".")}


### PR DESCRIPTION
Fixes QA issue: Inline link on the /about page has insufficient contrast on the gray card background.

<img width="1316" height="834" alt="Screenshot 2026-08-26 at 7 57 33 AM" src="https://github.com/user-attachments/assets/6e37474f-abdd-4596-b99b-9d008a5d5b16" />

Solution: convert the link to intention:neutral:
<img width="1278" height="802" alt="Screenshot 2026-08-26 at 8 29 33 AM" src="https://github.com/user-attachments/assets/aa25da21-d4d2-46bb-94b4-4fbd9e4873c0" />
<img width="1254" height="788" alt="Screenshot 2026-08-26 at 8 29 43 AM" src="https://github.com/user-attachments/assets/502a4997-26ec-4c16-9b31-1b6c771b1740" />
