### PR TITLE
add aria label in both en and ja to language picker btn

### DIFF
--- a/@l10n/ja/translations.yaml
+++ b/@l10n/ja/translations.yaml
@@ -782,6 +782,7 @@ Delete All Responses: 全レスポンスを削除
 # resources/dev-tools/websocket-api/connection-modal.tsx
 Connection Settings: 接続先設定
 Close: 閉じる
+Select language: 言語を選択
 # resources/dev-tools/websocket-api/curl-modal.tsx
 cURL Syntax: cURL構文
 resources.dev-tools.websocket-api.curl.modal.desc.part1: コマンドラインインターフェースから

--- a/@theme/components/LanguagePicker/LanguagePicker.tsx
+++ b/@theme/components/LanguagePicker/LanguagePicker.tsx
@@ -19,8 +19,9 @@ export type LanguagePickerProps = {
 
 export function LanguagePicker(props: LanguagePickerProps): JSX.Element | null {
   const { currentLocale, locales, setLocale } = useLanguagePicker();
-  const { useTelemetry } = useThemeHooks();
+  const { useTelemetry, useTranslate } = useThemeHooks();
   const telemetry = useTelemetry();
+  const { translate } = useTranslate();
 
   if (locales.length < 2 || !currentLocale) {
     return null;
@@ -31,6 +32,7 @@ export function LanguagePicker(props: LanguagePickerProps): JSX.Element | null {
       icon={<GlobalOutlinedIcon color="--button-content-color" />}
       variant="text"
       size="medium"
+      aria-label={translate("Select language")}
     />
   );
 


### PR DESCRIPTION
Quick accessibility fix for language picker button. Adds aria label and "Select language" text in both English and Japanese.

<img width="901" height="495" alt="Screenshot 2026-08-27 at 12 24 41 PM" src="https://github.com/user-attachments/assets/4fc43638-07a0-4876-a0c6-561cb880129e" />
<img width="903" height="574" alt="Screenshot 2026-08-27 at 12 24 24 PM" src="https://github.com/user-attachments/assets/0e88634f-f6a8-4e8a-9a86-5e7def59ffec" />
