### PR TITLE
TOML checker: show error message instead of crashing on missing/invalid toml

### DIFF
--- a/resources/dev-tools/toml-checker/ValidateTomlSteps.tsx
+++ b/resources/dev-tools/toml-checker/ValidateTomlSteps.tsx
@@ -165,7 +165,7 @@ async function parseXRPLToml(
     } catch(e) {
         updateLogEntry(setLogEntries, {...parsingTomlLogEntry, status: {
             icon: {
-                label: e,
+                label: e.message,
                 type: "ERROR",
             },
         }})
@@ -278,7 +278,7 @@ export async function fetchFile(
     } catch (e) {
         const errorUpdate: LogEntryItem = {...logEntry, status: {
             icon: {
-                label: e,
+                label: e.message,
                 type: "ERROR",
             },
             followUpMessage: (<p>


### PR DESCRIPTION
Fixes #3793

## What

The TOML Checker crashes the page when the domain has no valid `xrp-ledger.toml` (e.g. `example.com`) with:

```
Objects are not valid as a React child (found: [object Error])
```

Both `catch` blocks in `ValidateTomlSteps.tsx` (fetch failure and TOML parse failure) put the raw `Error` object into `status.icon.label`, which `LogEntry` renders as a React child. This came in with the axios removal (b5c817fd0) — the old code mapped the axios error to a status string.

## Fix

Use `e.message` as the label in both places, matching what `domain-verifier.page.tsx` already does. For `example.com` the badge now reads `Server returned status code 404` / `Failed to fetch`; for a non-TOML body it shows the `smol-toml` message (`Invalid TOML document: …`).

## Validation

- Standalone React 19 harness rendering the `LogEntry` `<li>` shape: with `label: e` → throws `Objects are not valid as a React child (found: [object Error])`; with `label: e.message` → renders `<span class="badge">Failed to fetch</span>`.
- Confirmed `smol-toml` `parse()` throws a `TomlError` (an `Error` subclass with `.message`), so the parse-failure branch has the same shape.
- `tsc --noEmit` on the file: no new diagnostics vs. master (the pre-existing ones are all unresolved `@redocly/*` module imports outside this change).

I couldn't run `realm develop` here, so no in-browser screenshot — happy to adjust if you'd prefer a different label wording.
