### PR TITLE
Add signing changes from 3.4.0 release

### DIFF
--- a/docs/references/protocol/data-types/basic-data-types.md
+++ b/docs/references/protocol/data-types/basic-data-types.md
@@ -34,20 +34,25 @@ In many cases, the XRP Ledger prefixes an object's binary data with a 4-byte cod
 
 Some types of hash appear in API requests and responses. Others are only calculated as the first step of signing a certain type of data, or calculating a higher-level hash. The following table shows all 4-byte hash prefixes the XRP Ledger uses:
 
-| Object Type                           | API Fields                           | Hash Prefix (Hex) | Hash Prefix (Text) |
-|:--------------------------------------|:-------------------------------------|:------------------|:--|
-| Consensus proposal                    | N/A                                  | `0x50525000`      | `PRP\0` |
-| Ledger Version                        | `ledger_hash`                        | `0x4C575200`      | `LWR\0` |
-| Ledger state data                     | `account_state` in [ledger header][] | `0x4D4C4E00`      | `MLN\0` |
-| Ledger data inner node                | N/A                                  | `0x4D494E00`      | `MIN\0` |
-| Ledger data inner node ([SHAMapv2][]) | N/A                                  | `0x494E5200`      | `INR\0` |
-| Payment Channel Claim                 | N/A                                  | `0x434C4D00`      | `CLM\0` |
-| Signed Transaction                    | `hash` of transactions               | `0x54584E00`      | `TXN\0` |
-| Transaction with metadata             | N/A                                  | `0x534E4400`      | `SND\0` |
-| Unsigned Transaction (Single-signing) | N/A                                  | `0x53545800`      | `STX\0` |
-| Unsigned Transaction (Multi-signing)  | N/A                                  | `0x534D5400`      | `SMT\0` |
-| Validation vote                       | N/A                                  | `0x56414C00`      | `VAL\0` |
-| Validator manifest                    | N/A                                  | `0x4D414E00`      | `MAN\0` |
+| Object Type                             | API Fields                           | Hash Prefix (Hex) | Hash Prefix (Text) |
+|:----------------------------------------|:-------------------------------------|:------------------|:-------------------|
+| Consensus proposal                      | N/A                                  | `0x50525000`      | `PRP\0`            |
+| Ledger Version                          | `ledger_hash`                        | `0x4C575200`      | `LWR\0`            |
+| Ledger state data                       | `account_state` in [ledger header][] | `0x4D4C4E00`      | `MLN\0`            |
+| Ledger data inner node                  | N/A                                  | `0x4D494E00`      | `MIN\0`            |
+| Ledger data inner node ([SHAMapv2][])   | N/A                                  | `0x494E5200`      | `INR\0`            |
+| Payment Channel Claim                   | N/A                                  | `0x434C4D00`      | `CLM\0`            |
+| Signed Transaction                      | `hash` of transactions               | `0x54584E00`      | `TXN\0`            |
+| Transaction with metadata               | N/A                                  | `0x534E4400`      | `SND\0`            |
+| Unsigned Transaction (Single-signing)   | N/A                                  | `0x53545800`      | `STX\0`            |
+| Unsigned Transaction (Multi-signing)    | N/A                                  | `0x534D5400`      | `SMT\0`            |
+| Counterparty Signature (Single-signing) | N/A                                  | `0x43505400`      | `CPT\0`            |
+| Counterparty Signature (Multi-signing)  | N/A                                  | `0x43504D00`      | `CPM\0`            |
+| Sponsor Signature (Single-signing)      | N/A                                  | `0x53504E00`      | `SPN\0`            |
+| Sponsor Signature (Multi-signing)       | N/A                                  | `0x53504D00`      | `SPM\0`            |
+| Validation vote                         | N/A                                  | `0x56414C00`      | `VAL\0`            |
+| Validator manifest                      | N/A                                  | `0x4D414E00`      | `MAN\0`            |
+| Batch                                   | N/A                                  | `0x42434800`      | `BCH\0`            |
 
 [ledger header]: ../ledger-data/ledger-header.md
 [SHAMapv2]: /resources/known-amendments.md#shamapv2

--- a/docs/references/protocol/transactions/common-fields.md
+++ b/docs/references/protocol/transactions/common-fields.md
@@ -242,8 +242,8 @@ The `SponsorSignature` field is an object containing the sponsor's signing infor
 | Field Name      | JSON Type | [Internal Type][] | Required? | Description  |
 | :-------------- | :-------- | :---------------- | :-------- | :----------- |
 | `SigningPubKey` | String    | Blob              | No        | The `SigningPubKey` for the `Sponsor`, if single-signing. |
-| `TxnSignature`  | String    | Blob              | No        | A signature of the transaction from the sponsor, to indicate their approval of this transaction, if single-signing. |
-| `Signers`       | Array     | Array             | No        | An array of signatures of the transaction from the sponsor's signers to indicate their approval of this transaction, if the sponsor is [multi-signing](../../../concepts/accounts/multi-signing.md). |
+| `TxnSignature`  | String    | Blob              | No        | A signature of the transaction indicating the sponsor's approval, if single-signing. Must be generated using role-specific hash prefixes {% amendment-disclaimer name="fixCleanup3_4_0" /%}. Standard transaction signatures will be rejected. |
+| `Signers`       | Array     | Array             | No        | An array of signatures of the transaction from the sponsor's signers to indicate their approval, if the sponsor is [multi-signing](../../../concepts/accounts/multi-signing.md). Must be generated using role-specific hash prefixes {% amendment-disclaimer name="fixCleanup3_4_0" /%}. Standard transaction signatures will be rejected. |
 
 These fields are not included in transaction signatures, though they are still included in the stored transaction. There is no additional transaction fee for using `TxnSignature`.
 


### PR DESCRIPTION
-  SponsorSignature/CounterpartySignature get distinct signing prefixes in PR [#8162](https://github.com/XRPLF/rippled/pull/8162)
- Updated hash prefix table
- Added note to "SponsorSignature Field" in Common Fields