### PR TITLE
Fix WebSocket Tool modals

### DIFF
--- a/resources/dev-tools/components/Modal.tsx
+++ b/resources/dev-tools/components/Modal.tsx
@@ -6,11 +6,11 @@ interface ModalProps {
   title: string,
   children: ReactNode,
   footer?: ReactNode,
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 /**
- * Reusable component that leverages bootstrap's jquery library
+ * Reusable Bootstrap 5 modal. Markup must stay in the DOM so data-bs-toggle can find it.
  */
 export const Modal = ({title, footer, children, onClose, id}: ModalProps) => {
   return <div
@@ -29,7 +29,7 @@ export const Modal = ({title, footer, children, onClose, id}: ModalProps) => {
             className="close"
             aria-label="Close"
             onClick={onClose}
-            data-dismiss="modal"
+            data-bs-dismiss="modal"
           >
             <span aria-hidden="true">&times;</span>
           </button>
@@ -47,14 +47,14 @@ export const Modal = ({title, footer, children, onClose, id}: ModalProps) => {
   </div>
 }
 
-export const ModalCloseBtn = ({onClick}) => {
+export const ModalCloseBtn = ({onClick}: {onClick?: () => void}) => {
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
 
   return <button
     type="button"
     className="btn btn-outline-secondary"
-    data-dismiss="modal"
+    data-bs-dismiss="modal"
     onClick={onClick}
   >
     {translate('Close')}

--- a/resources/dev-tools/components/websocket-api/connection-modal.tsx
+++ b/resources/dev-tools/components/websocket-api/connection-modal.tsx
@@ -3,20 +3,15 @@ import { Connection } from './types';
 import { ChangeEvent } from 'react';
 import { Modal } from '../Modal';
 
-interface ConnectionButtonProps {
+interface ConnectionModalProps {
   selectedConnection: Connection;
   setSelectedConnection: (value: Connection) => void;
   connections: Connection[];
 }
 
-interface ConnectionProps extends ConnectionButtonProps {
-  closeConnectionModal: any;
-}
-
-export const ConnectionModal: React.FC<ConnectionProps> = ({
+export const ConnectionModal: React.FC<ConnectionModalProps> = ({
                                                              selectedConnection,
                                                              setSelectedConnection,
-                                                             closeConnectionModal,
                                                              connections,
                                                            }) => {
   const { useTranslate } = useThemeHooks();                                                  
@@ -31,7 +26,7 @@ export const ConnectionModal: React.FC<ConnectionProps> = ({
   };
 
   return (
-    <Modal id="wstool-1-connection-settings" title={translate('Connection Settings')} onClose={closeConnectionModal}>
+    <Modal id="wstool-1-connection-settings" title={translate('Connection Settings')}>
       {connections.map((conn) => (
         <div className="form-check" key={conn.id}>
           <input

--- a/resources/dev-tools/components/websocket-api/curl-modal.tsx
+++ b/resources/dev-tools/components/websocket-api/curl-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useThemeHooks } from '@redocly/theme/core/hooks';
 import { Connection } from './types';
 import { Modal, ModalClipboardBtn, ModalCloseBtn } from '../Modal';
@@ -8,12 +8,7 @@ interface CurlButtonProps {
   selectedConnection: Connection;
 }
 
-interface CurlProps extends CurlButtonProps{
-  closeCurlModal: () => void;
-}
-
-export const CurlModal: React.FC<CurlProps> = ({
-                                                  closeCurlModal,
+export const CurlModal: React.FC<CurlButtonProps> = ({
                                                   currentBody,
                                                   selectedConnection,
                                                }) => {
@@ -23,14 +18,13 @@ export const CurlModal: React.FC<CurlProps> = ({
 
   const footer = <>
     <ModalClipboardBtn textareaRef={curlRef} />
-    <ModalCloseBtn onClick={closeCurlModal} />
+    <ModalCloseBtn />
   </>
 
   return (
     <Modal
       id="wstool-1-curl"
       title={translate("cURL Syntax")}
-      onClose={() => {}}
       footer={footer}
     >
       <form>
@@ -54,29 +48,20 @@ export const CurlModal: React.FC<CurlProps> = ({
   );
 };
 
-export function CurlButton ({selectedConnection, currentBody}: CurlButtonProps) {
-  const [showCurlModal, setShowCurlModal] = useState(false);
+export function CurlButton () {
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
 
-  return <>
+  return (
       <button
         className="btn btn-outline-secondary curl"
         data-bs-toggle="modal"
         data-bs-target="#wstool-1-curl"
         title={translate("cURL Syntax")}
-        onClick={() => setShowCurlModal(true)}
       >
         <i className="fa fa-terminal"></i>
       </button>
-      {showCurlModal && (
-        <CurlModal
-          closeCurlModal={() => setShowCurlModal(false)}
-          currentBody={currentBody}
-          selectedConnection={selectedConnection}
-        />
-      )}
-  </>
+  )
 }
 
 function getCurl(selectedConnection: Connection, currentBody) {

--- a/resources/dev-tools/components/websocket-api/permalink-modal.tsx
+++ b/resources/dev-tools/components/websocket-api/permalink-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useThemeHooks } from '@redocly/theme/core/hooks';
 import { Connection } from './types';
 import { Modal, ModalClipboardBtn, ModalCloseBtn } from '../Modal';
@@ -8,22 +8,22 @@ interface PermaLinkButtonProps {
   selectedConnection: Connection;
 }
 
-interface PermaLinkProps extends PermaLinkButtonProps {
-  closePermalinkModal: () => void;
-}
-
-const PermalinkModal: React.FC<PermaLinkProps> = ({
-                                                    closePermalinkModal,
+export const PermalinkModal: React.FC<PermaLinkButtonProps> = ({
                                                     currentBody,
                                                     selectedConnection
 }) => {
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
   const permalinkRef = useRef(null);
+  const [permalink, setPermalink] = useState('');
+
+  useEffect(() => {
+    setPermalink(getPermalink(selectedConnection, currentBody));
+  }, [selectedConnection, currentBody]);
 
   const footer = <>
     <ModalClipboardBtn textareaRef={permalinkRef} />
-    <ModalCloseBtn onClick={closePermalinkModal} />
+    <ModalCloseBtn />
   </>
 
   return (
@@ -31,7 +31,6 @@ const PermalinkModal: React.FC<PermaLinkProps> = ({
       id="wstool-1-permalink"
       title={translate("Permalink")}
       footer={footer}
-      onClose={closePermalinkModal}
     >
       <form>
         <div className="form-group">
@@ -45,7 +44,7 @@ const PermalinkModal: React.FC<PermaLinkProps> = ({
             className="form-control"
             rows={8}
             ref={permalinkRef}
-            value={getPermalink(selectedConnection, currentBody)}
+            value={permalink}
             onChange={() => {}}
           />
         </div>
@@ -54,29 +53,20 @@ const PermalinkModal: React.FC<PermaLinkProps> = ({
   );
 };
 
-export function PermalinkButton ({currentBody, selectedConnection}: PermaLinkButtonProps) {
-  const [showPermalinkModal, setShowPermalinkModal] = useState(false);
+export function PermalinkButton () {
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
 
-  return <>
+  return (
     <button
       className="btn btn-outline-secondary permalink"
       data-bs-toggle="modal"
       data-bs-target="#wstool-1-permalink"
       title={translate("Permalink")}
-      onClick={() => setShowPermalinkModal(true)}
     >
       <i className="fa fa-link"></i>
     </button>
-    {showPermalinkModal && (
-      <PermalinkModal
-        closePermalinkModal={() => setShowPermalinkModal(false)}
-        currentBody={currentBody}
-        selectedConnection={selectedConnection}
-      />
-    )}
-  </>
+  )
 }
 
 function getPermalink (selectedConnection: Connection, currentBody) {

--- a/resources/dev-tools/websocket-api-tool.page.tsx
+++ b/resources/dev-tools/websocket-api-tool.page.tsx
@@ -11,8 +11,8 @@ import {
 } from "use-query-params"
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
-import { PermalinkButton } from './components/websocket-api/permalink-modal';
-import { CurlButton } from './components/websocket-api/curl-modal';
+import { PermalinkButton, PermalinkModal } from './components/websocket-api/permalink-modal';
+import { CurlButton, CurlModal } from './components/websocket-api/curl-modal';
 import { ConnectionModal } from "./components/websocket-api/connection-modal";
 
 import { RightSideBar } from "./components/websocket-api/right-sidebar";
@@ -42,8 +42,6 @@ export function WebsocketApiTool() {
   const { hash: slug } = useLocation();
   const { useTranslate } = useThemeHooks();
   const { translate } = useTranslate();
-  const [isConnectionModalVisible, setIsConnectionModalVisible] =
-    useState(false);
   const [selectedConnection, setSelectedConnection] = useState((params.server) ? connections.find((connection) => { return connection?.ws_url === params.server }) : connections[0]);  const [connected, setConnected] = useState(false);
   const [connectionError, setConnectionError] = useState(false);
   const [keepLast, setKeepLast] = useState(50);
@@ -94,14 +92,6 @@ export function WebsocketApiTool() {
   const handleKeepLastChange = (event) => {
     const newValue = event.target.value;
     setKeepLast(newValue);
-  };
-
-  const openConnectionModal = () => {
-    setIsConnectionModalVisible(true);
-  };
-
-  const closeConnectionModal = () => {
-    setIsConnectionModalVisible(false);
   };
 
   const [ws, setWs] = useState(null);
@@ -276,7 +266,6 @@ export function WebsocketApiTool() {
                     className={`btn connection ${
                       connected ? "btn-success" : "btn-outline-secondary"
                     } ${connectionError ?? "btn-danger"}`}
-                    onClick={openConnectionModal}
                     data-bs-toggle="modal"
                     data-bs-target="#wstool-1-connection-settings"
                   >
@@ -284,14 +273,6 @@ export function WebsocketApiTool() {
                       connected ? ` (${translate('Connected')})` : ` (${translate('Not Connected')})`
                     }${connectionError ? ` (${translate('Failed to Connect')})` : ""}`}
                   </button>
-                  {isConnectionModalVisible && (
-                    <ConnectionModal
-                      selectedConnection={selectedConnection}
-                      setSelectedConnection={setSelectedConnection}
-                      closeConnectionModal={closeConnectionModal}
-                      connections={connections}
-                    />
-                  )}
                   {wsLoading && (
                     <div className="input-group loader connect-loader">
                       <span className="input-group-append">
@@ -299,14 +280,23 @@ export function WebsocketApiTool() {
                       </span>
                     </div>
                   )}
-                  <PermalinkButton
-                    currentBody={currentBody}
-                    selectedConnection={selectedConnection}
-                  />
+                  <PermalinkButton />
                   {!currentMethod.ws_only &&
-                    (<CurlButton currentBody={currentBody} selectedConnection={selectedConnection}/>)
+                    (<CurlButton />)
                   }
                 </div>
+                <ConnectionModal
+                  selectedConnection={selectedConnection}
+                  setSelectedConnection={setSelectedConnection}
+                  connections={connections}
+                />
+                <PermalinkModal
+                  currentBody={currentBody}
+                  selectedConnection={selectedConnection}
+                />
+                {!currentMethod.ws_only && (
+                  <CurlModal currentBody={currentBody} selectedConnection={selectedConnection} />
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
Fixes the network selector, permalink, and cURL buttons on the WebSocket API Tool (`/resources/dev-tools/websocket-api-tool`). Those buttons used Bootstrap’s `data-bs-toggle="modal"`, but React only mounted the modal after the click, so Bootstrap couldn’t find the target.

- First click threw `TypeError: Cannot read properties of undefined (reading 'backdrop')`.
- Second click opened the modal, but closing it left the backdrop in place and blocked the rest of the page until reload.

Keep the modal markup in the DOM so Bootstrap can find it on the first click, and switch close buttons to Bootstrap 5’s `data-bs-dismiss="modal"` so the overlay is actually removed.

## Test plan
- [ ] Open `/resources/dev-tools/websocket-api-tool`
- [ ] Click the network selector once — modal opens with no console error
- [ ] Close it — overlay is gone and the page is clickable
- [ ] Repeat for the permalink and cURL buttons
- [ ] Confirm you can open/close all three in sequence without reloading