### PR TITLE
Update AI resources ahead of lending hackathon

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,30 +9,16 @@
 
 ## XRPL Reference Sources
 
-For up-to-date XRPL protocol, API, or SDK info, use the `context7` MCP server. The following authoritative sources are indexed:
+For up-to-date XRPL protocol, API, or SDK info, use the `xrpl-docs` MCP server. Prefer this over web search or memory when writing code samples, documenting protocol behavior, or answering SDK API questions. The following authoritative sources are indexed weekly:
 
-### Documentation Sites
+- [xrpl.org](https://xrpl.org/docs): The official developer portal for up-to-date XRPL docs, including use cases, concepts, tutorials, references, and code samples.
+- [opensource.ripple.com](https://opensource.ripple.com/): The technical doc site for all features in development by Ripple.
+- [docs.xrplevm.org](https://docs.xrplevm.org/): The technical doc site for the XRPL EVM Sidechain.
+- [XRPL-Standards](https://github.com/XRPLF/XRPL-Standards): The repo for community defined suggestions, proposals, and feature specifications for the XRPL.
+- [XRPL JavaScript SDK](https://github.com/xrplf/xrpl.js)
+- [XRPL Python SDK](https://github.com/xrplf/xrpl-py)
 
-- `/websites/xrpl` — xrpl.org (this dev portal's published content)
-- `/websites/opensource_ripple` — opensource.ripple.com (Ripple's open-source projects)
-- `/websites/xrplevm` — docs.xrplevm.org (XRPL EVM sidechain)
-
-### Protocol Implementation
-
-- `/xrplf/rippled` — rippled (C++ reference implementation; authoritative for protocol behavior, transaction validation, and ledger entry structure)
-
-### SDK Libraries
-
-- `/xrplf/xrpl-py` — Python
-- `/xrplf/xrpl.js` — JavaScript / TypeScript
-- `/xrplf/xrpl-go` — Go
-- `/xrplf/xrpl4j` — Java
-
-Since the library IDs are listed above, skip `mcp__context7__resolve-library-id` and call `mcp__context7__query-docs` directly with the relevant ID. Prefer this over web search or memory when writing code samples, documenting protocol behavior, or answering SDK API questions.
-
-### Live xrpl.org Content
-
-Use the `xrpl-dev-portal` MCP server (xrpl.org content only) as a fallback if `context7` is unavailable. **Only `mcp__xrpl-dev-portal__search` is functional**. Do not call the other tools.
+If `xrpl-docs` isn't available, use the `xrpl.org` MCP server (xrpl.org content only) as a fallback. Only call the `search` tool when using `xrpl.org`.
 
 ## Localization
 

--- a/.claude/rules/code-guide.md
+++ b/.claude/rules/code-guide.md
@@ -14,7 +14,7 @@ This guide and language-specific rules are not concrete. If the user gives you d
     |:-----|:-------|:--------|
     | HTTP | `https://s.devnet.rippletest.net:51234` | `https://s.altnet.rippletest.net:51234` |
     | WSS  | `wss://s.devnet.rippletest.net:51233`   | `wss://s.altnet.rippletest.net:51233`   |
-2. Check the SDK library documentation via the `context7` MCP server.
+2. Check the SDK library documentation via the `xrpl-docs` MCP server.
   - Get the latest stable version to pin the SDK at.
   - Get all relevant documentation for the transactions and helpers used.
   - Prefer the SDK's built-in helpers over custom code. Only use your own helpers if the library has no equivalent.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
-    "context7": {
+    "xrpl-docs": {
       "type": "http",
-      "url": "https://mcp.context7.com/mcp"
+      "url": "https://mcp.xrpledger.ai"
     },
-    "xrpl-dev-portal": {
+    "xrpl.org": {
       "type": "http",
       "url": "https://xrpl.org/mcp"
     }

--- a/docs/agents/agentic-transactions.page.tsx
+++ b/docs/agents/agentic-transactions.page.tsx
@@ -114,7 +114,7 @@ const requirementCards = [
     title: 'Machine-Readable Docs',
     description:
       'The XRPL Docs MCP Server exposes the full developer documentation as tool-callable context, so your LLM always has accurate, up-to-date reference material.',
-    href: 'https://context7.com/websites/xrpl',
+    href: '/resources/dev-tools/ai-tools#xrpl-docs-mcp-server',
     external: true
   },
   {

--- a/resources/dev-tools/ai-tools.md
+++ b/resources/dev-tools/ai-tools.md
@@ -11,21 +11,23 @@ Augment your AI with additional tools to accelerate development, automate integr
 
 AI models are limited by their training data, which will always be out-of-date with the most recent XRPL features and SDK improvements. MCP servers solve this by giving your AI real-time access to current documentation through a standardized interface. Instead of relying on potentially outdated training data, your AI can query an MCP server for accurate, up-to-date context. Below is a list of available MCP servers:
 
-### Context7
+### XRPL Docs MCP Server
 
-[Context7](https://context7.com/) is a searchable database of user-submitted repos and websites. Official XRPL docs are maintained on the site and include:
+**Endpoint**: `https://mcp.xrpledger.ai`
+
+The XRPL Docs MCP Server can be wired into any MCP-capable client, such as Claude Code or Codex. It is an up-to-date, authoritative source for XRPL documentation that includes:
 - [xrpl.org](https://xrpl.org/docs): The official developer portal for up-to-date XRPL docs, including use cases, concepts, tutorials, references, and code samples.
 - [opensource.ripple.com](https://opensource.ripple.com/): The technical doc site for all features in development by Ripple.
 - [docs.xrplevm.org](https://docs.xrplevm.org/): The technical doc site for the XRPL EVM Sidechain.
+- [XRPL-Standards](https://github.com/XRPLF/XRPL-Standards): The repo for community defined suggestions, proposals, and feature specifications for the XRPL.
 - [XRPL JavaScript SDK](https://github.com/xrplf/xrpl.js)
 - [XRPL Python SDK](https://github.com/xrplf/xrpl-py)
-- [XRPL Go SDK](https://github.com/xrplf/xrpl-go)
-
-To set up Context7, see: [Installation](https://github.com/upstash/context7?tab=readme-ov-file#installation).
 
 ### xrpl.org MCP Server
 
-The xrpl.org site hosts a standalone MCP server, which only contains documentation hosted on the site. From any doc page, you can click the **Copy** dropdown by the page title and select either **Connect to Cursor** or **Connect to VS Code**. If you are using a different code editor, you can manually configure the MCP server using the `https://xrpl.org/mcp` endpoint.
+**Endpoint**: `https://xrpl.org/mcp`
+
+The xrpl.org site hosts a standalone MCP server, which only contains documentation hosted on the site. From any doc page, you can click the **Copy** dropdown by the page title and select either **Connect to Cursor** or **Connect to VS Code**. If you are using a different code editor, you can manually configure the MCP server using the endpoint.
 
 
 ## SKILL.md

--- a/resources/dev-tools/ai-tools.md
+++ b/resources/dev-tools/ai-tools.md
@@ -27,7 +27,7 @@ The XRPL Docs MCP Server can be wired into any MCP-capable client, such as Claud
 
 **Endpoint**: `https://xrpl.org/mcp`
 
-The xrpl.org site hosts a standalone MCP server, which only contains documentation hosted on the site. From any doc page, you can click the **Copy** dropdown by the page title and select either **Connect to Cursor** or **Connect to VS Code**. If you are using a different code editor, you can manually configure the MCP server using the endpoint.
+The xrpl.org site hosts a standalone MCP server that only indexes what is on the site. This server is intended as a backup for the XRPL Docs MCP Server. From any doc page, you can click the **Copy** dropdown by the page title and select either **Connect to Cursor** or **Connect to VS Code**. If you are using a different code editor, you can manually configure the MCP server using the endpoint.
 
 
 ## SKILL.md

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -1574,9 +1574,7 @@ Specification: [XLS-66](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-A revision of the [LendingProtocol][] amendment with improvements and fixes, including adding a `MemoData` field to the `VaultDelete` transaction.
-
-Specification: [XLS-66](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0066-lending-protocol).
+Extends the [LendingProtocol][] and [SingleAssetVault][] amendments with a new _closed-ended_ vault and cash-basis accounting. Closed-ended vaults have a defined lifecycle split into three phases: subscription, investment, and redemption; these phases determine when assets can be deposited into vaults, loans can be originated, and when assets can be redeemed. After the amendment is enabled, new loan brokers can only be created against closed-ended vaults. Cash-basis accounting changes vault accounting to only realize interest as income when payments are actually made, shifting from a whole-life model where all scheduled interest was recognized at the time of loan origination.
 
 
 ### MPTokensV1

--- a/resources/known-amendments.md
+++ b/resources/known-amendments.md
@@ -1574,7 +1574,7 @@ Specification: [XLS-66](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-
 | Default Vote (Latest stable release) | No |
 | Pre-amendment functionality retired? | No |
 
-Extends the [LendingProtocol][] and [SingleAssetVault][] amendments with a new _closed-ended_ vault and cash-basis accounting. Closed-ended vaults have a defined lifecycle split into three phases: subscription, investment, and redemption; these phases determine when assets can be deposited into vaults, loans can be originated, and when assets can be redeemed. After the amendment is enabled, new loan brokers can only be created against closed-ended vaults. Cash-basis accounting changes vault accounting to only realize interest as income when payments are actually made, shifting from a whole-life model where all scheduled interest was recognized at the time of loan origination.
+Extends the [LendingProtocol][] and [SingleAssetVault][] amendments with a new _closed-ended_ vault and _cash-basis_ accounting. Closed-ended vaults have a defined lifecycle split into three phases: subscription, investment, and redemption; these phases determine when assets can be deposited into vaults, loans can be originated, and when assets can be redeemed. After the amendment is enabled, new loan brokers can only be created against closed-ended vaults. Cash-basis accounting changes vault accounting to only realize interest as income when payments are actually made, shifting from an _instant interest recognition_ model where all scheduled interest was recognized at the time of loan origination.
 
 
 ### MPTokensV1


### PR DESCRIPTION
This PR switches out the main `context7` MCP server for the `xrpl-docs` server. It also fixes the `LendingProtocolV1_1` description on the known amendments page.