### PR TITLE
Fix link errors

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -14,10 +14,6 @@ ignore:
   # Component demos and non-page documentation files
   - showcase/**/*.page.tsx
   - showcase/**/*.md
-  - shared/components/CardOffgrid/CardOffgrid.md
-  - shared/sections/FeatureSingleTopic/README.md
-  - shared/patterns/CarouselFeatured/README.md
-  - shared/components/Link/Link.md
 l10n:
   defaultLocale: en-US
   locales:

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -10,9 +10,14 @@ ignore:
   # From branch: Internal design-system showcase pages — keep out of production
   # builds. These ~32 component demos widen the module graph and contributed to
   # a Redocly cloud OOM build failure. They remain usable in `realm develop`.
+  - .claude/**
+  # Component demos and non-page documentation files
   - showcase/**/*.page.tsx
   - showcase/**/*.md
-  - .claude/**
+  - shared/components/CardOffgrid/CardOffgrid.md
+  - shared/sections/FeatureSingleTopic/README.md
+  - shared/patterns/CarouselFeatured/README.md
+  - shared/components/Link/Link.md
 l10n:
   defaultLocale: en-US
   locales:

--- a/shared/components/CardOffgrid/CardOffgrid.md
+++ b/shared/components/CardOffgrid/CardOffgrid.md
@@ -454,4 +454,5 @@ interface CardOffgridProps {
 
 ## Examples
 
-See the [CardOffgrid Showcase](/about/card-offgrid-showcase) for live examples and interactive demos.
+See [When to Use Each Variant](#when-to-use-each-variant) and
+[Interaction Patterns](#interaction-patterns) above for examples.

--- a/shared/components/Link/Link.md
+++ b/shared/components/Link/Link.md
@@ -92,9 +92,9 @@ Most of the site's links aren't JSX — they're `[text](url)` or raw
 `<a href="...">` inside `.md`/`.mdx` files. Two mechanisms make sure those
 still get themed, without every markdown file needing to import a component:
 
-1. **`MarkdownLink` override** — [`@theme/components/MarkdownLink.tsx`](../../../@theme/components/MarkdownLink.tsx)
+1. **`MarkdownLink` override** — `@theme/components/MarkdownLink.tsx`
    replaces Redocly's default renderer for markdoc's `[text](url)` syntax
-   (registered in [`@theme/markdoc/components.tsx`](../../../@theme/markdoc/components.tsx)).
+   (registered in `@theme/markdoc/components.tsx`).
    It still renders Redocly's own routing `Link` (so client-side navigation
    keeps working) but stamps it with `Link`'s class scheme via the exported
    `linkClassName()` helper, forced to `intention="neutral" variation="inline"`

--- a/shared/patterns/CarouselFeatured/README.md
+++ b/shared/patterns/CarouselFeatured/README.md
@@ -121,7 +121,8 @@ The component supports three background variants that adapt to light/dark mode:
 
 ## Examples
 
-See the [showcase page](../../../about/carousel-featured-showcase.page.tsx) for live examples with different configurations.
+See the [Props](#props) and [Transitions](#transitions) sections above for the
+available configurations.
 
 ## Notes
 

--- a/shared/sections/FeatureSingleTopic/README.md
+++ b/shared/sections/FeatureSingleTopic/README.md
@@ -56,7 +56,7 @@ interface ButtonConfig {
 }
 ```
 
-**Note:** Button configurations are handled by the `ButtonGroup` component. See [ButtonGroup documentation](../ButtonGroup/README.md) for more details.
+**Note:** Button configurations are handled by the `ButtonGroup` component. See [ButtonGroup documentation](../../patterns/ButtonGroup/README.md) for more details.
 
 ## Button Behavior
 


### PR DESCRIPTION
## Why

Several component doc .md files rendered links to pages that were either moved, deleted, or were relative links to files, which would work in an IDE but not the website.

This repairs all 5.

In the future, consider one of these options:
1. redocly ignores all /shared/*/*.md files, to avoid building pages that are not intended to be viewed in the website (they're not in any nav)
2. use a consistent naming scheme for internal developer doc files, like .../README.md, and add these pages to the docs nav

### Before
<img width="862" height="164" alt="Screenshot 2026-08-28 at 10 09 56 AM" src="https://github.com/user-attachments/assets/2949ade5-3f89-4904-870a-2023277712d8" />

### After
<img width="580" height="182" alt="Screenshot 2026-08-28 at 10 04 04 AM" src="https://github.com/user-attachments/assets/95d54b27-a9c8-4a25-8e90-d5eb946af7bb" />
